### PR TITLE
Phase 5: Support same-repo tentacle sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,11 +300,15 @@ commit restrictions — it fires at the filesystem level regardless of which age
 git. The `preToolUse` hook provides defense-in-depth but cannot be relied on inside delegated
 subagent contexts. Enforcement is **local-only**; cloud-delegated runs are not covered.
 
-The marker now stores `active_tentacles` as a list of objects (`{name, ts, git_root}`) instead
-of a flat string list. Each entry carries its own dispatch timestamp and the git repository root
-where the dispatch originated. The hook compares `git_root` against the repo running git — a
-marker from a different repo does not block commits there (fixes cross-repo false-positive
-blocking). Markers written without `git_root` (old format or non-git CWD) conservatively block.
+The marker now stores `active_tentacles` as a list of objects (`{name, ts, git_root, tentacle_id}`)
+instead of a flat string list. Each entry carries its own dispatch timestamp, the git repository
+root where the dispatch originated, and a stable UUID (`tentacle_id`) generated at `create` time.
+Primary deduplication key is `tentacle_id` (phase 5, when present) with `(name, git_root)` as the
+fallback for legacy entries. Two instances with the same logical name — whether in different repos
+or in the same repo — each produce separate entries because their `tentacle_id` values differ.
+The hook compares `git_root` against the repo running git — a marker from a different repo does not
+block commits there (cross-repo isolation). Markers written without `git_root` (old format or
+non-git CWD) conservatively block.
 
 > **Upgrade migration:** Cross-repo isolation is not retroactive for in-flight old-format
 > markers. If a tentacle is still active when you upgrade, its existing marker entry has no
@@ -312,14 +316,21 @@ blocking). Markers written without `git_root` (old format or non-git CWD) conser
 > TTL expires. To get isolation immediately: `tentacle.py complete <name>` (or
 > `rm ~/.copilot/markers/dispatched-subagent-active`), then re-dispatch.
 
+**Same-repo multi-session (phase 5):** `tentacle.py create` now generates a `tentacle_id` UUID per
+instance and auto-resolves directory collisions — if `<name>` already exists, it creates
+`<name>-<uuid[:8]>` instead of exiting. All subsequent commands must use the printed slug name.
+Runtime identity ensures `complete` clears only the matching entry, not a sibling with the same
+logical name. **Working-tree caveat:** this isolation is at the marker/enforcement layer only.
+Concurrent tentacles in the same repo that touch overlapping files still share one working tree
+and git index — file-level conflicts must be managed through non-overlapping scope declarations.
+
 **Limitations:** `preToolUse` non-inheritance inside `task()`-spawned subagents remains a
-platform limitation — git hooks are the reliable surface. Two concurrent orchestrators in the
-same repo share one marker and are not isolated from each other; one orchestrator per repo at a
-time is the supported model. `auto-update-tools.py` does **not** auto-reinstall git hooks in
-registered repos — when hook files change it prints:
-`"Git hook scripts updated — installed per-repo hooks are NOT automatically refreshed."` and
-`"Re-run in each protected repo: python3 ~/.copilot/tools/install.py --install-git-hooks"`.
-Re-run that command in each protected repo after relevant tool updates.
+platform limitation — git hooks are the reliable surface. `auto-update-tools.py` does **not**
+auto-reinstall git hooks in registered repos — when hook files change it prints three warnings
+to stderr: `"Git hook scripts updated — installed per-repo hooks are NOT automatically
+refreshed."`, `"ACTION REQUIRED to pick up the cross-repo isolation fix (and future hook
+changes):"`, and `"Re-run in EVERY protected repo: python3 ~/.copilot/tools/install.py
+--install-git-hooks"`. Re-run that command in every protected repo after relevant tool updates.
 
 ```bash
 python3 ~/.copilot/tools/install.py --deploy-skill        # Deploy skill to project

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -98,7 +98,8 @@ The marker is a JSON file with the following contract:
 | `name` | Always `"dispatched-subagent-active"` |
 | `ts` | UNIX timestamp of the most-recent write (used for HMAC + global TTL anchor) |
 | `sig` | HMAC-SHA256 over `"name:ts"` (omitted when no secret is configured) |
-| `active_tentacles` | List of per-entry objects: `{"name": "<tentacle>", "ts": "<unix>", "git_root": "<abs-path>"}`. Each entry carries its own dispatch timestamp and the absolute path of the git repository where the tentacle was dispatched. Readers also accept the old string-list format for backward compatibility. |
+| `active_tentacles` | List of per-entry objects: `{"name": "<tentacle>", "ts": "<unix>", "git_root": "<abs-path>", "tentacle_id": "<uuid>"}`. Each entry carries its own dispatch timestamp, the git root of the dispatching repo, and a stable per-instance UUID generated at `create` time. `tentacle_id` is `null` in legacy entries. Readers also accept the old string-list format for backward compatibility. **Deduplication key: `tentacle_id` (primary, phase 5) → `(name, git_root)` fallback (phase 4, legacy entries without `tentacle_id`).** Two instances with the same logical name in the same repo each produce a separate entry because their `tentacle_id` values differ. |
+| `git_root` | Top-level field: absolute git root of the most-recent writer (used by the legacy path **only** for pure string-list `active_tentacles` — not for mixed-format or dict-list entries). Per-entry `git_root` is the authoritative source for all dict-list and mixed-format markers. |
 | `scope` | File-scope list from the most-recently-dispatching tentacle |
 | `dispatch_mode` | Dispatch mode of the most-recently-dispatching tentacle |
 | `ttl_seconds` | Expected lifetime; consumers treat markers older than this as stale |
@@ -109,8 +110,29 @@ entry (its `ts` is older than `ttl_seconds`) is treated as inactive even if the 
 file is still fresh.
 
 **Concurrent tentacles:** Multiple tentacles dispatched in parallel each add their dict entry to
-`active_tentacles`. `tentacle.py complete <name>` removes only that tentacle's entry; the marker
-is deleted only when `active_tentacles` becomes empty.
+`active_tentacles`. `tentacle.py complete <name>` removes only that tentacle's entry (matched by
+`tentacle_id` when present, falling back to `(name, git_root)` for legacy entries); the marker
+file is deleted only when `active_tentacles` becomes empty.
+
+**Tentacle identity (phase 5):** `tentacle.py create` now generates a UUID `tentacle_id` and
+stores it in the tentacle's `meta.json`. `swarm` and `bundle` read this UUID and embed it in the
+marker entry. This enables two orchestrators in the same repo using the same logical name to each
+hold a separate, non-colliding marker entry. `complete` reads `tentacle_id` from `meta.json` and
+removes only the entry with the matching identity — completing one session does not clear a
+same-named sibling in the same repo.
+
+**Same-repo directory collision avoidance (phase 5):** If `tentacle.py create <name>` finds that
+the directory `<name>` already exists, it automatically creates `<name>-<uuid[:8]>` instead of
+exiting with an error. The unique slug is printed to stderr and stored as `dir_name` in
+`meta.json`. **All subsequent commands (`todo`, `swarm`, `complete`, `handoff`, etc.) must use
+the printed slug** — `_validate_tentacle_name` resolves by exact directory name, so the logical
+name passed to `create` will find the original (other session's) directory, not the slug.
+
+**Migration cleanup:** When re-dispatching from a known git repo, `tentacle.py swarm` eagerly
+removes legacy entries whose `name` matches, `tentacle_id` is absent, and whose `git_root` is
+either `None` (old string-list artefacts with no repo identity) or equal to the current repo
+when the new dispatch carries a `tentacle_id` (crash-then-upgrade: stale phase-4 dict entry for
+the same repo that would otherwise keep blocking commits until TTL expiry).
 
 **Step 2 — Git pre-commit / pre-push (primary enforcement)**
 
@@ -127,6 +149,12 @@ false-positive that existed before phase 4.
 
 **Backward compatibility:** If a marker entry has no `git_root` (written by old code or
 dispatched from a non-git directory), the hook conservatively blocks — same behavior as before.
+
+**Mixed-format markers:** The format dispatch checks `all(isinstance(e, str) for e in active)`
+— only a *pure* string-list triggers the legacy top-level `git_root` path. A mixed-format
+marker (some string entries, some dict entries — possible when upgrading mid-flight) is routed
+through the per-entry check; string entries inside such a list carry no repo identity and
+conservatively block every repo, while dict entries are evaluated per-entry as usual.
 
 > **Upgrade migration note:** Cross-repo isolation is **not retroactive** for in-flight
 > old-format markers. If you upgrade while a tentacle is still active and the marker was
@@ -176,7 +204,7 @@ sessions that crash without calling `complete`.
 | Limitation | Detail |
 |---|---|
 | `preToolUse` non-inheritance | `preToolUse` hooks from the parent `hooks.json` may not fire inside `task()`-spawned subagents — platform-level behavior, not fixable here. Git hooks remain the reliable surface. |
-| Same-repo multi-orchestrator | Two concurrent orchestrators running in the **same** repo are not isolated from each other — both share the same marker `git_root` entry. One orchestrator per repo at a time is the supported model. |
+| Same-repo multi-orchestrator | Supported (phase 5): each tentacle gets a stable `tentacle_id` at create time. Two instances with the same logical name in the same repo each hold a separate marker entry and `complete` removes only the matching identity. **Caveat: working-tree / git-index side effects are not isolated** — concurrent tentacles in the same repo that touch the same files will still produce conflicts in the shared working tree and index. |
 | Cloud/remote agents | Hooks are local-only. Cloud-delegated or remote agent runs have no coverage. |
 | `auto-update` does not reinstall git hooks | `auto-update-tools.py` updates tools-repo files but does **not** re-run `--install-git-hooks` in registered repos. It prints a warning when hook files change. Users must re-run `install.py --install-git-hooks` manually to apply new hook logic in each protected repo. |
 
@@ -198,11 +226,12 @@ config to ensure the hooks fire even when a project-level override is present.
 After tool updates (`git pull` or `auto-update-tools.py --force`), re-run
 `--install-git-hooks` to refresh the hook scripts in `.git/hooks/`. `auto-update-tools.py`
 does **not** perform this reinstallation automatically — it cannot safely enumerate every repo
-where hooks are installed. When hook files change, it emits these two warnings to stdout:
+where hooks are installed. When hook files change, it emits these three warnings to stderr:
 
 ```
-WARNING: Git hook scripts updated — installed per-repo hooks are NOT automatically refreshed.
-WARNING: Re-run in each protected repo: python3 ~/.copilot/tools/install.py --install-git-hooks
+[sk-update] ⚠️  Git hook scripts updated — installed per-repo hooks are NOT automatically refreshed.
+[sk-update] ⚠️  ACTION REQUIRED to pick up the cross-repo isolation fix (and future hook changes):
+[sk-update] ⚠️    Re-run in EVERY protected repo: python3 ~/.copilot/tools/install.py --install-git-hooks
 ```
 
 ### Fail-open behavior

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -98,7 +98,7 @@ The marker is a JSON file with the following contract:
 | `name` | Always `"dispatched-subagent-active"` |
 | `ts` | UNIX timestamp of the most-recent write (used for HMAC + global TTL anchor) |
 | `sig` | HMAC-SHA256 over `"name:ts"` (omitted when no secret is configured) |
-| `active_tentacles` | List of per-entry objects: `{"name": "<tentacle>", "ts": "<unix>", "git_root": "<abs-path>", "tentacle_id": "<uuid>"}`. Each entry carries its own dispatch timestamp, the git root of the dispatching repo, and a stable per-instance UUID generated at `create` time. `tentacle_id` is `null` in legacy entries. Readers also accept the old string-list format for backward compatibility. **Deduplication key: `tentacle_id` (primary, phase 5) → `(name, git_root)` fallback (phase 4, legacy entries without `tentacle_id`).** Two instances with the same logical name in the same repo each produce a separate entry because their `tentacle_id` values differ. |
+| `active_tentacles` | List of per-entry objects: `{"name": "<tentacle>", "ts": "<unix>", "git_root": "<abs-path>", "tentacle_id": "<uuid>"}` where `tentacle_id` is optional for legacy entries. Each entry carries its own dispatch timestamp, the git root of the dispatching repo, and, for newer entries, a stable per-instance UUID generated at `create` time. Legacy entries may omit `tentacle_id` entirely, and some readers may also encounter `null`, so consumers should use `.get("tentacle_id")`. Readers also accept the old string-list format for backward compatibility. **Deduplication key: `tentacle_id` (primary, phase 5) → `(name, git_root)` fallback (phase 4, legacy entries without `tentacle_id`).** Two instances with the same logical name in the same repo each produce a separate entry because their `tentacle_id` values differ. |
 | `git_root` | Top-level field: absolute git root of the most-recent writer (used by the legacy path **only** for pure string-list `active_tentacles` — not for mixed-format or dict-list entries). Per-entry `git_root` is the authoritative source for all dict-list and mixed-format markers. |
 | `scope` | File-scope list from the most-recently-dispatching tentacle |
 | `dispatch_mode` | Dispatch mode of the most-recently-dispatching tentacle |
@@ -129,7 +129,7 @@ the printed slug** — `_validate_tentacle_name` resolves by exact directory nam
 name passed to `create` will find the original (other session's) directory, not the slug.
 
 **Migration cleanup:** When re-dispatching from a known git repo, `tentacle.py swarm` eagerly
-removes legacy entries whose `name` matches, `tentacle_id` is absent, and whose `git_root` is
+removes legacy entries whose `name` matches, `tentacle_id` is absent or null, and whose `git_root` is
 either `None` (old string-list artefacts with no repo identity) or equal to the current repo
 when the new dispatch carries a `tentacle_id` (crash-then-upgrade: stale phase-4 dict entry for
 the same repo that would otherwise keep blocking commits until TTL expiry).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -242,8 +242,11 @@ These apply to every dispatched sub-agent.
   orchestrator commits, after merging and verifying all tentacle results. A sub-agent commit
   mid-run risks corrupting the orchestrator's merge flow.
 
-  > **Cross-repo isolation:** A marker written in repo A does not block `git commit` in repo B.
-  > Each marker entry carries a `git_root` field; the hook skips entries from different repos.
+  > **Cross-repo isolation (phase 4+):** A marker written in repo A does not block `git commit`
+  > in repo B. Each marker entry carries a `git_root` field; the hook skips entries from
+  > different repos. The same tentacle name can be active in multiple repos at once — each
+  > produces a separate marker entry. Dedup key: `tentacle_id` (primary, for phase-5 entries)
+  > → `(name, git_root)` fallback (for phase-4 / legacy entries without `tentacle_id`).
   > Entries without `git_root` (old format) conservatively block all repos.
   >
   > **Upgrade migration:** Cross-repo isolation is not retroactive. In-flight old-format markers
@@ -253,9 +256,21 @@ These apply to every dispatched sub-agent.
   > **Local-only enforcement**: the git hook guard fires only on local machines where hooks are
   > installed. Cloud-delegated or remote agent runs are not covered.
 
-  > **Same-repo multi-orchestrator**: Two concurrent orchestrators in the **same** repo share
-  > one marker entry and are not isolated from each other. One orchestrator per repo at a time
-  > is the supported model.
+  > **Same-repo multi-session (phase 5 — supported at runtime, with caveats):**
+  > `tentacle.py create` now generates a `tentacle_id` UUID per instance. If the requested
+  > directory already exists, `create` auto-resolves the collision by creating
+  > `<name>-<8-char-uuid>` and printing the slug. Two sessions in the same repo can each hold
+  > separate, non-colliding marker entries; `complete` removes only the matching identity.
+  >
+  > **Working-tree caveat:** Runtime identity isolation does not create separate working trees
+  > or index snapshots. Two tentacles in the same repo with overlapping file scopes will still
+  > produce merge conflicts or overwritten files in the shared working directory. Keep tentacle
+  > scopes non-overlapping when running same-repo concurrent sessions.
+  >
+  > **Slug name caveat:** When a collision-resolved slug (`<name>-<uuid[:8]>`) is created, all
+  > subsequent commands (`todo`, `swarm`, `complete`, `handoff`) must use the slug, not the
+  > original logical name. The slug is printed by `create` and stored as `dir_name` in
+  > `meta.json`.
 
 - **Stay in scope**: Avoid editing files outside your tentacle's declared scope.
 - **Escalate, don't expand**: If scope is insufficient, record the gap in `handoff.md` and stop.

--- a/hooks/check_subagent_marker.py
+++ b/hooks/check_subagent_marker.py
@@ -22,7 +22,10 @@ Repo-scope check (cross-repo false-positive prevention):
 
 Dual-format support:
   active_tentacles may be a list of strings (old format) or a list of dicts
-  with {name, ts, git_root} fields (new format).  Both are handled transparently.
+  with {name, ts, git_root} fields (new format), or a mix of both.  All are
+  handled transparently.  Format detection uses all() across the whole list so
+  that mixed-format markers (string entry followed by dict entries for the current
+  repo) cannot bypass blocking via the top-level git_root path.
 """
 
 import json
@@ -262,18 +265,26 @@ def is_marker_fresh() -> bool:
     # the marker was written for a different repository — don't block.
     # Old string-list entries with no git_root → conservative block (unchanged).
     # Exception here → fail-conservative: scope uncertainty keeps blocking.
+    #
+    # Format dispatch uses all() rather than active[0] type so that mixed-format
+    # markers (legacy string entry followed by dict entries for the current repo)
+    # are routed through _any_entry_relevant.  Branching on active[0] alone would
+    # cause the top-level git_root of a different-repo dispatch to shadow any
+    # same-repo dict entries that come later in the list, silently allowing a commit.
     try:
         if isinstance(active, list) and active:
-            if isinstance(active[0], str):
-                # Old string-list format: check top-level git_root if present.
+            if all(isinstance(e, str) for e in active):
+                # Pure old string-list format: check top-level git_root if present.
                 marker_git_root = data.get("git_root")
                 if marker_git_root:
                     current_git_root = _get_current_git_root()
                     if current_git_root and not _roots_match(current_git_root, marker_git_root):
                         return False  # Confirmed different repo — don't block.
                 # No top-level git_root → conservative block (old marker).
-            elif isinstance(active[0], dict):
-                # New dict-list format: per-entry git_root check.
+            else:
+                # New dict-list format or mixed format: use per-entry checks.
+                # String entries inside a mixed list are treated conservatively
+                # (relevant to every repo) by _any_entry_relevant.
                 current_git_root = _get_current_git_root()
                 if not _any_entry_relevant(active, current_git_root, now):
                     return False  # All entries confirmed for other repos.

--- a/hooks/rules/subagent_guard.py
+++ b/hooks/rules/subagent_guard.py
@@ -16,7 +16,10 @@ Repo-scope check (cross-repo false-positive prevention):
 
 Dual-format support:
   active_tentacles may be a list of strings (old format) or a list of dicts
-  with {name, ts, git_root} fields (new format).  Both are handled transparently.
+  with {name, ts, git_root} fields (new format), or a mix of both.  All are
+  handled transparently.  Format detection uses all() across the whole list so
+  that mixed-format markers (string entry followed by dict entries for the current
+  repo) cannot bypass blocking via the top-level git_root path.
 
 Note: preToolUse does NOT reliably fire inside task()-spawned delegated subagents.
 Git hooks (pre-commit/pre-push) remain the primary enforcement surface.
@@ -154,17 +157,25 @@ def _marker_is_fresh() -> bool:
 
         # Repo-scope check: prevent cross-repo false positives.
         # Exception here → fail-open (consistent with the outer except).
+        #
+        # Format dispatch uses all() rather than active[0] type so that mixed-format
+        # markers (legacy string entry followed by dict entries for the current repo)
+        # are routed through _any_entry_relevant.  Branching on active[0] alone would
+        # cause the top-level git_root of a different-repo dispatch to shadow any
+        # same-repo dict entries that come later in the list, silently allowing a commit.
         if isinstance(active, list) and active:
-            if isinstance(active[0], str):
-                # Old string-list format: check top-level git_root if present.
+            if all(isinstance(e, str) for e in active):
+                # Pure old string-list format: check top-level git_root if present.
                 marker_git_root = data.get("git_root")
                 if marker_git_root:
                     current_git_root = _get_current_git_root()
                     if current_git_root and not _roots_match(current_git_root, marker_git_root):
                         return False  # Confirmed different repo — don't block.
                 # No top-level git_root → conservative block (old marker).
-            elif isinstance(active[0], dict):
-                # New dict-list format: per-entry git_root check.
+            else:
+                # New dict-list format or mixed format: use per-entry checks.
+                # String entries inside a mixed list are treated conservatively
+                # (relevant to every repo) by _any_entry_relevant.
                 current_git_root = _get_current_git_root()
                 if not _any_entry_relevant(active, current_git_root, now):
                     return False  # All entries confirmed for other repos.

--- a/skills/tentacle-orchestration/SKILL.md
+++ b/skills/tentacle-orchestration/SKILL.md
@@ -36,21 +36,28 @@ context.
 it — they are the reliable enforcement surface.
 
 **How enforcement works:**
-1. `tentacle.py swarm` writes an HMAC-signed marker file at
-   `~/.copilot/markers/dispatched-subagent-active` containing an `active_tentacles` list of
-   per-entry objects: `{"name": "<tentacle>", "ts": "<unix>", "git_root": "<abs-path>"}`.
+1. `tentacle.py create` generates a UUID `tentacle_id` stored in the tentacle's `meta.json`.
+   If the requested name directory already exists, `create` auto-resolves the collision by
+   creating `<name>-<uuid[:8]>` — the slug is printed and must be used for all subsequent
+   commands. `tentacle.py swarm` reads `tentacle_id` from `meta.json` and writes an HMAC-signed
+   marker file at `~/.copilot/markers/dispatched-subagent-active` containing `active_tentacles`
+   entries of the form `{"name": ..., "ts": ..., "git_root": ..., "tentacle_id": ...}`.
+   **Primary deduplication key: `tentacle_id`** (when present) — two instances with the same
+   logical name in the same repo each get a separate entry. Fallback for legacy entries without
+   `tentacle_id`: `(name, git_root)`.
 2. `hooks/pre-commit` and `hooks/pre-push` call `hooks/check_subagent_marker.py`, which blocks
    the git operation when the marker is present, auth-valid, within its 4-hour TTL, **and the
    entry's `git_root` matches the repo running the git command**. A marker from a different repo
-   does not block commits here — this isolates multi-session, multi-repo setups. Entries without
-   `git_root` (old format) conservatively block all repos.
+   does not block commits there — this prevents cross-repo false positives when tentacles are
+   active in other repos concurrently. Entries without `git_root` (old format) conservatively
+   block all repos.
    > **Upgrade migration:** Cross-repo isolation is not retroactive. In-flight old-format marker
    > entries (no `git_root`) continue to block all repos until completed, cleared, or expired (4h
    > TTL). To get isolation immediately: `tentacle.py complete <name>` then re-dispatch.
 3. `hooks/rules/subagent_guard.py` provides a secondary `preToolUse` intercept for the
    orchestrator session (defense-in-depth only — not the primary path).
-4. `tentacle.py complete <name>` removes the tentacle's entry; the marker is deleted when
-   `active_tentacles` becomes empty.
+4. `tentacle.py complete <name>` reads `tentacle_id` from `meta.json` and removes only the
+   matching marker entry; the marker is deleted when `active_tentacles` becomes empty.
 
 **Install the git hooks** (once per repository):
 
@@ -64,9 +71,13 @@ python3 ~/.copilot/tools/install.py --install-git-hooks
 - **`preToolUse` non-inheritance.** The `preToolUse` guard in the main session is
   defense-in-depth — it does not replace git hooks. Whether `preToolUse` propagates into
   `task()`-spawned subagents is undefined by the platform.
-- **Same-repo multi-orchestrator not supported.** Two concurrent orchestrators in the same repo
-  share one marker entry and are not isolated from each other. One orchestrator per repo at a
-  time is the supported model.
+- **Same-repo multi-session supported (phase 5) — with working-tree caveat.** `tentacle_id`
+  isolation at the marker/runtime layer means two instances with the same logical name in the
+  same repo each hold a separate entry and `complete` only clears the matching one. However,
+  the working tree and git index are shared — concurrent tentacles with overlapping file scopes
+  will produce conflicts. Keep scopes non-overlapping.
+- **Collision-resolved slug names:** When `create` auto-resolves a directory collision, the
+  printed `<name>-<uuid[:8]>` slug must be used for all subsequent commands.
 - **After tool updates,** `auto-update-tools.py` does NOT auto-reinstall git hooks. Re-run
   `install.py --install-git-hooks` in each protected repo after relevant updates.
 

--- a/tentacle.py
+++ b/tentacle.py
@@ -36,6 +36,7 @@ import subprocess
 import sys
 import textwrap
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -306,6 +307,7 @@ def _write_dispatched_subagent_marker(
     tentacle_name: str,
     scope: list,
     dispatch_mode: str,
+    tentacle_id: str | None = None,
 ) -> bool:
     """Write/update the dispatched-subagent-active marker (set-based, concurrency-safe).
 
@@ -321,9 +323,11 @@ def _write_dispatched_subagent_marker(
                         originated (None when CWD is not inside a git repo).
                         Enforcement surfaces can use this to skip markers from
                         unrelated repositories (cross-repo false-positive guard).
-      active_tentacles: list of per-entry objects {name, ts, git_root}.  Each entry
-                        carries its own UNIX timestamp (TTL anchor) and git_root so
-                        cross-session refreshes do not extend unrelated entries.
+      active_tentacles: list of per-entry objects {name, ts, git_root[, tentacle_id]}.
+                        Each entry carries its own UNIX timestamp (TTL anchor) and
+                        git_root so cross-session refreshes do not extend unrelated
+                        entries.  When a tentacle_id is available it is included for
+                        per-instance identity-based dedup (phase 5).
                         Readers must tolerate the legacy string-list format produced
                         by older versions (see backward-compat note below).
       scope:            file-scope list from the most-recently-dispatching tentacle
@@ -336,9 +340,11 @@ def _write_dispatched_subagent_marker(
     normalises both to the dict-list format on every write.  Old string entries are
     treated as having git_root=None (unknown repo).
 
-    Deduplication key: (name, git_root).  Same-name tentacles from different repos
-    produce separate entries so enforcement surfaces can discriminate by repo.
-    Same-name same-repo re-dispatch refreshes the existing entry's per-entry ts.
+    Deduplication key: tentacle_id (when present) > (name, git_root) fallback.
+    When tentacle_id is supplied (phase-5 tentacles), dedup is by stable identity so
+    two orchestrators in the same repo with the same logical name produce separate
+    entries and do not overwrite each other.  When tentacle_id is absent (old
+    tentacles), dedup falls back to (name, git_root) preserving phase-4 semantics.
 
     Downstream enforcement surfaces (git hooks, preToolUse guards) can read this marker
     to detect active dispatched-subagent sessions.  This surface is advisory only —
@@ -373,43 +379,73 @@ def _write_dispatched_subagent_marker(
                 except (json.JSONDecodeError, OSError):
                     pass
 
-            # Deduplicate by (name, git_root): update ts in-place when match found;
-            # add a new entry for the same name from a different repo.
+            # Build the new entry dict.  Include tentacle_id when provided so that
+            # per-instance identity-based dedup can distinguish same-name same-repo
+            # tentacles created by different orchestrator sessions (phase-5 support).
             entry_ts = str(int(time.time()))
             new_entry: dict = {
                 "name": tentacle_name,
                 "ts": entry_ts,
                 "git_root": current_git_root_str,
             }
-            # Migration cleanup: when dispatching from a known repo, eagerly remove all
-            # legacy entries for this tentacle name whose git_root is None.  Such entries
-            # are artefacts of the old string-list format — they carry no repo identity,
-            # so hook readers conservatively treat them as active in every repo, silently
-            # defeating the cross-repo fix until TTL expiry.
+            if tentacle_id is not None:
+                new_entry["tentacle_id"] = tentacle_id
+
+            # Migration cleanup: when dispatching from a known repo, eagerly remove
+            # legacy entries for this tentacle name that have no tentacle_id and whose
+            # git_root is either:
+            #   - None: old string-format promotions with no repo identity; always stale.
+            #   - Equal to current repo (phase-5 dispatch only): phase-4 dict entries
+            #     without identity from a crash-then-upgrade scenario.  If left alive
+            #     they strand a stale phase-4 entry that blocks commits until TTL expiry.
             #
-            # Removing them before the dedup step ensures:
-            #   - A single (name, None) legacy entry is absorbed cleanly.
-            #   - A (name, None) entry that coexists with a real (name, /repo) entry
-            #     (e.g. from a race between old and new code) is also cleaned up, avoiding
-            #     duplicate entries that would arise from the "first match" search below.
+            # Entries that carry a tentacle_id are never touched — they belong to a
+            # live instance that owns its own identity.
             #
-            # If current_git_root_str is None we skip cleanup — the exact-match branch
-            # below handles (None == None) dedup correctly.
+            # For legacy dispatches (tentacle_id=None) only git_root=None entries are
+            # cleaned; same-repo phase-4 entries are left for the legacy dedup path.
+            #
+            # If current_git_root_str is None we skip cleanup entirely — the dedup
+            # branch below handles (None == None) correctly.
             if current_git_root_str is not None:
                 active = [
                     e for e in active
-                    if not (e.get("name") == tentacle_name and e.get("git_root") is None)
+                    if not (
+                        e.get("name") == tentacle_name
+                        and "tentacle_id" not in e
+                        and (
+                            e.get("git_root") is None
+                            or (tentacle_id is not None and e.get("git_root") == current_git_root_str)
+                        )
+                    )
                 ]
 
-            # Normal dedup: update ts in-place for exact (name, git_root) match;
-            # append a new entry for the same name from a different real repo.
+            # Dedup: when tentacle_id is provided, match by stable per-instance
+            # identity so that two sessions with the same logical name in the same
+            # repo each keep their own entry.  Fall back to (name, git_root) for
+            # old tentacles without tentacle_id to preserve phase-4 semantics.
             existing_idx: int | None = None
-            for i, entry in enumerate(active):
-                if entry.get("name") != tentacle_name:
-                    continue
-                if entry.get("git_root") == current_git_root_str:
-                    existing_idx = i
-                    break
+            if tentacle_id is not None:
+                # Phase-5 path: identity-based dedup
+                for i, entry in enumerate(active):
+                    if entry.get("tentacle_id") == tentacle_id:
+                        existing_idx = i
+                        break
+            else:
+                # Legacy path: (name, git_root) dedup — but only match entries that
+                # also lack tentacle_id.  A phase-5 entry that happens to share
+                # (name, git_root) must NOT be overwritten by a legacy dispatch; it
+                # belongs to a different session with its own stable identity.
+                for i, entry in enumerate(active):
+                    if entry.get("name") != tentacle_name:
+                        continue
+                    if (
+                        entry.get("git_root") == current_git_root_str
+                        and entry.get("tentacle_id") is None
+                    ):
+                        existing_idx = i
+                        break
+
             if existing_idx is not None:
                 active[existing_idx] = new_entry  # Refresh per-entry ts
             else:
@@ -440,7 +476,10 @@ def _write_dispatched_subagent_marker(
         return False
 
 
-def _clear_dispatched_subagent_marker(tentacle_name: str) -> bool:
+def _clear_dispatched_subagent_marker(
+    tentacle_name: str,
+    tentacle_id: str | None = None,
+) -> bool:
     """Remove a tentacle from the dispatched-subagent-active marker set.
 
     Deletes the marker file only when active_tentacles becomes empty after removal.
@@ -449,7 +488,11 @@ def _clear_dispatched_subagent_marker(tentacle_name: str) -> bool:
     Called by cmd_complete so a completing tentacle's entry is removed without
     disturbing sibling tentacles that are still running.
 
-    Removal is scoped by (name, git_root) when both are available, so completing a
+    When tentacle_id is supplied, removal is scoped to the exact per-instance identity
+    so two orchestrators with the same logical name in the same repo each only clear
+    their own entry (phase-5 same-repo multi-session support).
+
+    When tentacle_id is absent, removal falls back to (name, git_root) so completing a
     tentacle in one repo does not accidentally clear a same-named tentacle in another
     repo that may be running in a parallel session.
 
@@ -488,9 +531,23 @@ def _clear_dispatched_subagent_marker(tentacle_name: str) -> bool:
             def _should_remove(entry: dict) -> bool:
                 if entry.get("name") != tentacle_name:
                     return False
+                entry_id = entry.get("tentacle_id")
+                # Phase-5 path: both sides have tentacle_id → match by identity only.
+                # This prevents a same-repo same-name complete from clearing a sibling.
+                if tentacle_id is not None and entry_id is not None:
+                    return entry_id == tentacle_id
+                # Phase-5 caller clearing a legacy entry: don't remove it — we can't
+                # confirm ownership without identity on both sides.
+                if tentacle_id is not None and entry_id is None:
+                    return False
+                # HIGH-bug guard: legacy caller (tentacle_id=None) must NEVER remove
+                # a phase-5 entry that carries its own tentacle_id.  Without a matching
+                # identity we cannot confirm the caller owns this entry.
+                if tentacle_id is None and entry_id is not None:
+                    return False
+                # Pure legacy path: both sides have no tentacle_id → (name, git_root)
+                # match with conservative removal when repo info is missing on either side.
                 entry_git_root = entry.get("git_root")
-                # If either side lacks git_root info, match by name only (conservative
-                # removal: can't distinguish repos, so err on the side of cleaning up).
                 if entry_git_root is None or current_git_root_str is None:
                     return True
                 return entry_git_root == current_git_root_str
@@ -561,7 +618,7 @@ def _get_marker_state() -> dict:
       path:                    string path to marker file
       active_tentacles:        list of tentacle names currently dispatched
                                (backward-compat: always a list of strings)
-      active_tentacle_entries: list of full per-entry dicts {name, ts, git_root}
+      active_tentacle_entries: list of full per-entry dicts {name, ts, git_root[, tentacle_id]}
                                (new field: enriched data for enforcement surfaces)
       git_root:                top-level git_root from the marker (last writer's repo)
       dispatch_mode:           dispatch_mode from marker (or null)
@@ -587,17 +644,21 @@ def _get_marker_state() -> dict:
     elif "tentacle" in data:
         raw_active = [data["tentacle"]]
 
-    # Normalise to both a name-list (backward compat) and enriched entry-list (new)
+    # Normalise to both a name-list (backward compat) and enriched entry-list (new).
+    # Preserve tentacle_id when present so consumers can discriminate per-instance.
     names: list[str] = []
     entries: list[dict] = []
     for entry in raw_active:
         if isinstance(entry, str):
             names.append(entry)
-            entries.append({"name": entry, "ts": None, "git_root": None})
+            entries.append({"name": entry, "ts": None, "git_root": None, "tentacle_id": None})
         elif isinstance(entry, dict):
             name = entry.get("name", "")
             names.append(name)
-            entries.append(entry)
+            # Include tentacle_id in the enriched entry (None for old entries)
+            enriched = {"name": name, "ts": entry.get("ts"), "git_root": entry.get("git_root"),
+                        "tentacle_id": entry.get("tentacle_id")}
+            entries.append(enriched)
 
     return {
         "active": len(names) > 0,
@@ -808,9 +869,19 @@ def cmd_create(args):
     tentacles = get_tentacles_dir(args.session_dir)
     tentacle_dir = _validate_tentacle_name(args.name, tentacles)
 
+    # Generate a stable per-instance identity used for dedup/clear in marker operations.
+    tentacle_id = str(uuid.uuid4())
+
+    # Phase-5 collision avoidance: if the requested name dir already exists (e.g. two
+    # orchestrators in the same session), use a unique slug instead of hard-erroring.
+    actual_dir_name = args.name
     if tentacle_dir.exists():
-        print(f"ERROR: Tentacle '{args.name}' already exists.", file=sys.stderr)
-        sys.exit(1)
+        actual_dir_name = f"{args.name}-{tentacle_id[:8]}"
+        tentacle_dir = tentacles / actual_dir_name
+        print(
+            f"ℹ️  Tentacle '{args.name}' dir already exists — creating as '{actual_dir_name}'",
+            file=sys.stderr,
+        )
 
     tentacle_dir.mkdir(parents=True)
 
@@ -873,10 +944,14 @@ def cmd_create(args):
         "scope": [s.strip() for s in args.scope.split(",")] if args.scope else [],
         "description": desc,
         "status": "idle",
+        "tentacle_id": tentacle_id,
     }
+    # When dir_name differs from name (collision case), record it explicitly.
+    if actual_dir_name != args.name:
+        meta["dir_name"] = actual_dir_name
     (tentacle_dir / "meta.json").write_text(json.dumps(meta, indent=2) + "\n")
 
-    print(f"✅ Tentacle '{args.name}' created at {tentacle_dir}")
+    print(f"✅ Tentacle '{actual_dir_name}' created at {tentacle_dir}")
     print(f"   📄 CONTEXT.md — edit to add area-specific context")
     print(f"   📋 todo.md    — add checkbox items for delegation")
 
@@ -1142,7 +1217,8 @@ def cmd_complete(args):
 
     # 4. Clear dispatched-subagent-active marker entry for this tentacle
     had_marker = _DISPATCHED_MARKER_PATH.is_file()
-    _clear_dispatched_subagent_marker(args.name)
+    tentacle_id = meta.get("tentacle_id")
+    _clear_dispatched_subagent_marker(args.name, tentacle_id=tentacle_id)
     if had_marker:
         print(f"🧹 Dispatched-subagent marker updated (removed '{args.name}')")
 
@@ -1303,10 +1379,12 @@ def cmd_swarm(args):
     # Write dispatched-subagent-active marker so local enforcement surfaces can
     # observe that a dispatch is in flight. The marker is advisory — tentacle.py
     # is not itself an enforcement layer. Cleared by cmd_complete.
+    tentacle_id = meta.get("tentacle_id")
     marker_written = _write_dispatched_subagent_marker(
         tentacle_name=args.name,
         scope=meta.get("scope", []),
         dispatch_mode=args.output,
+        tentacle_id=tentacle_id,
     )
     if marker_written:
         print(f"📌 Marker: {_DISPATCHED_MARKER_PATH}")
@@ -1495,6 +1573,20 @@ def cmd_delete(args):
         print(f"ERROR: Tentacle '{args.name}' not found.", file=sys.stderr)
         sys.exit(1)
 
+    # Read tentacle_id from meta before removing the directory so targeted
+    # marker cleanup can still use identity-based matching.
+    meta_path = tentacle_dir / "meta.json"
+    tentacle_id: str | None = None
+    if meta_path.exists():
+        try:
+            tentacle_id = json.loads(meta_path.read_text()).get("tentacle_id")
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Clear any active marker entry before deleting (fail-open: proceed even on error).
+    if _DISPATCHED_MARKER_PATH.is_file():
+        _clear_dispatched_subagent_marker(args.name, tentacle_id=tentacle_id)
+
     import shutil
     shutil.rmtree(tentacle_dir)
     print(f"🗑️  Tentacle '{args.name}' deleted.")
@@ -1536,10 +1628,12 @@ def cmd_bundle(args):
     )
 
     # Write dispatched-subagent-active marker when materializing a bundle
+    tentacle_id = meta.get("tentacle_id")
     _write_dispatched_subagent_marker(
         tentacle_name=args.name,
         scope=meta.get("scope", []),
         dispatch_mode="bundle",
+        tentacle_id=tentacle_id,
     )
 
     if getattr(args, "output", "text") == "json":

--- a/tentacle.py
+++ b/tentacle.py
@@ -392,8 +392,8 @@ def _write_dispatched_subagent_marker(
                 new_entry["tentacle_id"] = tentacle_id
 
             # Migration cleanup: when dispatching from a known repo, eagerly remove
-            # legacy entries for this tentacle name that have no tentacle_id and whose
-            # git_root is either:
+            # legacy entries for this tentacle name whose tentacle_id is absent or
+            # null and whose git_root is either:
             #   - None: old string-format promotions with no repo identity; always stale.
             #   - Equal to current repo (phase-5 dispatch only): phase-4 dict entries
             #     without identity from a crash-then-upgrade scenario.  If left alive
@@ -412,7 +412,7 @@ def _write_dispatched_subagent_marker(
                     e for e in active
                     if not (
                         e.get("name") == tentacle_name
-                        and "tentacle_id" not in e
+                        and e.get("tentacle_id") is None
                         and (
                             e.get("git_root") is None
                             or (tentacle_id is not None and e.get("git_root") == current_git_root_str)

--- a/test_hooks.py
+++ b/test_hooks.py
@@ -1653,6 +1653,484 @@ except Exception as e:
     test("14g: _roots_match docstring checks", False, str(e))
 
 
+# ═══════════════════════════════════════════════════════════════════
+#  Section 15: Phase-5 per-tentacle tentacle_id field
+#
+#  Phase-5 runtime adds an optional "tentacle_id" field to each
+#  active_tentacles entry so that same-name, same-repo tentacles
+#  dispatched concurrently remain distinct entries.  Hook readers
+#  already iterate dict entries with get(); the extra field is
+#  silently ignored — no hook logic changes are required.
+#
+#  These tests verify:
+#    a. Extra tentacle_id field doesn't break _any_entry_relevant
+#    b. Multiple same-repo entries with distinct tentacle_ids → ALL block
+#    c. _read_tentacle_info still returns names correctly with tentacle_id
+#    d. Subprocess: multi-tentacle_id same-repo marker → exit 1 (blocks)
+#    e. Subprocess: one same-repo + one different-repo tentacle_id entry → exit 1
+#    f. SubagentGitGuardRule: multi-tentacle_id same-repo entries → deny
+#    g. tentacle_id field present in fresh single-entry marker → still blocks
+#    h. All same-repo tentacle_id entries expired → allow
+# ═══════════════════════════════════════════════════════════════════
+
+print("\n── Section 15: Phase-5 per-tentacle tentacle_id field ──")
+
+# 15a. _any_entry_relevant: entry with extra "tentacle_id" field → still True (same repo)
+try:
+    import rules.subagent_guard as _sg15
+    import importlib.util as _ilu15
+    _csm_spec15 = _ilu15.spec_from_file_location("csm15", _csm_path)
+    _csm15 = _ilu15.module_from_spec(_csm_spec15)
+    _csm_spec15.loader.exec_module(_csm15)
+
+    _now15 = _time12.time()
+    _same_repo = tempfile.mkdtemp(prefix="test-15-repo-")
+    _entry_with_id = {
+        "name": "build-api",
+        "ts": str(int(_now15)),
+        "git_root": _same_repo,
+        "tentacle_id": "abc-uuid-1",
+    }
+    result_sg15a = _sg15._any_entry_relevant([_entry_with_id], _same_repo, _now15)
+    test("15a: subagent_guard._any_entry_relevant ignores tentacle_id field, returns True for same-repo",
+         result_sg15a is True,
+         f"Got {result_sg15a!r}")
+    result_csm15a = _csm15._any_entry_relevant([_entry_with_id], _same_repo, _now15)
+    test("15a2: check_subagent_marker._any_entry_relevant ignores tentacle_id field, returns True for same-repo",
+         result_csm15a is True,
+         f"Got {result_csm15a!r}")
+    shutil.rmtree(_same_repo, ignore_errors=True)
+    test("15a: tentacle_id field tolerance tests ran", True)
+except Exception as e:
+    test("15a: tentacle_id field tolerance tests", False, str(e))
+
+# 15b. Multiple same-repo entries with distinct tentacle_ids → _any_entry_relevant returns True
+try:
+    import rules.subagent_guard as _sg15b
+    _now15b = _time12.time()
+    _repo15b = tempfile.mkdtemp(prefix="test-15b-repo-")
+    _entries15b = [
+        {"name": "worker", "ts": str(int(_now15b)), "git_root": _repo15b, "tentacle_id": "tid-1"},
+        {"name": "worker", "ts": str(int(_now15b)), "git_root": _repo15b, "tentacle_id": "tid-2"},
+    ]
+    result_sg15b = _sg15b._any_entry_relevant(_entries15b, _repo15b, _now15b)
+    test("15b: subagent_guard._any_entry_relevant: two same-repo tentacle_id entries → True (blocks)",
+         result_sg15b is True,
+         f"Got {result_sg15b!r}")
+
+    import importlib.util as _ilu15b
+    _csm_spec15b = _ilu15b.spec_from_file_location("csm15b", _csm_path)
+    _csm15b = _ilu15b.module_from_spec(_csm_spec15b)
+    _csm_spec15b.loader.exec_module(_csm15b)
+    result_csm15b = _csm15b._any_entry_relevant(_entries15b, _repo15b, _now15b)
+    test("15b2: check_subagent_marker._any_entry_relevant: two same-repo tentacle_id entries → True",
+         result_csm15b is True,
+         f"Got {result_csm15b!r}")
+    shutil.rmtree(_repo15b, ignore_errors=True)
+    test("15b: multi-tentacle_id same-repo tests ran", True)
+except Exception as e:
+    test("15b: multi-tentacle_id same-repo tests", False, str(e))
+
+# 15c. _read_tentacle_info: tentacle_id field doesn't break name extraction
+try:
+    import rules.subagent_guard as _sg15c
+    _now15c = _time12.time()
+    _home15c = Path(tempfile.mkdtemp(prefix="test-15c-"))
+    (_home15c / ".copilot" / "markers").mkdir(parents=True)
+    _marker15c = _home15c / ".copilot" / "markers" / "dispatched-subagent-active"
+    _marker15c.write_text(json.dumps({
+        "name": "dispatched-subagent-active",
+        "ts": str(int(_now15c)),
+        "active_tentacles": [
+            {"name": "alpha", "ts": str(int(_now15c)), "git_root": "/r", "tentacle_id": "tid-A"},
+            {"name": "beta",  "ts": str(int(_now15c)), "git_root": "/r", "tentacle_id": "tid-B"},
+        ],
+    }), encoding="utf-8")
+
+    # Patch SUBAGENT_MARKER so _read_tentacle_info uses our file
+    _orig_sm15c = _sg15c.SUBAGENT_MARKER
+    _sg15c.SUBAGENT_MARKER = _marker15c
+    info15c = _sg15c._read_tentacle_info()
+    _sg15c.SUBAGENT_MARKER = _orig_sm15c
+
+    test("15c: subagent_guard._read_tentacle_info with tentacle_id entries returns both names",
+         "alpha" in info15c and "beta" in info15c,
+         f"Got: {info15c!r}")
+
+    # Same for check_subagent_marker
+    import importlib.util as _ilu15c
+    _csm_spec15c = _ilu15c.spec_from_file_location("csm15c", _csm_path)
+    _csm15c2 = _ilu15c.module_from_spec(_csm_spec15c)
+    _csm_spec15c.loader.exec_module(_csm15c2)
+    _orig_mp15c = _csm15c2.MARKER_PATH
+    _csm15c2.MARKER_PATH = _marker15c
+    info15c2 = _csm15c2._read_tentacle_info()
+    _csm15c2.MARKER_PATH = _orig_mp15c
+
+    test("15c2: check_subagent_marker._read_tentacle_info with tentacle_id entries returns both names",
+         "alpha" in info15c2 and "beta" in info15c2,
+         f"Got: {info15c2!r}")
+    shutil.rmtree(str(_home15c), ignore_errors=True)
+    test("15c: _read_tentacle_info tentacle_id tests ran", True)
+except Exception as e:
+    test("15c: _read_tentacle_info tentacle_id tests", False, str(e))
+
+# 15d. Subprocess: marker with two same-repo entries (distinct tentacle_ids) → exit 1
+try:
+    _now15d = _time12.time()
+    _home15d = Path(tempfile.mkdtemp(prefix="test-15d-"))
+    (_home15d / ".copilot" / "markers").mkdir(parents=True)
+    _repo15d = tempfile.mkdtemp(prefix="test-15d-repo-")
+    (_home15d / ".copilot" / "markers" / "dispatched-subagent-active").write_text(
+        json.dumps({
+            "name": "dispatched-subagent-active",
+            "ts": str(int(_now15d)),
+            "git_root": _repo15d,
+            "active_tentacles": [
+                {"name": "worker", "ts": str(int(_now15d)), "git_root": _repo15d, "tentacle_id": "tid-1"},
+                {"name": "worker", "ts": str(int(_now15d)), "git_root": _repo15d, "tentacle_id": "tid-2"},
+            ],
+        }), encoding="utf-8"
+    )
+    r15d = subprocess.run(
+        [sys.executable, str(_csm_path)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+        cwd=_repo15d,
+        env={**os.environ, "HOME": str(_home15d)},
+    )
+    test("15d: subprocess same-repo two tentacle_id entries → exit 1 (blocks)",
+         r15d.returncode == 1,
+         f"exit={r15d.returncode} stdout={r15d.stdout[:120]}")
+    shutil.rmtree(str(_home15d), ignore_errors=True)
+    shutil.rmtree(_repo15d, ignore_errors=True)
+except Exception as e:
+    test("15d: subprocess multi-tentacle_id same-repo test", False, str(e))
+
+# 15e. Subprocess: one same-repo tentacle_id entry + one different-repo → still exit 1
+try:
+    _now15e = _time12.time()
+    _home15e = Path(tempfile.mkdtemp(prefix="test-15e-"))
+    (_home15e / ".copilot" / "markers").mkdir(parents=True)
+    _repo15e_current = tempfile.mkdtemp(prefix="test-15e-current-")
+    _repo15e_other   = tempfile.mkdtemp(prefix="test-15e-other-")
+    (_home15e / ".copilot" / "markers" / "dispatched-subagent-active").write_text(
+        json.dumps({
+            "name": "dispatched-subagent-active",
+            "ts": str(int(_now15e)),
+            "git_root": _repo15e_current,
+            "active_tentacles": [
+                {"name": "t-other",   "ts": str(int(_now15e)), "git_root": _repo15e_other,   "tentacle_id": "tid-A"},
+                {"name": "t-current", "ts": str(int(_now15e)), "git_root": _repo15e_current, "tentacle_id": "tid-B"},
+            ],
+        }), encoding="utf-8"
+    )
+    r15e = subprocess.run(
+        [sys.executable, str(_csm_path)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+        cwd=_repo15e_current,
+        env={**os.environ, "HOME": str(_home15e)},
+    )
+    test("15e: subprocess mixed-repo tentacle_id entries → exit 1 (same-repo entry still blocks)",
+         r15e.returncode == 1,
+         f"exit={r15e.returncode} stdout={r15e.stdout[:120]}")
+    shutil.rmtree(str(_home15e), ignore_errors=True)
+    shutil.rmtree(_repo15e_current, ignore_errors=True)
+    shutil.rmtree(_repo15e_other, ignore_errors=True)
+except Exception as e:
+    test("15e: subprocess mixed-repo tentacle_id test", False, str(e))
+
+# 15f. SubagentGitGuardRule: multiple same-repo tentacle_id entries → deny
+try:
+    import rules.subagent_guard as _sg15f
+    _now15f = _time12.time()
+    _home15f = Path(tempfile.mkdtemp(prefix="test-15f-"))
+    (_home15f / ".copilot" / "markers").mkdir(parents=True)
+    _repo15f = tempfile.mkdtemp(prefix="test-15f-repo-")
+    _marker15f = _home15f / ".copilot" / "markers" / "dispatched-subagent-active"
+    _marker15f.write_text(json.dumps({
+        "name": "dispatched-subagent-active",
+        "ts": str(int(_now15f)),
+        "git_root": _repo15f,
+        "active_tentacles": [
+            {"name": "svc-a", "ts": str(int(_now15f)), "git_root": _repo15f, "tentacle_id": "run-1"},
+            {"name": "svc-b", "ts": str(int(_now15f)), "git_root": _repo15f, "tentacle_id": "run-2"},
+        ],
+    }), encoding="utf-8")
+    _orig_sm15f = _sg15f.SUBAGENT_MARKER
+    _orig_vm15f = _sg15f.verify_marker
+    _orig_gcr15f = _sg15f._get_current_git_root
+    _sg15f.SUBAGENT_MARKER = _marker15f
+    _sg15f.verify_marker = lambda p, n: True  # bypass HMAC; testing routing logic only
+    _sg15f._get_current_git_root = lambda: _repo15f
+    rule15f = _sg15f.SubagentGitGuardRule()
+    result15f = rule15f.evaluate("preToolUse", {"toolArgs": {"command": "git commit -m 'x'"}})
+    _sg15f.SUBAGENT_MARKER = _orig_sm15f
+    _sg15f.verify_marker = _orig_vm15f
+    _sg15f._get_current_git_root = _orig_gcr15f
+    test("15f: SubagentGitGuardRule multi-tentacle_id same-repo → deny",
+         result15f is not None,
+         f"Got None (allowed) — should have been denied")
+    if result15f is not None:
+        msg15f = result15f.get("permissionDecisionReason", "") if isinstance(result15f, dict) else str(result15f)
+        test("15f2: deny message mentions subagent mode",
+             "subagent" in msg15f.lower(),
+             f"permissionDecisionReason: {msg15f[:80]!r}")
+    shutil.rmtree(str(_home15f), ignore_errors=True)
+    shutil.rmtree(_repo15f, ignore_errors=True)
+    test("15f: SubagentGitGuardRule multi-tentacle_id tests ran", True)
+except Exception as e:
+    test("15f: SubagentGitGuardRule multi-tentacle_id tests", False, str(e))
+
+# 15g. Single tentacle_id entry (fresh) still blocks — regression guard
+try:
+    _now15g = _time12.time()
+    _home15g = Path(tempfile.mkdtemp(prefix="test-15g-"))
+    (_home15g / ".copilot" / "markers").mkdir(parents=True)
+    _repo15g = tempfile.mkdtemp(prefix="test-15g-repo-")
+    (_home15g / ".copilot" / "markers" / "dispatched-subagent-active").write_text(
+        json.dumps({
+            "name": "dispatched-subagent-active",
+            "ts": str(int(_now15g)),
+            "git_root": _repo15g,
+            "active_tentacles": [
+                {"name": "solo", "ts": str(int(_now15g)), "git_root": _repo15g, "tentacle_id": "uid-xyz"},
+            ],
+        }), encoding="utf-8"
+    )
+    r15g = subprocess.run(
+        [sys.executable, str(_csm_path)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+        cwd=_repo15g,
+        env={**os.environ, "HOME": str(_home15g)},
+    )
+    test("15g: single tentacle_id entry still blocks (regression guard)",
+         r15g.returncode == 1,
+         f"exit={r15g.returncode}")
+    shutil.rmtree(str(_home15g), ignore_errors=True)
+    shutil.rmtree(_repo15g, ignore_errors=True)
+except Exception as e:
+    test("15g: single tentacle_id entry regression guard", False, str(e))
+
+# 15h. All same-repo tentacle_id entries expired → allow
+try:
+    import rules.subagent_guard as _sg15h
+    _now15h = _time12.time()
+    _stale_ts15h = str(int(_now15h - 20000))  # well past 4h TTL
+    _repo15h = tempfile.mkdtemp(prefix="test-15h-repo-")
+    _entries15h = [
+        {"name": "t1", "ts": _stale_ts15h, "git_root": _repo15h, "tentacle_id": "tid-1"},
+        {"name": "t2", "ts": _stale_ts15h, "git_root": _repo15h, "tentacle_id": "tid-2"},
+    ]
+    result_sg15h = _sg15h._any_entry_relevant(_entries15h, _repo15h, _now15h)
+    test("15h: all same-repo tentacle_id entries expired → _any_entry_relevant returns False",
+         result_sg15h is False,
+         f"Got {result_sg15h!r} — expired entries should not block")
+
+    import importlib.util as _ilu15h
+    _csm_spec15h = _ilu15h.spec_from_file_location("csm15h", _csm_path)
+    _csm15h = _ilu15h.module_from_spec(_csm_spec15h)
+    _csm_spec15h.loader.exec_module(_csm15h)
+    result_csm15h = _csm15h._any_entry_relevant(_entries15h, _repo15h, _now15h)
+    test("15h2: check_subagent_marker all expired tentacle_id entries → False",
+         result_csm15h is False,
+         f"Got {result_csm15h!r}")
+    shutil.rmtree(_repo15h, ignore_errors=True)
+    test("15h: expired tentacle_id entries tests ran", True)
+except Exception as e:
+    test("15h: expired tentacle_id entries test", False, str(e))
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Section 16: Mixed-format marker bypass regression tests
+#
+#  Bug: when active_tentacles[0] is a string (old format), the previous
+#  code entered the "old string-list" branch and checked only the
+#  top-level git_root — completely skipping any later dict entries that
+#  may carry a different (current-repo) git_root.  A crafted or migrating
+#  marker with active[0]=string, top-level git_root=/other/repo, and a
+#  dict entry for /current/repo would return False (allow commit).
+#
+#  Fix: use all(isinstance(e, str) for e in active) so a mixed list is
+#  routed through _any_entry_relevant, which handles strings conservatively.
+#
+#  Tests:
+#   a. _any_entry_relevant: mixed list with string first → True (conservative)
+#   b. Subprocess: mixed list, string first + dict for current repo,
+#      top-level git_root=/other → exit 1 (BLOCKS — was bypass before fix)
+#   c. Subprocess: pure old string list + top-level git_root=/other → exit 0
+#      (cross-repo skip still works for purely old-format markers)
+#   d. SubagentGitGuardRule: mixed list, string first + current-repo dict → deny
+#   e. Source check: both hook files use all() not active[0] for format dispatch
+# ═══════════════════════════════════════════════════════════════════
+
+print("\n── Section 16: Mixed-format marker bypass regression ──")
+
+# 16a. _any_entry_relevant: string entry first in mixed list → True (conservative)
+try:
+    import rules.subagent_guard as _sg16
+    import importlib.util as _ilu16
+    _csm_spec16 = _ilu16.spec_from_file_location("csm16", _csm_path)
+    _csm16 = _ilu16.module_from_spec(_csm_spec16)
+    _csm_spec16.loader.exec_module(_csm16)
+
+    _now16 = _time12.time()
+    _repo16 = tempfile.mkdtemp(prefix="test-16-repo-")
+    _other16 = tempfile.mkdtemp(prefix="test-16-other-")
+    # Mixed: string first (no repo metadata) + dict for current repo
+    _mixed16 = [
+        "legacy-tentacle",
+        {"name": "current-work", "ts": str(int(_now16)), "git_root": _repo16},
+    ]
+    result_sg16a = _sg16._any_entry_relevant(_mixed16, _repo16, _now16)
+    test("16a: subagent_guard._any_entry_relevant mixed (string first) → True (conservative block)",
+         result_sg16a is True,
+         f"Got {result_sg16a!r}")
+    result_csm16a = _csm16._any_entry_relevant(_mixed16, _repo16, _now16)
+    test("16a2: check_subagent_marker._any_entry_relevant mixed (string first) → True",
+         result_csm16a is True,
+         f"Got {result_csm16a!r}")
+    shutil.rmtree(_repo16, ignore_errors=True)
+    shutil.rmtree(_other16, ignore_errors=True)
+    test("16a: mixed-format _any_entry_relevant tests ran", True)
+except Exception as e:
+    test("16a: mixed-format _any_entry_relevant tests", False, str(e))
+
+# 16b. Subprocess: mixed list (string first) + dict for current repo +
+#      top-level git_root = other repo → must exit 1 (was bypass before fix)
+try:
+    _now16b = _time12.time()
+    _home16b = Path(tempfile.mkdtemp(prefix="test-16b-"))
+    (_home16b / ".copilot" / "markers").mkdir(parents=True)
+    _current16b = tempfile.mkdtemp(prefix="test-16b-current-")
+    _other16b   = tempfile.mkdtemp(prefix="test-16b-other-")
+    # Top-level git_root points to OTHER repo; active_tentacles[1] dict is for CURRENT repo.
+    # Before fix: active[0] is string → string branch → top-level git_root mismatch → exit 0 (BYPASS)
+    # After fix: all() check → mixed → _any_entry_relevant → string entry → True → exit 1 (BLOCKS)
+    (_home16b / ".copilot" / "markers" / "dispatched-subagent-active").write_text(
+        json.dumps({
+            "name": "dispatched-subagent-active",
+            "ts": str(int(_now16b)),
+            "git_root": _other16b,          # top-level points to other repo
+            "active_tentacles": [
+                "legacy-tentacle",          # old string entry (no repo metadata)
+                {"name": "current-work", "ts": str(int(_now16b)), "git_root": _current16b},
+            ],
+        }), encoding="utf-8"
+    )
+    r16b = subprocess.run(
+        [sys.executable, str(_csm_path)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+        cwd=_current16b,
+        env={**os.environ, "HOME": str(_home16b)},
+    )
+    test("16b: mixed list (string first + current-repo dict, other top-level git_root) → exit 1 (blocks)",
+         r16b.returncode == 1,
+         f"exit={r16b.returncode} — was exit 0 (bypass) before fix; stdout={r16b.stdout[:80]}")
+    shutil.rmtree(str(_home16b), ignore_errors=True)
+    shutil.rmtree(_current16b, ignore_errors=True)
+    shutil.rmtree(_other16b, ignore_errors=True)
+except Exception as e:
+    test("16b: mixed-format bypass subprocess test", False, str(e))
+
+# 16c. Subprocess: pure old string list + top-level git_root = other repo → exit 0
+#      (cross-repo skip for purely old-format markers must still work)
+try:
+    _now16c = _time12.time()
+    _home16c = Path(tempfile.mkdtemp(prefix="test-16c-"))
+    (_home16c / ".copilot" / "markers").mkdir(parents=True)
+    _current16c = Path(tempfile.mkdtemp(prefix="test-16c-current-"))
+    _other16c   = Path(tempfile.mkdtemp(prefix="test-16c-other-"))
+    # current repo needs git init so _get_current_git_root() returns a real path
+    subprocess.run(["git", "init", str(_current16c)], capture_output=True, check=True, timeout=10)
+    subprocess.run(["git", "config", "user.email", "t@t.com"],
+                   cwd=str(_current16c), capture_output=True, timeout=5)
+    subprocess.run(["git", "config", "user.name", "T"],
+                   cwd=str(_current16c), capture_output=True, timeout=5)
+    (_home16c / ".copilot" / "markers" / "dispatched-subagent-active").write_text(
+        json.dumps({
+            "name": "dispatched-subagent-active",
+            "ts": str(int(_now16c)),
+            "git_root": str(_other16c),     # top-level: other repo
+            "active_tentacles": ["legacy-only"],  # pure old string list
+        }), encoding="utf-8"
+    )
+    r16c = subprocess.run(
+        [sys.executable, str(_csm_path)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+        cwd=str(_current16c),
+        env={**os.environ, "HOME": str(_home16c)},
+    )
+    test("16c: pure old string list + other-repo top-level git_root → exit 0 (backward compat preserved)",
+         r16c.returncode == 0,
+         f"exit={r16c.returncode} — cross-repo skip for pure old-format markers must still work")
+    shutil.rmtree(str(_home16c), ignore_errors=True)
+    shutil.rmtree(str(_current16c), ignore_errors=True)
+    shutil.rmtree(str(_other16c), ignore_errors=True)
+except subprocess.CalledProcessError as e:
+    test("16c: pure-old-format backward-compat test (git init)", False, str(e))
+except Exception as e:
+    test("16c: pure-old-format backward-compat test", False, str(e))
+
+# 16d. SubagentGitGuardRule: mixed list (string first) + current-repo dict → deny
+try:
+    import rules.subagent_guard as _sg16d
+    _now16d = _time12.time()
+    _home16d = Path(tempfile.mkdtemp(prefix="test-16d-"))
+    (_home16d / ".copilot" / "markers").mkdir(parents=True)
+    _current16d = tempfile.mkdtemp(prefix="test-16d-current-")
+    _other16d   = tempfile.mkdtemp(prefix="test-16d-other-")
+    _marker16d = _home16d / ".copilot" / "markers" / "dispatched-subagent-active"
+    _marker16d.write_text(json.dumps({
+        "name": "dispatched-subagent-active",
+        "ts": str(int(_now16d)),
+        "git_root": _other16d,
+        "active_tentacles": [
+            "legacy-tentacle",
+            {"name": "current-work", "ts": str(int(_now16d)), "git_root": _current16d},
+        ],
+    }), encoding="utf-8")
+    _orig_sm16d = _sg16d.SUBAGENT_MARKER
+    _orig_vm16d = _sg16d.verify_marker
+    _orig_gcr16d = _sg16d._get_current_git_root
+    _sg16d.SUBAGENT_MARKER = _marker16d
+    _sg16d.verify_marker = lambda p, n: True  # bypass HMAC; testing routing logic
+    _sg16d._get_current_git_root = lambda: _current16d
+    rule16d = _sg16d.SubagentGitGuardRule()
+    result16d = rule16d.evaluate("preToolUse", {"toolArgs": {"command": "git commit -m 'x'"}})
+    _sg16d.SUBAGENT_MARKER = _orig_sm16d
+    _sg16d.verify_marker = _orig_vm16d
+    _sg16d._get_current_git_root = _orig_gcr16d
+    test("16d: SubagentGitGuardRule mixed list (string first + current-repo dict) → deny",
+         result16d is not None and isinstance(result16d, dict)
+         and result16d.get("permissionDecision") == "deny",
+         f"Got {result16d!r:.80} — was allowed (bypass) before fix")
+    shutil.rmtree(str(_home16d), ignore_errors=True)
+    shutil.rmtree(_current16d, ignore_errors=True)
+    shutil.rmtree(_other16d, ignore_errors=True)
+    test("16d: SubagentGitGuardRule mixed-format tests ran", True)
+except Exception as e:
+    test("16d: SubagentGitGuardRule mixed-format tests", False, str(e))
+
+# 16e. Source check: both hook files dispatch on all() not active[0]
+try:
+    _sg_src16 = (REPO / "hooks" / "rules" / "subagent_guard.py").read_text(encoding="utf-8")
+    _csm_src16 = (REPO / "hooks" / "check_subagent_marker.py").read_text(encoding="utf-8")
+    test("16e: subagent_guard.py uses all(isinstance(e, str) for e in active) for format dispatch",
+         "all(isinstance(e, str) for e in active)" in _sg_src16,
+         "Format detection should use all() not active[0] type check")
+    test("16e2: check_subagent_marker.py uses all(isinstance(e, str) for e in active) for format dispatch",
+         "all(isinstance(e, str) for e in active)" in _csm_src16,
+         "Format detection should use all() not active[0] type check")
+    test("16e3: subagent_guard.py does not dispatch on isinstance(active[0], str) in repo-scope check",
+         "isinstance(active[0], str)" not in _sg_src16.split("Repo-scope check")[-1],
+         "Old active[0] dispatch pattern should be gone from repo-scope check")
+    test("16e4: check_subagent_marker.py does not dispatch on isinstance(active[0], str) in repo-scope check",
+         "isinstance(active[0], str)" not in _csm_src16.split("Repo-scope check")[-1],
+         "Old active[0] dispatch pattern should be gone from repo-scope check")
+except Exception as e:
+    test("16e: format-dispatch source checks", False, str(e))
+
+
 import ast
 
 py_files = list(REPO.glob("*.py")) + list((REPO / "hooks").glob("*.py")) + list((REPO / "hooks" / "rules").glob("*.py"))

--- a/test_tentacle_runtime.py
+++ b/test_tentacle_runtime.py
@@ -3197,15 +3197,20 @@ class TestMigrationCleanupGap(unittest.TestCase):
         if SCRATCH_DIR.exists():
             shutil.rmtree(SCRATCH_DIR)
 
-    def _write_phase4_entry(self, name, git_root):
-        """Directly inject a phase-4 style dict entry (no tentacle_id) into the marker."""
+    def _write_phase4_entry(self, name, git_root, tentacle_id_sentinel=...):
+        """Inject a phase-4 style dict entry into the marker.
+
+        By default the entry omits tentacle_id entirely; passing None writes an
+        explicit null to cover mixed-version/manual-marker edge cases.
+        """
+        entry = {"name": name, "ts": str(int(time.time())), "git_root": str(git_root)}
+        if tentacle_id_sentinel is not ...:
+            entry["tentacle_id"] = tentacle_id_sentinel
         self.marker_path.write_text(json.dumps({
             "name": self.MARKER_NAME,
             "ts": str(int(time.time())),
             "git_root": str(git_root),
-            "active_tentacles": [
-                {"name": name, "ts": str(int(time.time())), "git_root": str(git_root)},
-            ],
+            "active_tentacles": [entry],
         }))
 
     # ── core gap fix ──────────────────────────────────────────────────────────
@@ -3225,6 +3230,17 @@ class TestMigrationCleanupGap(unittest.TestCase):
         )
         self.assertEqual(entries[0].get("tentacle_id"), tid,
                          "The surviving entry must be the new phase-5 entry")
+
+    def test_phase5_dispatch_absorbs_same_repo_entry_with_null_tentacle_id(self):
+        """Explicit null tentacle_id must be treated as legacy identity-less state."""
+        self._write_phase4_entry("feature-x", self.repo, tentacle_id_sentinel=None)
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt", tentacle_id=tid)
+        data = json.loads(self.marker_path.read_text())
+        entries = data["active_tentacles"]
+        self.assertEqual(len(entries), 1, "Null tentacle_id legacy entry must be absorbed")
+        self.assertEqual(entries[0].get("tentacle_id"), tid)
 
     def test_phase5_complete_leaves_no_stale_phase4_entry(self):
         """Full lifecycle: existing phase-4 entry → phase-5 dispatch → phase-5 complete
@@ -3263,6 +3279,23 @@ class TestMigrationCleanupGap(unittest.TestCase):
         self.assertEqual(
             len(entries), 2,
             "Phase-4 entry from a different repo must NOT be absorbed"
+        )
+        git_roots = {e.get("git_root") for e in entries}
+        self.assertIn(str(other_repo), git_roots, "Other-repo entry must survive")
+        self.assertIn(str(self.repo), git_roots, "Current-repo entry must exist")
+
+    def test_phase5_dispatch_does_not_absorb_different_repo_entry_with_null_tentacle_id(self):
+        """Explicit null tentacle_id must not allow cross-repo absorption."""
+        other_repo = self.base / "other-repo"
+        self._write_phase4_entry("feature-x", other_repo, tentacle_id_sentinel=None)
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt", tentacle_id=tid)
+        data = json.loads(self.marker_path.read_text())
+        entries = data["active_tentacles"]
+        self.assertEqual(
+            len(entries), 2,
+            "Different-repo null-tentacle_id entry must not be absorbed"
         )
         git_roots = {e.get("git_root") for e in entries}
         self.assertIn(str(other_repo), git_roots, "Other-repo entry must survive")
@@ -3308,4 +3341,3 @@ class TestMigrationCleanupGap(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
-

--- a/test_tentacle_runtime.py
+++ b/test_tentacle_runtime.py
@@ -15,10 +15,12 @@ Does NOT write to /tmp — uses a subdirectory of the tools dir instead.
 import json
 import os
 import sys
+import argparse
 import subprocess
 import textwrap
 import time
 import types
+import uuid
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
@@ -2104,10 +2106,6 @@ class TestDispatchedSubagentMarkerConcurrency(unittest.TestCase):
 
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
-
-
 # ---------------------------------------------------------------------------
 # Phase-4 new-format marker tests
 # ---------------------------------------------------------------------------
@@ -2761,5 +2759,553 @@ class TestMarkerLegacyUpgradePath(unittest.TestCase):
         self.assertEqual(state["active_tentacles"], ["tent-a"])
         self.assertEqual(state["active_tentacle_entries"][0]["git_root"], str(repo_a))
 
+
+class TestSameRepoMultiSession(unittest.TestCase):
+    """Phase-5: two orchestrators in the same git repo with the same tentacle name
+    must not collide on marker dedup/cleanup.  Each tentacle is identified by its
+    unique tentacle_id; (name, git_root) is the fallback for legacy entries.
+    """
+
+    MARKER_NAME = "dispatched-subagent-active"
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "same_repo_tests"
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.marker_path = self.base / self.MARKER_NAME
+        self._orig_path = T._DISPATCHED_MARKER_PATH
+        T._DISPATCHED_MARKER_PATH = self.marker_path
+        self._orig_markers_dir = T.MARKERS_DIR
+        T.MARKERS_DIR = self.base
+        self.repo = self.base / "my-repo"
+
+    def tearDown(self):
+        T._DISPATCHED_MARKER_PATH = self._orig_path
+        T.MARKERS_DIR = self._orig_markers_dir
+        import shutil
+        if SCRATCH_DIR.exists():
+            shutil.rmtree(SCRATCH_DIR)
+
+    # ── core coexistence behaviour ────────────────────────────────────────────
+
+    def test_two_instances_same_name_same_repo_coexist_in_marker(self):
+        """Two tentacles with the same name and same repo but different tentacle_id
+        must each produce a separate marker entry — no dedup collision."""
+        tid_a = str(uuid.uuid4())
+        tid_b = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("my-tent", [], "prompt", tentacle_id=tid_a)
+            T._write_dispatched_subagent_marker("my-tent", [], "prompt", tentacle_id=tid_b)
+        data = json.loads(self.marker_path.read_text())
+        active = data["active_tentacles"]
+        self.assertEqual(len(active), 2, "Both entries must coexist")
+        ids = {e["tentacle_id"] for e in active}
+        self.assertIn(tid_a, ids)
+        self.assertIn(tid_b, ids)
+
+    def test_complete_only_removes_own_entry_by_tentacle_id(self):
+        """Completing tentacle A must leave tentacle B's entry untouched."""
+        tid_a = str(uuid.uuid4())
+        tid_b = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("my-tent", [], "prompt", tentacle_id=tid_a)
+            T._write_dispatched_subagent_marker("my-tent", [], "prompt", tentacle_id=tid_b)
+            T._clear_dispatched_subagent_marker("my-tent", tentacle_id=tid_a)
+        data = json.loads(self.marker_path.read_text())
+        active = data["active_tentacles"]
+        self.assertEqual(len(active), 1, "Only one entry should remain")
+        self.assertEqual(active[0]["tentacle_id"], tid_b)
+
+    def test_complete_removes_last_entry_deletes_file(self):
+        """When the last entry is removed the marker file should be deleted."""
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("solo", [], "prompt", tentacle_id=tid)
+            T._clear_dispatched_subagent_marker("solo", tentacle_id=tid)
+        self.assertFalse(self.marker_path.exists(), "Marker file should be deleted when empty")
+
+    def test_redispatch_same_tentacle_id_refreshes_ts_no_duplicate(self):
+        """Re-dispatching the same tentacle (same tentacle_id) updates ts, no duplicate."""
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("tent-x", [], "prompt", tentacle_id=tid)
+        ts1 = json.loads(self.marker_path.read_text())["active_tentacles"][0]["ts"]
+
+        time.sleep(0.01)  # ensure ts advances
+
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("tent-x", [], "prompt", tentacle_id=tid)
+        data = json.loads(self.marker_path.read_text())
+        active = data["active_tentacles"]
+        self.assertEqual(len(active), 1, "No duplicate after re-dispatch")
+        # ts should be refreshed (numeric string comparison is enough as both are
+        # epoch-second strings; the second write happened strictly after the first)
+        self.assertGreaterEqual(active[0]["ts"], ts1)
+
+    # ── cmd_create collision avoidance ────────────────────────────────────────
+
+    def test_create_collision_produces_unique_dir(self):
+        """cmd_create on an existing name must NOT exit(1); it must create a unique dir."""
+        tentacles_dir = self.base / "tentacles"
+        tentacles_dir.mkdir(parents=True, exist_ok=True)
+        # Simulate existing tentacle dir
+        (tentacles_dir / "alpha").mkdir()
+
+        args = argparse.Namespace(
+            name="alpha",
+            desc="",
+            scope="",
+            briefing=False,
+            session_dir=str(self.base),
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=tentacles_dir):
+            T.cmd_create(args)  # Must not raise SystemExit
+
+        dirs = [d.name for d in tentacles_dir.iterdir() if d.is_dir()]
+        slug_dirs = [d for d in dirs if d.startswith("alpha-") and len(d) == len("alpha-") + 8]
+        self.assertTrue(len(slug_dirs) >= 1, f"Expected slug dir, got: {dirs}")
+
+    def test_create_collision_dir_is_usable(self):
+        """The collision-avoidance dir must contain CONTEXT.md and meta.json."""
+        tentacles_dir = self.base / "tentacles2"
+        tentacles_dir.mkdir(parents=True, exist_ok=True)
+        (tentacles_dir / "beta").mkdir()
+
+        args = argparse.Namespace(
+            name="beta",
+            desc="",
+            scope="",
+            briefing=False,
+            session_dir=str(self.base),
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=tentacles_dir):
+            T.cmd_create(args)
+
+        slug_dirs = [d for d in tentacles_dir.iterdir()
+                     if d.is_dir() and d.name.startswith("beta-")]
+        self.assertEqual(len(slug_dirs), 1)
+        slug_dir = slug_dirs[0]
+        self.assertTrue((slug_dir / "CONTEXT.md").exists())
+        self.assertTrue((slug_dir / "meta.json").exists())
+
+    def test_create_collision_preserves_logical_name_in_meta(self):
+        """meta.json must store the original logical name even after slug collision."""
+        tentacles_dir = self.base / "tentacles3"
+        tentacles_dir.mkdir(parents=True, exist_ok=True)
+        (tentacles_dir / "gamma").mkdir()
+
+        args = argparse.Namespace(
+            name="gamma",
+            desc="",
+            scope="",
+            briefing=False,
+            session_dir=str(self.base),
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=tentacles_dir):
+            T.cmd_create(args)
+
+        slug_dirs = [d for d in tentacles_dir.iterdir()
+                     if d.is_dir() and d.name.startswith("gamma-")]
+        meta = json.loads((slug_dirs[0] / "meta.json").read_text())
+        self.assertEqual(meta["name"], "gamma")
+        self.assertIn("dir_name", meta, "meta must record the actual dir name")
+        self.assertNotEqual(meta["dir_name"], "gamma")
+
+    def test_create_sets_tentacle_id_in_meta(self):
+        """Freshly created tentacle must have a non-empty tentacle_id in meta.json."""
+        tentacles_dir = self.base / "tentacles4"
+        tentacles_dir.mkdir(parents=True, exist_ok=True)
+
+        args = argparse.Namespace(
+            name="delta",
+            desc="",
+            scope="",
+            briefing=False,
+            session_dir=str(self.base),
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=tentacles_dir):
+            T.cmd_create(args)
+
+        meta = json.loads((tentacles_dir / "delta" / "meta.json").read_text())
+        self.assertIn("tentacle_id", meta)
+        # Must be a valid UUID4 (36 chars with hyphens)
+        self.assertEqual(len(meta["tentacle_id"]), 36)
+
+    # ── backward compat: old tentacle without tentacle_id ─────────────────────
+
+    def test_old_tentacle_without_tentacle_id_write_still_works(self):
+        """Calling _write_dispatched_subagent_marker without tentacle_id must succeed."""
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            result = T._write_dispatched_subagent_marker("legacy-tent", [], "prompt")
+        self.assertTrue(result)
+        self.assertTrue(self.marker_path.exists())
+
+    def test_old_tentacle_without_tentacle_id_clear_still_works(self):
+        """Calling _clear_dispatched_subagent_marker without tentacle_id must succeed."""
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("legacy-tent", [], "prompt")
+            result = T._clear_dispatched_subagent_marker("legacy-tent")
+        self.assertTrue(result)
+        self.assertFalse(self.marker_path.exists())
+
+    def test_get_marker_state_includes_tentacle_id_field(self):
+        """_get_marker_state entries must expose tentacle_id (None for old entries)."""
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("t1", [], "prompt", tentacle_id=tid)
+            # Old-style write without tentacle_id
+            T._write_dispatched_subagent_marker("t2", [], "prompt")
+        state = T._get_marker_state()
+        entries_by_name = {e["name"]: e for e in state["active_tentacle_entries"]}
+        self.assertEqual(entries_by_name["t1"]["tentacle_id"], tid)
+        self.assertIsNone(entries_by_name["t2"]["tentacle_id"])
+
+    # ── phase-4 cross-repo not regressed ─────────────────────────────────────
+
+    def test_phase4_cross_repo_not_regressed(self):
+        """Same name in different repos must still produce two separate entries."""
+        repo_a = self.base / "repo-a"
+        repo_b = self.base / "repo-b"
+        tid_a = str(uuid.uuid4())
+        tid_b = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("worker", [], "prompt", tentacle_id=tid_a)
+        with patch.object(T, "find_git_root", return_value=repo_b):
+            T._write_dispatched_subagent_marker("worker", [], "prompt", tentacle_id=tid_b)
+        data = json.loads(self.marker_path.read_text())
+        self.assertEqual(len(data["active_tentacles"]), 2)
+
+    def test_phase4_complete_only_clears_own_repo_entry(self):
+        """Completing in repo-A must not remove repo-B's same-named entry."""
+        repo_a = self.base / "repo-a"
+        repo_b = self.base / "repo-b"
+        tid_a = str(uuid.uuid4())
+        tid_b = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._write_dispatched_subagent_marker("worker", [], "prompt", tentacle_id=tid_a)
+        with patch.object(T, "find_git_root", return_value=repo_b):
+            T._write_dispatched_subagent_marker("worker", [], "prompt", tentacle_id=tid_b)
+        # Complete from repo_a perspective
+        with patch.object(T, "find_git_root", return_value=repo_a):
+            T._clear_dispatched_subagent_marker("worker", tentacle_id=tid_a)
+        data = json.loads(self.marker_path.read_text())
+        remaining = data["active_tentacles"]
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0]["tentacle_id"], tid_b)
+
+
+# ---------------------------------------------------------------------------
+# Cross-review bug fixes — regression tests
+# ---------------------------------------------------------------------------
+
+class TestCrossReviewFixes(unittest.TestCase):
+    """Regression tests for three cross-review findings.
+
+    Finding #1 (HIGH): legacy write/clear must not collide with phase-5 entries.
+    Finding #2 (MEDIUM): cmd_delete must clear the marker before deleting the dir.
+    Finding #3 is structural (__main__ guard at EOF) and has no runtime tests.
+    """
+
+    MARKER_NAME = "dispatched-subagent-active"
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "crossreview_tests"
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.marker_path = self.base / self.MARKER_NAME
+        self._orig_path = T._DISPATCHED_MARKER_PATH
+        T._DISPATCHED_MARKER_PATH = self.marker_path
+        self._orig_markers_dir = T.MARKERS_DIR
+        T.MARKERS_DIR = self.base
+        self.repo = self.base / "my-repo"
+
+    def tearDown(self):
+        T._DISPATCHED_MARKER_PATH = self._orig_path
+        T.MARKERS_DIR = self._orig_markers_dir
+        import shutil
+        if SCRATCH_DIR.exists():
+            shutil.rmtree(SCRATCH_DIR)
+
+    # ── Finding #1 write path ─────────────────────────────────────────────────
+
+    def test_legacy_write_does_not_overwrite_phase5_entry(self):
+        """A legacy dispatch (no tentacle_id) for the same (name, git_root) must NOT
+        overwrite an existing phase-5 entry — it must append a separate entry."""
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            # Phase-5 entry written first
+            T._write_dispatched_subagent_marker("work", [], "prompt", tentacle_id=tid)
+            # Legacy dispatch arrives for the same name/repo
+            T._write_dispatched_subagent_marker("work", [], "prompt")  # no tentacle_id
+        data = json.loads(self.marker_path.read_text())
+        entries = data["active_tentacles"]
+        # Both entries must coexist; phase-5 identity must be preserved
+        self.assertEqual(len(entries), 2, "Legacy write must not overwrite phase-5 entry")
+        ids = [e.get("tentacle_id") for e in entries]
+        self.assertIn(tid, ids, "Phase-5 tentacle_id must still be present")
+        self.assertIn(None, ids, "Legacy entry (no tentacle_id) must also be present")
+
+    def test_legacy_write_deduplicates_against_other_legacy_entries(self):
+        """Two legacy dispatches (no tentacle_id) for the same (name, git_root) still
+        produce a single entry — the original phase-4 dedup is preserved."""
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("work", [], "prompt")
+            T._write_dispatched_subagent_marker("work", [], "prompt")
+        data = json.loads(self.marker_path.read_text())
+        names = _names_from_entries(data["active_tentacles"])
+        self.assertEqual(names.count("work"), 1, "Two legacy writes must still dedup to one entry")
+
+    # ── Finding #1 clear path ─────────────────────────────────────────────────
+
+    def test_phase5_clear_does_not_remove_legacy_entry(self):
+        """A phase-5 complete (with tentacle_id) must not clear a legacy entry
+        (no tentacle_id) for the same (name, git_root) — that entry belongs to a
+        different, still-running old-code session."""
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            # Phase-5 entry + co-existing legacy entry
+            T._write_dispatched_subagent_marker("work", [], "prompt", tentacle_id=tid)
+            T._write_dispatched_subagent_marker("work", [], "prompt")
+        # Phase-5 tentacle completes
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._clear_dispatched_subagent_marker("work", tentacle_id=tid)
+        # Marker file must survive (legacy entry remains)
+        self.assertTrue(self.marker_path.is_file(), "Marker must not be deleted while legacy entry exists")
+        data = json.loads(self.marker_path.read_text())
+        remaining = data["active_tentacles"]
+        self.assertEqual(len(remaining), 1)
+        self.assertIsNone(remaining[0].get("tentacle_id"), "Only the legacy entry must remain")
+
+    def test_phase5_clear_only_its_own_entry_among_two_phase5(self):
+        """Two phase-5 tentacles: completing one must leave the other untouched."""
+        tid_a = str(uuid.uuid4())
+        tid_b = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("work", [], "prompt", tentacle_id=tid_a)
+            T._write_dispatched_subagent_marker("work", [], "prompt", tentacle_id=tid_b)
+            T._clear_dispatched_subagent_marker("work", tentacle_id=tid_a)
+        data = json.loads(self.marker_path.read_text())
+        ids = [e.get("tentacle_id") for e in data["active_tentacles"]]
+        self.assertNotIn(tid_a, ids)
+        self.assertIn(tid_b, ids)
+
+    def test_legacy_clear_still_works_for_legacy_entry(self):
+        """A legacy complete (no tentacle_id) must still remove a legacy entry."""
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("work", [], "prompt")
+            T._clear_dispatched_subagent_marker("work")  # no tentacle_id
+        self.assertFalse(self.marker_path.is_file())
+
+    def test_legacy_clear_does_not_remove_phase5_entry(self):
+        """A legacy clear (no tentacle_id) must NOT remove a phase-5 entry that carries
+        its own tentacle_id.  Without matching identity the caller cannot prove ownership
+        of the entry, so it is left alone (conservative protection)."""
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("work", [], "prompt", tentacle_id=tid)
+            T._clear_dispatched_subagent_marker("work")  # no tentacle_id — legacy clear
+        # Phase-5 entry must survive: legacy caller cannot prove it owns this entry
+        self.assertTrue(self.marker_path.is_file(),
+                        "Phase-5 entry must not be removed by a legacy clear")
+        data = json.loads(self.marker_path.read_text())
+        ids = [e.get("tentacle_id") for e in data["active_tentacles"]]
+        self.assertIn(tid, ids, "Phase-5 tentacle_id must still be in the active set")
+
+    # ── Finding #2: cmd_delete clears marker before deleting dir ─────────────
+
+    def test_delete_clears_active_marker_before_removing_dir(self):
+        """cmd_delete must remove the marker entry for the deleted tentacle."""
+        tentacles_dir = self.base / "tentacles_del"
+        tentacles_dir.mkdir(parents=True, exist_ok=True)
+        d = make_tentacle("del-test", tentacles_dir)
+        # Give the tentacle a tentacle_id
+        meta = json.loads((d / "meta.json").read_text())
+        tid = str(uuid.uuid4())
+        meta["tentacle_id"] = tid
+        (d / "meta.json").write_text(json.dumps(meta))
+        # Write an active marker entry for it
+        T._write_dispatched_subagent_marker("del-test", [], "prompt", tentacle_id=tid)
+        self.assertTrue(self.marker_path.is_file(), "Pre-condition: marker must exist")
+        # Delete the tentacle
+        args = fake_args(name="del-test")
+        with patch.object(T, "get_tentacles_dir", return_value=tentacles_dir):
+            with patch("builtins.print"):
+                T.cmd_delete(args)
+        # Marker must have been cleared
+        self.assertFalse(self.marker_path.is_file(), "Marker must be cleared by cmd_delete")
+
+    def test_delete_does_not_clear_sibling_marker_entry(self):
+        """cmd_delete must only clear the deleted tentacle's entry, not siblings."""
+        tentacles_dir = self.base / "tentacles_del2"
+        tentacles_dir.mkdir(parents=True, exist_ok=True)
+        d = make_tentacle("del-me", tentacles_dir)
+        meta = json.loads((d / "meta.json").read_text())
+        tid = str(uuid.uuid4())
+        meta["tentacle_id"] = tid
+        (d / "meta.json").write_text(json.dumps(meta))
+        T._write_dispatched_subagent_marker("del-me", [], "prompt", tentacle_id=tid)
+        # Sibling tentacle also active
+        sibling_tid = str(uuid.uuid4())
+        T._write_dispatched_subagent_marker("sibling", [], "prompt", tentacle_id=sibling_tid)
+        args = fake_args(name="del-me")
+        with patch.object(T, "get_tentacles_dir", return_value=tentacles_dir):
+            with patch("builtins.print"):
+                T.cmd_delete(args)
+        # Marker file must survive; sibling must still be active
+        self.assertTrue(self.marker_path.is_file(), "Marker must survive when sibling is active")
+        data = json.loads(self.marker_path.read_text())
+        ids = [e.get("tentacle_id") for e in data["active_tentacles"]]
+        self.assertIn(sibling_tid, ids, "Sibling entry must still be active")
+        self.assertNotIn(tid, ids, "Deleted tentacle's entry must be gone")
+
+    def test_delete_safe_when_no_active_marker(self):
+        """cmd_delete must succeed even when no active marker file exists."""
+        tentacles_dir = self.base / "tentacles_del3"
+        tentacles_dir.mkdir(parents=True, exist_ok=True)
+        make_tentacle("safe-del", tentacles_dir)
+        self.assertFalse(self.marker_path.is_file(), "Pre-condition: no marker")
+        args = fake_args(name="safe-del")
+        with patch.object(T, "get_tentacles_dir", return_value=tentacles_dir):
+            with patch("builtins.print"):
+                T.cmd_delete(args)  # Must not raise
+        self.assertFalse((tentacles_dir / "safe-del").exists())
+
+
+class TestMigrationCleanupGap(unittest.TestCase):
+    """Regression tests for the migration cleanup gap.
+
+    Scenario: a phase-4 dict entry {name, ts, git_root=/repo} with no tentacle_id
+    coexists with a new phase-5 dispatch for the same (name, git_root).  Without the
+    fix the stale phase-4 entry strands in the active set after the phase-5 complete
+    clears only its own identity-tagged entry, blocking commits until TTL expiry.
+    """
+
+    MARKER_NAME = "dispatched-subagent-active"
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "migration_cleanup_tests"
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.marker_path = self.base / self.MARKER_NAME
+        self._orig_path = T._DISPATCHED_MARKER_PATH
+        T._DISPATCHED_MARKER_PATH = self.marker_path
+        self._orig_markers_dir = T.MARKERS_DIR
+        T.MARKERS_DIR = self.base
+        self.repo = self.base / "my-repo"
+
+    def tearDown(self):
+        T._DISPATCHED_MARKER_PATH = self._orig_path
+        T.MARKERS_DIR = self._orig_markers_dir
+        import shutil
+        if SCRATCH_DIR.exists():
+            shutil.rmtree(SCRATCH_DIR)
+
+    def _write_phase4_entry(self, name, git_root):
+        """Directly inject a phase-4 style dict entry (no tentacle_id) into the marker."""
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "git_root": str(git_root),
+            "active_tentacles": [
+                {"name": name, "ts": str(int(time.time())), "git_root": str(git_root)},
+            ],
+        }))
+
+    # ── core gap fix ──────────────────────────────────────────────────────────
+
+    def test_phase5_dispatch_absorbs_stale_phase4_same_repo_entry(self):
+        """A phase-5 dispatch for the same (name, git_root) must absorb/remove a
+        pre-existing phase-4 entry (no tentacle_id) rather than coexisting with it."""
+        self._write_phase4_entry("feature-x", self.repo)
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt", tentacle_id=tid)
+        data = json.loads(self.marker_path.read_text())
+        entries = data["active_tentacles"]
+        self.assertEqual(
+            len(entries), 1,
+            "Phase-5 dispatch must absorb the stale phase-4 entry, leaving exactly one entry"
+        )
+        self.assertEqual(entries[0].get("tentacle_id"), tid,
+                         "The surviving entry must be the new phase-5 entry")
+
+    def test_phase5_complete_leaves_no_stale_phase4_entry(self):
+        """Full lifecycle: existing phase-4 entry → phase-5 dispatch → phase-5 complete
+        must leave the marker empty (no stranded entry)."""
+        self._write_phase4_entry("feature-x", self.repo)
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt", tentacle_id=tid)
+            T._clear_dispatched_subagent_marker("feature-x", tentacle_id=tid)
+        self.assertFalse(
+            self.marker_path.is_file(),
+            "Marker must be deleted after complete — no stale phase-4 entry should remain"
+        )
+
+    def test_phase5_dispatch_does_not_absorb_different_name_phase4_entry(self):
+        """Absorption must be scoped to the dispatching tentacle name only."""
+        self._write_phase4_entry("other-feature", self.repo)
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt", tentacle_id=tid)
+        data = json.loads(self.marker_path.read_text())
+        names = _names_from_entries(data["active_tentacles"])
+        self.assertIn("other-feature", names, "Unrelated phase-4 entry must not be touched")
+        self.assertIn("feature-x", names)
+        self.assertEqual(len(data["active_tentacles"]), 2)
+
+    def test_phase5_dispatch_does_not_absorb_different_repo_phase4_entry(self):
+        """Absorption must be scoped to the current repo only."""
+        other_repo = self.base / "other-repo"
+        self._write_phase4_entry("feature-x", other_repo)
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt", tentacle_id=tid)
+        data = json.loads(self.marker_path.read_text())
+        entries = data["active_tentacles"]
+        self.assertEqual(
+            len(entries), 2,
+            "Phase-4 entry from a different repo must NOT be absorbed"
+        )
+        git_roots = {e.get("git_root") for e in entries}
+        self.assertIn(str(other_repo), git_roots, "Other-repo entry must survive")
+        self.assertIn(str(self.repo), git_roots, "Current-repo entry must exist")
+
+    def test_legacy_dispatch_does_not_absorb_same_repo_phase4_entry(self):
+        """A legacy dispatch (no tentacle_id) must NOT absorb a same-name same-repo
+        phase-4 entry — that absorption is reserved for phase-5 dispatches only."""
+        self._write_phase4_entry("feature-x", self.repo)
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt")  # no tentacle_id
+        data = json.loads(self.marker_path.read_text())
+        names = _names_from_entries(data["active_tentacles"])
+        # Legacy dedup: same (name, git_root), no tentacle_id on either side → merge to 1
+        self.assertEqual(names.count("feature-x"), 1,
+                         "Legacy-on-phase-4 dedup must still collapse to a single entry")
+
+    def test_phase5_dispatch_does_not_absorb_phase4_entry_with_tentacle_id(self):
+        """A phase-4-shaped entry that already has a tentacle_id (edge case: partial
+        upgrade) must NOT be absorbed — it belongs to a live instance."""
+        sibling_tid = str(uuid.uuid4())
+        self.marker_path.write_text(json.dumps({
+            "name": self.MARKER_NAME,
+            "ts": str(int(time.time())),
+            "active_tentacles": [
+                {"name": "feature-x", "ts": str(int(time.time())),
+                 "git_root": str(self.repo), "tentacle_id": sibling_tid},
+            ],
+        }))
+        tid = str(uuid.uuid4())
+        with patch.object(T, "find_git_root", return_value=self.repo):
+            T._write_dispatched_subagent_marker("feature-x", [], "prompt", tentacle_id=tid)
+        data = json.loads(self.marker_path.read_text())
+        entries = data["active_tentacles"]
+        self.assertEqual(
+            len(entries), 2,
+            "Entry with tentacle_id must NOT be absorbed even if same (name, git_root)"
+        )
+        ids = {e.get("tentacle_id") for e in entries}
+        self.assertIn(sibling_tid, ids, "Sibling phase-5 entry must survive")
+        self.assertIn(tid, ids, "New phase-5 entry must be present")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- add `tentacle_id`-based same-repo tentacle session support
- fix mixed-format hook marker bypass
- clean up stale phase-4 same-repo entries during phase-5 dispatch
- align runtime/docs/tests around `tentacle_id` and phase attribution

## Verification
- runtime: 234 passed
- hooks: 408 passed
- final review: CLEAN

## Notes
- shared working tree/index is still not isolated; only marker/session identity collisions are addressed
- branch author/committer is `magicpro97 <linhnt99x@gmail.com>`