### PR TITLE
Phase 4: Isolate subagent hooks by repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,23 @@ python3 ~/.copilot/tools/tentacle.py complete api-export
 
 **Commit restriction:** Sub-agents must not run `git commit` or `git push`. When git hooks
 are installed (`install.py --install-git-hooks`), both operations are **blocked at the git level**
-while a `dispatched-subagent-active` marker is active. Even without hooks, this is a hard
-convention: only the orchestrator commits, after merging and verifying tentacle results.
-Enforcement is local-only — cloud-delegated runs are not covered.
+while a `dispatched-subagent-active` marker is active and the marker's `git_root` matches the
+current repo. Even without hooks, this is a hard convention: only the orchestrator commits,
+after merging and verifying tentacle results. Enforcement is local-only — cloud-delegated runs
+are not covered.
+
+> **Cross-repo isolation:** Each marker entry carries a `git_root` field. If Terminal A has an
+> active tentacle in repo A, a `git commit` in repo B is **not blocked** — the hook skips
+> markers whose `git_root` doesn't match the committing repo. Markers written without `git_root`
+> (old format or dispatch from a non-git directory) conservatively block as before.
+
+> **Stuck marker:** If the orchestrator crashes before `tentacle.py complete`, the marker stays
+> active for up to 4 hours (TTL dead-man switch). To clear it manually:
+> ```bash
+> python3 ~/.copilot/tools/tentacle.py complete <name>
+> # or directly:
+> rm ~/.copilot/markers/dispatched-subagent-active
+> ```
 
 ### Tentacle Next Step
 
@@ -278,13 +292,34 @@ Smart pipeline analyzes `git diff` to run only what changed. Post-merge hook aut
 
 Unified hook runner architecture — 1 Python process per event with fail-open, HMAC-signed markers, audit logging, and tamper protection. Hook deployment is **Copilot CLI only**; Claude Code does not support the `hook_runner.py` format.
 
-**Dispatched-subagent git guard (phase 3):** `install.py --install-git-hooks` deploys
+**Dispatched-subagent git guard (phase 3+):** `install.py --install-git-hooks` deploys
 `pre-commit` and `pre-push` scripts into the current repo's `.git/hooks/`. When the
-`dispatched-subagent-active` marker is fresh, both scripts block the git operation. This is the
-**primary enforcement surface** for subagent commit restrictions — it fires at the filesystem
-level regardless of which agent process calls git. The `preToolUse` hook provides
-defense-in-depth but cannot be relied on inside delegated subagent contexts. Enforcement is
-**local-only**; cloud-delegated runs are not covered.
+`dispatched-subagent-active` marker is fresh and its `git_root` matches the committing repo,
+both scripts block the git operation. This is the **primary enforcement surface** for subagent
+commit restrictions — it fires at the filesystem level regardless of which agent process calls
+git. The `preToolUse` hook provides defense-in-depth but cannot be relied on inside delegated
+subagent contexts. Enforcement is **local-only**; cloud-delegated runs are not covered.
+
+The marker now stores `active_tentacles` as a list of objects (`{name, ts, git_root}`) instead
+of a flat string list. Each entry carries its own dispatch timestamp and the git repository root
+where the dispatch originated. The hook compares `git_root` against the repo running git — a
+marker from a different repo does not block commits there (fixes cross-repo false-positive
+blocking). Markers written without `git_root` (old format or non-git CWD) conservatively block.
+
+> **Upgrade migration:** Cross-repo isolation is not retroactive for in-flight old-format
+> markers. If a tentacle is still active when you upgrade, its existing marker entry has no
+> `git_root` and will continue to block all repos until it completes, is cleared, or the 4-hour
+> TTL expires. To get isolation immediately: `tentacle.py complete <name>` (or
+> `rm ~/.copilot/markers/dispatched-subagent-active`), then re-dispatch.
+
+**Limitations:** `preToolUse` non-inheritance inside `task()`-spawned subagents remains a
+platform limitation — git hooks are the reliable surface. Two concurrent orchestrators in the
+same repo share one marker and are not isolated from each other; one orchestrator per repo at a
+time is the supported model. `auto-update-tools.py` does **not** auto-reinstall git hooks in
+registered repos — when hook files change it prints:
+`"Git hook scripts updated — installed per-repo hooks are NOT automatically refreshed."` and
+`"Re-run in each protected repo: python3 ~/.copilot/tools/install.py --install-git-hooks"`.
+Re-run that command in each protected repo after relevant tool updates.
 
 ```bash
 python3 ~/.copilot/tools/install.py --deploy-skill        # Deploy skill to project

--- a/auto-update-tools.py
+++ b/auto-update-tools.py
@@ -404,6 +404,18 @@ def post_pull_pipeline(old_sha: str, new_sha: str):
     if changes.get("launchd"):
         reinstall_launchagents()
 
+    # 3b. Git hook scripts changed → remind user to re-install per-repo hooks.
+    # auto-update deliberately does NOT auto-reinstall git hooks into other repos:
+    # it has no registry of which repos have hooks installed, and silently modifying
+    # .git/hooks/ in arbitrary repos would be unsafe.  Users must re-run install.py.
+    if changes.get("hooks"):
+        hook_files = [f for f in changes["hooks"]
+                      if "pre-commit" in f or "pre-push" in f or "check_subagent" in f]
+        if hook_files:
+            warn("Git hook scripts updated — installed per-repo hooks are NOT automatically refreshed.")
+            warn("ACTION REQUIRED to pick up the cross-repo isolation fix (and future hook changes):")
+            warn("  Re-run in EVERY protected repo: python3 ~/.copilot/tools/install.py --install-git-hooks")
+
     # 4. Template/SKILL.md changed → redeploy
     if changes.get("templates") or changes.get("skills"):
         deploy_skills()

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -218,10 +218,9 @@ Enforcement surfaces are **selectively fail-open**. The behavior differs by erro
 | Empty `active_tentacles` list (zombie marker) | allow |
 | Exception during entry processing or repo-scope check | **conservative (block)** — errors in parsing `active_tentacles` entries or the `git_root` comparison fall through to blocking to avoid accidentally unblocking an active session |
 
-> **Note:** The docstring in `is_marker_fresh()` says "Fail-open on any exception" but the
-> outer exception handlers around the zombie check and repo-scope check both use `pass`
-> (continue to block). Only structural errors before active-entries processing are fail-open.
-> `subagent_guard.py` uses `return False` on its outermost exception, so it is fully fail-open.
+> **Note:** The `is_marker_fresh()` docstring and implementation are now aligned: auth/parse
+> failures are fail-open (return `False` → allow), while repo-scope check exceptions are
+> fail-conservative (`pass` → keep blocking). See `hooks/check_subagent_marker.py`.
 
 To clear a stuck marker manually:
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -96,23 +96,52 @@ The marker is a JSON file with the following contract:
 | Field | Description |
 |-------|-------------|
 | `name` | Always `"dispatched-subagent-active"` |
-| `ts` | UNIX timestamp of the most-recent write (used for HMAC + TTL) |
+| `ts` | UNIX timestamp of the most-recent write (used for HMAC + global TTL anchor) |
 | `sig` | HMAC-SHA256 over `"name:ts"` (omitted when no secret is configured) |
-| `active_tentacles` | Ordered list of tentacle names currently dispatched (deduped, concurrency-safe) |
+| `active_tentacles` | List of per-entry objects: `{"name": "<tentacle>", "ts": "<unix>", "git_root": "<abs-path>"}`. Each entry carries its own dispatch timestamp and the absolute path of the git repository where the tentacle was dispatched. Readers also accept the old string-list format for backward compatibility. |
 | `scope` | File-scope list from the most-recently-dispatching tentacle |
 | `dispatch_mode` | Dispatch mode of the most-recently-dispatching tentacle |
 | `ttl_seconds` | Expected lifetime; consumers treat markers older than this as stale |
 | `written_at` | ISO 8601 human-readable timestamp |
 
-**Concurrent tentacles:** Multiple tentacles dispatched in parallel each add their name to
-`active_tentacles` rather than overwriting the file. `tentacle.py complete <name>` removes only
-that tentacle's entry; the marker is deleted only when `active_tentacles` becomes empty.
+**Per-entry TTL:** Each `active_tentacles` entry's `ts` is used for its own TTL check. A stale
+entry (its `ts` is older than `ttl_seconds`) is treated as inactive even if the global marker
+file is still fresh.
+
+**Concurrent tentacles:** Multiple tentacles dispatched in parallel each add their dict entry to
+`active_tentacles`. `tentacle.py complete <name>` removes only that tentacle's entry; the marker
+is deleted only when `active_tentacles` becomes empty.
 
 **Step 2 — Git pre-commit / pre-push (primary enforcement)**
 
 `hooks/check_subagent_marker.py` is called by both `hooks/pre-commit` and `hooks/pre-push`.
-When the marker is present, auth-valid, and within the 4-hour TTL, it exits with code 1 and
-prints a diagnostic message — blocking the git operation.
+When the marker is present, auth-valid, within the 4-hour TTL, and its `git_root` matches the
+repository where the git operation is running, it exits with code 1 and prints a diagnostic
+message — blocking the git operation.
+
+**Repo-scope check:** Each `active_tentacles` entry carries a `git_root` field. The hook
+resolves the current repo's root with `git rev-parse --show-toplevel` and compares it against
+the entry's `git_root`. If they differ, that entry does not block the operation. This prevents
+a tentacle active in repo A from falsely blocking unrelated commits in repo B — the cross-repo
+false-positive that existed before phase 4.
+
+**Backward compatibility:** If a marker entry has no `git_root` (written by old code or
+dispatched from a non-git directory), the hook conservatively blocks — same behavior as before.
+
+> **Upgrade migration note:** Cross-repo isolation is **not retroactive** for in-flight
+> old-format markers. If you upgrade while a tentacle is still active and the marker was
+> written by old code (string-list `active_tentacles`, no per-entry `git_root`), that marker
+> carries no repo identity and will continue to block **all** repos conservatively until the
+> tentacle completes, the marker is cleared manually, or the 4-hour TTL expires.
+>
+> **Recommended action:** Before upgrading on a machine with active tentacles, run
+> `tentacle.py complete <name>` for each active tentacle, then re-dispatch after upgrading.
+> Or clear the marker immediately:
+> ```bash
+> rm ~/.copilot/markers/dispatched-subagent-active
+> ```
+> After clearing, re-dispatch any tentacles that still need to run — they will now write
+> new-format entries with `git_root` and benefit from cross-repo isolation.
 
 This is the **primary enforcement surface**: git hooks fire at the filesystem level for any
 `git commit` or `git push` call, regardless of which agent spawned the process.
@@ -123,7 +152,9 @@ This is the **primary enforcement surface**: git hooks fire at the filesystem le
 `preToolUse` event that contains a `git commit` or `git push` bash command. This provides a
 second interception point when `preToolUse` does fire inside the subagent. However, it is
 **not the primary path** — whether `preToolUse` events from the parent `hooks.json` propagate
-into a delegated subagent context is undefined by the platform.
+into a delegated subagent context is undefined by the platform. Git hooks remain the reliable
+enforcement surface. If the platform ever guarantees `preToolUse` propagation into
+`task()`-spawned agents, `subagent_guard.py` could become the primary path and replace git hooks.
 
 **Step 4 — Marker cleanup**
 
@@ -139,6 +170,15 @@ sessions that crash without calling `complete`.
 > - Cloud-hosted or remote-delegated agent runs (hooks.json is not copied to cloud environments)
 > - Any environment where git hooks are not installed (`install.py --install-git-hooks`)
 > - Manual filesystem operations that bypass git (direct file writes without committing)
+
+### Known limitations
+
+| Limitation | Detail |
+|---|---|
+| `preToolUse` non-inheritance | `preToolUse` hooks from the parent `hooks.json` may not fire inside `task()`-spawned subagents — platform-level behavior, not fixable here. Git hooks remain the reliable surface. |
+| Same-repo multi-orchestrator | Two concurrent orchestrators running in the **same** repo are not isolated from each other — both share the same marker `git_root` entry. One orchestrator per repo at a time is the supported model. |
+| Cloud/remote agents | Hooks are local-only. Cloud-delegated or remote agent runs have no coverage. |
+| `auto-update` does not reinstall git hooks | `auto-update-tools.py` updates tools-repo files but does **not** re-run `--install-git-hooks` in registered repos. It prints a warning when hook files change. Users must re-run `install.py --install-git-hooks` manually to apply new hook logic in each protected repo. |
 
 ### Installing the git hooks
 
@@ -156,16 +196,32 @@ python "$env:USERPROFILE\.copilot\tools\install.py" --install-git-hooks
 config to ensure the hooks fire even when a project-level override is present.
 
 After tool updates (`git pull` or `auto-update-tools.py --force`), re-run
-`--install-git-hooks` to refresh the hook scripts in `.git/hooks/`.
+`--install-git-hooks` to refresh the hook scripts in `.git/hooks/`. `auto-update-tools.py`
+does **not** perform this reinstallation automatically — it cannot safely enumerate every repo
+where hooks are installed. When hook files change, it emits these two warnings to stdout:
+
+```
+WARNING: Git hook scripts updated — installed per-repo hooks are NOT automatically refreshed.
+WARNING: Re-run in each protected repo: python3 ~/.copilot/tools/install.py --install-git-hooks
+```
 
 ### Fail-open behavior
 
-All enforcement surfaces are fail-open:
+Enforcement surfaces are **selectively fail-open**. The behavior differs by error type:
 
-- Missing marker → allow (no false positives)
-- Stale marker (age ≥ 4 hours) → allow
-- HMAC auth failure (marker tampered or written without secret) → allow
-- Any unexpected error in `check_subagent_marker.py` → allow
+| Condition | Behavior |
+|-----------|----------|
+| Missing marker file | allow (no false positives) |
+| Stale marker (age ≥ 4 hours) | allow |
+| HMAC auth failure (tampered or written without secret) | allow |
+| Missing or unparseable timestamp | allow |
+| Empty `active_tentacles` list (zombie marker) | allow |
+| Exception during entry processing or repo-scope check | **conservative (block)** — errors in parsing `active_tentacles` entries or the `git_root` comparison fall through to blocking to avoid accidentally unblocking an active session |
+
+> **Note:** The docstring in `is_marker_fresh()` says "Fail-open on any exception" but the
+> outer exception handlers around the zombie check and repo-scope check both use `pass`
+> (continue to block). Only structural errors before active-entries processing are fail-open.
+> `subagent_guard.py` uses `return False` on its outermost exception, so it is fully fail-open.
 
 To clear a stuck marker manually:
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -237,12 +237,25 @@ These apply to every dispatched sub-agent.
 - **Commit restriction (enforced + convention)**: Sub-agents must not run `git commit` or
   `git push`. When git hooks are installed (`install.py --install-git-hooks`), both operations
   are **blocked at the git level** by `hooks/check_subagent_marker.py` whenever the
-  `dispatched-subagent-active` marker is present and fresh. Even without git hooks, this
-  remains a firm convention: only the orchestrator commits, after merging and verifying all
-  tentacle results. A sub-agent commit mid-run risks corrupting the orchestrator's merge flow.
+  `dispatched-subagent-active` marker is present, fresh, and its `git_root` matches the repo
+  running the git command. Even without git hooks, this remains a firm convention: only the
+  orchestrator commits, after merging and verifying all tentacle results. A sub-agent commit
+  mid-run risks corrupting the orchestrator's merge flow.
+
+  > **Cross-repo isolation:** A marker written in repo A does not block `git commit` in repo B.
+  > Each marker entry carries a `git_root` field; the hook skips entries from different repos.
+  > Entries without `git_root` (old format) conservatively block all repos.
+  >
+  > **Upgrade migration:** Cross-repo isolation is not retroactive. In-flight old-format markers
+  > have no `git_root` and continue to block all repos until completed, cleared, or expired.
+  > To get isolation immediately after upgrading: `tentacle.py complete <name>`, then re-dispatch.
 
   > **Local-only enforcement**: the git hook guard fires only on local machines where hooks are
   > installed. Cloud-delegated or remote agent runs are not covered.
+
+  > **Same-repo multi-orchestrator**: Two concurrent orchestrators in the **same** repo share
+  > one marker entry and are not isolated from each other. One orchestrator per repo at a time
+  > is the supported model.
 
 - **Stay in scope**: Avoid editing files outside your tentacle's declared scope.
 - **Escalate, don't expand**: If scope is insufficient, record the gap in `handoff.md` and stop.

--- a/hooks/check_subagent_marker.py
+++ b/hooks/check_subagent_marker.py
@@ -13,10 +13,21 @@ Verification follows the same semantics as marker_auth.verify_marker():
 This script imports marker_auth from the hooks/ directory when available, and
 falls back to the same logic inline so the git hook works even when invoked
 from an arbitrary working directory.
+
+Repo-scope check (cross-repo false-positive prevention):
+  New-format markers carry a git_root field (top-level and/or per-entry in
+  active_tentacles).  When present, the marker only blocks commits in the same
+  repository.  Absent git_root → conservative block (backward compat with old
+  markers that carry no repo metadata).
+
+Dual-format support:
+  active_tentacles may be a list of strings (old format) or a list of dicts
+  with {name, ts, git_root} fields (new format).  Both are handled transparently.
 """
 
 import json
 import os
+import subprocess as _subprocess
 import sys
 import time
 from pathlib import Path
@@ -99,14 +110,25 @@ def _read_marker_ts(marker_path: Path):
 
 
 def _read_tentacle_info() -> str:
-    """Extract tentacle name(s) from marker for UX messaging (best-effort)."""
+    """Extract tentacle name(s) from marker for UX messaging (best-effort).
+
+    Supports both old string-list and new dict-list active_tentacles formats.
+    """
     try:
         data = json.loads(MARKER_PATH.read_text(encoding="utf-8"))
         if isinstance(data, dict):
-            # New format: active_tentacles list
             active = data.get("active_tentacles")
             if isinstance(active, list) and active:
-                return ", ".join(active)
+                names = []
+                for entry in active:
+                    if isinstance(entry, str):
+                        names.append(entry)
+                    elif isinstance(entry, dict):
+                        name = entry.get("name")
+                        if name:
+                            names.append(str(name))
+                if names:
+                    return ", ".join(names)
             # Old single-owner format
             return data.get("tentacle") or data.get("detail", "")
     except Exception:
@@ -114,42 +136,149 @@ def _read_tentacle_info() -> str:
     return ""
 
 
+def _get_current_git_root() -> "str | None":
+    """Return the git root of the current working directory, or None on failure."""
+    try:
+        r = _subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if r.returncode == 0:
+            return r.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def _roots_match(root_a: str, root_b: str) -> bool:
+    """Return True iff two git root paths resolve to the same directory.
+
+    Fail-conservative: returns True on any exception so that an uncertain
+    path comparison never silently lets a commit through.  Callers that skip
+    an entry on non-match (``if not _roots_match(...): continue``) will
+    therefore keep the entry active when comparison fails, preserving the
+    blocking behaviour.
+    """
+    try:
+        return Path(root_a).resolve() == Path(root_b).resolve()
+    except Exception:
+        return True  # fail-conservative: uncertain → treat as same repo (block)
+
+
+def _any_entry_relevant(active: list, current_git_root: "str | None", now: float) -> bool:
+    """Return True if at least one active_tentacles entry is relevant to the current repo.
+
+    Old string entries: no per-entry repo metadata → conservative (relevant).
+    New dict entries: check per-entry git_root and per-entry TTL.
+      - git_root absent or None → conservative (relevant, blocks).
+      - git_root present + different repo → skip entry.
+      - git_root present + same repo → relevant.
+    Fail-conservative: any exception → entry treated as relevant.
+    """
+    for entry in active:
+        try:
+            if isinstance(entry, str):
+                # Old format: no repo metadata → conservatively block.
+                return True
+            if isinstance(entry, dict):
+                # Per-entry TTL check (new format only).
+                entry_ts = entry.get("ts")
+                if entry_ts is not None:
+                    try:
+                        age = now - int(entry_ts)
+                        if not (0 <= age < MARKER_TTL):
+                            continue  # This entry has expired; skip it.
+                    except (ValueError, TypeError):
+                        pass  # Can't parse entry ts → don't skip.
+
+                # Per-entry repo-scope check.
+                entry_git_root = entry.get("git_root")
+                if not entry_git_root:
+                    # Absent or None: conservative → relevant.
+                    return True
+                if current_git_root and not _roots_match(current_git_root, entry_git_root):
+                    continue  # Different repo — skip this entry.
+                return True  # Same repo (or can't determine current → conservative).
+        except Exception:
+            return True  # fail-conservative
+    return False  # No relevant entries found.
+
+
 def is_marker_fresh() -> bool:
     """Return True iff the marker is auth-valid (HMAC or existence fallback) and within TTL.
 
-    Step 1 — marker_auth check (mirrors verify_marker semantics):
-      secret present  → requires valid HMAC signature
-      no secret       → any readable file is considered valid
-    Step 2 — TTL check: 0 ≤ age < MARKER_TTL
-    Step 3 — Zombie check: active_tentacles field exists and is [] → inactive, allow
-    Fail-open on any exception.
+    Step 1 — File-exists check.
+    Step 2 — HMAC/existence-fallback check via _verify_marker (reads file internally).
+    Step 3 — Parse once; all subsequent checks reuse the same parsed dict to
+             avoid repeated file reads and narrow the TOCTOU window between
+             verification and content inspection.
+    Step 4 — TTL check: 0 ≤ age < MARKER_TTL.
+    Step 5 — Zombie check: active_tentacles == [] → inactive, allow.
+    Step 6 — Repo-scope check: if all active entries belong to a different git
+             repo, don't block (cross-repo false-positive prevention).
+             Absent git_root → conservative block (backward compat with old
+             markers carrying no repo metadata).
+
+    Fail-open on auth/parse failure (stale or unreadable markers should not
+    block indefinitely).  Fail-conservative on repo-scope exceptions (a marker
+    that passed auth but whose scope cannot be determined is treated as
+    potentially relevant to the current repo).
     """
     if not MARKER_PATH.is_file():
         return False
 
-    # Reuse the repo's marker_auth verification scheme.
+    # HMAC / existence-fallback check (reads file internally — unavoidable).
     if not _verify_marker(MARKER_PATH, MARKER_NAME):
         return False
 
-    # TTL check — read timestamp from marker JSON.
-    ts = _read_marker_ts(MARKER_PATH)
-    if ts is None:
-        # Marker passed auth but has no readable timestamp → fail-open.
+    # Parse once; reuse for all remaining checks.
+    try:
+        data = json.loads(MARKER_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return False  # Unreadable / unparseable after auth → fail-open.
+
+    if not isinstance(data, dict):
+        return False  # Unrecognised format → fail-open.
+
+    # TTL check.
+    ts_raw = data.get("ts")
+    if ts_raw is None:
+        return False  # No timestamp → fail-open.
+    try:
+        now = time.time()
+        age = now - int(ts_raw)
+    except (ValueError, TypeError):
         return False
-    age = time.time() - ts
     if not (0 <= age < MARKER_TTL):
         return False
 
-    # Zombie marker check: orchestrator wrote the marker but cleared all active
-    # tentacles without removing the file.  active_tentacles: [] → allow.
+    # Zombie check: orchestrator cleared all tentacles without removing the file.
+    active = data.get("active_tentacles")
+    if isinstance(active, list) and len(active) == 0:
+        return False
+
+    # Repo-scope check: prevent cross-repo false positives.
+    # If all active entries have a git_root that doesn't match the current repo,
+    # the marker was written for a different repository — don't block.
+    # Old string-list entries with no git_root → conservative block (unchanged).
+    # Exception here → fail-conservative: scope uncertainty keeps blocking.
     try:
-        data = json.loads(MARKER_PATH.read_text(encoding="utf-8"))
-        if isinstance(data, dict):
-            active = data.get("active_tentacles")
-            if isinstance(active, list) and len(active) == 0:
-                return False
+        if isinstance(active, list) and active:
+            if isinstance(active[0], str):
+                # Old string-list format: check top-level git_root if present.
+                marker_git_root = data.get("git_root")
+                if marker_git_root:
+                    current_git_root = _get_current_git_root()
+                    if current_git_root and not _roots_match(current_git_root, marker_git_root):
+                        return False  # Confirmed different repo — don't block.
+                # No top-level git_root → conservative block (old marker).
+            elif isinstance(active[0], dict):
+                # New dict-list format: per-entry git_root check.
+                current_git_root = _get_current_git_root()
+                if not _any_entry_relevant(active, current_git_root, now):
+                    return False  # All entries confirmed for other repos.
     except Exception:
-        pass  # Unreadable field → conservatively keep blocking
+        pass  # fail-conservative: scope check failed → keep blocking.
 
     return True
 

--- a/hooks/rules/subagent_guard.py
+++ b/hooks/rules/subagent_guard.py
@@ -8,10 +8,23 @@ It fires inside the Copilot CLI session's preToolUse event, which may or may
 not be active inside a delegated subagent context (see handoff notes for caveat).
 
 TTL: 4 hours.  Fail-open: stale, missing, or unreadable markers allow through.
+
+Repo-scope check (cross-repo false-positive prevention):
+  New-format markers carry git_root metadata.  When present, blocking is scoped
+  to the repo that dispatched the tentacle.  Absent git_root → conservative block
+  (backward compat with old markers carrying no repo metadata).
+
+Dual-format support:
+  active_tentacles may be a list of strings (old format) or a list of dicts
+  with {name, ts, git_root} fields (new format).  Both are handled transparently.
+
+Note: preToolUse does NOT reliably fire inside task()-spawned delegated subagents.
+Git hooks (pre-commit/pre-push) remain the primary enforcement surface.
 """
 
 import json
 import re
+import subprocess as _subprocess
 import sys
 import time
 from pathlib import Path
@@ -33,13 +46,83 @@ MARKER_NAME = "dispatched-subagent-active"
 MARKER_TTL = 14400  # 4 hours
 
 
+def _get_current_git_root() -> "str | None":
+    """Return git root of CWD, or None on failure."""
+    try:
+        r = _subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if r.returncode == 0:
+            return r.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def _roots_match(root_a: str, root_b: str) -> bool:
+    """Return True iff two git root paths resolve to the same directory.
+
+    Fail-conservative: returns True on any exception so that an uncertain
+    path comparison never silently lets a commit through.  Callers that skip
+    an entry on non-match (``if not _roots_match(...): continue``) will
+    therefore keep the entry active when comparison fails, preserving the
+    blocking behaviour.
+    """
+    try:
+        return Path(root_a).resolve() == Path(root_b).resolve()
+    except Exception:
+        return True  # fail-conservative: uncertain → treat as same repo (block)
+
+
+def _any_entry_relevant(active: list, current_git_root: "str | None", now: float) -> bool:
+    """Return True if at least one active_tentacles entry is relevant to the current repo.
+
+    Old string entries: no per-entry repo metadata → conservative (relevant, blocks).
+    New dict entries: check per-entry git_root and per-entry TTL.
+    Fail-conservative: any exception → entry treated as relevant.
+    """
+    for entry in active:
+        try:
+            if isinstance(entry, str):
+                return True  # Old format: no repo metadata → conservative block.
+            if isinstance(entry, dict):
+                # Per-entry TTL check.
+                entry_ts = entry.get("ts")
+                if entry_ts is not None:
+                    try:
+                        age = now - int(entry_ts)
+                        if not (0 <= age < MARKER_TTL):
+                            continue  # Expired entry.
+                    except (ValueError, TypeError):
+                        pass
+                # Per-entry repo-scope check.
+                entry_git_root = entry.get("git_root")
+                if not entry_git_root:
+                    return True  # Absent/None → conservative.
+                if current_git_root and not _roots_match(current_git_root, entry_git_root):
+                    continue  # Different repo.
+                return True  # Same repo or can't determine → conservative.
+        except Exception:
+            return True  # fail-conservative
+    return False
+
+
 def _marker_is_fresh() -> bool:
     """Return True iff the marker is present, HMAC-valid (or unsigned), within TTL, and not a zombie.
 
-    Step 1 — HMAC check via verify_marker (falls back to existence when no secret configured)
-    Step 2 — TTL check: 0 ≤ age < MARKER_TTL
-    Step 3 — Zombie check: active_tentacles exists and is [] → inactive, allow
-    Fail-open on any exception.
+    Step 1 — HMAC check via verify_marker (falls back to existence when no secret configured).
+    Step 2 — Parse once; reuse data for TTL, zombie, and repo-scope checks to
+             avoid repeated reads and narrow the TOCTOU window.
+    Step 3 — TTL check: 0 ≤ age < MARKER_TTL.
+    Step 4 — Zombie check: active_tentacles == [] → inactive, allow.
+    Step 5 — Repo-scope check: prevent cross-repo false positives.
+             Absent git_root → conservative block (backward compat).
+
+    Fail-open on auth failure or parse failure (stale / unreadable markers
+    should not block indefinitely).
+    Note: preToolUse does NOT reliably fire inside task()-spawned subagents;
+    git pre-commit/pre-push hooks remain the primary enforcement surface.
     """
     if not SUBAGENT_MARKER.is_file():
         return False
@@ -48,41 +131,70 @@ def _marker_is_fresh() -> bool:
     if not verify_marker(SUBAGENT_MARKER, MARKER_NAME):
         return False
 
-    # TTL check — read timestamp from marker JSON
+    # Parse once; reuse for all remaining checks.
     try:
         content = SUBAGENT_MARKER.read_text(encoding="utf-8").strip()
         data = json.loads(content)
         if not isinstance(data, dict):
-            return False  # Unrecognised format → fail-open
+            return False  # Unrecognised format → fail-open.
 
         ts_raw = data.get("ts")
         if ts_raw is None:
-            return False  # No timestamp field → fail-open
+            return False  # No timestamp field → fail-open.
 
-        age = time.time() - int(ts_raw)
+        now = time.time()
+        age = now - int(ts_raw)
         if not (0 <= age < MARKER_TTL):
             return False
 
-        # Zombie marker: marker exists but all tentacles have been cleared.
+        # Zombie marker: all tentacles cleared without removing the file.
         active = data.get("active_tentacles")
         if isinstance(active, list) and len(active) == 0:
             return False
 
+        # Repo-scope check: prevent cross-repo false positives.
+        # Exception here → fail-open (consistent with the outer except).
+        if isinstance(active, list) and active:
+            if isinstance(active[0], str):
+                # Old string-list format: check top-level git_root if present.
+                marker_git_root = data.get("git_root")
+                if marker_git_root:
+                    current_git_root = _get_current_git_root()
+                    if current_git_root and not _roots_match(current_git_root, marker_git_root):
+                        return False  # Confirmed different repo — don't block.
+                # No top-level git_root → conservative block (old marker).
+            elif isinstance(active[0], dict):
+                # New dict-list format: per-entry git_root check.
+                current_git_root = _get_current_git_root()
+                if not _any_entry_relevant(active, current_git_root, now):
+                    return False  # All entries confirmed for other repos.
+
     except Exception:
-        return False  # Any parse/type error → fail-open
+        return False  # Any parse/type error → fail-open.
 
     return True
 
 
 def _read_tentacle_info() -> str:
-    """Best-effort read of tentacle name(s) from marker for UX messaging."""
+    """Best-effort read of tentacle name(s) from marker for UX messaging.
+
+    Supports both old string-list and new dict-list active_tentacles formats.
+    """
     try:
         data = json.loads(SUBAGENT_MARKER.read_text(encoding="utf-8"))
         if isinstance(data, dict):
-            # New format: active_tentacles list
             active = data.get("active_tentacles")
             if isinstance(active, list) and active:
-                return ", ".join(active)
+                names = []
+                for entry in active:
+                    if isinstance(entry, str):
+                        names.append(entry)
+                    elif isinstance(entry, dict):
+                        name = entry.get("name")
+                        if name:
+                            names.append(str(name))
+                if names:
+                    return ", ".join(names)
             # Old single-owner format
             return data.get("tentacle") or data.get("detail", "")
     except Exception:

--- a/install.py
+++ b/install.py
@@ -1213,6 +1213,8 @@ def install_git_hooks(target_dir: "Path | None" = None) -> None:
     else:
         print(f"\n  {len(installed)} installed, {len(skipped)} already up to date (of {total} hooks).")
         print("  Hooks block git commit/push when dispatched-subagent-active marker is fresh.")
+        print("  NOTE: After each 'auto-update-tools.py' run, re-run --install-git-hooks here")
+        print("        to pick up new hook logic (auto-update cannot do this for you safely).")
 
 
 def main():

--- a/skills/tentacle-orchestration/SKILL.md
+++ b/skills/tentacle-orchestration/SKILL.md
@@ -37,9 +37,16 @@ it — they are the reliable enforcement surface.
 
 **How enforcement works:**
 1. `tentacle.py swarm` writes an HMAC-signed marker file at
-   `~/.copilot/markers/dispatched-subagent-active` containing an `active_tentacles` list.
+   `~/.copilot/markers/dispatched-subagent-active` containing an `active_tentacles` list of
+   per-entry objects: `{"name": "<tentacle>", "ts": "<unix>", "git_root": "<abs-path>"}`.
 2. `hooks/pre-commit` and `hooks/pre-push` call `hooks/check_subagent_marker.py`, which blocks
-   the git operation when the marker is present, auth-valid, and within its 4-hour TTL.
+   the git operation when the marker is present, auth-valid, within its 4-hour TTL, **and the
+   entry's `git_root` matches the repo running the git command**. A marker from a different repo
+   does not block commits here — this isolates multi-session, multi-repo setups. Entries without
+   `git_root` (old format) conservatively block all repos.
+   > **Upgrade migration:** Cross-repo isolation is not retroactive. In-flight old-format marker
+   > entries (no `git_root`) continue to block all repos until completed, cleared, or expired (4h
+   > TTL). To get isolation immediately: `tentacle.py complete <name>` then re-dispatch.
 3. `hooks/rules/subagent_guard.py` provides a secondary `preToolUse` intercept for the
    orchestrator session (defense-in-depth only — not the primary path).
 4. `tentacle.py complete <name>` removes the tentacle's entry; the marker is deleted when
@@ -51,8 +58,17 @@ it — they are the reliable enforcement surface.
 python3 ~/.copilot/tools/install.py --install-git-hooks
 ```
 
-**Enforcement scope:** Local-only. Cloud-delegated or remote agent runs are not covered.
-The `preToolUse` guard in the main session is defense-in-depth — it does not replace git hooks.
+**Enforcement scope and known limitations:**
+
+- **Local-only.** Cloud-delegated or remote agent runs are not covered.
+- **`preToolUse` non-inheritance.** The `preToolUse` guard in the main session is
+  defense-in-depth — it does not replace git hooks. Whether `preToolUse` propagates into
+  `task()`-spawned subagents is undefined by the platform.
+- **Same-repo multi-orchestrator not supported.** Two concurrent orchestrators in the same repo
+  share one marker entry and are not isolated from each other. One orchestrator per repo at a
+  time is the supported model.
+- **After tool updates,** `auto-update-tools.py` does NOT auto-reinstall git hooks. Re-run
+  `install.py --install-git-hooks` in each protected repo after relevant updates.
 
 | Convention | What to do |
 |------------|-----------|
@@ -282,4 +298,4 @@ tentacle.py delete <name>
 4. **Complete before delete** — `complete` saves learnings; `delete` alone loses them
 5. **Commit after each phase** — uncommitted code is lost if the session crashes or compacts
 6. **Run the app** — build+test ≠ works. Launch the app to verify DI resolution and runtime behavior
-7. **⚠️ Commit restriction** — Sub-agents must not run `git commit`/`git push`. When git hooks are installed (`install.py --install-git-hooks`), both are blocked at the filesystem level while the `dispatched-subagent-active` marker is fresh. Even without hooks, a sub-agent commit mid-run corrupts the orchestrator's merge flow. Enforcement is local-only; cloud-delegated runs are not covered.
+7. **⚠️ Commit restriction** — Sub-agents must not run `git commit`/`git push`. When git hooks are installed (`install.py --install-git-hooks`), both are blocked at the filesystem level for the repo where the tentacle was dispatched, while the `dispatched-subagent-active` marker is fresh. Commits in other repos are not affected. Even without hooks, a sub-agent commit mid-run corrupts the orchestrator's merge flow. Enforcement is local-only; cloud-delegated runs are not covered.

--- a/tentacle.py
+++ b/tentacle.py
@@ -317,11 +317,28 @@ def _write_dispatched_subagent_marker(
       name:             "dispatched-subagent-active"
       ts:               UNIX timestamp of the most-recent write (used for HMAC + TTL)
       sig:              HMAC-SHA256 over "name:ts" (omitted when no secret is present)
-      active_tentacles: ordered list of tentacle names currently dispatched (deduped)
+      git_root:         absolute path of the git repository from which this write
+                        originated (None when CWD is not inside a git repo).
+                        Enforcement surfaces can use this to skip markers from
+                        unrelated repositories (cross-repo false-positive guard).
+      active_tentacles: list of per-entry objects {name, ts, git_root}.  Each entry
+                        carries its own UNIX timestamp (TTL anchor) and git_root so
+                        cross-session refreshes do not extend unrelated entries.
+                        Readers must tolerate the legacy string-list format produced
+                        by older versions (see backward-compat note below).
       scope:            file-scope list from the most-recently-dispatching tentacle
       dispatch_mode:    mode of the most-recently-dispatching tentacle
       ttl_seconds:      expected lifetime; consumers treat older markers as stale
       written_at:       ISO 8601 human-readable timestamp of the most-recent write
+
+    Backward compat: existing markers may carry active_tentacles as a flat list of
+    strings (old format) or the legacy single-owner 'tentacle' field.  This writer
+    normalises both to the dict-list format on every write.  Old string entries are
+    treated as having git_root=None (unknown repo).
+
+    Deduplication key: (name, git_root).  Same-name tentacles from different repos
+    produce separate entries so enforcement surfaces can discriminate by repo.
+    Same-name same-repo re-dispatch refreshes the existing entry's per-entry ts.
 
     Downstream enforcement surfaces (git hooks, preToolUse guards) can read this marker
     to detect active dispatched-subagent sessions.  This surface is advisory only —
@@ -332,24 +349,77 @@ def _write_dispatched_subagent_marker(
     try:
         MARKERS_DIR.mkdir(parents=True, exist_ok=True)
         with file_locked(_DISPATCHED_MARKER_PATH):
-            # Merge with existing active set (if any)
-            active: list = []
+            current_git_root = find_git_root()
+            current_git_root_str = str(current_git_root) if current_git_root else None
+
+            # Read and normalise existing active entries to list of dicts
+            active: list[dict] = []
             if _DISPATCHED_MARKER_PATH.is_file():
                 try:
                     existing = json.loads(_DISPATCHED_MARKER_PATH.read_text())
+                    raw: list = []
                     if "active_tentacles" in existing:
-                        active = list(existing["active_tentacles"])
+                        raw = list(existing["active_tentacles"])
                     elif "tentacle" in existing:
                         # Backward-compat: promote old single-owner field
-                        active = [existing["tentacle"]]
+                        raw = [existing["tentacle"]]
+                    for entry in raw:
+                        if isinstance(entry, str):
+                            # Old string format — no per-entry metadata
+                            active.append({"name": entry, "ts": None, "git_root": None})
+                        elif isinstance(entry, dict):
+                            active.append(entry)
+                        # Silently skip malformed entries
                 except (json.JSONDecodeError, OSError):
                     pass
-            if tentacle_name not in active:
-                active.append(tentacle_name)
+
+            # Deduplicate by (name, git_root): update ts in-place when match found;
+            # add a new entry for the same name from a different repo.
+            entry_ts = str(int(time.time()))
+            new_entry: dict = {
+                "name": tentacle_name,
+                "ts": entry_ts,
+                "git_root": current_git_root_str,
+            }
+            # Migration cleanup: when dispatching from a known repo, eagerly remove all
+            # legacy entries for this tentacle name whose git_root is None.  Such entries
+            # are artefacts of the old string-list format — they carry no repo identity,
+            # so hook readers conservatively treat them as active in every repo, silently
+            # defeating the cross-repo fix until TTL expiry.
+            #
+            # Removing them before the dedup step ensures:
+            #   - A single (name, None) legacy entry is absorbed cleanly.
+            #   - A (name, None) entry that coexists with a real (name, /repo) entry
+            #     (e.g. from a race between old and new code) is also cleaned up, avoiding
+            #     duplicate entries that would arise from the "first match" search below.
+            #
+            # If current_git_root_str is None we skip cleanup — the exact-match branch
+            # below handles (None == None) dedup correctly.
+            if current_git_root_str is not None:
+                active = [
+                    e for e in active
+                    if not (e.get("name") == tentacle_name and e.get("git_root") is None)
+                ]
+
+            # Normal dedup: update ts in-place for exact (name, git_root) match;
+            # append a new entry for the same name from a different real repo.
+            existing_idx: int | None = None
+            for i, entry in enumerate(active):
+                if entry.get("name") != tentacle_name:
+                    continue
+                if entry.get("git_root") == current_git_root_str:
+                    existing_idx = i
+                    break
+            if existing_idx is not None:
+                active[existing_idx] = new_entry  # Refresh per-entry ts
+            else:
+                active.append(new_entry)
+
             ts = str(int(time.time()))
             data: dict = {
                 "name": _DISPATCHED_MARKER_NAME,
                 "ts": ts,
+                "git_root": current_git_root_str,
                 "active_tentacles": active,
                 "scope": list(scope),
                 "dispatch_mode": dispatch_mode,
@@ -379,6 +449,14 @@ def _clear_dispatched_subagent_marker(tentacle_name: str) -> bool:
     Called by cmd_complete so a completing tentacle's entry is removed without
     disturbing sibling tentacles that are still running.
 
+    Removal is scoped by (name, git_root) when both are available, so completing a
+    tentacle in one repo does not accidentally clear a same-named tentacle in another
+    repo that may be running in a parallel session.
+
+    Backward compat: old string entries and old single-owner 'tentacle' field are
+    normalised to dicts before removal.  An old string entry (git_root=None) is
+    removed by name alone (conservative: we have no repo info to discriminate with).
+
     Fail-open: returns False on error without raising.
     """
     try:
@@ -390,20 +468,39 @@ def _clear_dispatched_subagent_marker(tentacle_name: str) -> bool:
             except (json.JSONDecodeError, OSError):
                 _DISPATCHED_MARKER_PATH.unlink(missing_ok=True)
                 return True
-            # Support old single-owner format
+
+            current_git_root = find_git_root()
+            current_git_root_str = str(current_git_root) if current_git_root else None
+
+            # Normalise to list of dicts (handles both old string-list and new dict-list)
+            raw: list = []
             if "active_tentacles" in data:
-                active: list = list(data["active_tentacles"])
+                raw = list(data["active_tentacles"])
             elif "tentacle" in data:
-                active = [data["tentacle"]]
-            else:
-                active = []
-            if tentacle_name in active:
-                active.remove(tentacle_name)
-            if not active:
+                raw = [data["tentacle"]]
+            normalized: list[dict] = []
+            for entry in raw:
+                if isinstance(entry, str):
+                    normalized.append({"name": entry, "ts": None, "git_root": None})
+                elif isinstance(entry, dict):
+                    normalized.append(entry)
+
+            def _should_remove(entry: dict) -> bool:
+                if entry.get("name") != tentacle_name:
+                    return False
+                entry_git_root = entry.get("git_root")
+                # If either side lacks git_root info, match by name only (conservative
+                # removal: can't distinguish repos, so err on the side of cleaning up).
+                if entry_git_root is None or current_git_root_str is None:
+                    return True
+                return entry_git_root == current_git_root_str
+
+            remaining = [e for e in normalized if not _should_remove(e)]
+            if not remaining:
                 _DISPATCHED_MARKER_PATH.unlink()
             else:
                 ts = str(int(time.time()))
-                data["active_tentacles"] = active
+                data["active_tentacles"] = remaining
                 data["ts"] = ts
                 data["written_at"] = datetime.now(timezone.utc).isoformat()
                 data.pop("tentacle", None)  # Remove old single-owner field
@@ -460,12 +557,16 @@ def _get_marker_state() -> dict:
     """Return machine-readable marker state dict for JSON consumers.
 
     Fields:
-      active:           bool — active_tentacles list is non-empty
-      path:             string path to marker file
-      active_tentacles: list of tentacle names currently dispatched
-      dispatch_mode:    dispatch_mode from marker (or null)
-      stale:            bool — marker age exceeds its declared TTL
-      written_at:       ISO timestamp from marker (or null)
+      active:                  bool — active_tentacles list is non-empty
+      path:                    string path to marker file
+      active_tentacles:        list of tentacle names currently dispatched
+                               (backward-compat: always a list of strings)
+      active_tentacle_entries: list of full per-entry dicts {name, ts, git_root}
+                               (new field: enriched data for enforcement surfaces)
+      git_root:                top-level git_root from the marker (last writer's repo)
+      dispatch_mode:           dispatch_mode from marker (or null)
+      stale:                   bool — marker age exceeds its declared TTL
+      written_at:              ISO timestamp from marker (or null)
     """
     data = _read_dispatched_subagent_marker()
     if data is None:
@@ -473,21 +574,37 @@ def _get_marker_state() -> dict:
             "active": False,
             "path": str(_DISPATCHED_MARKER_PATH),
             "active_tentacles": [],
+            "active_tentacle_entries": [],
+            "git_root": None,
             "dispatch_mode": None,
             "stale": False,
             "written_at": None,
         }
     # Support old single-owner format for backward-compat reads
+    raw_active: list = []
     if "active_tentacles" in data:
-        active_tentacles = list(data["active_tentacles"])
+        raw_active = list(data["active_tentacles"])
     elif "tentacle" in data:
-        active_tentacles = [data["tentacle"]]
-    else:
-        active_tentacles = []
+        raw_active = [data["tentacle"]]
+
+    # Normalise to both a name-list (backward compat) and enriched entry-list (new)
+    names: list[str] = []
+    entries: list[dict] = []
+    for entry in raw_active:
+        if isinstance(entry, str):
+            names.append(entry)
+            entries.append({"name": entry, "ts": None, "git_root": None})
+        elif isinstance(entry, dict):
+            name = entry.get("name", "")
+            names.append(name)
+            entries.append(entry)
+
     return {
-        "active": len(active_tentacles) > 0,
+        "active": len(names) > 0,
         "path": str(_DISPATCHED_MARKER_PATH),
-        "active_tentacles": active_tentacles,
+        "active_tentacles": names,           # backward compat: list of names
+        "active_tentacle_entries": entries,  # new: enriched per-entry data
+        "git_root": data.get("git_root"),    # top-level git_root of last writer
         "dispatch_mode": data.get("dispatch_mode"),
         "stale": _is_marker_stale(data),
         "written_at": data.get("written_at"),

--- a/tentacle.py
+++ b/tentacle.py
@@ -595,7 +595,9 @@ def _get_marker_state() -> dict:
             names.append(entry)
             entries.append({"name": entry, "ts": None, "git_root": None})
         elif isinstance(entry, dict):
-            name = entry.get("name", "")
+            name = entry.get("name")
+            if not isinstance(name, str) or not name:
+                continue
             names.append(name)
             entries.append(entry)
 

--- a/test_hooks.py
+++ b/test_hooks.py
@@ -1154,6 +1154,505 @@ else:
         shutil.rmtree(str(_e2e_repo), ignore_errors=True)
 
 
+# ═══════════════════════════════════════════════════════════════════
+#  Section 13: Repo-scope isolation & dual-format tests
+# ═══════════════════════════════════════════════════════════════════
+
+print("\n── Section 13: Repo-scope isolation & dual-format ──")
+
+# 13a. _read_tentacle_info handles old string-list format
+try:
+    import importlib.util as _ilu13
+    _csm_spec = _ilu13.spec_from_file_location("check_subagent_marker_13", _csm_path)
+    _csm13 = _ilu13.module_from_spec(_csm_spec)
+    _csm_spec.loader.exec_module(_csm13)
+
+    _old_mp13 = _csm13.MARKER_PATH
+    _t13_home = Path(tempfile.mkdtemp(prefix="test-dualfmt-"))
+    _t13_marker = _t13_home / ".copilot" / "markers" / "dispatched-subagent-active"
+    _t13_marker.parent.mkdir(parents=True)
+
+    # Write old string-list format
+    _t13_marker.write_text(json.dumps({
+        "name": "dispatched-subagent-active",
+        "ts": str(int(_time12.time())),
+        "active_tentacles": ["tentacle-alpha", "tentacle-beta"],
+    }))
+    _csm13.MARKER_PATH = _t13_marker
+
+    info_old = _csm13._read_tentacle_info()
+    test("13a: _read_tentacle_info handles old string-list format",
+         "tentacle-alpha" in info_old and "tentacle-beta" in info_old,
+         f"Got: {info_old!r}")
+
+    # 13b. _read_tentacle_info handles new dict-list format
+    _t13_marker.write_text(json.dumps({
+        "name": "dispatched-subagent-active",
+        "ts": str(int(_time12.time())),
+        "active_tentacles": [
+            {"name": "tentacle-alpha", "ts": str(int(_time12.time())), "git_root": "/some/repo"},
+            {"name": "tentacle-beta", "ts": str(int(_time12.time())), "git_root": "/some/repo"},
+        ],
+    }))
+    _csm13.MARKER_PATH = _t13_marker
+    info_new = _csm13._read_tentacle_info()
+    test("13b: _read_tentacle_info handles new dict-list format",
+         "tentacle-alpha" in info_new and "tentacle-beta" in info_new,
+         f"Got: {info_new!r}")
+
+    _csm13.MARKER_PATH = _old_mp13
+    shutil.rmtree(str(_t13_home), ignore_errors=True)
+    test("13a-b: dual-format tentacle info tests ran", True)
+except Exception as e:
+    test("13a-b: dual-format tentacle info tests ran", False, str(e))
+
+# 13c-d. Old-format marker: different vs same git_root
+if _csm_path.is_file():
+    _repo_a = Path(tempfile.mkdtemp(prefix="test-repo-a-"))
+    _repo_b = Path(tempfile.mkdtemp(prefix="test-repo-b-"))
+
+    try:
+        subprocess.run(["git", "init", str(_repo_a)], capture_output=True, check=True, timeout=10)
+        subprocess.run(["git", "config", "user.email", "t@t.com"],
+                       cwd=str(_repo_a), capture_output=True, timeout=5)
+        subprocess.run(["git", "config", "user.name", "T"],
+                       cwd=str(_repo_a), capture_output=True, timeout=5)
+
+        _rA_home = Path(tempfile.mkdtemp(prefix="test-roota-home-"))
+        (_rA_home / ".copilot" / "markers").mkdir(parents=True)
+        _rA_marker = _rA_home / ".copilot" / "markers" / "dispatched-subagent-active"
+
+        # Marker from repo-b → should NOT block in repo-a
+        _rA_marker.write_text(json.dumps({
+            "name": "dispatched-subagent-active",
+            "ts": str(int(_time12.time())),
+            "active_tentacles": ["my-tentacle"],
+            "git_root": str(_repo_b),
+        }))
+        r_cross = subprocess.run(
+            [sys.executable, str(_csm_path)],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+            env={**os.environ, "HOME": str(_rA_home)},
+            cwd=str(_repo_a),
+        )
+        test("13c: old-format marker different git_root → exit 0 (cross-repo skip)",
+             r_cross.returncode == 0,
+             f"exit={r_cross.returncode} stdout={r_cross.stdout[:120]}")
+
+        # Marker from repo-a → should block in repo-a
+        _rA_marker.write_text(json.dumps({
+            "name": "dispatched-subagent-active",
+            "ts": str(int(_time12.time())),
+            "active_tentacles": ["my-tentacle"],
+            "git_root": str(_repo_a),
+        }))
+        r_same = subprocess.run(
+            [sys.executable, str(_csm_path)],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+            env={**os.environ, "HOME": str(_rA_home)},
+            cwd=str(_repo_a),
+        )
+        test("13d: old-format marker same git_root → exit 1 (blocks)",
+             r_same.returncode == 1,
+             f"exit={r_same.returncode} stdout={r_same.stdout[:120]}")
+
+        shutil.rmtree(str(_rA_home), ignore_errors=True)
+    except subprocess.CalledProcessError as e:
+        test("13c-d: git-root repo-scope tests (subprocess setup)", False, str(e))
+    except Exception as e:
+        test("13c-d: git-root repo-scope tests", False, str(e))
+    finally:
+        shutil.rmtree(str(_repo_a), ignore_errors=True)
+        shutil.rmtree(str(_repo_b), ignore_errors=True)
+
+# 13e. Old-format marker without git_root → conservative block
+if _csm_path.is_file():
+    _c_home = Path(tempfile.mkdtemp(prefix="test-conservative-"))
+    (_c_home / ".copilot" / "markers").mkdir(parents=True)
+    (_c_home / ".copilot" / "markers" / "dispatched-subagent-active").write_text(json.dumps({
+        "name": "dispatched-subagent-active",
+        "ts": str(int(_time12.time())),
+        "active_tentacles": ["my-tentacle"],
+        # No git_root — old marker without repo metadata
+    }))
+    r_conservative = subprocess.run(
+        [sys.executable, str(_csm_path)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+        env={**os.environ, "HOME": str(_c_home)},
+    )
+    test("13e: absent git_root → exit 1 (conservative block, backward compat)",
+         r_conservative.returncode == 1,
+         f"exit={r_conservative.returncode} stdout={r_conservative.stdout[:120]}")
+    shutil.rmtree(str(_c_home), ignore_errors=True)
+
+# 13f-g. New dict-list format: all-other-repo vs one-matching-repo
+if _csm_path.is_file():
+    _nf_repo = Path(tempfile.mkdtemp(prefix="test-nf-repo-"))
+    _nf_other = Path(tempfile.mkdtemp(prefix="test-nf-other-"))
+    try:
+        subprocess.run(["git", "init", str(_nf_repo)], capture_output=True, check=True, timeout=10)
+        subprocess.run(["git", "config", "user.email", "t@t.com"],
+                       cwd=str(_nf_repo), capture_output=True, timeout=5)
+
+        _nf_home = Path(tempfile.mkdtemp(prefix="test-nf-home-"))
+        (_nf_home / ".copilot" / "markers").mkdir(parents=True)
+        _nf_marker = _nf_home / ".copilot" / "markers" / "dispatched-subagent-active"
+
+        # All entries for other repo → exit 0
+        _nf_marker.write_text(json.dumps({
+            "name": "dispatched-subagent-active",
+            "ts": str(int(_time12.time())),
+            "active_tentacles": [
+                {"name": "t1", "ts": str(int(_time12.time())), "git_root": str(_nf_other)},
+            ],
+        }))
+        r_all_other = subprocess.run(
+            [sys.executable, str(_csm_path)],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+            env={**os.environ, "HOME": str(_nf_home)},
+            cwd=str(_nf_repo),
+        )
+        test("13f: new dict-list all entries other repo → exit 0",
+             r_all_other.returncode == 0,
+             f"exit={r_all_other.returncode} stdout={r_all_other.stdout[:120]}")
+
+        # Mixed: one entry for current repo → exit 1
+        _nf_marker.write_text(json.dumps({
+            "name": "dispatched-subagent-active",
+            "ts": str(int(_time12.time())),
+            "active_tentacles": [
+                {"name": "t-other", "ts": str(int(_time12.time())), "git_root": str(_nf_other)},
+                {"name": "t-current", "ts": str(int(_time12.time())), "git_root": str(_nf_repo)},
+            ],
+        }))
+        r_one_match = subprocess.run(
+            [sys.executable, str(_csm_path)],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+            env={**os.environ, "HOME": str(_nf_home)},
+            cwd=str(_nf_repo),
+        )
+        test("13g: new dict-list one entry for current repo → exit 1 (blocks)",
+             r_one_match.returncode == 1,
+             f"exit={r_one_match.returncode} stdout={r_one_match.stdout[:120]}")
+
+        shutil.rmtree(str(_nf_home), ignore_errors=True)
+    except subprocess.CalledProcessError as e:
+        test("13f-g: new dict-list repo-scope tests (subprocess setup)", False, str(e))
+    except Exception as e:
+        test("13f-g: new dict-list repo-scope tests", False, str(e))
+    finally:
+        shutil.rmtree(str(_nf_repo), ignore_errors=True)
+        shutil.rmtree(str(_nf_other), ignore_errors=True)
+
+# 13h. New dict entry absent git_root → conservative block
+if _csm_path.is_file():
+    _ca_home = Path(tempfile.mkdtemp(prefix="test-consv-absent-"))
+    (_ca_home / ".copilot" / "markers").mkdir(parents=True)
+    (_ca_home / ".copilot" / "markers" / "dispatched-subagent-active").write_text(json.dumps({
+        "name": "dispatched-subagent-active",
+        "ts": str(int(_time12.time())),
+        "active_tentacles": [{"name": "t1", "ts": str(int(_time12.time()))}],  # No git_root
+    }))
+    r_ca = subprocess.run(
+        [sys.executable, str(_csm_path)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+        env={**os.environ, "HOME": str(_ca_home)},
+    )
+    test("13h: dict entry absent git_root → exit 1 (conservative block)",
+         r_ca.returncode == 1,
+         f"exit={r_ca.returncode} stdout={r_ca.stdout[:120]}")
+    shutil.rmtree(str(_ca_home), ignore_errors=True)
+
+# 13i. New dict entry with expired per-entry ts → exit 0
+if _csm_path.is_file():
+    _exp_home = Path(tempfile.mkdtemp(prefix="test-expired-entry-"))
+    (_exp_home / ".copilot" / "markers").mkdir(parents=True)
+    stale_entry_ts = str(int(_time12.time()) - 99999)
+    (_exp_home / ".copilot" / "markers" / "dispatched-subagent-active").write_text(json.dumps({
+        "name": "dispatched-subagent-active",
+        "ts": str(int(_time12.time())),  # Global ts is fresh
+        "active_tentacles": [
+            {"name": "t-expired", "ts": stale_entry_ts},  # No git_root → conservative but expired
+        ],
+    }))
+    r_exp = subprocess.run(
+        [sys.executable, str(_csm_path)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+        env={**os.environ, "HOME": str(_exp_home)},
+    )
+    test("13i: dict entry with stale per-entry ts → exit 0 (entry expired)",
+         r_exp.returncode == 0,
+         f"exit={r_exp.returncode} stdout={r_exp.stdout[:120]}")
+    shutil.rmtree(str(_exp_home), ignore_errors=True)
+
+# 13j. SubagentGitGuardRule: cross-repo dict entry → allowed; same-repo → denied
+try:
+    import rules.subagent_guard as _sg13
+    _rule_sg13 = _sg13.SubagentGitGuardRule()
+
+    _j_other = Path(tempfile.mkdtemp(prefix="test-j-other-"))
+    _j_current = Path(tempfile.mkdtemp(prefix="test-j-current-"))
+    _j_marker_dir = Path(tempfile.mkdtemp(prefix="test-sg-cross-"))
+    (_j_marker_dir / "markers").mkdir(parents=True)
+    _j_marker_file = _j_marker_dir / "markers" / "dispatched-subagent-active"
+    _j_marker_file.write_text(json.dumps({
+        "name": "dispatched-subagent-active",
+        "ts": str(int(_time12.time())),
+        "active_tentacles": [
+            {"name": "t1", "ts": str(int(_time12.time())), "git_root": str(_j_other)},
+        ],
+    }))
+
+    _orig_sm13 = _sg13.SUBAGENT_MARKER
+    _orig_vm13 = _sg13.verify_marker
+    _orig_gcr13 = _sg13._get_current_git_root
+    _sg13.SUBAGENT_MARKER = _j_marker_file
+    _sg13.verify_marker = lambda p, n: True
+    _sg13._get_current_git_root = lambda: str(_j_current)
+
+    result_cross = _rule_sg13.evaluate("preToolUse", {
+        "toolName": "bash", "toolArgs": {"command": "git commit -m test"},
+    })
+    test("13j: SubagentGitGuardRule cross-repo dict entry → allowed",
+         result_cross is None,
+         f"Got: {result_cross!r:.80}")
+
+    # Same repo → blocks
+    _sg13._get_current_git_root = lambda: str(_j_other)
+    result_sameRepo = _rule_sg13.evaluate("preToolUse", {
+        "toolName": "bash", "toolArgs": {"command": "git commit -m test"},
+    })
+    test("13j2: SubagentGitGuardRule same-repo dict entry → denied",
+         isinstance(result_sameRepo, dict) and result_sameRepo.get("permissionDecision") == "deny",
+         f"Got: {result_sameRepo!r:.80}")
+
+    _sg13.SUBAGENT_MARKER = _orig_sm13
+    _sg13.verify_marker = _orig_vm13
+    _sg13._get_current_git_root = _orig_gcr13
+    shutil.rmtree(str(_j_marker_dir), ignore_errors=True)
+    shutil.rmtree(str(_j_other), ignore_errors=True)
+    shutil.rmtree(str(_j_current), ignore_errors=True)
+    test("13j: SubagentGitGuardRule cross-repo tests ran", True)
+except Exception as e:
+    test("13j: SubagentGitGuardRule cross-repo tests ran", False, str(e))
+
+# 13k. auto-update-tools.py emits reinstall warning when hooks change
+try:
+    _au_src = (REPO / "auto-update-tools.py").read_text(encoding="utf-8")
+    test("13k: auto-update-tools.py has --install-git-hooks reminder",
+         "--install-git-hooks" in _au_src,
+         "Expected --install-git-hooks in auto-update warning")
+    test("13k2: auto-update-tools.py states it does NOT auto-reinstall git hooks",
+         "NOT auto" in _au_src or "NOT automatically" in _au_src,
+         "Expected explicit non-propagation statement")
+except Exception as e:
+    test("13k: auto-update hook reminder source checks", False, str(e))
+
+# 13l. install.py mentions re-run after auto-update
+try:
+    _install_src_13 = (REPO / "install.py").read_text(encoding="utf-8")
+    test("13l: install.py --install-git-hooks mentions re-run after update",
+         "auto-update" in _install_src_13,
+         "Expected auto-update reference in install_git_hooks output")
+except Exception as e:
+    test("13l: install.py update reminder source check", False, str(e))
+
+# 13m. Dual-format readers present in both hook files
+try:
+    _sg_src_13 = (REPO / "hooks" / "rules" / "subagent_guard.py").read_text(encoding="utf-8")
+    _csm_src_13 = (REPO / "hooks" / "check_subagent_marker.py").read_text(encoding="utf-8")
+    test("13m: subagent_guard.py supports dict entries",
+         "isinstance(active[0], dict)" in _sg_src_13 or "isinstance(entry, dict)" in _sg_src_13)
+    test("13m2: subagent_guard.py supports string entries",
+         "isinstance(active[0], str)" in _sg_src_13 or "isinstance(entry, str)" in _sg_src_13)
+    test("13m3: check_subagent_marker.py supports dict entries",
+         "isinstance(active[0], dict)" in _csm_src_13 or "isinstance(entry, dict)" in _csm_src_13)
+    test("13m4: check_subagent_marker.py supports string entries",
+         "isinstance(active[0], str)" in _csm_src_13 or "isinstance(entry, str)" in _csm_src_13)
+    test("13m5: subagent_guard.py has repo-scope check",
+         "git_root" in _sg_src_13 and "_get_current_git_root" in _sg_src_13)
+    test("13m6: check_subagent_marker.py has repo-scope check",
+         "git_root" in _csm_src_13 and "_get_current_git_root" in _csm_src_13)
+except Exception as e:
+    test("13m: dual-format source checks", False, str(e))
+
+# 13n. Installed-hook path uses canonical tools-dir (not dirname)
+try:
+    _pc_src_13 = (REPO / "hooks" / "pre-commit").read_text(encoding="utf-8")
+    _pp_src_13 = (REPO / "hooks" / "pre-push").read_text(encoding="utf-8")
+    test("13n: pre-commit uses canonical $HOME/.copilot/tools path",
+         "$HOME/.copilot/tools/hooks/check_subagent_marker.py" in _pc_src_13)
+    test("13n2: pre-push uses canonical $HOME/.copilot/tools path",
+         "$HOME/.copilot/tools/hooks/check_subagent_marker.py" in _pp_src_13)
+    test("13n3: pre-commit does not use dirname for guard path",
+         "$(dirname" not in _pc_src_13.split("check_subagent_marker.py")[0].split("SUBAGENT_CHECK")[-1])
+except Exception as e:
+    test("13n: canonical-path source checks", False, str(e))
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Section 14: _roots_match fail-conservative & parse-once tests
+# ═══════════════════════════════════════════════════════════════════
+
+print("\n── Section 14: _roots_match fail-conservative & parse-once ──")
+
+# 14a. _roots_match returns True on exception (fail-conservative)
+try:
+    import importlib.util as _ilu14
+    _csm_spec14 = _ilu14.spec_from_file_location("csm14", _csm_path)
+    _csm14 = _ilu14.module_from_spec(_csm_spec14)
+    _csm_spec14.loader.exec_module(_csm14)
+
+    # Normal match
+    import tempfile as _tf14
+    _d1 = Path(_tf14.mkdtemp(prefix="root-a-"))
+    _d2 = Path(_tf14.mkdtemp(prefix="root-b-"))
+    test("14a: _roots_match same dir returns True", _csm14._roots_match(str(_d1), str(_d1)))
+    test("14a2: _roots_match different dirs returns False", not _csm14._roots_match(str(_d1), str(_d2)))
+
+    # Exception path: passing a non-string/non-path that causes resolve() to fail
+    # We trigger an OSError by passing a path with embedded null byte.
+    try:
+        result_exc = _csm14._roots_match("/valid/path", "/invalid\x00path")
+    except Exception:
+        result_exc = None  # If it raises instead of returning, mark as failing
+    test("14a3: _roots_match on exception returns True (fail-conservative)",
+         result_exc is True,
+         f"Got: {result_exc!r} — should be True (conservative), not False (fail-open)")
+
+    shutil.rmtree(str(_d1), ignore_errors=True)
+    shutil.rmtree(str(_d2), ignore_errors=True)
+    test("14a: _roots_match tests ran", True)
+except Exception as e:
+    test("14a: _roots_match tests ran", False, str(e))
+
+# 14a-sg. Same check in subagent_guard._roots_match
+try:
+    import rules.subagent_guard as _sg14
+    _d1sg = Path(tempfile.mkdtemp(prefix="sg-root-a-"))
+    _d2sg = Path(tempfile.mkdtemp(prefix="sg-root-b-"))
+
+    test("14a-sg: _roots_match same dir returns True", _sg14._roots_match(str(_d1sg), str(_d1sg)))
+    test("14a-sg2: _roots_match different dirs returns False",
+         not _sg14._roots_match(str(_d1sg), str(_d2sg)))
+
+    try:
+        result_sg_exc = _sg14._roots_match("/valid/path", "/invalid\x00path")
+    except Exception:
+        result_sg_exc = None
+    test("14a-sg3: subagent_guard._roots_match on exception returns True (fail-conservative)",
+         result_sg_exc is True,
+         f"Got: {result_sg_exc!r} — should be True (conservative), not False (fail-open)")
+
+    shutil.rmtree(str(_d1sg), ignore_errors=True)
+    shutil.rmtree(str(_d2sg), ignore_errors=True)
+    test("14a-sg: subagent_guard._roots_match tests ran", True)
+except Exception as e:
+    test("14a-sg: subagent_guard._roots_match tests ran", False, str(e))
+
+# 14b. _any_entry_relevant: entry with bad git_root path → conservative block
+# (relies on _roots_match returning True on exception, so the entry is kept active)
+try:
+    import rules.subagent_guard as _sg14b
+    now14b = _time12.time()
+    entry_bad_root = {"name": "t", "ts": str(int(now14b)), "git_root": "/invalid\x00path"}
+    result_bad = _sg14b._any_entry_relevant([entry_bad_root], "/some/current/repo", now14b)
+    test("14b: _any_entry_relevant with bad git_root path → True (conservative block)",
+         result_bad is True,
+         f"Got: {result_bad!r} — bad path should not silently skip the entry")
+except Exception as e:
+    test("14b: _any_entry_relevant bad-path conservative test", False, str(e))
+
+# 14b2. Same for check_subagent_marker._any_entry_relevant
+try:
+    now14b2 = _time12.time()
+    entry_bad_root2 = {"name": "t", "ts": str(int(now14b2)), "git_root": "/invalid\x00path"}
+    result_bad2 = _csm14._any_entry_relevant([entry_bad_root2], "/some/repo", now14b2)
+    test("14b2: check_subagent_marker._any_entry_relevant bad path → True (conservative)",
+         result_bad2 is True,
+         f"Got: {result_bad2!r}")
+except Exception as e:
+    test("14b2: check_subagent_marker._any_entry_relevant bad-path test", False, str(e))
+
+# 14c. is_marker_fresh parses once: verify no second MARKER_PATH.read_text call
+# after the parse.  We check this at source level.
+try:
+    _csm_src14 = _csm_path.read_text(encoding="utf-8")
+    # Find the body of is_marker_fresh
+    fn_start = _csm_src14.index("def is_marker_fresh()")
+    # Find the next top-level def after is_marker_fresh
+    fn_end = _csm_src14.index("\ndef ", fn_start + 1)
+    fn_body = _csm_src14[fn_start:fn_end]
+
+    # There should be exactly ONE MARKER_PATH.read_text call in is_marker_fresh
+    read_count = fn_body.count("MARKER_PATH.read_text")
+    test("14c: is_marker_fresh reads MARKER_PATH exactly once (parse-once refactor)",
+         read_count == 1,
+         f"Found {read_count} MARKER_PATH.read_text call(s) in is_marker_fresh — expected 1")
+    test("14c2: is_marker_fresh does NOT call _read_marker_ts (parse-once refactor)",
+         "_read_marker_ts" not in fn_body,
+         "is_marker_fresh should extract ts from the already-parsed dict, not re-read the file")
+except Exception as e:
+    test("14c: parse-once source checks", False, str(e))
+
+# 14d. is_marker_fresh behaves identically to before: fresh marker still blocks
+if _csm_path.is_file():
+    _d14_home = Path(tempfile.mkdtemp(prefix="test-14d-"))
+    (_d14_home / ".copilot" / "markers").mkdir(parents=True)
+    (_d14_home / ".copilot" / "markers" / "dispatched-subagent-active").write_text(json.dumps({
+        "name": "dispatched-subagent-active",
+        "ts": str(int(_time12.time())),
+        "active_tentacles": ["my-tentacle"],
+    }))
+    r14d = subprocess.run(
+        [sys.executable, str(_csm_path)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+        env={**os.environ, "HOME": str(_d14_home)},
+    )
+    test("14d: parse-once refactor: fresh marker still exits 1 (blocks)",
+         r14d.returncode == 1,
+         f"exit={r14d.returncode} stdout={r14d.stdout[:80]}")
+    shutil.rmtree(str(_d14_home), ignore_errors=True)
+
+# 14e. fail-conservative comment is accurate in source: no "fail-open" on scope check
+try:
+    _csm_src14e = _csm_path.read_text(encoding="utf-8")
+    fn_start = _csm_src14e.index("def is_marker_fresh()")
+    fn_end = _csm_src14e.index("\ndef ", fn_start + 1)
+    fn_body14e = _csm_src14e[fn_start:fn_end]
+    # The repo-scope except clause should say "fail-conservative", not "fail-open"
+    # Locate the repo-scope check except block
+    scope_part = fn_body14e.split("Repo-scope check")[-1] if "Repo-scope check" in fn_body14e else fn_body14e
+    test("14e: is_marker_fresh repo-scope except comment says fail-conservative (not fail-open)",
+         "fail-conservative" in scope_part and "fail-open" not in scope_part.split("fail-conservative")[0][-30:],
+         "Comment should be 'fail-conservative' to accurately describe that scope errors keep blocking")
+except Exception as e:
+    test("14e: is_marker_fresh comment accuracy check", False, str(e))
+
+# 14f. auto-update warning text says "ACTION REQUIRED" and "EVERY"
+try:
+    _au_src14 = (REPO / "auto-update-tools.py").read_text(encoding="utf-8")
+    test("14f: auto-update warning says ACTION REQUIRED",
+         "ACTION REQUIRED" in _au_src14,
+         "Strengthened warning should say 'ACTION REQUIRED'")
+    test("14f2: auto-update warning says EVERY protected repo",
+         "EVERY" in _au_src14,
+         "Strengthened warning should say 'EVERY' to clarify scope")
+except Exception as e:
+    test("14f: auto-update warning strength checks", False, str(e))
+
+# 14g. _roots_match docstring in both files mentions fail-conservative
+try:
+    _sg_src14g = (REPO / "hooks" / "rules" / "subagent_guard.py").read_text(encoding="utf-8")
+    _csm_src14g = (REPO / "hooks" / "check_subagent_marker.py").read_text(encoding="utf-8")
+    test("14g: subagent_guard._roots_match docstring mentions fail-conservative",
+         "fail-conservative" in _sg_src14g.split("def _roots_match")[1].split("def ")[0])
+    test("14g2: check_subagent_marker._roots_match docstring mentions fail-conservative",
+         "fail-conservative" in _csm_src14g.split("def _roots_match")[1].split("def ")[0])
+except Exception as e:
+    test("14g: _roots_match docstring checks", False, str(e))
+
+
 import ast
 
 py_files = list(REPO.glob("*.py")) + list((REPO / "hooks").glob("*.py")) + list((REPO / "hooks" / "rules").glob("*.py"))

--- a/test_tentacle_runtime.py
+++ b/test_tentacle_runtime.py
@@ -34,6 +34,15 @@ import tentacle as T
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _names_from_entries(entries):
+    """Extract tentacle names from active_tentacles entries.
+
+    Handles both the new dict-list format {name, ts, git_root} and the legacy
+    string-list format so tests can assert on names without coupling to the
+    on-disk representation.
+    """
+    return [e["name"] if isinstance(e, dict) else e for e in entries]
+
 SCRATCH_DIR = TOOLS_DIR / "_test_tentacle_runtime_scratch"
 
 
@@ -1633,7 +1642,7 @@ class TestDispatchedSubagentMarker(unittest.TestCase):
         self.assertEqual(data["name"], self.MARKER_NAME)
         self.assertIn("ts", data)
         self.assertIn("active_tentacles", data)
-        self.assertIn("my-tent", data["active_tentacles"])
+        self.assertIn("my-tent", _names_from_entries(data["active_tentacles"]))
         self.assertEqual(data["scope"], ["a.py", "b.py"])
         self.assertEqual(data["dispatch_mode"], "parallel")
         self.assertIn("ttl_seconds", data)
@@ -1785,7 +1794,7 @@ class TestDispatchedSubagentMarker(unittest.TestCase):
                 T.cmd_swarm(args)
         self.assertTrue(self.marker_path.is_file())
         data = json.loads(self.marker_path.read_text())
-        self.assertIn("sp-test", data["active_tentacles"])
+        self.assertIn("sp-test", _names_from_entries(data["active_tentacles"]))
         self.assertEqual(data["dispatch_mode"], "prompt")
 
     def test_swarm_parallel_writes_marker(self):
@@ -1916,7 +1925,7 @@ class TestDispatchedSubagentMarker(unittest.TestCase):
         self.assertTrue(self.marker_path.is_file())
         data = json.loads(self.marker_path.read_text())
         self.assertEqual(data["dispatch_mode"], "bundle")
-        self.assertIn("bm-test", data["active_tentacles"])
+        self.assertIn("bm-test", _names_from_entries(data["active_tentacles"]))
 
     def test_bundle_json_output_includes_marker_state(self):
         """cmd_bundle --output json must include marker_state in the JSON output."""
@@ -1983,24 +1992,25 @@ class TestDispatchedSubagentMarkerConcurrency(unittest.TestCase):
         T._write_dispatched_subagent_marker("tent-a", ["a.py"], "prompt")
         T._write_dispatched_subagent_marker("tent-b", ["b.py"], "parallel")
         data = json.loads(self.marker_path.read_text())
-        active = data["active_tentacles"]
-        self.assertIn("tent-a", active)
-        self.assertIn("tent-b", active)
-        self.assertEqual(len(active), 2)
+        names = _names_from_entries(data["active_tentacles"])
+        self.assertIn("tent-a", names)
+        self.assertIn("tent-b", names)
+        self.assertEqual(len(names), 2)
 
     def test_dispatch_deduplicates_same_tentacle(self):
         """Writing the same tentacle twice must not create duplicate entries."""
         T._write_dispatched_subagent_marker("tent-a", [], "prompt")
         T._write_dispatched_subagent_marker("tent-a", [], "prompt")
         data = json.loads(self.marker_path.read_text())
-        self.assertEqual(data["active_tentacles"].count("tent-a"), 1)
+        names = _names_from_entries(data["active_tentacles"])
+        self.assertEqual(names.count("tent-a"), 1)
 
     def test_dispatch_on_existing_preserves_prior_entries(self):
         """Writing tent-b after tent-a keeps tent-a in active_tentacles."""
         T._write_dispatched_subagent_marker("tent-a", [], "prompt")
         T._write_dispatched_subagent_marker("tent-b", [], "json")
         data = json.loads(self.marker_path.read_text())
-        self.assertIn("tent-a", data["active_tentacles"])
+        self.assertIn("tent-a", _names_from_entries(data["active_tentacles"]))
 
     # ── partial complete ──────────────────────────────────────────────────────
 
@@ -2011,8 +2021,9 @@ class TestDispatchedSubagentMarkerConcurrency(unittest.TestCase):
         T._clear_dispatched_subagent_marker("tent-a")
         self.assertTrue(self.marker_path.is_file())
         data = json.loads(self.marker_path.read_text())
-        self.assertNotIn("tent-a", data["active_tentacles"])
-        self.assertIn("tent-b", data["active_tentacles"])
+        names = _names_from_entries(data["active_tentacles"])
+        self.assertNotIn("tent-a", names)
+        self.assertIn("tent-b", names)
 
     def test_last_complete_deletes_marker_file(self):
         """File must be deleted once active_tentacles is empty."""
@@ -2028,7 +2039,7 @@ class TestDispatchedSubagentMarkerConcurrency(unittest.TestCase):
         T._clear_dispatched_subagent_marker("tent-x")  # not in active set
         self.assertTrue(self.marker_path.is_file())
         data = json.loads(self.marker_path.read_text())
-        self.assertIn("tent-a", data["active_tentacles"])
+        self.assertIn("tent-a", _names_from_entries(data["active_tentacles"]))
 
     # ── HMAC integrity across lifecycle ──────────────────────────────────────
 
@@ -2081,7 +2092,7 @@ class TestDispatchedSubagentMarkerConcurrency(unittest.TestCase):
         T._write_dispatched_subagent_marker("new-tent", [], "prompt")
         data = json.loads(self.marker_path.read_text())
         self.assertIn("active_tentacles", data)
-        self.assertIn("new-tent", data["active_tentacles"])
+        self.assertIn("new-tent", _names_from_entries(data["active_tentacles"]))
 
     def test_old_single_owner_format_cleared_correctly(self):
         """Old marker with 'tentacle' field is deleted when that owner clears."""
@@ -2091,6 +2102,664 @@ class TestDispatchedSubagentMarkerConcurrency(unittest.TestCase):
         T._clear_dispatched_subagent_marker("legacy-tent")
         self.assertFalse(self.marker_path.is_file())
 
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+
+
+# ---------------------------------------------------------------------------
+# Phase-4 new-format marker tests
+# ---------------------------------------------------------------------------
+
+class TestMarkerNewFormat(unittest.TestCase):
+    """Tests for the new dict-list active_tentacles format and git_root field."""
+
+    MARKER_NAME = "dispatched-subagent-active"
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "new_format_tests"
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.marker_path = self.base / self.MARKER_NAME
+        self._orig_path = T._DISPATCHED_MARKER_PATH
+        T._DISPATCHED_MARKER_PATH = self.marker_path
+        self._orig_markers_dir = T.MARKERS_DIR
+        T.MARKERS_DIR = self.base
+
+    def tearDown(self):
+        T._DISPATCHED_MARKER_PATH = self._orig_path
+        T.MARKERS_DIR = self._orig_markers_dir
+        import shutil
+        if SCRATCH_DIR.exists():
+            shutil.rmtree(SCRATCH_DIR)
+
+    # ── entry shape ─────────────────────────────────────────────────────────
+
+    def test_write_creates_dict_entries_not_strings(self):
+        """active_tentacles must be a list of dicts, not strings."""
+        T._write_dispatched_subagent_marker("my-tent", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        self.assertTrue(len(data["active_tentacles"]) > 0)
+        for entry in data["active_tentacles"]:
+            self.assertIsInstance(entry, dict, "Each active_tentacles entry must be a dict")
+
+    def test_entry_has_name_field(self):
+        T._write_dispatched_subagent_marker("my-tent", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entry = data["active_tentacles"][0]
+        self.assertEqual(entry["name"], "my-tent")
+
+    def test_entry_has_ts_field(self):
+        """Each entry must carry its own UNIX timestamp."""
+        T._write_dispatched_subagent_marker("my-tent", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entry = data["active_tentacles"][0]
+        self.assertIn("ts", entry)
+        self.assertIsNotNone(entry["ts"])
+        # ts must be a parseable integer string
+        self.assertGreater(int(entry["ts"]), 0)
+
+    def test_entry_has_git_root_field(self):
+        """Each entry must carry a git_root key (even if None for non-git CWD)."""
+        T._write_dispatched_subagent_marker("my-tent", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entry = data["active_tentacles"][0]
+        self.assertIn("git_root", entry)
+
+    def test_top_level_git_root_written(self):
+        """Marker must carry a top-level git_root field from the writing context."""
+        T._write_dispatched_subagent_marker("my-tent", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        self.assertIn("git_root", data)
+
+    def test_global_ts_still_present_for_hmac(self):
+        """Global ts must still be present — it anchors the HMAC signature."""
+        T._write_dispatched_subagent_marker("my-tent", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        self.assertIn("ts", data)
+        self.assertIsNotNone(data["ts"])
+
+    def test_per_entry_ts_is_independent_of_global_ts(self):
+        """Per-entry ts is distinct from the global ts field."""
+        T._write_dispatched_subagent_marker("my-tent", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        # Both exist — they are separate fields serving separate purposes
+        self.assertIn("ts", data)                            # global HMAC anchor
+        self.assertIn("ts", data["active_tentacles"][0])     # per-entry TTL anchor
+
+    # ── per-entry ts independence across different entries ────────────────────
+
+    def test_second_entry_gets_its_own_ts(self):
+        """Two distinct entries each have independently set ts values."""
+        T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        time.sleep(0.02)
+        T._write_dispatched_subagent_marker("tent-b", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entries = {e["name"]: e for e in data["active_tentacles"]}
+        self.assertIn("tent-a", entries)
+        self.assertIn("tent-b", entries)
+        # tent-b's per-entry ts must be >= tent-a's (set later)
+        self.assertGreaterEqual(int(entries["tent-b"]["ts"]), int(entries["tent-a"]["ts"]))
+
+    def test_same_name_redispatch_refreshes_per_entry_ts(self):
+        """Re-dispatching the same tentacle in the same repo must refresh its per-entry ts."""
+        T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        ts_before = json.loads(self.marker_path.read_text())["active_tentacles"][0]["ts"]
+        time.sleep(0.02)
+        T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        entries = json.loads(self.marker_path.read_text())["active_tentacles"]
+        names = _names_from_entries(entries)
+        # Must still be exactly one entry (deduped)
+        self.assertEqual(names.count("tent-a"), 1)
+        ts_after = entries[0]["ts"]
+        self.assertGreaterEqual(int(ts_after), int(ts_before))
+
+    # ── git_root repo identity ────────────────────────────────────────────────
+
+    def test_git_root_matches_find_git_root(self):
+        """Entry git_root must equal the result of find_git_root() at write time."""
+        fake_root = self.base / "fake_repo"
+        fake_root.mkdir(exist_ok=True)
+        with patch.object(T, "find_git_root", return_value=fake_root):
+            T._write_dispatched_subagent_marker("my-tent", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        self.assertEqual(data["active_tentacles"][0]["git_root"], str(fake_root))
+        self.assertEqual(data["git_root"], str(fake_root))
+
+    def test_git_root_none_when_not_in_git_repo(self):
+        """When CWD is outside any git repo, git_root must be null."""
+        with patch.object(T, "find_git_root", return_value=None):
+            T._write_dispatched_subagent_marker("my-tent", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        self.assertIsNone(data["active_tentacles"][0]["git_root"])
+        self.assertIsNone(data["git_root"])
+
+    # ── _get_marker_state enriched output ──────────────────────────────────────
+
+    def test_get_state_includes_active_tentacle_entries(self):
+        """_get_marker_state must include the new active_tentacle_entries field."""
+        T._write_dispatched_subagent_marker("a-tent", [], "prompt")
+        state = T._get_marker_state()
+        self.assertIn("active_tentacle_entries", state)
+        self.assertIsInstance(state["active_tentacle_entries"], list)
+
+    def test_get_state_entries_are_dicts(self):
+        T._write_dispatched_subagent_marker("a-tent", [], "prompt")
+        state = T._get_marker_state()
+        for entry in state["active_tentacle_entries"]:
+            self.assertIsInstance(entry, dict)
+            self.assertIn("name", entry)
+            self.assertIn("ts", entry)
+            self.assertIn("git_root", entry)
+
+    def test_get_state_active_tentacles_still_returns_names(self):
+        """active_tentacles in marker_state must remain a list of strings (backward compat)."""
+        T._write_dispatched_subagent_marker("a-tent", [], "prompt")
+        state = T._get_marker_state()
+        for item in state["active_tentacles"]:
+            self.assertIsInstance(item, str, "active_tentacles must be strings (backward compat)")
+
+    def test_get_state_includes_git_root(self):
+        """_get_marker_state must expose top-level git_root."""
+        T._write_dispatched_subagent_marker("a-tent", [], "prompt")
+        state = T._get_marker_state()
+        self.assertIn("git_root", state)
+
+    def test_get_state_inactive_includes_new_fields(self):
+        """Empty marker_state must still have the new fields with safe defaults."""
+        state = T._get_marker_state()
+        self.assertFalse(state["active"])
+        self.assertEqual(state["active_tentacle_entries"], [])
+        self.assertIsNone(state["git_root"])
+
+    def test_get_state_entries_match_names_list(self):
+        """active_tentacle_entries and active_tentacles must represent the same set."""
+        T._write_dispatched_subagent_marker("tent-x", [], "prompt")
+        T._write_dispatched_subagent_marker("tent-y", [], "parallel")
+        state = T._get_marker_state()
+        entry_names = [e["name"] for e in state["active_tentacle_entries"]]
+        self.assertEqual(sorted(state["active_tentacles"]), sorted(entry_names))
+
+
+class TestMarkerOldFormatCompatibility(unittest.TestCase):
+    """Backward-compatibility: old string-list and single-owner formats must still work."""
+
+    MARKER_NAME = "dispatched-subagent-active"
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "compat_tests"
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.marker_path = self.base / self.MARKER_NAME
+        self._orig_path = T._DISPATCHED_MARKER_PATH
+        T._DISPATCHED_MARKER_PATH = self.marker_path
+        self._orig_markers_dir = T.MARKERS_DIR
+        T.MARKERS_DIR = self.base
+
+    def tearDown(self):
+        T._DISPATCHED_MARKER_PATH = self._orig_path
+        T.MARKERS_DIR = self._orig_markers_dir
+        import shutil
+        if SCRATCH_DIR.exists():
+            shutil.rmtree(SCRATCH_DIR)
+
+    def test_old_string_list_readable_via_get_state(self):
+        """_get_marker_state must return names from an old string-list marker."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": ["old-tent-a", "old-tent-b"],
+            "dispatch_mode": "prompt",
+        }))
+        state = T._get_marker_state()
+        self.assertTrue(state["active"])
+        self.assertIn("old-tent-a", state["active_tentacles"])
+        self.assertIn("old-tent-b", state["active_tentacles"])
+
+    def test_old_string_list_entries_normalised_in_state(self):
+        """active_tentacle_entries must normalise old string entries to dicts."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": ["old-tent"],
+        }))
+        state = T._get_marker_state()
+        entries = state["active_tentacle_entries"]
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "old-tent")
+        self.assertIsNone(entries[0]["ts"])
+        self.assertIsNone(entries[0]["git_root"])
+
+    def test_old_string_list_clear_by_name(self):
+        """Clearing an old-format string entry must work (conservative name-only match)."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": "1000",
+            "active_tentacles": ["old-tent"],
+        }))
+        T._clear_dispatched_subagent_marker("old-tent")
+        self.assertFalse(self.marker_path.is_file())
+
+    def test_old_string_list_partial_clear_leaves_other_entries(self):
+        """Clearing one entry from an old string-list marker preserves other entries."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": ["tent-keep", "tent-remove"],
+        }))
+        T._clear_dispatched_subagent_marker("tent-remove")
+        self.assertTrue(self.marker_path.is_file())
+        data = json.loads(self.marker_path.read_text())
+        names = _names_from_entries(data["active_tentacles"])
+        self.assertIn("tent-keep", names)
+        self.assertNotIn("tent-remove", names)
+
+    def test_new_write_on_old_marker_normalises_to_dict_list(self):
+        """A new write on top of an old string-list marker must produce dict entries."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": "1000",
+            "active_tentacles": ["old-string-tent"],
+        }))
+        T._write_dispatched_subagent_marker("new-tent", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        for entry in data["active_tentacles"]:
+            self.assertIsInstance(entry, dict, "All entries must be dicts after write")
+
+    def test_mixed_format_entries_handled_gracefully(self):
+        """Marker with a mix of dict and string entries must not raise."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": [
+                "old-string",
+                {"name": "new-dict", "ts": "12345", "git_root": None},
+            ],
+        }))
+        # Reading must not raise
+        state = T._get_marker_state()
+        self.assertIn("old-string", state["active_tentacles"])
+        self.assertIn("new-dict", state["active_tentacles"])
+
+    def test_clear_after_mixed_format_write_normalises(self):
+        """Clearing from a mixed-format marker must write back clean dict entries."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": [
+                "string-to-keep",
+                {"name": "dict-to-remove", "ts": "123", "git_root": None},
+            ],
+        }))
+        T._clear_dispatched_subagent_marker("dict-to-remove")
+        self.assertTrue(self.marker_path.is_file())
+        data = json.loads(self.marker_path.read_text())
+        names = _names_from_entries(data["active_tentacles"])
+        self.assertIn("string-to-keep", names)
+        self.assertNotIn("dict-to-remove", names)
+        # Written back as dicts
+        for entry in data["active_tentacles"]:
+            self.assertIsInstance(entry, dict)
+
+    # ── targeted upgrade-path tests (migration correctness) ──────────────────
+
+    def test_legacy_string_entry_absorbed_by_dispatch_from_known_repo(self):
+        """Old string entry for tent-a + new dispatch of tent-a from /repo-a
+        must produce exactly one entry with git_root=/repo-a (not two entries)."""
+        repo_a = self.base / "repo-a"
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": "1000",
+            "active_tentacles": ["tent-a"],
+        }))
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entries = data["active_tentacles"]
+        self.assertEqual(len(entries), 1, "Legacy entry must be absorbed, not duplicated")
+        self.assertEqual(entries[0]["name"], "tent-a")
+        self.assertEqual(entries[0]["git_root"], str(repo_a))
+
+    def test_coexisting_none_and_real_repo_entry_deduplicated_on_dispatch(self):
+        """If a marker somehow contains both (tent-a, None) and (tent-a, /repo-b),
+        dispatching tent-a from /repo-b must collapse them into a single entry
+        rather than producing a duplicate."""
+        repo_b = self.base / "repo-b"
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": [
+                {"name": "tent-a", "ts": None, "git_root": None},
+                {"name": "tent-a", "ts": "1000", "git_root": str(repo_b)},
+            ],
+        }))
+        with patch.object(T, "find_git_root", return_value=repo_b):
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        names = _names_from_entries(data["active_tentacles"])
+        self.assertEqual(
+            names.count("tent-a"), 1,
+            "Legacy None entry + real-repo entry must collapse to one entry"
+        )
+        self.assertEqual(data["active_tentacles"][0]["git_root"], str(repo_b))
+
+    def test_legacy_cleanup_only_affects_dispatching_tentacle_name(self):
+        """Legacy (tent-b, None) must NOT be removed when dispatching tent-a."""
+        repo_a = self.base / "repo-a"
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": [
+                {"name": "tent-b", "ts": None, "git_root": None},
+            ],
+        }))
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        names = _names_from_entries(data["active_tentacles"])
+        # tent-b's legacy entry must remain untouched
+        self.assertIn("tent-b", names)
+        self.assertIn("tent-a", names)
+        tent_b = next(e for e in data["active_tentacles"] if e["name"] == "tent-b")
+        self.assertIsNone(tent_b["git_root"], "tent-b legacy entry must be unchanged")
+
+    def test_no_legacy_cleanup_when_dispatching_from_unknown_git_root(self):
+        """When current_git_root is None, existing (name, None) entries are handled
+        by normal dedup (None==None) rather than being removed."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": [
+                {"name": "tent-a", "ts": "1000", "git_root": None},
+            ],
+        }))
+        with patch.object(T, "find_git_root", return_value=None):
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        names = _names_from_entries(data["active_tentacles"])
+        # Must still be one entry (deduped by None==None exact match)
+        self.assertEqual(names.count("tent-a"), 1)
+        self.assertIsNone(data["active_tentacles"][0]["git_root"])
+
+
+class TestMarkerCrossRepoIsolation(unittest.TestCase):
+    """Same tentacle name from different repos must not collapse into one entry."""
+
+    MARKER_NAME = "dispatched-subagent-active"
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "cross_repo_tests"
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.marker_path = self.base / self.MARKER_NAME
+        self._orig_path = T._DISPATCHED_MARKER_PATH
+        T._DISPATCHED_MARKER_PATH = self.marker_path
+        self._orig_markers_dir = T.MARKERS_DIR
+        T.MARKERS_DIR = self.base
+
+    def tearDown(self):
+        T._DISPATCHED_MARKER_PATH = self._orig_path
+        T.MARKERS_DIR = self._orig_markers_dir
+        import shutil
+        if SCRATCH_DIR.exists():
+            shutil.rmtree(SCRATCH_DIR)
+
+    def test_same_name_different_repos_produce_two_entries(self):
+        """Dispatching the same tentacle name from two repos creates two distinct entries."""
+        repo_a = self.base / "repo-a"
+        repo_b = self.base / "repo-b"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt")
+        with patch.object(T, "find_git_root", return_value=repo_b):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entries = data["active_tentacles"]
+        self.assertEqual(len(entries), 2, "Different-repo same-name dispatches must not collapse")
+        git_roots = {e["git_root"] for e in entries}
+        self.assertIn(str(repo_a), git_roots)
+        self.assertIn(str(repo_b), git_roots)
+
+    def test_same_name_same_repo_is_deduped(self):
+        """Two dispatches of the same name in the same repo stay as one entry."""
+        repo_a = self.base / "repo-a"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt")
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        names = _names_from_entries(data["active_tentacles"])
+        self.assertEqual(names.count("feature-x"), 1)
+
+    def test_clear_only_removes_matching_repo_entry(self):
+        """Completing a tentacle in repo-a must not remove the same-named entry for repo-b."""
+        repo_a = self.base / "repo-a"
+        repo_b = self.base / "repo-b"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt")
+        with patch.object(T, "find_git_root", return_value=repo_b):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt")
+        # Complete from repo-a context
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._clear_dispatched_subagent_marker("feature-x")
+        # Marker file must still exist (repo-b entry remains)
+        self.assertTrue(self.marker_path.is_file())
+        data = json.loads(self.marker_path.read_text())
+        remaining = data["active_tentacles"]
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0]["git_root"], str(repo_b))
+
+    def test_clear_from_no_git_context_removes_all_matching_names(self):
+        """When CWD has no git repo, clearing by name removes all same-named entries
+        (conservative: no repo info means we can't discriminate)."""
+        repo_a = self.base / "repo-a"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("tent-x", [], "prompt")
+        # Clear from a non-git context (git_root=None)
+        with patch.object(T, "find_git_root", return_value=None):
+            T._clear_dispatched_subagent_marker("tent-x")
+        # Conservative: entry with known git_root is removed because current git_root is None
+        self.assertFalse(self.marker_path.is_file())
+
+    def test_different_names_different_repos_both_coexist(self):
+        """Different tentacle names from different repos all appear in active list."""
+        repo_a = self.base / "repo-a"
+        repo_b = self.base / "repo-b"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("alpha", [], "prompt")
+        with patch.object(T, "find_git_root", return_value=repo_b):
+            T._write_dispatched_subagent_marker("beta", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        names = _names_from_entries(data["active_tentacles"])
+        self.assertIn("alpha", names)
+        self.assertIn("beta", names)
+
+    def test_marker_state_entries_carry_per_repo_git_root(self):
+        """active_tentacle_entries in _get_marker_state must expose per-entry git_root."""
+        repo_a = self.base / "repo-a"
+        repo_b = self.base / "repo-b"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("task", [], "prompt")
+        with patch.object(T, "find_git_root", return_value=repo_b):
+            T._write_dispatched_subagent_marker("task", [], "prompt")
+        state = T._get_marker_state()
+        roots = {e["git_root"] for e in state["active_tentacle_entries"]}
+        self.assertIn(str(repo_a), roots)
+        self.assertIn(str(repo_b), roots)
+
+    def test_json_swarm_output_marker_state_has_git_root(self):
+        """marker_state in swarm JSON output must include git_root field."""
+        import io
+        from contextlib import redirect_stdout
+        swarm_base = self.base / "swarm_test"
+        swarm_base.mkdir()
+        make_tentacle("xr-test", swarm_base)
+        args = fake_args(
+            name="xr-test",
+            agent_type="general-purpose",
+            model="claude-sonnet-4.6",
+            output="json",
+            briefing=False,
+            bundle=False,
+        )
+        buf = io.StringIO()
+        with patch.object(T, "get_tentacles_dir", return_value=swarm_base):
+            with redirect_stdout(buf):
+                T.cmd_swarm(args)
+        out = buf.getvalue()
+        decoder = json.JSONDecoder()
+        idx = out.find("{")
+        dispatch_data, _ = decoder.raw_decode(out, idx)
+        ms = dispatch_data["marker_state"]
+        self.assertIn("git_root", ms)
+        self.assertIn("active_tentacle_entries", ms)
+
+
+# ---------------------------------------------------------------------------
+# Legacy-entry upgrade path tests (cross-review fix)
+# ---------------------------------------------------------------------------
+
+class TestMarkerLegacyUpgradePath(unittest.TestCase):
+    """When a known git_root dispatch encounters a legacy git_root=None entry with the
+    same tentacle name, it must absorb/replace the legacy entry rather than appending
+    a duplicate — which would cause hook readers to conservatively short-circuit on
+    the unscoped entry and silently defeat the cross-repo fix.
+    """
+
+    MARKER_NAME = "dispatched-subagent-active"
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "upgrade_tests"
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.marker_path = self.base / self.MARKER_NAME
+        self._orig_path = T._DISPATCHED_MARKER_PATH
+        T._DISPATCHED_MARKER_PATH = self.marker_path
+        self._orig_markers_dir = T.MARKERS_DIR
+        T.MARKERS_DIR = self.base
+
+    def tearDown(self):
+        T._DISPATCHED_MARKER_PATH = self._orig_path
+        T.MARKERS_DIR = self._orig_markers_dir
+        import shutil
+        if SCRATCH_DIR.exists():
+            shutil.rmtree(SCRATCH_DIR)
+
+    def _write_legacy_entry(self, name):
+        """Write an old-format dict entry with git_root=None directly to the marker."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": [{"name": name, "ts": None, "git_root": None}],
+        }))
+
+    # ── core upgrade-path behaviour ───────────────────────────────────────────
+
+    def test_legacy_none_entry_absorbed_by_known_repo_dispatch(self):
+        """A git_root=None legacy entry must be replaced (not duplicated) when the
+        same tentacle is re-dispatched with a real git_root."""
+        self._write_legacy_entry("tent-a")
+        repo_a = self.base / "repo-a"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entries = data["active_tentacles"]
+        # Must be exactly one entry — no duplicate
+        self.assertEqual(len(entries), 1, "Legacy entry must be absorbed, not duplicated")
+
+    def test_absorbed_entry_gets_real_git_root(self):
+        """After absorption the single entry must carry the known git_root, not None."""
+        self._write_legacy_entry("tent-a")
+        repo_a = self.base / "repo-a"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entry = data["active_tentacles"][0]
+        self.assertEqual(entry["git_root"], str(repo_a))
+
+    def test_absorbed_entry_gets_fresh_ts(self):
+        """After absorption the entry ts must be refreshed (not left as None)."""
+        self._write_legacy_entry("tent-a")
+        repo_a = self.base / "repo-a"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entry = data["active_tentacles"][0]
+        self.assertIsNotNone(entry["ts"])
+        self.assertGreater(int(entry["ts"]), 0)
+
+    def test_other_entries_preserved_during_upgrade(self):
+        """Absorption of one legacy entry must not disturb unrelated entries."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": [
+                {"name": "tent-a", "ts": None, "git_root": None},   # legacy → will be upgraded
+                {"name": "tent-b", "ts": "9999", "git_root": "/other/repo"},  # real → untouched
+            ],
+        }))
+        repo_a = self.base / "repo-a"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entries = {e["name"]: e for e in data["active_tentacles"]}
+        self.assertIn("tent-b", entries, "Unrelated entry must survive")
+        self.assertEqual(entries["tent-b"]["git_root"], "/other/repo")
+        self.assertEqual(entries["tent-a"]["git_root"], str(repo_a))
+        self.assertEqual(len(entries), 2)
+
+    def test_old_string_list_entry_absorbed_by_known_repo_dispatch(self):
+        """An old string-list entry (promoted to git_root=None dict) is also absorbed."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": "1000",
+            "active_tentacles": ["tent-a"],   # old string format
+        }))
+        repo_a = self.base / "repo-a"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entries = data["active_tentacles"]
+        self.assertEqual(len(entries), 1, "String-list legacy entry must also be absorbed")
+        self.assertEqual(entries[0]["git_root"], str(repo_a))
+
+    # ── same-name different-real-repo entries stay distinct ───────────────────
+
+    def test_known_repo_entry_not_absorbed_by_different_real_repo(self):
+        """A real-repo entry must NOT be absorbed by a different real-repo dispatch."""
+        repo_a = self.base / "repo-a"
+        repo_b = self.base / "repo-b"
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": [{"name": "tent-x", "ts": "9999", "git_root": str(repo_a)}],
+        }))
+        with patch.object(T, "find_git_root", return_value=repo_b):
+            T._write_dispatched_subagent_marker("tent-x", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        entries = data["active_tentacles"]
+        self.assertEqual(len(entries), 2, "Different real-repo entries must stay distinct")
+        roots = {e["git_root"] for e in entries}
+        self.assertIn(str(repo_a), roots)
+        self.assertIn(str(repo_b), roots)
+
+    # ── both-None dedup regression ────────────────────────────────────────────
+
+    def test_none_plus_none_still_deduped(self):
+        """Two dispatches both from unknown-repo context must still deduplicate."""
+        with patch.object(T, "find_git_root", return_value=None):
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        names = _names_from_entries(data["active_tentacles"])
+        self.assertEqual(names.count("tent-a"), 1)
+
+    # ── upgrade does not break _get_marker_state names list ───────────────────
+
+    def test_state_names_correct_after_upgrade(self):
+        """_get_marker_state active_tentacles must still return names after upgrade."""
+        self._write_legacy_entry("tent-a")
+        repo_a = self.base / "repo-a"
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("tent-a", [], "prompt")
+        state = T._get_marker_state()
+        self.assertEqual(state["active_tentacles"], ["tent-a"])
+        self.assertEqual(state["active_tentacle_entries"][0]["git_root"], str(repo_a))
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test_tentacle_runtime.py
+++ b/test_tentacle_runtime.py
@@ -2104,10 +2104,6 @@ class TestDispatchedSubagentMarkerConcurrency(unittest.TestCase):
 
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
-
-
 # ---------------------------------------------------------------------------
 # Phase-4 new-format marker tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Overview
This PR ships phase 4 of the dispatched-subagent guard rollout by isolating hook enforcement at the repository level instead of sharing one global block across unrelated repos.

The runtime marker now stores per-entry objects with `name`, `ts`, and `git_root`, and both enforcement surfaces accept old and new marker formats during migration. This removes the cross-repo false positive from phase 3 while keeping the same-repo multi-orchestrator case explicitly serialized and documented.

## Changes Made
- Added repo-scoped marker entries and legacy-upgrade handling in `tentacle.py`
- Updated `check_subagent_marker.py` and `subagent_guard.py` to evaluate per-entry relevance with repo matching and conservative fallback behavior
- Added rollout messaging in `auto-update-tools.py` and `install.py` so users re-install per-repo git hooks after updates
- Updated README, HOOKS, USAGE, and the tentacle-orchestration skill to document migration behavior and known limitations
- Expanded runtime and hook regression coverage for cross-repo isolation, legacy absorption, and fail-conservative repo matching

<details><summary>Modified files</summary>

- `README.md`
- `auto-update-tools.py`
- `docs/HOOKS.md`
- `docs/USAGE.md`
- `hooks/check_subagent_marker.py`
- `hooks/rules/subagent_guard.py`
- `install.py`
- `skills/tentacle-orchestration/SKILL.md`
- `tentacle.py`
- `test_hooks.py`
- `test_tentacle_runtime.py`

</details>

## Diff Summary
```text
11 files changed, 1769 insertions(+), 109 deletions(-)
```

## Validation
- `python3 -m pytest test_tentacle_runtime.py -q` → 206 passed
- `python3 test_hooks.py` → 379 passed
- Final code review verdict: CLEAN

## Known limitation
- Same-repo multi-orchestrator is still not supported. This PR only fixes cross-repo false positives.
