### PR TITLE
feat(sk): automate launcher rollout

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,10 @@
 # Copilot Instructions — copilot-session-knowledge
 
+## Short Command: `sk`
+
+> **`sk` is the preferred command** — a managed launcher/shim provisioned by the installer.
+> Check: `sk --help`. Not on PATH yet? Fall back to `python3 ~/.copilot/tools/<script>.py`.
+
 ## Agent Rules (MANDATORY)
 
 > **⚠️ These rules are NON-NEGOTIABLE.** Every agent (main, sub-agent, explore, task, general-purpose) MUST follow them. Violations = shipping broken code.
@@ -23,7 +28,8 @@
 Before starting any task that touches >1 file or involves unfamiliar code:
 
 ```bash
-python3 ~/.copilot/tools/briefing.py "your task description"
+sk briefing "your task description"
+# fallback: python3 ~/.copilot/tools/briefing.py "your task description"
 ```
 
 This surfaces past mistakes, proven patterns, and relevant decisions. Skip only for trivial changes (typo fix, renaming, formatting).
@@ -94,14 +100,14 @@ When running inside a tentacle (dispatched by the orchestrator via `tentacle.py`
 
 1. **Read the bundle first** — read `manifest.json`, `session-metadata.md`, `recall-pack.json`, and `instructions.md` from the bundle path before any edit.
 2. **Stay in scope** — only edit files listed in the tentacle's declared scope; write a scope escalation note to the handoff for any exception.
-3. **Mark todos as you complete them**: `python3 ~/.copilot/tools/tentacle.py todo <tentacle-name> done <index>`
+3. **Mark todos as you complete them**: `sk tentacle todo <tentacle-name> done <index>` (fallback: `python3 ~/.copilot/tools/tentacle.py todo <tentacle-name> done <index>`)
 4. **No git operations** — do NOT run `git commit` or `git push`; the orchestrator owns all git operations.
-5. **Write a structured handoff before stopping**: `python3 ~/.copilot/tools/tentacle.py handoff <tentacle-name> "<summary>" --status <STATUS> [--changed-file <path>] --learn`
+5. **Write a structured handoff before stopping**: `sk tentacle handoff <tentacle-name> "<summary>" --status <STATUS> [--changed-file <path>] --learn` (fallback: `python3 ~/.copilot/tools/tentacle.py handoff ...`)
 6. Use one of `DONE`, `BLOCKED`, `TOO_BIG`, `AMBIGUOUS`, or `REGRESSED` for `<STATUS>`. Add one `--changed-file` per modified file; omit it when no files changed. Handoff must list changed rules, source-of-truth file for each rule, and any remaining ambiguity.
 
 **Goal-loop (orchestrators only)** — after all tentacle handoffs pass verification gates, evaluate whether the overarching goal is met. If unmet, loop back to Phase 1 (new tentacles for remaining gaps). Only commit and close when success criteria are verifiably satisfied. Sub-agents report via handoff and stop; the orchestrator owns continuation. Record goal-eval evidence with `python3 ~/.copilot/tools/tentacle.py verify <name> "<check-command>" --label "goal-eval"`.
 
-See [docs/AGENT-RULES.md](../docs/AGENT-RULES.md) for the complete Rule 8 text and goal-loop pattern.
+See [docs/AGENT-RULES.md](../docs/AGENT-RULES.md) for the complete Rule 8 text and goal-loop pattern. Goal-eval: `sk tentacle verify <name> "<check-command>" --label "goal-eval"` (fallback: `python3 ~/.copilot/tools/tentacle.py verify ...`).
 
 > **Drift-lock:** `docs/AGENT-RULES.md` is the canonical source for all agent rules. This file (`copilot-instructions.md`) is the Copilot CLI runtime enforcement surface — keep it in sync with `docs/AGENT-RULES.md`. Changes to agent rules should be reflected in both places.
 
@@ -124,6 +130,7 @@ Hooks **fail-open**: if a hook crashes or is unavailable, the guarded operation 
 ```bash
 python3 test_security.py    # 11 security tests (SQL injection, pickle, locks, paths)
 python3 test_fixes.py       # 137 tests (noise filter, sub-agent, launchd, DB health)
+# sk has no shortcut for project-local test scripts — use python3 directly
 ```
 
 Python validation runs through `run_all_tests.py`, but individual files use a mix of the custom `test()` helper and `unittest`/`test_*` style. For `browse-ui/` or CI changes, also run the relevant `pnpm` gates (`typecheck`, `lint`, `format:check`, `test`, `build`, and `test:e2e` when intentionally validating that surface). Keep GitHub Actions CI green.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,18 +6,24 @@
 >
 > **Drift-lock:** `docs/AGENT-RULES.md` is the canonical source for all agent rules. This file is a concise summary — when in doubt, defer to `docs/AGENT-RULES.md`.
 
+## Short Command: `sk`
+
+> **`sk` is the preferred command** — a managed launcher/shim provisioned by the installer.
+> Check availability: `sk --help`. If not yet on PATH, fall back to `python3 ~/.copilot/tools/<script>.py`.
+> Full fallback paths always work; use them during bootstrap or in non-interactive environments.
+
 ## Mandatory Rules
 
 1. **Investigate before acting** — read target files with `grep`/`glob`/`view` before any edit; never modify without reading first.
-2. **Briefing before complex tasks** — run `python3 ~/.copilot/tools/briefing.py "<task>"` for tasks touching >1 file.
+2. **Briefing before complex tasks** — run `sk briefing "<task>"` for tasks touching >1 file. (fallback: `python3 ~/.copilot/tools/briefing.py "<task>"`)
 3. **Test after every change** — run `python3 test_security.py` and/or `python3 test_fixes.py` after Python edits; do not mark complete until tests pass.
 4. **Verify before committing** — AST-parse every modified `.py` file; run both test suites; `git diff --stat` before commit.
 5. **Sub-agent model selection** — use `claude-sonnet-4.6` for code generation; `claude-opus-4.6` for security audits; never dispatch sub-agents with the default (haiku) model for code changes.
 6. **No guessing** — verify table names, function signatures, and file paths from source; never assume.
 7. **Docs output quality** — distinguish Facts / Interpretation / Actions / Verification evidence; never present inference as fact; every action must include the executable command.
-8. **Tentacle execution obligations** — when dispatched inside a tentacle: (a) read bundle files first, (b) stay in declared scope, (c) mark todos done with `tentacle.py todo <name> done <index>`, (d) do NOT run `git commit`/`git push`, (e) write a structured handoff with explicit `--status` (`DONE`, `BLOCKED`, `TOO_BIG`, `AMBIGUOUS`, or `REGRESSED`) via `tentacle.py handoff <name> "<summary>" --status <STATUS> [--changed-file <path>] --learn` before stopping.
+8. **Tentacle execution obligations** — when dispatched inside a tentacle: (a) read bundle files first, (b) stay in declared scope, (c) mark todos done with `sk tentacle todo <name> done <index>`, (d) do NOT run `git commit`/`git push`, (e) write a structured handoff with explicit `--status` (`DONE`, `BLOCKED`, `TOO_BIG`, `AMBIGUOUS`, or `REGRESSED`) via `sk tentacle handoff <name> "<summary>" --status <STATUS> [--changed-file <path>] --learn` before stopping.
 
-**Goal-loop (orchestrators only)** — after all tentacle handoffs pass verification gates, evaluate whether the overarching goal is met. If unmet, loop back to Phase 1 (new tentacles for remaining gaps). Only commit and close when success criteria are verifiably satisfied. Sub-agents report via handoff and stop; orchestrators own continuation. Record goal-eval evidence with `tentacle.py verify <name> "<check-command>" --label "goal-eval"`.
+**Goal-loop (orchestrators only)** — after all tentacle handoffs pass verification gates, evaluate whether the overarching goal is met. If unmet, loop back to Phase 1 (new tentacles for remaining gaps). Only commit and close when success criteria are verifiably satisfied. Sub-agents report via handoff and stop; orchestrators own continuation. Record goal-eval evidence with `sk tentacle verify <name> "<check-command>" --label "goal-eval"`.
 
 See [docs/AGENT-RULES.md](docs/AGENT-RULES.md) for the complete rule text, goal-loop pattern, and hook-enforcement table.
 
@@ -56,7 +62,7 @@ For `browse-ui/` changes: `cd browse-ui && pnpm typecheck && pnpm lint && pnpm f
 - NEVER run `git commit` or `git push` as a dispatched sub-agent
 - NEVER modify files outside your declared tentacle scope without a scope escalation note in the handoff
 - ALWAYS use `O_CREAT | O_EXCL` for process locks (no TOCTOU races)
-- ALWAYS run `briefing.py` before starting work on unfamiliar code
+- ALWAYS run `sk briefing` before starting work on unfamiliar code (fallback: `python3 ~/.copilot/tools/briefing.py`)
 
 ## Hook Enforcement (Principle)
 

--- a/README.md
+++ b/README.md
@@ -41,22 +41,22 @@ Each Copilot CLI / Claude Code session accumulates valuable experience — bugs 
 This tool **indexes all session data** into SQLite FTS5, **auto-extracts knowledge** into 7 categories (mistakes, patterns, decisions, tools, features, refactors, discoveries), and provides **search + briefing** so your AI agent never forgets what it learned.
 
 ## Quick Start
-
 ```bash
 # 1. Clone
 git clone https://github.com/magicpro97/copilot-session-knowledge.git ~/.copilot/tools
 
 # 2. Build knowledge base
-python3 ~/.copilot/tools/build-session-index.py && python3 ~/.copilot/tools/extract-knowledge.py
+python3 ~/.copilot/tools/sk.py index build && python3 ~/.copilot/tools/sk.py index extract
+# (fallback: python3 ~/.copilot/tools/build-session-index.py && python3 ~/.copilot/tools/extract-knowledge.py)
 
 # 3. Get a briefing
-python3 ~/.copilot/tools/briefing.py "your task description"
+python3 ~/.copilot/tools/sk.py briefing "your task description"
+# (fallback: python3 ~/.copilot/tools/briefing.py "your task description")
 ```
-
+After `install.py --test` (full install), the `sk` launcher is on your PATH automatically. On Windows without a PATH update, use `python ~/.copilot/tools/sk.py`.
 That's it. Your AI agent now has memory across sessions.
 
 ## Installation
-
 > 📖 **Full install guide (all methods, verification, upgrade, uninstall):** [docs/INSTALL.md](docs/INSTALL.md)
 
 ### Prerequisites
@@ -74,32 +74,36 @@ python3 ~/.copilot/tools/build-session-index.py
 python3 ~/.copilot/tools/extract-knowledge.py
 python3 ~/.copilot/tools/migrate.py
 python3 ~/.copilot/tools/install.py --test
+# → sk launcher auto-provisioned on PATH
 
 # macOS: install LaunchAgents (auto-start watcher + daily auto-update)
 python3 ~/.copilot/tools/launchd/install-launchd.py
 ```
 
-### Alternative (manual copy)
-
-Use the canonical install guide for manual-copy installs and caveats:
+### Other install paths
 
 - [Method 2 — Manual Copy](docs/INSTALL.md#method-2--manual-copy)
-
-### Windows (PowerShell)
-
-Use the canonical install guide for the full Windows walkthrough:
-
 - [Method 3 — Windows (PowerShell)](docs/INSTALL.md#method-3--windows-powershell)
+- Windows / no-PATH fallback: `python3 ~/.copilot/tools/sk.py`
 
-### Aliases (optional)
-
-```bash
-alias qs='python3 ~/.copilot/tools/query-session.py'
-alias brief='python3 ~/.copilot/tools/briefing.py'
-alias learn='python3 ~/.copilot/tools/learn.py'
-```
+📖 **Full command surface:** [docs/USAGE.md — sk unified CLI](docs/USAGE.md#sk--unified-cli)
 
 ## Usage
+
+> 📖 **Full command reference with `sk` namespaces:** [docs/USAGE.md](docs/USAGE.md)
+
+`sk` is the unified CLI front door. Common commands:
+
+```bash
+sk briefing "task"
+sk query "error message"
+sk learn --mistake "..." "..."
+sk index build && sk index extract
+sk tentacle create <name> --scope "src/**/*.py" --desc "..."
+sk update && sk browse --port 8080 --token TOKEN
+```
+
+Each `sk` command delegates to the underlying script; all scripts remain directly invocable as a fallback. See [docs/USAGE.md#sk--unified-cli](docs/USAGE.md#sk--unified-cli) for all namespaces (`index`, `sync`, `checkpoint`, `profile`, `context`, `scout`).
 
 ### Briefing (before every task)
 
@@ -410,13 +414,12 @@ flowchart TD
 ## Auto-Update
 
 ```bash
-python3 ~/.copilot/tools/auto-update-tools.py           # Auto-update (24h cooldown)
-python3 ~/.copilot/tools/auto-update-tools.py --force    # Force update now
-python3 ~/.copilot/tools/auto-update-tools.py --doctor   # Health check
-python3 ~/.copilot/tools/auto-update-tools.py --restart-watch
-python3 ~/.copilot/tools/auto-update-tools.py --watch-status
-python3 ~/.copilot/tools/auto-update-tools.py --health-check
-python3 ~/.copilot/tools/auto-update-tools.py --audit-runtime
+sk update                  # Auto-update (24h cooldown)
+sk update --force          # Force update now
+sk update --doctor         # Health check
+sk update --restart-watch  # Restart watcher
+sk update --watch-status   # Watcher status
+# fallback: python3 ~/.copilot/tools/auto-update-tools.py [flags]
 ```
 
 Smart pipeline analyzes `git diff` to run only what changed. Post-merge hook auto-triggers on `git pull`.
@@ -543,7 +546,7 @@ A: `~/.copilot/session-state/knowledge.db` — a single SQLite file with FTS5 in
 A: Yes. All scripts include Windows encoding fixes. Use `python` instead of `python3`. See [Installation](#windows-powershell). POSIX-style home paths from Git Bash (`/c/Users/...`), WSL (`/mnt/c/...`), and Cygwin (`/cygdrive/c/...`) are automatically normalised to native Windows paths for marker lookups.
 
 **Q: How do I update?**
-A: `python3 ~/.copilot/tools/auto-update-tools.py --force` or just `git pull` (post-merge hook handles the rest).
+A: `sk update --force` or `git pull` (post-merge hook handles the rest).
 
 **Q: Will hooks crash my AI agent?**
 A: No. The unified hook runner uses fail-open architecture — if any rule crashes, it logs the error and allows the action to proceed.

--- a/auto-update-tools.py
+++ b/auto-update-tools.py
@@ -126,6 +126,7 @@ COVERAGE_MANIFEST: "dict[str, list[tuple[str, str]]]" = {
     "Hooks": [
         ("hooks/",               "all Python hook scripts — install.py --deploy-hooks; "
                                  "git hooks (pre-commit/pre-push): install.py --install-git-hooks per repo"),
+        (".github/hooks/",       "legacy fallback hook config source — deployed via install.py --deploy-hooks"),
         ("hooks/rules/",         "hook rule modules (auto-discovered by install.py)"),
     ],
     "Workflows": [
@@ -144,6 +145,9 @@ COVERAGE_MANIFEST: "dict[str, list[tuple[str, str]]]" = {
     "Other": [
         ("docs/",                "documentation"),
         ("presets/",             "preset configurations"),
+    ],
+    "Launcher": [
+        ("~/.copilot/bin/",      "managed sk launcher directory — refreshed on sk.py / install.py changes"),
     ],
 }
 
@@ -524,6 +528,7 @@ def classify_changes(old_sha: str, new_sha: str) -> dict:
         "templates":    [f for f in changed if f.startswith("templates/")],
         "skills":       [f for f in changed if f.startswith("skills/")],
         "hooks":        [f for f in changed if f.startswith("hooks/")],
+        "github_hooks": [f for f in changed if f.startswith(".github/hooks/")],
         "hooks_rules":  [f for f in changed if f.startswith("hooks/rules/")],
         "browse":       [f for f in changed if f.startswith("browse/")],
         "browse_ui":    [f for f in changed if f.startswith("browse-ui/") and not f.startswith("browse-ui/dist/")],
@@ -534,6 +539,20 @@ def classify_changes(old_sha: str, new_sha: str) -> dict:
         "migrate":      "migrate.py" in changed,
         "self_update":  "auto-update-tools.py" in changed,
         "watch_sessions": "watch-sessions.py" in changed,
+        "global_instructions": [
+            f for f in changed
+            if f == "templates/copilot-instructions.md"
+            or f == "templates/session-knowledge.instructions.md"
+            or f.startswith("templates/instructions/")
+        ],
+        "managed_hooks": [
+            f for f in changed
+            if f == "hooks/hooks.json"
+            or f == ".github/hooks/hooks.json"
+            or (f.startswith("hooks/") and f.endswith(".py"))
+        ],
+        # Refresh the managed sk launcher when sk.py or install.py changes
+        "sk_launcher":  any(f in changed for f in ("sk.py", "install.py")),
     }
 
 
@@ -593,29 +612,38 @@ def post_pull_pipeline(old_sha: str, new_sha: str):
         # auto-update deliberately does NOT auto-reinstall git hooks into other repos:
         # it has no registry of which repos have hooks installed, and silently modifying
         # .git/hooks/ in arbitrary repos would be unsafe.  Users must re-run install.py.
-        if changes.get("hooks"):
-            hook_files = [f for f in changes["hooks"]
+        if changes.get("managed_hooks"):
+            refresh_global_hooks()
+            hook_files = [f for f in changes["managed_hooks"]
                           if "pre-commit" in f or "pre-push" in f or "check_subagent" in f]
             if hook_files:
                 warn("Git hook scripts updated — installed per-repo hooks are NOT automatically refreshed.")
                 warn("ACTION REQUIRED to pick up the cross-repo isolation fix (and future hook changes):")
                 warn("  Re-run in EVERY protected repo: python3 ~/.copilot/tools/install.py --install-git-hooks")
 
-        # 4. Template/SKILL.md changed → redeploy
+        # 4. Instruction templates changed → redeploy global instructions
+        if changes.get("global_instructions"):
+            refresh_global_instructions()
+
+        # 5. Template/SKILL.md changed → redeploy
         if changes.get("templates") or changes.get("skills"):
             deploy_skills()
 
-        # 5. Python scripts changed → restart watcher service
+        # 6. Python scripts changed → restart watcher service
         if changes.get("py_scripts"):
             restart_processes()
 
-        # 6. Embedding logic changed → trigger rebuild (async, non-blocking)
+        # 7. Embedding logic changed → trigger rebuild (async, non-blocking)
         if changes.get("embed"):
             trigger_embedding_rebuild()
 
-        # 6b. browse-ui source changed → rebuild Next.js UI (dist/ must stay fresh)
+        # 7b. browse-ui source changed → rebuild Next.js UI (dist/ must stay fresh)
         if changes.get("browse_ui"):
             _rebuild_browse_ui()
+
+        # 7c. sk.py or install.py changed → refresh managed sk launcher
+        if changes.get("sk_launcher"):
+            refresh_sk_launcher()
 
         # 7. Install/update post-merge hook
         ensure_post_merge_hook()
@@ -638,7 +666,7 @@ def post_pull_pipeline(old_sha: str, new_sha: str):
             pass
     else:
         warn("Pipeline failed mid-run — some components may not be updated.")
-        warn("Run 'sk-update --force' to retry.")
+        warn("Run 'sk update --force' to retry.")
         try:
             _FAILED_MARKER = TOOLS_DIR / ".update-failed.json"
             _atomic_write_text(_FAILED_MARKER, json.dumps({
@@ -706,6 +734,60 @@ def _pnpm_cmd() -> list[str]:
     if shutil.which("corepack"):
         return ["corepack", "pnpm"]
     return ["pnpm"]  # will raise FileNotFoundError if neither is present
+
+
+# ---------------------------------------------------------------------------
+# Refresh managed install.py surfaces
+# ---------------------------------------------------------------------------
+def _refresh_via_install(flag: str, label: str, reason: str, timeout: int = 30) -> bool:
+    """Run install.py with a specific refresh flag, without cross-imports."""
+    install_script = TOOLS_DIR / "install.py"
+    if not install_script.exists():
+        warn(f"install.py not found — cannot refresh {label}")
+        return False
+    log(reason)
+    r = subprocess.run(
+        [sys.executable, str(install_script), flag, "--quiet"],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if r.returncode == 0:
+        ok(f"{label} refreshed")
+        return True
+    detail = (r.stderr or r.stdout).strip()
+    warn(f"{label} refresh failed: {detail[:200]}")
+    return False
+
+
+def refresh_sk_launcher():
+    """Refresh the managed sk launcher via install.py --install-sk --quiet."""
+    _refresh_via_install(
+        "--install-sk",
+        "sk launcher",
+        "sk.py or install.py changed — refreshing managed sk launcher...",
+        timeout=30,
+    )
+
+
+def refresh_global_instructions():
+    """Refresh managed global instructions from the current templates."""
+    _refresh_via_install(
+        "--deploy-instructions",
+        "global instructions",
+        "Instruction templates changed — refreshing managed global instructions...",
+        timeout=60,
+    )
+
+
+def refresh_global_hooks():
+    """Refresh managed Copilot CLI hook config from the current sources."""
+    _refresh_via_install(
+        "--deploy-hooks",
+        "global hooks",
+        "Hook config changed — refreshing managed Copilot hooks...",
+        timeout=60,
+    )
 
 
 def _rebuild_browse_ui():
@@ -899,7 +981,8 @@ def write_manifest(sha: str, changes: dict):
     manifest["changed_categories"] = {
         key: bool(changes.get(key))
         for key in ("browse", "browse_ui", "providers", "skills", "hooks", "hooks_rules",
-                    "scripts", "workflows", "launchd", "templates", "py_scripts")
+                    "scripts", "workflows", "launchd", "templates", "py_scripts",
+                    "sk_launcher")
         if key in changes
     }
     try:
@@ -1402,7 +1485,7 @@ def doctor():
         try:
             fdata = json.loads(_FAILED_MARKER.read_text(encoding="utf-8"))
             warn(f"Previous update incomplete (failed at {fdata.get('failed_at', '?')}). "
-                 "Run 'sk-update --force' to retry.")
+                 "Run 'sk update --force' to retry.")
             issues += 1
         except Exception:
             pass

--- a/docs/AGENT-RULES.md
+++ b/docs/AGENT-RULES.md
@@ -23,7 +23,8 @@
 Before starting any task that touches >1 file or involves unfamiliar code:
 
 ```bash
-python3 ~/.copilot/tools/briefing.py "your task description"
+sk briefing "your task description"
+# fallback: python3 ~/.copilot/tools/briefing.py "your task description"
 ```
 
 This surfaces past mistakes, proven patterns, and relevant decisions. Skip only for trivial changes (typo fix, renaming, formatting).
@@ -105,13 +106,16 @@ When running inside a tentacle (dispatched by the orchestrator via `tentacle.py`
 2. **Stay in scope** — only edit files listed in the tentacle's declared scope. Any edit outside that scope requires a scope escalation note written to the handoff before proceeding.
 3. **Mark todos as you complete them** — after completing each task:
    ```bash
-   python3 ~/.copilot/tools/tentacle.py todo <tentacle-name> done <index>
+   sk tentacle todo <tentacle-name> done <index>
+   # fallback: python3 ~/.copilot/tools/tentacle.py todo <tentacle-name> done <index>
    ```
 4. **No git operations** — do NOT run `git commit` or `git push`; the orchestrator owns all git operations.
 5. **Write a structured handoff before stopping**:
    ```bash
-   python3 ~/.copilot/tools/tentacle.py handoff <tentacle-name> "<summary>" \
+   sk tentacle handoff <tentacle-name> "<summary>" \
      --status <STATUS> [--changed-file <path>] --learn
+   # fallback: python3 ~/.copilot/tools/tentacle.py handoff <tentacle-name> "<summary>" \
+   #   --status <STATUS> [--changed-file <path>] --learn
    ```
    Use one of `DONE`, `BLOCKED`, `TOO_BIG`, `AMBIGUOUS`, or `REGRESSED` for `<STATUS>`. Add one `--changed-file` per modified file; omit it when no files changed. The handoff must list: which rules changed, which file is source of truth for each rule, and any remaining ambiguity.
 6. **Review-ready handoff** — the handoff must include enough detail for an independent reviewer to verify all claims independently.
@@ -127,7 +131,8 @@ When acting as an orchestrator with an active goal, the lifecycle is iterative, 
 1. **State success criteria upfront** — before dispatching any tentacle, write the goal's success criteria explicitly in `CONTEXT.md` or a shared artifact. Weak criteria ("make it work") prevent clean goal evaluation; strong criteria ("all 137 tests pass, benchmark score ≥ 90") enable independent verification.
 2. **Evaluate after each Verify phase** — once Build → Lint → Test → Review gates pass, evaluate whether the overarching goal is met. Record evidence:
    ```bash
-   python3 ~/.copilot/tools/tentacle.py verify <name> "<check-command>" --label "goal-eval"
+   sk tentacle verify <name> "<check-command>" --label "goal-eval"
+   # fallback: python3 ~/.copilot/tools/tentacle.py verify <name> "<check-command>" --label "goal-eval"
    ```
 3. **Loop if unmet** — if the goal is not satisfied, return to Phase 1 (Plan). Create new tentacles scoped to the remaining gap. Do not re-open completed tentacles; create new ones.
 4. **Close only when verified** — proceed to commit and close only when goal success criteria are verifiably met and evidence is recorded.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,8 @@
 
 This repo is a **set of standalone Python CLI scripts** — not a package or library. Each script is independently runnable, duplicates its own constants, and has no inter-script imports. This is intentional: the goal is operator-first simplicity, not framework cohesion.
 
+**`sk` thin front door:** `sk.py` is a thin dispatcher that maps memorable sub-commands (`sk briefing`, `sk query`, `sk index build`, …) to the underlying standalone scripts. It adds nothing to the data pipeline or business logic — it is purely a routing layer. After the standard install (`install.py --test`), a managed cross-platform `sk` launcher is provisioned automatically on your PATH — no manual alias or pip install needed. Windows PowerShell users without a PATH update can invoke `python ~/.copilot/tools/sk.py` directly as an equivalent fallback. All standalone scripts remain directly invocable as a fallback or for advanced use. The `sk` front door does not change the architectural contract below.
+
 ## Data Pipeline
 
 ```

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -186,11 +186,16 @@ Hook files are locked with OS immutable flags:
 - **Windows**: `attrib +R` — read-only (weaker)
 
 ```bash
-python3 ~/.copilot/tools/install.py --deploy-hooks       # Deploy Copilot CLI hooks
-python3 ~/.copilot/tools/install.py --lock-hooks          # Lock (AI can't modify)
-python3 ~/.copilot/tools/install.py --unlock-hooks        # Unlock for updates
-python3 ~/.copilot/tools/install.py --install-git-hooks   # Install pre-commit/pre-push into current repo
+sk install --deploy-hooks       # Deploy Copilot CLI hooks
+sk install --lock-hooks         # Lock (AI can't modify)
+sk install --unlock-hooks       # Unlock for updates
+sk install --install-git-hooks  # Install pre-commit/pre-push into current repo
+# fallback: python3 ~/.copilot/tools/install.py [flags]
 ```
+
+`~/.copilot/hooks/hooks.json` is treated as a **managed global file**. `sk update` may redeploy it
+from this repo when hook config changes; differing local content is backed up before overwrite, but
+long-lived customizations should live in source-controlled hook code instead of manual edits there.
 
 > **Note:** `--install-git-hooks` must be run separately per repository to install the git-level
 > subagent guard. It is not performed automatically by `--deploy-hooks`. Re-run after major tool
@@ -347,7 +352,8 @@ The git-level guard requires installation per repository:
 
 ```bash
 # Install into the current repo's .git/hooks/
-python3 ~/.copilot/tools/install.py --install-git-hooks
+sk install --install-git-hooks
+# fallback: python3 ~/.copilot/tools/install.py --install-git-hooks
 
 # On Windows (PowerShell)
 python "$env:USERPROFILE\.copilot\tools\install.py" --install-git-hooks
@@ -360,15 +366,15 @@ config to ensure the hooks fire even when a project-level override is present.
 > already exists in `.git/hooks/` and differs from the source, installation is skipped with a
 > warning. Back up the existing hook and re-run interactively to overwrite it.
 
-After tool updates (`git pull` or `auto-update-tools.py --force`), re-run
-`--install-git-hooks` to refresh the hook scripts in `.git/hooks/`. `auto-update-tools.py`
+After tool updates (`git pull` or `sk update --force`), re-run
+`sk install --install-git-hooks` to refresh the hook scripts in `.git/hooks/`. `sk update`
 does **not** perform this reinstallation automatically — it cannot safely enumerate every repo
 where hooks are installed. When hook files change, it emits these three warnings to stderr:
 
 ```
 [sk-update] ⚠️  Git hook scripts updated — installed per-repo hooks are NOT automatically refreshed.
 [sk-update] ⚠️  ACTION REQUIRED to pick up the cross-repo isolation fix (and future hook changes):
-[sk-update] ⚠️    Re-run in EVERY protected repo: python3 ~/.copilot/tools/install.py --install-git-hooks
+[sk-update] ⚠️    Re-run in EVERY protected repo: sk install --install-git-hooks
 ```
 
 ### Fail-open behavior
@@ -391,7 +397,7 @@ Enforcement surfaces are **selectively fail-open**. The behavior differs by erro
 To clear a stuck marker manually:
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py complete <name>
+sk tentacle complete <name>
 # or delete the marker file directly:
 rm ~/.copilot/markers/dispatched-subagent-active
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -31,9 +31,12 @@ python3 ~/.copilot/tools/extract-knowledge.py
 # 3. Apply DB migrations
 python3 ~/.copilot/tools/migrate.py
 
-# 4. Verify install
+# 4. Verify install — also auto-provisions the sk launcher on your PATH
 python3 ~/.copilot/tools/install.py --test
 ```
+
+After step 4, the `sk` launcher is available on your PATH. Verify with `sk --help`.
+On Windows PowerShell without a PATH update, run `python ~/.copilot/tools/sk.py` as the equivalent fallback.
 
 ### macOS — LaunchAgent (auto-start on login)
 
@@ -79,19 +82,64 @@ python "$env:USERPROFILE\.copilot\tools\migrate.py"
 
 ---
 
+## Method 4 — Alternative: editable pip install
+
+The standard install auto-provisions `sk` via the launcher. Use this method only if you need a formal console-script entry point (e.g., system-wide packaging or non-standard PATH environments).
+
+```bash
+git clone https://github.com/magicpro97/copilot-session-knowledge.git ~/.copilot/tools
+python3 -m pip install -e ~/.copilot/tools
+
+# Now the unified front door is available as a pip-registered console command
+sk briefing "test query"
+sk index status
+```
+
+Notes:
+- This is additive. All direct `python3 ~/.copilot/tools/<script>.py` workflows still work.
+- If you move the repo later, reinstall or set `SK_TOOLS_DIR=/new/path/to/copilot-session-knowledge`.
+- Before removing the checkout, run `python3 -m pip uninstall copilot-session-knowledge` so the pip-registered `sk` wrapper is removed cleanly.
+- For most users, the auto-provisioned launcher from Method 1 is sufficient; this method adds pip packaging overhead.
+
+---
+
 ## Post-Install Verification
 
 ```bash
 # Check index status
-python3 ~/.copilot/tools/index-status.py
+sk index status
 
 # Get a test briefing
-python3 ~/.copilot/tools/briefing.py "test query"
+sk briefing "test query"
 
 # Run the test suites
 python3 ~/.copilot/tools/test_security.py
 python3 ~/.copilot/tools/test_fixes.py
 ```
+
+---
+
+## The `sk` Unified CLI
+
+After the standard install (`install.py --test`), the `sk` command is automatically available on your PATH:
+
+```bash
+sk briefing "your task"
+sk index build && sk index extract
+sk query "docker error"
+```
+
+`sk` is a thin dispatcher — it routes sub-commands to the underlying standalone scripts without adding business logic. All scripts remain directly invocable as a fallback.
+
+### When to use `sk` vs direct scripts
+
+| Situation | Recommended |
+|-----------|-------------|
+| Day-to-day usage after standard install | `sk <command>` |
+| Passing extra flags not yet surfaced by `sk` | `python3 ~/.copilot/tools/<script>.py <flags>` |
+| CI / automation pipelines (explicit, reproducible) | Direct script invocation |
+| Windows (PowerShell, no PATH update) | `python ~/.copilot/tools/sk.py <command>` |
+| Debugging a specific script | Direct script invocation |
 
 ---
 
@@ -134,14 +182,23 @@ python3 ~/.copilot/tools/setup-project.py --profile fullstack   # Full-stack web
 
 ---
 
-## Shell Aliases (optional, recommended)
+## Shell Aliases (optional — fallback for non-standard environments)
+
+The `sk` launcher is provisioned automatically by the standard install. Shell aliases below are useful if the launcher is unavailable (e.g., non-standard PATH on some shells, Windows without a PATH update, or minimal CI environments).
 
 ```bash
-# Add to ~/.bashrc or ~/.zshrc
+# Add to ~/.bashrc or ~/.zshrc (optional backup)
+
+# Unified sk front door
+alias sk='python3 ~/.copilot/tools/sk.py'
+
+# Legacy per-script aliases (still work; use sk above if available)
 alias qs='python3 ~/.copilot/tools/query-session.py'
 alias brief='python3 ~/.copilot/tools/briefing.py'
 alias learn='python3 ~/.copilot/tools/learn.py'
 ```
+
+With the `sk` alias you can run: `sk briefing "task"`, `sk query "docker"`, `sk index build`, etc. See [docs/USAGE.md](USAGE.md#sk--unified-cli) for the full command surface.
 
 ---
 
@@ -149,16 +206,16 @@ alias learn='python3 ~/.copilot/tools/learn.py'
 
 ```bash
 # Auto-update (24h cooldown)
-python3 ~/.copilot/tools/auto-update-tools.py
+sk update
 
 # Force update now
-python3 ~/.copilot/tools/auto-update-tools.py --force
+sk update --force
 
 # Or: plain git pull (post-merge hook runs the update pipeline automatically)
 cd ~/.copilot/tools && git pull
 ```
 
-> **After tool updates:** re-run `python3 ~/.copilot/tools/install.py --install-git-hooks` in every protected repo to refresh the per-repo git hooks.
+> **After tool updates:** the `sk` launcher stays current automatically (it points to the checkout). Re-run `sk install --install-git-hooks` in every protected repo to refresh per-repo git hooks.
 
 ---
 
@@ -187,8 +244,15 @@ python3 ~/.copilot/tools/sync-daemon.py --daemon
 ## Uninstall
 
 ```bash
-# Remove tools
-rm -rf ~/.copilot/tools/
+# Remove the sk launcher (auto-provisioned by install.py --test)
+python3 ~/.copilot/tools/install.py --uninstall-launcher 2>/dev/null || true
+
+# If you also used the editable pip install, remove that console command
+python3 -m pip uninstall copilot-session-knowledge 2>/dev/null || true
+
+# Then remove tools
+python3 ~/.copilot/tools/install.py --uninstall
+# or: rm -rf ~/.copilot/tools/
 
 # Remove knowledge DB (data loss — back up first)
 rm ~/.copilot/session-state/knowledge.db

--- a/docs/OPERATOR-PLAYBOOK.md
+++ b/docs/OPERATOR-PLAYBOOK.md
@@ -7,28 +7,32 @@
 ### Knowledge base health
 
 ```bash
-python3 ~/.copilot/tools/index-status.py              # Row counts, FTS integrity, event-offset coverage
-python3 ~/.copilot/tools/knowledge-health.py           # Full health dashboard
-python3 ~/.copilot/tools/knowledge-health.py --recall  # Recall-only telemetry
-python3 ~/.copilot/tools/knowledge-health.py --recall --json  # Machine-readable recall stats
+sk index status                        # Row counts, FTS integrity, event-offset coverage
+sk index health                        # Full health dashboard
+sk index health --recall               # Recall-only telemetry
+sk index health --recall --json        # Machine-readable recall stats
+# fallback: python3 ~/.copilot/tools/index-status.py
+# fallback: python3 ~/.copilot/tools/knowledge-health.py [--recall] [--json]
 ```
 
 ### Sync health
 
 ```bash
-python3 ~/.copilot/tools/sync-status.py               # Local sync state summary
-python3 ~/.copilot/tools/sync-status.py --health-check --json  # Exit 0/2 health check
-python3 ~/.copilot/tools/sync-status.py --audit --json         # Detailed audit
-python3 ~/.copilot/tools/sync-status.py --watch-status --json  # File-watcher status
+sk sync status                                  # Local sync state summary
+sk sync status --health-check --json            # Exit 0/2 health check
+sk sync status --audit --json                   # Detailed audit
+sk sync status --watch-status --json            # File-watcher status
+# fallback: python3 ~/.copilot/tools/sync-status.py [--health-check|--audit|--watch-status] [--json]
 ```
 
 ### Runtime health
 
 ```bash
-python3 ~/.copilot/tools/auto-update-tools.py --doctor        # Auto-update pipeline health
-python3 ~/.copilot/tools/auto-update-tools.py --watch-status  # Watcher daemon status
-python3 ~/.copilot/tools/auto-update-tools.py --health-check  # Exit-code health check
-python3 ~/.copilot/tools/auto-update-tools.py --audit-runtime # Runtime audit
+sk update --doctor                     # Auto-update pipeline health
+sk update --watch-status               # Watcher daemon status
+sk update --health-check               # Exit-code health check
+sk update --audit-runtime              # Runtime audit
+# fallback: python3 ~/.copilot/tools/auto-update-tools.py [--doctor|--watch-status|...]
 ```
 
 ---
@@ -36,14 +40,15 @@ python3 ~/.copilot/tools/auto-update-tools.py --audit-runtime # Runtime audit
 ## Auto-Update
 
 ```bash
-python3 ~/.copilot/tools/auto-update-tools.py          # Auto-update (24h cooldown)
-python3 ~/.copilot/tools/auto-update-tools.py --force  # Force update now
-python3 ~/.copilot/tools/auto-update-tools.py --restart-watch  # Restart watcher daemon
+sk update                  # Auto-update (24h cooldown)
+sk update --force          # Force update now
+sk update --restart-watch  # Restart watcher daemon
+# fallback: python3 ~/.copilot/tools/auto-update-tools.py [--force|--restart-watch]
 ```
 
 The smart pipeline analyzes `git diff` to run only what changed. The post-merge hook auto-triggers on `git pull`.
 
-> **After major updates:** re-run `python3 ~/.copilot/tools/install.py --install-git-hooks` in every protected repo to refresh per-repo git hooks.
+> **After major updates:** re-run `sk install --install-git-hooks` in every protected repo to refresh per-repo git hooks.
 
 📖 Full auto-update reference: [docs/AUTO-UPDATE.md](AUTO-UPDATE.md)
 
@@ -53,16 +58,17 @@ The smart pipeline analyzes `git diff` to run only what changed. The post-merge 
 
 ```bash
 # Deploy / re-deploy hooks
-python3 ~/.copilot/tools/install.py --deploy-hooks
+sk install --deploy-hooks
 
 # Lock hooks against AI modification (OS immutable flags)
-python3 ~/.copilot/tools/install.py --lock-hooks
+sk install --lock-hooks
 
 # Unlock for updates
-python3 ~/.copilot/tools/install.py --unlock-hooks
+sk install --unlock-hooks
 
 # Install per-repo git-level subagent guard
-python3 ~/.copilot/tools/install.py --install-git-hooks
+sk install --install-git-hooks
+# fallback: python3 ~/.copilot/tools/install.py [--deploy-hooks|--lock-hooks|--unlock-hooks|--install-git-hooks]
 ```
 
 ### Dry-run mode
@@ -86,7 +92,8 @@ tail -f ~/.copilot/markers/audit.jsonl
 ## DB Migrations
 
 ```bash
-python3 ~/.copilot/tools/migrate.py     # Apply all pending migrations
+sk index migrate     # Apply all pending migrations
+# fallback: python3 ~/.copilot/tools/migrate.py
 ```
 
 Migrations are versioned in `migrate.py`'s `MIGRATIONS` list. Running `migrate.py` is idempotent — it only applies migrations not already applied.
@@ -105,7 +112,7 @@ python3 ~/.copilot/tools/watch-sessions.py
 launchctl load ~/Library/LaunchAgents/com.copilot.watch-sessions.plist
 
 # Restart via auto-update operator surface
-python3 ~/.copilot/tools/auto-update-tools.py --restart-watch
+sk update --restart-watch
 ```
 
 The watcher uses adaptive polling: 5 s / 30 s / 300 s tiers based on session activity.
@@ -119,9 +126,10 @@ The watcher uses adaptive polling: 5 s / 30 s / 300 s tiers based on session act
 If `copilot update` fails with `ENOENT` or `EPERM` on a rename inside `pkg/universal/`:
 
 ```bash
-python3 ~/.copilot/tools/copilot-cli-healer.py --status   # Diagnose
-python3 ~/.copilot/tools/copilot-cli-healer.py --heal     # Fix
-python3 ~/.copilot/tools/copilot-cli-healer.py --update   # Heal + retry copilot update
+sk heal --status   # Diagnose
+sk heal --heal     # Fix
+sk heal --update   # Heal + retry copilot update
+# fallback: python3 ~/.copilot/tools/copilot-cli-healer.py [--status|--heal|--update]
 ```
 
 Root cause: upstream Node updater calls `fs.rename(src, dst)` without checking that `src` exists, leaving stale `.replaced-*` dirs behind.
@@ -129,9 +137,9 @@ Root cause: upstream Node updater calls `fs.rename(src, dst)` without checking t
 Prevent recurrence by scheduling a daily heal:
 
 ```bash
-python3 ~/.copilot/tools/copilot-cli-healer.py --install-schedule
+sk heal --install-schedule
 # or:
-python3 ~/.copilot/tools/install.py --install-healer
+sk install --install-healer
 ```
 
 📖 Details: [docs/copilot-cli-healer.md](copilot-cli-healer.md)
@@ -142,7 +150,7 @@ If `git commit` is blocked by a stale `dispatched-subagent-active` marker:
 
 ```bash
 # Preferred: complete the tentacle cleanly
-python3 ~/.copilot/tools/tentacle.py complete <name>
+sk tentacle complete <name>
 
 # Emergency: remove marker directly
 rm ~/.copilot/markers/dispatched-subagent-active
@@ -153,16 +161,19 @@ Markers expire automatically after 4 hours (TTL dead-man switch). After clearing
 ### FTS integrity errors
 
 ```bash
-python3 ~/.copilot/tools/index-status.py   # Check FTS integrity
-python3 ~/.copilot/tools/build-session-index.py  # Rebuild index
+sk index status            # Check FTS integrity
+sk index build             # Rebuild index
 ```
 
 ### Sync not working
 
 ```bash
-python3 ~/.copilot/tools/sync-config.py --status --json  # Check config
-python3 ~/.copilot/tools/sync-status.py --health-check   # Health check
-python3 ~/.copilot/tools/sync-daemon.py --once           # Manual one-shot sync
+sk sync config --status --json   # Check config
+sk sync status --health-check    # Health check
+sk sync run --once               # Manual one-shot sync
+# fallback: python3 ~/.copilot/tools/sync-config.py --status --json
+# fallback: python3 ~/.copilot/tools/sync-status.py --health-check
+# fallback: python3 ~/.copilot/tools/sync-daemon.py --once
 ```
 
 Common issues:
@@ -174,14 +185,14 @@ Common issues:
 
 ```bash
 # Trigger a manual re-index
-python3 ~/.copilot/tools/build-session-index.py
-python3 ~/.copilot/tools/extract-knowledge.py
+sk index build
+sk index extract
 ```
 
 If running in watch mode, check watcher status:
 
 ```bash
-python3 ~/.copilot/tools/auto-update-tools.py --watch-status
+sk update --watch-status
 ```
 
 ---
@@ -239,18 +250,17 @@ git diff --stat
 
 ```bash
 # Save a checkpoint
-python3 ~/.copilot/tools/checkpoint-save.py --title "Auth done" --overview "JWT added"
+sk checkpoint save --title "Auth done" --overview "JWT added"
 
 # List checkpoints
-python3 ~/.copilot/tools/checkpoint-restore.py --list
+sk checkpoint restore --list
 
 # Restore / inspect
-python3 ~/.copilot/tools/checkpoint-restore.py --show latest
-python3 ~/.copilot/tools/checkpoint-restore.py --export latest --format json
+sk checkpoint restore --show latest
 
 # Diff checkpoints
-python3 ~/.copilot/tools/checkpoint-diff.py --from 1 --to latest
-python3 ~/.copilot/tools/checkpoint-diff.py --summary
+sk checkpoint diff --from 1 --to latest
+# fallback: python3 ~/.copilot/tools/checkpoint-save.py / checkpoint-restore.py / checkpoint-diff.py
 ```
 
 Hooks **never** auto-save checkpoints. Save them manually at meaningful milestones.
@@ -261,20 +271,19 @@ Hooks **never** auto-save checkpoints. Save them manually at meaningful mileston
 
 ```bash
 # Dashboard: all tentacles and states
-python3 ~/.copilot/tools/tentacle.py status
+sk tentacle status
 
 # Next step for a specific tentacle
-python3 ~/.copilot/tools/tentacle.py next-step <name>
-python3 ~/.copilot/tools/tentacle.py next-step <name> --all     # All pending todos
-python3 ~/.copilot/tools/tentacle.py next-step <name> --format json
+sk tentacle next-step <name>
+sk tentacle next-step <name> --all     # All pending todos
 
 # Verify and close
-python3 ~/.copilot/tools/tentacle.py verify <name> "python3 test_fixes.py" --label "tests"
-python3 ~/.copilot/tools/tentacle.py handoff <name> "Summary" --learn
-python3 ~/.copilot/tools/tentacle.py complete <name>
+sk tentacle verify <name> "python3 test_fixes.py" --label "tests"
+sk tentacle handoff <name> "Summary" --learn
+sk tentacle complete <name>
 # Or: combine verify + complete in one step (fail-open)
-python3 ~/.copilot/tools/tentacle.py complete <name> --auto-verify "python3 test_fixes.py"
-python3 ~/.copilot/tools/tentacle.py complete <name> --auto-verify "python3 test_fixes.py" --auto-verify-timeout 180
+sk tentacle complete <name> --auto-verify "python3 test_fixes.py"
+# fallback: python3 ~/.copilot/tools/tentacle.py [status|next-step|verify|handoff|complete] ...
 ```
 
 > Full tentacle workflow: **[docs/USAGE.md](USAGE.md#tentacle-orchestration)**
@@ -722,16 +731,17 @@ and a tentacle-handoff hint.
 
 ```bash
 # Combine with --search-only --dry-run for a safe local preview (no network writes)
-python3 ~/.copilot/tools/trend-scout.py --search-only --dry-run --research-pack
+sk scout run --search-only --dry-run --research-pack
 
 # Combine with --explain for full explainability coverage
-python3 ~/.copilot/tools/trend-scout.py --search-only --dry-run --research-pack --explain
+sk scout run --search-only --dry-run --research-pack --explain
 
 # Full pipeline run with research pack written after issue creation
-python3 ~/.copilot/tools/trend-scout.py --research-pack
+sk scout run --research-pack
 
 # Custom output path
-python3 ~/.copilot/tools/trend-scout.py --research-pack --research-pack-output my-pack.json
+sk scout run --research-pack --research-pack-output my-pack.json
+# fallback: python3 ~/.copilot/tools/trend-scout.py [flags]
 ```
 
 The artifact is written to `.trend-scout-research-pack.json` adjacent to the script.
@@ -798,19 +808,20 @@ View the composite operator score across knowledge, skills, hooks, and git signa
 
 ```bash
 # CLI — full text report
-python3 ~/.copilot/tools/retro.py
+sk retro
 
 # Repo-only (safe in CI; no local DB needed)
-python3 ~/.copilot/tools/retro.py --mode repo
+sk retro --mode repo
 
 # JSON payload (stable contract consumed by the browse API)
-python3 ~/.copilot/tools/retro.py --json
+sk retro --json
 
 # Single score line
-python3 ~/.copilot/tools/retro.py --score
+sk retro --score
 
 # One section only: knowledge | skills | hooks | git | behavior (local mode)
-python3 ~/.copilot/tools/retro.py --subreport knowledge
+sk retro --subreport knowledge
+# fallback: python3 ~/.copilot/tools/retro.py [flags]
 ```
 
 ### Local vs CI (repo-mode) retro
@@ -833,13 +844,14 @@ Record commit-keyed snapshots so hardening work is tied to measurable deltas.
 
 ```bash
 # Record the current snapshot into benchmark_snapshots
-python3 ~/.copilot/tools/benchmark.py record
+sk benchmark record
 
 # Inspect recent snapshots
-python3 ~/.copilot/tools/benchmark.py list --limit 5
+sk benchmark list --limit 5
 
 # Compare two commits or snapshot IDs
-python3 ~/.copilot/tools/benchmark.py compare --commits <older> <newer>
+sk benchmark compare --commits <older> <newer>
+# fallback: python3 ~/.copilot/tools/benchmark.py [record|list|compare] [flags]
 ```
 
 `benchmark.py` stores snapshots in `benchmark_snapshots` inside the default knowledge DB unless
@@ -899,7 +911,7 @@ signals such as command-execution breadth.  Available in the full local report o
 standalone subreport:
 
 ```bash
-python3 ~/.copilot/tools/retro.py --subreport behavior
+sk retro --subreport behavior
 ```
 
 **Skills subscore — verification evidence discipline:**
@@ -913,9 +925,9 @@ To raise the skills subscore above sub-neutral: complete tentacles with an expli
 verification step so that `tentacle_verifications` rows are populated:
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py verify <name> "python3 test_fixes.py" --label "tests"
+sk tentacle verify <name> "python3 test_fixes.py" --label "tests"
 # Or in one step with complete --auto-verify (Wave 3; fail-open):
-python3 ~/.copilot/tools/tentacle.py complete <name> --auto-verify "python3 test_fixes.py"
+sk tentacle complete <name> --auto-verify "python3 test_fixes.py"
 ```
 
 **Recorded baseline (commit `2850fe12153f`):** repo retro `83.3`, local retro `61.5`,
@@ -932,7 +944,7 @@ migration and recurrence reward.  **Remaining gaps still requiring operator acti
 | Gap | Current (live, pre-commit) | How to close |
 |-----|--------------------------|-------------|
 | `behavior.completion_rate` / `efficiency_ratio` | Low (in `37.2` composite) | Complete more tentacles with verified outcomes; increase session-to-commit cadence |
-| `knowledge.embed_pct` | Below target | Run `python3 ~/.copilot/tools/embed.py` to populate embeddings |
+| `knowledge.embed_pct` | Below target | Run `sk index embed` to populate embeddings |
 | `health.relation_density` | Below target | Extract-knowledge run on larger session corpus grows relations |
 | `health.embedding_coverage` | Below target | Same as embed_pct — run `embed.py` after re-indexing |
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -85,13 +85,14 @@ python3 ~/.copilot/tools/hooks/lint-skills.py /path/to/project
 ## Project Setup
 
 ```bash
-python3 ~/.copilot/tools/setup-project.py              # Full setup
-python3 ~/.copilot/tools/setup-project.py --skill-only  # Skills only
-python3 ~/.copilot/tools/setup-project.py --dry-run     # Dry run
-python3 ~/.copilot/tools/setup-project.py --profile python      # Python hooks + WORKFLOW.md
-python3 ~/.copilot/tools/setup-project.py --profile typescript  # TypeScript hooks + WORKFLOW.md
-python3 ~/.copilot/tools/setup-project.py --profile mobile      # Android/iOS/KMP hooks + WORKFLOW.md
-python3 ~/.copilot/tools/setup-project.py --profile fullstack   # Full-stack web hooks + WORKFLOW.md
+sk setup              # Full setup (setup-project.py)
+sk setup --skill-only  # Skills only
+sk setup --dry-run     # Dry run
+sk setup --profile python      # Python hooks + WORKFLOW.md
+sk setup --profile typescript  # TypeScript hooks + WORKFLOW.md
+sk setup --profile mobile      # Android/iOS/KMP hooks + WORKFLOW.md
+sk setup --profile fullstack   # Full-stack web hooks + WORKFLOW.md
+# fallback: python3 ~/.copilot/tools/setup-project.py [flags]
 ```
 
 `--profile` installs a **preset hook bundle** and generates a starter `WORKFLOW.md`. Available
@@ -117,13 +118,14 @@ deployment to `.github/skills/<skill-name>/`.
 Use `profile-builder.py` to build a new profile and save it to `presets/`:
 
 ```bash
-python3 ~/.copilot/tools/profile-builder.py --list-hooks          # List available hook templates
-python3 ~/.copilot/tools/profile-builder.py --list-phases         # List available workflow phases
-python3 ~/.copilot/tools/profile-builder.py \
+sk profile build --list-hooks          # List available hook templates (profile-builder.py)
+sk profile build --list-phases         # List available workflow phases
+sk profile build \
   --name myteam \
   --description "My team workflow" \
   --hooks dangerous-blocker.py commit-gate.py \
   --phases CLARIFY BUILD TEST COMMIT
+# fallback: python3 ~/.copilot/tools/profile-builder.py [flags]
 ```
 
 ### Sharing profiles (export / import)
@@ -131,17 +133,19 @@ python3 ~/.copilot/tools/profile-builder.py \
 Export profiles to JSON for sharing across machines or teams:
 
 ```bash
-python3 ~/.copilot/tools/profile-export.py --profile python --output python.json
-python3 ~/.copilot/tools/profile-export.py --all --output-dir ./exported/
-python3 ~/.copilot/tools/profile-export.py --all --output all.bundle.json --format bundle
+sk profile export --profile python --output python.json
+sk profile export --all --output-dir ./exported/
+sk profile export --all --output all.bundle.json --format bundle
+# fallback: python3 ~/.copilot/tools/profile-export.py [flags]
 ```
 
 Import profiles shared by others:
 
 ```bash
-python3 ~/.copilot/tools/profile-import.py --file custom-profile.json
-python3 ~/.copilot/tools/profile-import.py --file bundle.json --name python  # one from bundle
-python3 ~/.copilot/tools/profile-import.py --file custom.json --dry-run      # validate first
+sk profile import --file custom-profile.json
+sk profile import --file bundle.json --name python  # one from bundle
+sk profile import --file custom.json --dry-run      # validate first
+# fallback: python3 ~/.copilot/tools/profile-import.py [flags]
 ```
 
 ### Installing hooks standalone

--- a/docs/SYNC-MATRIX.md
+++ b/docs/SYNC-MATRIX.md
@@ -27,10 +27,10 @@ Run through this before calling `task_complete`:
 
 ```
 1. Docs         — did behavior change? update docs/ accordingly
-2. Memory       — record mistakes / patterns: python3 ~/.copilot/tools/learn.py
-3. Handoff      — if inside a tentacle: tentacle.py handoff <name> "<summary>" --status <STATUS> [--changed-file <path>] --learn
+2. Memory       — record mistakes / patterns: sk learn
+3. Handoff      — if inside a tentacle: sk tentacle handoff <name> "<summary>" --status <STATUS> [--changed-file <path>] --learn
 4. Tests        — run tests for any changed Python files
-5. Sync          — if sync config or runtime changed: python3 sync-status.py --health-check
+5. Sync          — if sync config or runtime changed: sk sync status --health-check
 ```
 
 ---
@@ -40,10 +40,10 @@ Run through this before calling `task_complete`:
 Optional hygiene at session end:
 
 ```
-1. Index new sessions  — python3 ~/.copilot/tools/build-session-index.py
-2. Extract knowledge   — python3 ~/.copilot/tools/extract-knowledge.py
+1. Index new sessions  — sk index build
+2. Extract knowledge   — sk index extract
 3. Stale doc audit     — are any docs now outdated?
-4. Open tentacles      — python3 ~/.copilot/tools/tentacle.py status
+4. Open tentacles      — sk tentacle status
 ```
 
 ---
@@ -52,11 +52,11 @@ Optional hygiene at session end:
 
 | Surface | Command |
 |---|---|
-| Knowledge briefing | `python3 ~/.copilot/tools/briefing.py "<task>"` |
-| Record a learning | `python3 ~/.copilot/tools/learn.py` |
-| Sync runtime status | `python3 ~/.copilot/tools/sync-status.py --health-check` |
-| Knowledge insights | `python3 ~/.copilot/tools/knowledge-health.py --insights` |
-| Tentacle status | `python3 ~/.copilot/tools/tentacle.py status` |
+| Knowledge briefing | `sk briefing "<task>"` |
+| Record a learning | `sk learn` |
+| Sync runtime status | `sk sync status --health-check` |
+| Knowledge insights | `sk index health` |
+| Tentacle status | `sk tentacle status` |
 
 ---
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -9,8 +9,9 @@ Recall telemetry tracks how the knowledge base is accessed — counts, IDs, and 
 ### Commands
 
 ```bash
-python3 ~/.copilot/tools/knowledge-health.py --recall         # Recall-only text dashboard
-python3 ~/.copilot/tools/knowledge-health.py --recall --json  # Recall-only JSON payload
+sk index health --recall         # Recall-only text dashboard
+sk index health --recall --json  # Recall-only JSON payload
+# fallback: python3 ~/.copilot/tools/knowledge-health.py --recall [--json]
 ```
 
 ### Telemetry contract

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -2,6 +2,90 @@
 
 > Full command reference for all copilot-session-knowledge tools.
 
+## sk — Unified CLI
+
+`sk` is the unified front door over all standalone scripts. After the standard install, `sk` is available on your PATH automatically — no alias or pip install needed. Run `sk <command>` for day-to-day use; direct-script invocation (`python3 ~/.copilot/tools/sk.py <command>` or `python3 ~/.copilot/tools/<script>.py`) remains available as a fallback for bootstrapping, CI pipelines, and advanced use.
+
+### Top-level commands
+
+```bash
+sk briefing "implement user CRUD"        # → briefing.py
+sk query "docker error"                  # → query-session.py
+sk learn --mistake "Title" "Description" # → learn.py
+sk tentacle create api-export --scope "src/api/*.py" --desc "Export API"  # → tentacle.py
+sk install --deploy-skill                # → install.py
+sk setup --profile python                # → setup-project.py
+sk update                                # → auto-update-tools.py
+sk update --force
+sk browse --port 8080 --token TOKEN      # → browse.py
+sk benchmark record                      # → benchmark.py
+sk retro                                 # → retro.py
+sk heal                                  # → copilot-cli-healer.py
+```
+
+### `sk index` — knowledge index lifecycle
+
+```bash
+sk index build       # build-session-index.py  — index session files → FTS5 DB
+sk index extract     # extract-knowledge.py    — classify + deduplicate entries
+sk index migrate     # migrate.py              — apply DB schema migrations
+sk index status      # index-status.py         — row counts, FTS integrity, offset coverage
+sk index health      # knowledge-health.py     — health dashboard + recall telemetry
+sk index embed       # embed.py                — configure/run semantic embeddings
+```
+
+### `sk sync` — cross-machine sync
+
+```bash
+sk sync config --setup https://gateway.example.com  # sync-config.py --setup
+sk sync config --status                              # sync-config.py --status
+sk sync run --once                                   # sync-daemon.py --once
+sk sync run --daemon                                 # sync-daemon.py --daemon
+sk sync status                                       # sync-status.py
+sk sync status --health-check                        # sync-status.py --health-check
+sk sync gateway --host 127.0.0.1 --port 8765         # sync-gateway.py (reference/mock)
+sk sync merge --source /path/to/other.db             # sync-knowledge.py
+```
+
+### `sk checkpoint` — session checkpoints
+
+```bash
+sk checkpoint save --title "Auth done" --overview "JWT added"   # checkpoint-save.py
+sk checkpoint restore --list                                     # checkpoint-restore.py --list
+sk checkpoint restore --show latest                             # checkpoint-restore.py --show latest
+sk checkpoint diff --from 1 --to latest                         # checkpoint-diff.py
+```
+
+### `sk profile` — workflow profiles
+
+```bash
+sk profile build --name myteam --hooks dangerous-blocker.py --phases BUILD TEST COMMIT
+                                                    # profile-builder.py
+sk profile import --file myteam.json                # profile-import.py
+sk profile export --profile myteam --output out.json # profile-export.py
+```
+
+### `sk context` — project context
+
+```bash
+sk context project                  # project-context.py  — write project-context.md
+sk context project --stdout         # project-context.py --stdout
+sk context map                      # codebase-map.py     — refresh codebase structure snapshot
+```
+
+### `sk scout` — trend scout
+
+```bash
+sk scout run                        # trend-scout.py
+sk scout run --dry-run              # trend-scout.py --dry-run
+sk scout config                     # scout-config.py
+sk scout status                     # scout-status.py
+```
+
+> **Direct-script fallback:** every `sk` sub-command delegates to the underlying `python3 ~/.copilot/tools/<script>.py` call with identical flags. If `sk` is unavailable, use the direct-script form shown in each section below.
+
+---
+
 ## Briefing
 
 Run before every major task to surface past mistakes and relevant knowledge:

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -59,10 +59,15 @@ active enforcement runs through `hook_runner.py`.
 ### Installation
 
 ```bash
-python3 ~/.copilot/tools/install.py --deploy-hooks        # Deploy to ~/.copilot/hooks/
-python3 ~/.copilot/tools/install.py --lock-hooks          # Lock with OS immutable flags
-python3 ~/.copilot/tools/install.py --unlock-hooks        # Unlock for updates
-python3 ~/.copilot/tools/install.py --install-git-hooks   # Install pre-commit/pre-push (per repo)
+sk install --deploy-hooks        # Deploy to ~/.copilot/hooks/
+sk install --lock-hooks          # Lock with OS immutable flags
+sk install --unlock-hooks        # Unlock for updates
+sk install --install-git-hooks   # Install pre-commit/pre-push (per repo)
+# fallback: python3 ~/.copilot/tools/install.py <flag>
 ```
+
+`~/.copilot/hooks/hooks.json` is a **managed file**. `sk update` may refresh it from this repo
+(preserving a backup when the content changes), so keep durable customizations in source-controlled
+hook code or reapply them from the backup after an update.
 
 📖 **Full rule inventory, architecture, and dispatched-subagent guard:** [docs/HOOKS.md](../docs/HOOKS.md)

--- a/install.py
+++ b/install.py
@@ -4,6 +4,8 @@ install.py — Smart installer for session knowledge tools
 
 Usage:
     python install.py                        # Auto-detect and show status
+    python install.py --install-sk           # Install/refresh sk launcher in ~/.copilot/bin/
+    python install.py --uninstall-launcher   # Remove only the managed sk launcher
     python install.py --deploy-skill         # Deploy SKILL.md to current project
     python install.py --deploy-hooks         # Deploy hooks.json to ~/.copilot/hooks/
     python install.py --deploy-instructions  # Deploy global instructions to ~/.github/
@@ -14,6 +16,12 @@ Usage:
     python install.py --test                 # Run self-test
     python install.py --uninstall            # Remove installed files
     python install.py --help                 # Show this help
+
+sk Launcher (managed cross-platform):
+    --install-sk creates ~/.copilot/bin/sk  (POSIX) or ~/.copilot/bin/sk.cmd (Windows)
+    and idempotently adds ~/.copilot/bin to your shell profile PATH.
+    After install: open a new shell (or 'source ~/.zshrc') then type 'sk --help'.
+    auto-update-tools.py calls --install-sk --quiet whenever sk.py or install.py changes.
 
 Tamper Protection:
     --lock-hooks sets OS-level immutable flags on all hook scripts + hooks.json:
@@ -31,7 +39,10 @@ import sqlite3
 import subprocess
 import sys
 import textwrap
+from importlib import metadata
 from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 # ---------------------------------------------------------------------------
 # Windows console encoding fix (same pattern as other tools)
@@ -145,6 +156,7 @@ TOOL_FILES = [
     "sync-status.py",
     "sync-gateway.py",
     "generate-summary.py",
+    "sk.py",
     "install.py",
 ]
 
@@ -152,7 +164,13 @@ SUPPORT_FILES = [
     "README.md",
     "KNOWLEDGE.md",
     "embedding-config.json",
+    "pyproject.toml",
 ]
+
+# Managed sk launcher directory (cross-platform: ~/.copilot/bin/)
+SK_LAUNCHER_DIR = HOME / ".copilot" / "bin"
+_SK_PATH_MARKER_START = "# >>> session-knowledge sk launcher >>>"
+_SK_PATH_MARKER_END   = "# <<< session-knowledge sk launcher <<<"
 
 # ---------------------------------------------------------------------------
 # Markers
@@ -180,6 +198,53 @@ def _count_scripts(d: Path) -> int:
     if not d.is_dir():
         return 0
     return sum(1 for f in d.iterdir() if f.suffix == ".py")
+
+
+def _file_url_to_path(url: str) -> Path | None:
+    """Convert a file:// URL from direct_url.json to a local path."""
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if parsed.scheme != "file":
+        return None
+    path_str = url2pathname(parsed.path)
+    if parsed.netloc and parsed.netloc not in ("", "localhost"):
+        path_str = f"//{parsed.netloc}{path_str}"
+    if not path_str:
+        return None
+    return Path(path_str).expanduser().resolve()
+
+
+def _matching_editable_install_source_dir(target_dir: Path | None = None) -> Path | None:
+    """Return the editable-install source dir when it matches this checkout."""
+    target = (target_dir or TOOLS_DIR).resolve()
+    try:
+        distributions = metadata.distributions()
+    except Exception:
+        return None
+
+    for dist in distributions:
+        dist_name = (dist.metadata.get("Name") or "").strip().lower().replace("_", "-")
+        if dist_name != "copilot-session-knowledge":
+            continue
+        direct_url_text = dist.read_text("direct_url.json")
+        if not direct_url_text:
+            continue
+        try:
+            direct_url = json.loads(direct_url_text)
+        except Exception:
+            continue
+        if not direct_url.get("dir_info", {}).get("editable"):
+            continue
+        source_dir = _file_url_to_path(direct_url.get("url", ""))
+        if source_dir == target:
+            return source_dir
+    return None
+
+
+def _pip_uninstall_command() -> str:
+    """Command that removes the editable `sk` console entrypoint cleanly."""
+    return f"{sys.executable} -m pip uninstall copilot-session-knowledge"
 
 
 def _git_hook_install_text(src_text: str) -> str:
@@ -278,6 +343,237 @@ def _fts_working() -> bool:
         return rows[0] >= 0
     except Exception:
         return False
+
+
+# ===================================================================
+# SK Launcher: managed cross-platform sk command
+# ===================================================================
+
+def _sk_launcher_script_paths() -> "list[Path]":
+    """Return platform-appropriate launcher file paths under SK_LAUNCHER_DIR."""
+    if os.name == "nt":
+        return [SK_LAUNCHER_DIR / "sk.cmd"]
+    return [SK_LAUNCHER_DIR / "sk"]
+
+
+def _sk_launcher_content() -> str:
+    """Return the launcher script body for the current platform."""
+    if os.name == "nt":
+        return (
+            "@echo off\r\n"
+            'python "%USERPROFILE%\\.copilot\\tools\\sk.py" %*\r\n'
+        )
+    # POSIX: sh-compatible, expands $HOME at runtime so it survives home dir changes
+    return (
+        "#!/bin/sh\n"
+        'exec python3 "$HOME/.copilot/tools/sk.py" "$@"\n'
+    )
+
+
+def _shell_profiles() -> "list[Path]":
+    """Return candidate POSIX shell profile files for PATH injection."""
+    return [
+        HOME / ".bash_profile",
+        HOME / ".bashrc",
+        HOME / ".zprofile",
+        HOME / ".zshrc",
+        HOME / ".profile",
+    ]
+
+
+def _preferred_shell_profile() -> Path:
+    """Pick the best profile file to create when none already exist."""
+    shell_name = Path(os.environ.get("SHELL", "")).name.lower()
+    if "zsh" in shell_name:
+        return HOME / ".zshrc"
+    if "bash" in shell_name:
+        return HOME / ".bash_profile"
+    return HOME / ".profile"
+
+
+def _inject_launcher_path(quiet: bool = False) -> None:
+    """Idempotently add ~/.copilot/bin to existing shell profiles (POSIX only)."""
+    bin_str = str(SK_LAUNCHER_DIR)
+    block = (
+        f"\n{_SK_PATH_MARKER_START}\n"
+        f'export PATH="{bin_str}:$PATH"\n'
+        f"{_SK_PATH_MARKER_END}\n"
+    )
+    profiles = [profile for profile in _shell_profiles() if profile.exists()]
+    if not profiles:
+        profiles = [_preferred_shell_profile()]
+    for profile in profiles:
+        if not profile.parent.exists():
+            profile.parent.mkdir(parents=True, exist_ok=True)
+        content = profile.read_text(encoding="utf-8") if profile.exists() else ""
+        if _SK_PATH_MARKER_START in content or bin_str in content:
+            if not quiet:
+                print(f"  {INFO} sk PATH already in {_tilde(profile)}")
+            continue
+        new_content = block.lstrip("\n") if not content else content.rstrip("\n") + "\n" + block
+        _atomic_write_text(profile, new_content)
+        if not quiet:
+            print(f"  {OK} Added sk launcher PATH to {_tilde(profile)}")
+
+
+def _inject_launcher_path_windows(quiet: bool = False) -> None:
+    """Try adding ~/.copilot/bin to user PATH in Windows Registry."""
+    bin_str = str(SK_LAUNCHER_DIR)
+    try:
+        import winreg
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER, "Environment", 0,
+            winreg.KEY_READ | winreg.KEY_WRITE,
+        )
+        try:
+            cur_path, _ = winreg.QueryValueEx(key, "PATH")
+        except FileNotFoundError:
+            cur_path = ""
+        entries = [entry for entry in cur_path.split(";") if entry.strip()]
+        launcher_key = _windows_path_entry_key(bin_str)
+        if not any(_windows_path_entry_key(entry) == launcher_key for entry in entries):
+            new_path = f"{bin_str};{cur_path}" if cur_path else bin_str
+            winreg.SetValueEx(key, "PATH", 0, winreg.REG_EXPAND_SZ, new_path)
+            if not quiet:
+                print(f"  {OK} Added sk launcher dir to Windows user PATH")
+        else:
+            if not quiet:
+                print(f"  {INFO} sk launcher dir already in Windows user PATH")
+        winreg.CloseKey(key)
+    except Exception as exc:
+        if not quiet:
+            print(f"  {WARN} Could not update Windows PATH: {exc}")
+            print(f"    Add manually: {bin_str}")
+
+
+def _remove_launcher_path_windows(quiet: bool = False) -> bool:
+    """Try removing ~/.copilot/bin from the Windows user PATH."""
+    bin_str = str(SK_LAUNCHER_DIR)
+    try:
+        import winreg
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER, "Environment", 0,
+            winreg.KEY_READ | winreg.KEY_WRITE,
+        )
+        try:
+            cur_path, _ = winreg.QueryValueEx(key, "PATH")
+        except FileNotFoundError:
+            cur_path = ""
+        entries = [entry for entry in cur_path.split(";") if entry]
+        launcher_key = _windows_path_entry_key(bin_str)
+        filtered = [
+            entry for entry in entries
+            if _windows_path_entry_key(entry) != launcher_key
+        ]
+        if filtered != entries:
+            winreg.SetValueEx(
+                key, "PATH", 0, winreg.REG_EXPAND_SZ, ";".join(filtered),
+            )
+            if not quiet:
+                print("  {0} Removed sk launcher dir from Windows user PATH".format(OK))
+            winreg.CloseKey(key)
+            return True
+        if not quiet:
+            print("  {0} sk launcher dir not present in Windows user PATH".format(INFO))
+        winreg.CloseKey(key)
+    except Exception as exc:
+        if not quiet:
+            print(f"  {WARN} Could not remove Windows PATH entry: {exc}")
+    return False
+
+
+def _windows_path_entry_key(entry: str) -> str:
+    """Normalize a Windows PATH entry for stable comparisons."""
+    return entry.strip().rstrip("\\/").lower()
+
+
+def install_sk_launcher(quiet: bool = False) -> bool:
+    """Create/update the managed sk launcher in ~/.copilot/bin/.
+
+    Idempotent — safe to call on every install or update.
+    Returns True if any launcher file was created or updated.
+    """
+    SK_LAUNCHER_DIR.mkdir(parents=True, exist_ok=True)
+    content = _sk_launcher_content()
+    changed = False
+
+    for script in _sk_launcher_script_paths():
+        existing = script.read_text(encoding="utf-8") if script.is_file() else None
+        if existing == content:
+            if not quiet:
+                print(f"  {INFO} sk launcher — already up to date ({_tilde(script)})")
+        else:
+            _atomic_write_text(script, content)
+            if os.name != "nt":
+                script.chmod(script.stat().st_mode | 0o755)
+            if not quiet:
+                verb = "updated" if existing is not None else "created"
+                print(f"  {OK} sk launcher {verb}: {_tilde(script)}")
+            changed = True
+
+    if os.name != "nt":
+        _inject_launcher_path(quiet=quiet)
+    else:
+        _inject_launcher_path_windows(quiet=quiet)
+
+    return changed
+
+
+def uninstall_sk_launcher(quiet: bool = False) -> int:
+    """Remove managed sk launcher files and shell profile PATH injections.
+
+    Returns the number of items removed.
+    """
+    import re
+    removed = 0
+
+    for script in _sk_launcher_script_paths():
+        if script.is_file():
+            try:
+                script.unlink()
+                removed += 1
+                if not quiet:
+                    print(f"  {OK} Removed sk launcher: {_tilde(script)}")
+            except Exception as exc:
+                if not quiet:
+                    print(f"  {FAIL} Could not remove {_tilde(script)}: {exc}")
+
+    # Remove launcher dir if now empty
+    if SK_LAUNCHER_DIR.is_dir():
+        try:
+            remaining = list(SK_LAUNCHER_DIR.iterdir())
+            if not remaining:
+                SK_LAUNCHER_DIR.rmdir()
+                removed += 1
+                if not quiet:
+                    print(f"  {OK} Removed empty {_tilde(SK_LAUNCHER_DIR)}")
+        except Exception:
+            pass
+
+    # Remove PATH injections from POSIX shell profiles
+    if os.name != "nt":
+        for profile in _shell_profiles():
+            if not profile.exists():
+                continue
+            content = profile.read_text(encoding="utf-8")
+            if _SK_PATH_MARKER_START not in content:
+                continue
+            pattern = (
+                re.escape(_SK_PATH_MARKER_START)
+                + r".*?"
+                + re.escape(_SK_PATH_MARKER_END)
+                + r"\n?"
+            )
+            new_content = re.sub(pattern, "", content, flags=re.DOTALL)
+            if new_content != content:
+                _atomic_write_text(profile, new_content)
+                removed += 1
+                if not quiet:
+                    print(f"  {OK} Removed sk PATH injection from {_tilde(profile)}")
+    elif _remove_launcher_path_windows(quiet=quiet):
+        removed += 1
+
+    return removed
 
 
 # ===================================================================
@@ -770,10 +1066,18 @@ def run_self_test():
 # 4. Uninstall
 # ===================================================================
 
-def uninstall():
+def uninstall() -> int:
     """Remove installed tools. Preserves session-state data."""
     print("\nUninstall \u2014 Session Knowledge Tools")
     print("=" * 50)
+
+    editable_source = _matching_editable_install_source_dir()
+    if editable_source is not None:
+        print(f"\n  {WARN} Detected an editable pip install for this checkout.")
+        print("  Remove the `sk` console command first so it does not break:")
+        print(f"    {_pip_uninstall_command()}")
+        print("  Then rerun `python install.py --uninstall` if you also want to remove this checkout.")
+        return 1
 
     removable: list[Path] = []
 
@@ -792,32 +1096,40 @@ def uninstall():
     if LOCK_FILE.is_file():
         removable.append(LOCK_FILE)
 
-    if not removable:
+    # Include managed sk launcher files in the listing
+    launcher_scripts = [s for s in _sk_launcher_script_paths() if s.is_file()]
+
+    if not removable and not launcher_scripts:
         print(f"\n  Nothing to remove.")
-        return
+        return 0
 
     print(f"\n  Files to remove:")
     for p in removable:
         label = "dir " if p.is_dir() else ""
         print(f"    {label}{_tilde(p)}")
+    for s in launcher_scripts:
+        print(f"    {_tilde(s)}  (sk launcher)")
 
     print(f"\n  Preserved (your data):")
     print(f"    {_tilde(SESSION_STATE)}  (session data)")
     if DB_PATH.is_file():
         print(f"    {_tilde(DB_PATH)}  (knowledge database)")
+    print(f"\n  {INFO} If you also exposed `sk` with pip, remove that wrapper separately:")
+    print(f"    {_pip_uninstall_command()}")
 
     print()
     try:
         answer = input("  Proceed with uninstall? [y/N] ").strip().lower()
     except (EOFError, KeyboardInterrupt):
         print("\n  Cancelled.")
-        return
+        return 0
 
     if answer not in ("y", "yes"):
         print("  Cancelled.")
-        return
+        return 0
 
     removed = 0
+    had_error = False
     for p in removable:
         try:
             if p.is_dir():
@@ -828,6 +1140,7 @@ def uninstall():
             removed += 1
         except Exception as e:
             print(f"  {FAIL} Could not remove {_tilde(p)}: {e}")
+            had_error = True
 
     if TOOLS_DIR.is_dir():
         remaining = list(TOOLS_DIR.iterdir())
@@ -838,8 +1151,13 @@ def uninstall():
             except Exception:
                 pass
 
+    # Remove managed sk launcher files and PATH injections
+    launcher_removed = uninstall_sk_launcher(quiet=False)
+    removed += launcher_removed
+
     print(f"\n  Uninstall complete \u2014 removed {removed} item(s).")
     print(f"  Session data preserved at {_tilde(SESSION_STATE)}")
+    return 1 if had_error else 0
 
 
 # ===================================================================
@@ -910,6 +1228,9 @@ def install():
     print(f"\n{'=' * 50}")
     print(f"  Installation complete!")
     print(f"{'=' * 50}")
+    # Install the managed sk launcher
+    print(f"\n  Installing sk launcher...")
+    install_sk_launcher()
     _show_usage_hints()
 
 
@@ -919,11 +1240,20 @@ def _show_usage_hints():
     br = _tilde(TOOLS_DIR / "briefing.py")
     ws = _tilde(TOOLS_DIR / "watch-sessions.py")
     inst = _tilde(TOOLS_DIR / "install.py")
-    print(f"\n  Quick start:")
+    launcher_dir = _tilde(SK_LAUNCHER_DIR)
+    print(f"\n  Quick start (after opening a new shell or 'source ~/.zshrc'):")
+    print(f"    sk briefing \"your task\"         # Context briefing (short command)")
+    print(f"    sk query \"search terms\"          # Search knowledge base")
+    print(f"    sk learn --mistake \"Title\" \"...\" # Record a mistake")
+    print(f"    sk update                         # Pull latest tools update")
+    print(f"\n  Launcher location: {launcher_dir}/sk  (managed by install.py --install-sk)")
+    print(f"\n  Full path fallbacks also work:")
     print(f"    python {qs} \"search terms\"   # Search knowledge base")
     print(f"    python {br} \"your task\"       # Context briefing")
     print(f"    python {ws}                    # Start watcher daemon")
     print(f"\n  Management:")
+    print(f"    python {inst} --install-sk             # Refresh sk launcher")
+    print(f"    python {inst} --uninstall-launcher    # Remove sk launcher only")
     print(f"    python {inst} --deploy-skill          # Add skill to project")
     print(f"    python {inst} --deploy-hooks           # Deploy hooks")
     print(f"    python {inst} --deploy-instructions   # Deploy global instructions")
@@ -1290,6 +1620,20 @@ def main():
         _dispatch_healer("--uninstall-schedule")
         return
 
+    if "--install-sk" in args:
+        quiet = "--quiet" in args
+        if not quiet:
+            print("\nInstalling sk launcher...")
+        install_sk_launcher(quiet=quiet)
+        return
+
+    if "--uninstall-launcher" in args:
+        quiet = "--quiet" in args
+        if not quiet:
+            print("\nRemoving sk launcher...")
+        uninstall_sk_launcher(quiet=quiet)
+        return
+
     if "--deploy-skill" in args:
         deploy_skill()
         return
@@ -1323,8 +1667,7 @@ def main():
         return
 
     if "--uninstall" in args:
-        uninstall()
-        return
+        return uninstall()
 
     # Default: show status, then install if needed or show hints
     installed = show_status()
@@ -1337,4 +1680,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main() or 0)

--- a/learn.py
+++ b/learn.py
@@ -37,7 +37,6 @@ import sqlite3
 import sys
 import time
 from pathlib import Path
-from typing import Optional
 
 if os.name == "nt":
     try:
@@ -333,7 +332,7 @@ def with_retry(func, *args, max_attempts: int = 5, base_delay: float = 0.5, **kw
     ~800 MB DB can exceed it. This wrapper retries transient lock errors
     with delays of 0.5s, 1s, 2s, 4s, 8s before giving up.
     """
-    last_exc: Optional[sqlite3.OperationalError] = None
+    last_exc: sqlite3.OperationalError | None = None
     for attempt in range(1, max_attempts + 1):
         try:
             return func(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,20 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "copilot-session-knowledge"
+version = "1.0.0"
+description = "Unified front-door CLI for copilot-session-knowledge tools"
+requires-python = ">=3.10"
+readme = "README.md"
+
+[project.scripts]
+sk = "sk:main"
+
+[tool.setuptools]
+py-modules = ["sk"]
+
 [tool.ruff]
 line-length = 120
 target-version = "py310"

--- a/sk.py
+++ b/sk.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+sk — Unified front-door CLI for copilot-session-knowledge tools.
+
+Dispatches to the underlying standalone scripts via subprocess.
+All existing `python3 ~/.copilot/tools/*.py` workflows are preserved.
+
+Usage:
+    sk briefing [<args>...]       Run briefing.py
+    sk query    [<args>...]       Run query-session.py
+    sk learn    [<args>...]       Run learn.py
+    sk tentacle [<args>...]       Run tentacle.py
+    sk install  [<args>...]       Run install.py
+    sk setup    [<args>...]       Run setup-project.py
+    sk update   [<args>...]       Run auto-update-tools.py
+    sk browse   [<args>...]       Run browse.py
+    sk benchmark [<args>...]      Run benchmark.py
+    sk retro    [<args>...]       Run retro.py
+    sk heal     [<args>...]       Run copilot-cli-healer.py
+
+    sk index  build|extract|migrate|status|health|embed [<args>...]
+    sk sync   run|config|status|gateway|merge [<args>...]
+    sk checkpoint save|restore|diff [<args>...]
+    sk profile build|import|export [<args>...]
+    sk context project|map [<args>...]
+    sk scout  run|config|status [<args>...]
+
+    sk --help     Show this help
+    sk --version  Show version
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+__version__ = "1.0.0"
+
+DEFAULT_TOOLS_DIR = Path(__file__).parent.resolve()
+CHECKOUT_MARKERS = ("briefing.py", "query-session.py", "install.py")
+
+# ---------------------------------------------------------------------------
+# Command → script mapping
+# ---------------------------------------------------------------------------
+
+# Top-level direct commands: (script_name,)
+_DIRECT: dict[str, str] = {
+    "briefing": "briefing.py",
+    "query": "query-session.py",
+    "learn": "learn.py",
+    "tentacle": "tentacle.py",
+    "install": "install.py",
+    "setup": "setup-project.py",
+    "update": "auto-update-tools.py",
+    "browse": "browse.py",
+    "benchmark": "benchmark.py",
+    "retro": "retro.py",
+    "heal": "copilot-cli-healer.py",
+}
+
+# Grouped namespace commands: group → {subcommand: script_name}
+_GROUPS: dict[str, dict[str, str]] = {
+    "index": {
+        "build": "build-session-index.py",
+        "extract": "extract-knowledge.py",
+        "migrate": "migrate.py",
+        "status": "index-status.py",
+        "health": "knowledge-health.py",
+        "embed": "embed.py",
+    },
+    "sync": {
+        "run": "sync-daemon.py",
+        "config": "sync-config.py",
+        "status": "sync-status.py",
+        "gateway": "sync-gateway.py",
+        "merge": "sync-knowledge.py",
+    },
+    "checkpoint": {
+        "save": "checkpoint-save.py",
+        "restore": "checkpoint-restore.py",
+        "diff": "checkpoint-diff.py",
+    },
+    "profile": {
+        "build": "profile-builder.py",
+        "import": "profile-import.py",
+        "export": "profile-export.py",
+    },
+    "context": {
+        "project": "project-context.py",
+        "map": "codebase-map.py",
+    },
+    "scout": {
+        "run": "trend-scout.py",
+        "config": "scout-config.py",
+        "status": "scout-status.py",
+    },
+}
+
+
+def _resolve_tools_dir() -> tuple[Path, bool]:
+    """Return the tools checkout path, honoring an explicit override."""
+    override = os.environ.get("SK_TOOLS_DIR")
+    if override:
+        return Path(override).expanduser().resolve(), True
+    return DEFAULT_TOOLS_DIR, False
+
+
+def _looks_like_tools_checkout(tools_dir: Path) -> bool:
+    """Detect whether a directory looks like the standalone tools checkout."""
+    return all((tools_dir / marker).exists() for marker in CHECKOUT_MARKERS)
+
+
+def _print_missing_script_error(tools_dir: Path, script: str, *, from_env: bool) -> None:
+    """Emit an actionable error when the delegated script cannot be found."""
+    script_path = tools_dir / script
+    if from_env:
+        print(
+            f"sk: SK_TOOLS_DIR points to {tools_dir}, but required script is missing: {script_path}",
+            file=sys.stderr,
+        )
+        return
+
+    if not _looks_like_tools_checkout(tools_dir):
+        print(
+            "sk: this `sk` entrypoint cannot find the standalone tool checkout.",
+            file=sys.stderr,
+        )
+        print(
+            "sk: install from the repo with `python3 -m pip install -e ~/.copilot/tools`, "
+            "or set SK_TOOLS_DIR=/path/to/copilot-session-knowledge.",
+            file=sys.stderr,
+        )
+        return
+
+    print(f"sk: script not found: {script_path}", file=sys.stderr)
+
+
+def _run(script: str, extra_args: list[str]) -> int:
+    """Delegate to a standalone script via subprocess."""
+    tools_dir, from_env = _resolve_tools_dir()
+    script_path = tools_dir / script
+    if not script_path.exists():
+        _print_missing_script_error(tools_dir, script, from_env=from_env)
+        return 2
+    cmd = [sys.executable, str(script_path)] + extra_args
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def _help_groups() -> str:
+    lines = []
+    for group, subs in _GROUPS.items():
+        sub_list = "|".join(subs)
+        lines.append(f"  sk {group:<12} {sub_list}")
+    return "\n".join(lines)
+
+
+def _print_help() -> None:
+    direct_list = "  " + "\n  ".join(
+        f"sk {cmd:<12} → {script}" for cmd, script in _DIRECT.items()
+    )
+    print(
+        f"sk {__version__} — copilot-session-knowledge unified CLI\n"
+        "\nDirect commands:\n"
+        f"{direct_list}\n"
+        "\nGrouped namespaces:\n"
+        f"{_help_groups()}\n"
+        "\nUse `sk <command> --help` to see help for a specific script.\n"
+        "All direct `python3 ~/.copilot/tools/*.py` invocations still work.\n"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+
+    if not args or args[0] in ("-h", "--help"):
+        _print_help()
+        return 0
+
+    if args[0] in ("-V", "--version"):
+        print(f"sk {__version__}")
+        return 0
+
+    cmd = args[0]
+    rest = args[1:]
+
+    # Direct command?
+    if cmd in _DIRECT:
+        return _run(_DIRECT[cmd], rest)
+
+    # Grouped namespace?
+    if cmd in _GROUPS:
+        if not rest or rest[0] in ("-h", "--help"):
+            subs = list(_GROUPS[cmd].keys())
+            print(f"sk {cmd}: available subcommands: {', '.join(subs)}")
+            print(f"Usage: sk {cmd} <{'|'.join(subs)}> [args...]")
+            return 0
+        sub = rest[0]
+        sub_rest = rest[1:]
+        if sub not in _GROUPS[cmd]:
+            subs = list(_GROUPS[cmd].keys())
+            print(
+                f"sk {cmd}: unknown subcommand '{sub}'. "
+                f"Choose from: {', '.join(subs)}",
+                file=sys.stderr,
+            )
+            return 2
+        return _run(_GROUPS[cmd][sub], sub_rest)
+
+    # Unknown
+    all_cmds = sorted(list(_DIRECT) + list(_GROUPS))
+    print(
+        f"sk: unknown command '{cmd}'. Available: {', '.join(all_cmds)}",
+        file=sys.stderr,
+    )
+    print("Run `sk --help` for usage.", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/conductor-creator/SKILL.md
+++ b/skills/conductor-creator/SKILL.md
@@ -146,7 +146,7 @@ Common patterns: "review and fix" -> bug, "write test" -> test, "optimize X" -> 
 - `pre_task`: briefing (if session-knowledge exists)
 - `post_code`: review (if code-reviewer agent exists)
 - `post_feature`: PR creation (if pr-workflow skill exists)
-- `post_verify`: goal evaluation — when the task has an explicit overarching goal (e.g., "benchmarks must pass ≥ 90"), add a `goal_eval` step that evaluates the goal after all verification gates pass and before dispatching the next wave or closing. Use `tentacle.py verify <name> "<check>" --label "goal-eval"` for evidence capture. If the goal is unmet, the conductor should route back to the planning step rather than proceeding to commit.
+- `post_verify`: goal evaluation — when the task has an explicit overarching goal (e.g., "benchmarks must pass ≥ 90"), add a `goal_eval` step that evaluates the goal after all verification gates pass and before dispatching the next wave or closing. Use `sk tentacle verify <name> "<check>" --label "goal-eval"` for evidence capture. If the goal is unmet, the conductor should route back to the planning step rather than proceeding to commit.
 - `post_task`: learn (if session-knowledge exists)
 
 > **Goal-eval routing rule:** Include `goal_eval` in `mandatory_steps.post_verify` whenever `task_type` is `feature`, `bug`, or `refactor` AND the task description contains goal-indicator phrases ("until all pass", "reach score", "all tests green", "≥", "target", "threshold"). For bounded tasks ("rename this function", "add this column"), skip it.

--- a/skills/project-onboarding/SKILL.md
+++ b/skills/project-onboarding/SKILL.md
@@ -80,7 +80,7 @@ and guardrails being in place.
 The AI repeats mistakes, forgets past decisions, and has no institutional memory.
 Briefing gives pre-task context; learn records post-task insights.
 
-**Verify:** `python3 ~/.copilot/tools/briefing.py --wakeup` returns output.
+**Verify:** `sk briefing --wakeup` returns output.  (fallback: `python3 ~/.copilot/tools/briefing.py --wakeup`)
 
 ### 0.2 Agent Creator
 
@@ -214,7 +214,7 @@ python3 .github/skills/conductor/scripts/conductor.py --sync
 
 | Phase | Creator | Output | Verify |
 |-------|---------|--------|--------|
-| 0.1 | `session-knowledge-creator` | briefing.py, learn.py | `briefing.py --wakeup` |
+| 0.1 | `session-knowledge-creator` | briefing.py, learn.py | `sk briefing --wakeup` |
 | 0.2 | `agent-creator` | .github/agents/*.agent.md | `ls .github/agents/` |
 | 0.3 | `hook-creator` | .github/hooks/ | `cat hooks.json` |
 | 1.1 | `workflow-creator` | WORKFLOW.md | File exists with phases |
@@ -246,9 +246,9 @@ integration point that ties the ecosystem together.
 | Added/removed a skill | `conductor.py --sync --fix` then re-run load audit |
 | Added a new agent | Update `agent_routing` in conductor-rules.json |
 | Changed workflow phases | Update `workflows` in conductor-rules.json |
-| New session starts | `briefing.py --auto --compact` |
-| After fixing a bug | `learn.py --mistake "Title" "Details" --tags "tags"` |
-| After completing feature | `learn.py --feature "Title" "Details" --tags "tags"` |
+| New session starts | `sk briefing --auto --compact` |
+| After fixing a bug | `sk learn --mistake "Title" "Details" --tags "tags"` |
+| After completing feature | `sk learn --feature "Title" "Details" --tags "tags"` |
 | Skill installed globally | Remove project-local copy if it exists in `.github/skills/` |
 | Instruction added | Check that `applyTo` is as narrow as possible; re-run load audit |
 
@@ -266,7 +266,7 @@ integration point that ties the ecosystem together.
 | `--sync` shows orphans | New skill added after setup | `--sync --fix` |
 | Agent uses wrong model | Model not specified | Check `.instructions.md` model rules |
 | Hook blocks valid action | Overly strict regex | Edit `.github/hooks/scripts/` |
-| Briefing returns empty | No entries recorded | Start using `learn.py` after tasks |
+| Briefing returns empty | No entries recorded | Start using `sk learn` after tasks |
 | Context feels slow / bloated | Too many `applyTo: **/*` instructions | Narrow `applyTo` on each instruction file |
 | Same skill name in global + project | Old project copy not removed after global rollout | Delete `.github/skills/<name>/` when `~/.copilot/skills/<name>/` exists |
 | Conductor rules reference missing skill | Skill removed but rule not updated | `conductor.py --audit`, then remove stale rule or restore skill |

--- a/skills/session-knowledge-creator/SKILL.md
+++ b/skills/session-knowledge-creator/SKILL.md
@@ -45,7 +45,7 @@ cat AGENTS.md 2>/dev/null | head -30
 
 # Tools availability
 ls ~/.copilot/tools/briefing.py ~/.copilot/tools/learn.py 2>/dev/null
-python3 ~/.copilot/tools/learn.py --stats 2>/dev/null | head -10
+python3 ~/.copilot/tools/learn.py --stats 2>/dev/null | head -10  # or: sk learn --stats
 ```
 
 If `briefing.py` or `learn.py` are missing, tell the user to install first:
@@ -106,13 +106,15 @@ Add a brief section pointing to the other two files. Keep it short — enforceme
 ### Step 4: Verify
 
 ```bash
-python3 ~/.copilot/tools/briefing.py --wakeup
-python3 ~/.copilot/tools/briefing.py "task description" --json    # verify JSON output works
-python3 ~/.copilot/tools/learn.py --discovery "Setup test" "Session knowledge configured" --tags "setup" --json
+sk briefing --wakeup
+# fallback: python3 ~/.copilot/tools/briefing.py --wakeup
+sk briefing "task description" --json    # verify JSON output works
+sk learn --discovery "Setup test" "Session knowledge configured" --tags "setup" --json
+# fallback: python3 ~/.copilot/tools/learn.py --discovery ...
 cat .github/instructions/session-knowledge.instructions.md
 head -5 .github/skills/session-knowledge/SKILL.md
 
-# Validate the generated SKILL.md meets standards
+# Validate the generated SKILL.md meets standards (no sk shortcut)
 python3 ~/.copilot/tools/validate-skill.py .github/skills/session-knowledge/SKILL.md
 ```
 

--- a/skills/session-knowledge-creator/references/instructions-template.md
+++ b/skills/session-knowledge-creator/references/instructions-template.md
@@ -19,7 +19,8 @@ applyTo: "**/*"
 ## Before Starting ANY Task
 
 ```bash
-python3 ~/.copilot/tools/briefing.py --auto --compact
+sk briefing --auto --compact
+# fallback: python3 ~/.copilot/tools/briefing.py --auto --compact
 ```
 
 Read the output — it contains past mistakes to avoid and patterns to follow for
@@ -31,16 +32,17 @@ Record what you learned (choose appropriate type):
 
 ```bash
 # After fixing a bug:
-python3 ~/.copilot/tools/learn.py --mistake "Title" "Root cause and fix" \
+sk learn --mistake "Title" "Root cause and fix" \
   --tags "<MODULE>,<TECH>" --wing <WING> --room <ROOM>
 
 # After implementing a feature:
-python3 ~/.copilot/tools/learn.py --feature "Title" "What was built" \
+sk learn --feature "Title" "What was built" \
   --tags "<MODULE>,<TECH>" --wing <WING> --room <ROOM>
 
 # After discovering a useful pattern:
-python3 ~/.copilot/tools/learn.py --pattern "Title" "What works well" \
+sk learn --pattern "Title" "What works well" \
   --tags "<MODULE>,<TECH>"
+# fallback: python3 ~/.copilot/tools/learn.py <type> <args>
 ```
 
 ## Rules

--- a/skills/session-knowledge-creator/references/skill-template.md
+++ b/skills/session-knowledge-creator/references/skill-template.md
@@ -2,7 +2,7 @@
 
 > **Copy this file to** `.github/skills/session-knowledge/SKILL.md` in the target project.
 > Replace every `<PLACEHOLDER>` with project-specific values before saving.
-> The generated file must pass `python3 ~/.copilot/tools/validate-skill.py`.
+> The generated file must pass `python3 ~/.copilot/tools/validate-skill.py` (no sk shortcut for this tool).
 
 ---
 
@@ -36,20 +36,23 @@ proven solutions specific to this codebase.
 
 ```bash
 # Before task — get context
-python3 ~/.copilot/tools/briefing.py "<task description>" --compact
+sk briefing "<task description>" --compact
+# fallback: python3 ~/.copilot/tools/briefing.py "<task description>" --compact
 
 # Search for a specific error
-python3 ~/.copilot/tools/query-session.py "<error message>" --verbose
+sk query "<error message>" --verbose
+# fallback: python3 ~/.copilot/tools/query-session.py "<error message>" --verbose
 
 # See past decisions about <TECH>
-python3 ~/.copilot/tools/query-session.py "<TECH>" --decisions
+sk query "<TECH>" --decisions
 
 # After fixing a bug — record it
-python3 ~/.copilot/tools/learn.py --mistake "Title" "Root cause and fix" \
+sk learn --mistake "Title" "Root cause and fix" \
   --tags "<KEY_TAG_1>,<KEY_TAG_2>" --wing <WING> --room <ROOM>
+# fallback: python3 ~/.copilot/tools/learn.py --mistake ...
 
 # After implementing a feature
-python3 ~/.copilot/tools/learn.py --feature "Title" "What was built" \
+sk learn --feature "Title" "What was built" \
   --tags "<KEY_TAG_1>"
 ```
 
@@ -75,14 +78,14 @@ Knowledge is organized hierarchically. Use these when recording entries:
 **Task:** Fix <KEY_ACTIVITY_1> bug in <KEY_MODULE_1>
 
 ```bash
-python3 ~/.copilot/tools/briefing.py "fix <KEY_ACTIVITY_1> in <KEY_MODULE_1>"
+sk briefing "fix <KEY_ACTIVITY_1> in <KEY_MODULE_1>"
 # → shows 1 past mistake about <DOMAIN_ISSUE>, 1 pattern for <DOMAIN_SOLUTION>
 
-python3 ~/.copilot/tools/query-session.py "<ERROR_TYPE>" --verbose
+sk query "<ERROR_TYPE>" --verbose
 # → finds the root cause from a previous session
 
 # After fixing:
-python3 ~/.copilot/tools/learn.py --mistake "<KEY_MODULE_1> <ERROR_TYPE>" \
+sk learn --mistake "<KEY_MODULE_1> <ERROR_TYPE>" \
   "Root cause: <CAUSE>. Fix: <FIX_DESCRIPTION>" \
   --tags "<KEY_TAG_1>,<KEY_TAG_2>" --wing <WING_1> --room <ROOM_1_A>
 ```

--- a/skills/tentacle-creator/SKILL.md
+++ b/skills/tentacle-creator/SKILL.md
@@ -162,7 +162,8 @@ fi
 ### Step 6: Verify tentacle.py exists
 
 ```bash
-ls ~/.copilot/tools/tentacle.py && python3 ~/.copilot/tools/tentacle.py --help
+ls ~/.copilot/tools/tentacle.py && sk tentacle --help
+# fallback: python3 ~/.copilot/tools/tentacle.py --help
 ```
 
 If missing, tell the user:
@@ -186,7 +187,7 @@ Present a summary: project profile, files created, agent mappings detected, veri
 
 **Verification commands:** `npx tsc --noEmit` (build) · `npx eslint .` (lint) · `yarn test` (tests)
 
-**Usage:** `python3 ~/.copilot/tools/tentacle.py create api-routes --scope "src/app/api/**/*" --desc "REST endpoint changes" --briefing`
+**Usage:** `sk tentacle create api-routes --scope "src/app/api/**/*" --desc "REST endpoint changes" --briefing`
 </example>
 
 ## Compatibility

--- a/skills/tentacle-orchestration/SKILL.md
+++ b/skills/tentacle-orchestration/SKILL.md
@@ -53,16 +53,17 @@ it — they are the reliable enforcement surface.
    block all repos.
    > **Upgrade migration:** Cross-repo isolation is not retroactive. In-flight old-format marker
    > entries (no `git_root`) continue to block all repos until completed, cleared, or expired (4h
-   > TTL). To get isolation immediately: `tentacle.py complete <name>` then re-dispatch.
+   > TTL). To get isolation immediately: `sk tentacle complete <name>` then re-dispatch.
 3. `hooks/rules/subagent_guard.py` provides a secondary `preToolUse` intercept for the
    orchestrator session (defense-in-depth only — not the primary path).
-4. `tentacle.py complete <name>` reads `tentacle_id` from `meta.json` and removes only the
+4. `sk tentacle complete <name>` reads `tentacle_id` from `meta.json` and removes only the
    matching marker entry; the marker is deleted when `active_tentacles` becomes empty.
 
 **Install the git hooks** (once per repository):
 
 ```bash
-python3 ~/.copilot/tools/install.py --install-git-hooks
+sk install --install-git-hooks
+# fallback: python3 ~/.copilot/tools/install.py --install-git-hooks
 ```
 
 **Enforcement scope and known limitations:**
@@ -164,10 +165,11 @@ Read the task description and identify independent code regions. Each region bec
 #### Step 2: Create tentacles
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py create <module-name> \
+sk tentacle create <module-name> \
   --scope "<file-patterns>" \
   --desc "<short description>" \
   --briefing
+# fallback: python3 ~/.copilot/tools/tentacle.py create <module-name> ...
 ```
 
 The `--briefing` flag injects past mistakes and patterns from session-knowledge into CONTEXT.md — use it every time.
@@ -175,7 +177,8 @@ The `--briefing` flag injects past mistakes and patterns from session-knowledge 
 #### Step 3: Add todos
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py todo <name> add "<specific, atomic task>"
+sk tentacle todo <name> add "<specific, atomic task>"
+# fallback: python3 ~/.copilot/tools/tentacle.py todo <name> add "<task>"
 ```
 
 Each todo should be one deliverable — testable, reviewable, and completable in isolation.
@@ -194,9 +197,10 @@ This is the most important step. Agent quality is directly proportional to CONTE
 #### Step 5: Dispatch agents (swarm)
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py swarm <name> --agent-type <type> --model <model> --briefing
-python3 ~/.copilot/tools/tentacle.py swarm <name> --output parallel --briefing
-python3 ~/.copilot/tools/tentacle.py dispatch <name> --agent-type <type> --model <model> --briefing
+sk tentacle swarm <name> --agent-type <type> --model <model> --briefing
+sk tentacle swarm <name> --output parallel --briefing
+sk tentacle dispatch <name> --agent-type <type> --model <model> --briefing
+# fallback: python3 ~/.copilot/tools/tentacle.py swarm/dispatch <name> ...
 ```
 
 `swarm` and `dispatch` materialize a runtime bundle by default. The dispatch prompt stays
@@ -216,8 +220,8 @@ Use the output as the prompt for `task()`. Launch independent tentacles in paral
 #### Step 6: Monitor progress
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py status
-python3 ~/.copilot/tools/tentacle.py show <name>
+sk tentacle status
+sk tentacle show <name>
 ```
 
 ### Phase 3: Verify (Steps 7–12)
@@ -245,7 +249,8 @@ After all verification gates pass, evaluate whether the overarching goal is met 
 
 ```bash
 # Run the goal's success-criteria check and persist the result
-python3 ~/.copilot/tools/tentacle.py verify <name> "<success-criteria-command>" --label "goal-eval"
+sk tentacle verify <name> "<success-criteria-command>" --label "goal-eval"
+# fallback: python3 ~/.copilot/tools/tentacle.py verify <name> ...
 ```
 
 **Decision logic:**
@@ -315,7 +320,7 @@ won't catch this. A 30-second launch test catches what build+test cannot.
 #### Step 15: Complete and learn
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py complete <name>
+sk tentacle complete <name>
 ```
 
 Only call `complete` after all verification gates pass. This marks all todos done and auto-extracts learnings from handoff.md into long-term knowledge.
@@ -323,8 +328,9 @@ Only call `complete` after all verification gates pass. This marks all todos don
 #### Step 16: Resume a tentacle (when picking up interrupted work)
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py resume <name>             # Refresh briefing, mark active
-python3 ~/.copilot/tools/tentacle.py resume <name> --no-briefing  # Skip briefing injection
+sk tentacle resume <name>             # Refresh briefing, mark active
+sk tentacle resume <name> --no-briefing  # Skip briefing injection
+# fallback: python3 ~/.copilot/tools/tentacle.py resume <name> [--no-briefing]
 ```
 
 `resume` refreshes the live briefing in CONTEXT.md and marks the tentacle active again. Use it when returning to a tentacle after an interruption or session boundary. Pass `--no-briefing` only when the briefing is already fresh and re-fetching would be wasteful.
@@ -332,7 +338,7 @@ python3 ~/.copilot/tools/tentacle.py resume <name> --no-briefing  # Skip briefin
 #### Step 17: Cleanup
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py delete <name>
+sk tentacle delete <name>
 ```
 
 ## CLI reference
@@ -346,19 +352,20 @@ tentacle.py create <name> --scope "<paths>" --desc "<desc>" --briefing
 tentacle.py todo <name> add "<task>"
 tentacle.py swarm <name> --agent-type <type> --model <model> --briefing    # bundle-first default
 tentacle.py swarm <name> --output parallel --briefing                      # one worker per todo
-tentacle.py swarm <name> --output json --briefing                          # JSON + bundle_path
-tentacle.py dispatch <name> --agent-type <type> --briefing                 # single-agent dispatch
-tentacle.py swarm <name> --no-bundle                                       # rare opt-out for tiny prompts
-tentacle.py handoff <name> "<summary>" --status DONE --changed-file <path> --learn
-tentacle.py goal init --title "<goal title>" [--desc "<goal description>"]
-tentacle.py goal link <name>                                               # stamp goal metadata into meta.json
-tentacle.py goal eval --decision continue|pause|complete|abandon           # record orchestrator decision
-tentacle.py goal status [--format text|json]
-tentacle.py resume <name>                  # resume interrupted tentacle (refreshes briefing)
-tentacle.py resume <name> --no-briefing    # resume without re-fetching briefing
-tentacle.py status
-tentacle.py complete <name>
-tentacle.py delete <name>
+sk tentacle swarm <name> --output json --briefing                          # JSON + bundle_path
+sk tentacle dispatch <name> --agent-type <type> --briefing                 # single-agent dispatch
+sk tentacle swarm <name> --no-bundle                                       # rare opt-out for tiny prompts
+sk tentacle handoff <name> "<summary>" --status DONE --changed-file <path> --learn
+sk tentacle goal init --title "<goal title>" [--desc "<goal description>"]
+sk tentacle goal link <name>                                               # stamp goal metadata into meta.json
+sk tentacle goal eval --decision continue|pause|complete|abandon           # record orchestrator decision
+sk tentacle goal status [--format text|json]
+sk tentacle resume <name>                  # resume interrupted tentacle (refreshes briefing)
+sk tentacle resume <name> --no-briefing    # resume without re-fetching briefing
+sk tentacle status
+sk tentacle complete <name>
+sk tentacle delete <name>
+# fallback: python3 ~/.copilot/tools/tentacle.py <cmd> <args>
 ```
 
 ## Tips
@@ -369,4 +376,4 @@ tentacle.py delete <name>
 4. **Complete before delete** — `complete` saves learnings; `delete` alone loses them
 5. **Commit after each phase** — uncommitted code is lost if the session crashes or compacts
 6. **Run the app** — build+test ≠ works. Launch the app to verify DI resolution and runtime behavior
-7. **⚠️ Commit restriction** — Sub-agents must not run `git commit`/`git push`. When git hooks are installed (`install.py --install-git-hooks`), both are blocked at the filesystem level for the repo where the tentacle was dispatched, while the `dispatched-subagent-active` marker is fresh. Commits in other repos are not affected. Even without hooks, a sub-agent commit mid-run corrupts the orchestrator's merge flow. Enforcement is local-only; cloud-delegated runs are not covered.
+7. **⚠️ Commit restriction** — Sub-agents must not run `git commit`/`git push`. When git hooks are installed (`sk install --install-git-hooks`), both are blocked at the filesystem level for the repo where the tentacle was dispatched, while the `dispatched-subagent-active` marker is fresh. Commits in other repos are not affected. Even without hooks, a sub-agent commit mid-run corrupts the orchestrator's merge flow. Enforcement is local-only; cloud-delegated runs are not covered.

--- a/skills/tentacle-orchestration/references/cli-reference.md
+++ b/skills/tentacle-orchestration/references/cli-reference.md
@@ -1,60 +1,60 @@
 # Tentacle CLI Reference
 
-All commands use `python3 ~/.copilot/tools/tentacle.py`.
+All commands use `sk tentacle` (fallback: `python3 ~/.copilot/tools/tentacle.py`).
 
 ## Lifecycle Commands
 
 ```bash
 # Create a tentacle (--briefing injects past knowledge into CONTEXT.md)
-tentacle.py create <name> --scope "<paths>" --desc "<desc>" --briefing
+sk tentacle create <name> --scope "<paths>" --desc "<desc>" --briefing
 
 # Add todo items
-tentacle.py todo <name> add "<task>"
+sk tentacle todo <name> add "<task>"
 
 # View all tentacles
-tentacle.py status
+sk tentacle status
 
 # View one tentacle in detail
-tentacle.py show <name>
+sk tentacle show <name>
 
 # Mark a todo done
-tentacle.py todo <name> done <index>
+sk tentacle todo <name> done <index>
 
 # Record structured agent output (preferred form)
 # --status: DONE | BLOCKED | TOO_BIG | AMBIGUOUS | REGRESSED
 # --changed-file is repeatable (one per file modified)
-tentacle.py handoff <name> "<prose summary>" --status DONE --changed-file path/to/file.py --learn
+sk tentacle handoff <name> "<prose summary>" --status DONE --changed-file path/to/file.py --learn
 
 # Backward-compatible free-form handoff (no structured status)
-tentacle.py handoff <name> "<message>" --learn
+sk tentacle handoff <name> "<message>" --learn
 
 # Run a verification command and persist results (for goal-eval and gate evidence)
-tentacle.py verify <name> "<shell-command>" --label "<human-readable label>"
+sk tentacle verify <name> "<shell-command>" --label "<human-readable label>"
 
 # Orchestrator-level goal state helpers
-tentacle.py goal init --title "<goal title>" [--desc "<goal description>"] [--force]
-tentacle.py goal status [--format text|json]
-tentacle.py goal link <name>
-tentacle.py goal eval [--decision continue|pause|complete|abandon] [--notes "<notes>"]
-tentacle.py goal resume
+sk tentacle goal init --title "<goal title>" [--desc "<goal description>"] [--force]
+sk tentacle goal status [--format text|json]
+sk tentacle goal link <name>
+sk tentacle goal eval [--decision continue|pause|complete|abandon] [--notes "<notes>"]
+sk tentacle goal resume
 
 # Generate bundle-first dispatch prompt for an agent
-tentacle.py swarm <name> --agent-type <type> --model <model> --briefing
+sk tentacle swarm <name> --agent-type <type> --model <model> --briefing
 
 # Generate parallel dispatch (one agent per todo, bundle-first by default)
-tentacle.py swarm <name> --output parallel --briefing
+sk tentacle swarm <name> --output parallel --briefing
 
 # Structured JSON dispatch; includes bundle_path by default
-tentacle.py swarm <name> --output json --briefing
+sk tentacle swarm <name> --output json --briefing
 
 # Rare opt-out for tiny/manual prompts
-tentacle.py swarm <name> --no-bundle
+sk tentacle swarm <name> --no-bundle
 
 # Complete tentacle (auto-learn from handoff)
-tentacle.py complete <name>
+sk tentacle complete <name>
 
 # Delete a tentacle
-tentacle.py delete <name>
+sk tentacle delete <name>
 ```
 
 ## Session-Knowledge Integration
@@ -88,19 +88,19 @@ Lifecycle: `goal init → create/link → todo add → swarm/dispatch (bundle-fi
 
 ```bash
 # Successful completion with two changed files
-tentacle.py handoff my-feature "Implemented auth refresh. All tests pass." \
+sk tentacle handoff my-feature "Implemented auth refresh. All tests pass." \
   --status DONE \
   --changed-file src/auth/refresh.py \
   --changed-file tests/test_auth.py \
   --learn
 
 # Blocked — needs scope expansion
-tentacle.py handoff my-feature "Cannot complete: db schema change required in src/db/ (out of scope)" \
+sk tentacle handoff my-feature "Cannot complete: db schema change required in src/db/ (out of scope)" \
   --status BLOCKED \
   --learn
 
 # Free-form (no structured status — backward-compatible)
-tentacle.py handoff my-feature "Updated config docs" --learn
+sk tentacle handoff my-feature "Updated config docs" --learn
 ```
 
 ## CONTEXT.md Template

--- a/skills/tentacle-orchestration/references/verification-gates.md
+++ b/skills/tentacle-orchestration/references/verification-gates.md
@@ -99,7 +99,7 @@ Skip this step for low-risk changes (documentation, formatting, simple refactors
 
 ## Orchestrator Triage (Handoff Status)
 
-After a sub-agent writes its handoff, `tentacle.py handoff` and `tentacle.py complete` emit a
+After a sub-agent writes its handoff, `sk tentacle handoff` and `sk tentacle complete` emit a
 visible triage signal when `--status` is a non-`DONE` value. The orchestrator must act on these
 before running the standard verification gates.
 
@@ -129,16 +129,17 @@ during evaluation). Weak criteria ("looks good") cannot be evaluated; strong cri
 **How to record goal-eval evidence:**
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py verify <name> "<success-criteria-check>" --label "goal-eval"
+sk tentacle verify <name> "<success-criteria-check>" --label "goal-eval"
+# fallback: python3 ~/.copilot/tools/tentacle.py verify <name> ...
 ```
 
 Examples:
 ```bash
 # Verify tests all pass
-tentacle.py verify my-feature "python3 run_all_tests.py" --label "goal-eval: tests"
+sk tentacle verify my-feature "python3 run_all_tests.py" --label "goal-eval: tests"
 
 # Verify benchmark threshold
-tentacle.py verify my-feature "python3 benchmark.py --check --min-score 90" --label "goal-eval: score"
+sk tentacle verify my-feature "python3 benchmark.py --check --min-score 90" --label "goal-eval: score"
 ```
 
 **Decision table:**

--- a/templates/SKILL.md
+++ b/templates/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 You have access to a knowledge base built from past Copilot and Claude sessions.
 Use it to avoid repeating mistakes, reuse proven patterns, and recall past decisions.
 
-All tools are Python scripts in `~/.copilot/tools/` (cross-platform: `~` = home directory).
+All tools are available as `sk <command>` (the preferred short form) or `python3 ~/.copilot/tools/<script>.py` (fallback when `sk` is not yet on PATH).
 
 ## When to Use
 
@@ -42,14 +42,15 @@ surfaces nothing useful costs tokens without benefit.
 ### 1. Briefing (recommended first step)
 
 ```bash
-python3 ~/.copilot/tools/briefing.py "your task description"    # Compact ~500 tokens
-python3 ~/.copilot/tools/briefing.py "your task" --full         # Full detail ~3K tokens
-python3 ~/.copilot/tools/briefing.py --auto                     # Auto-detect from git/plan
-python3 ~/.copilot/tools/briefing.py --wakeup                   # Ultra-compact ~170 tokens for session start
-python3 ~/.copilot/tools/briefing.py --titles-only              # Index only ~10 tok/entry — progressive disclosure
-python3 ~/.copilot/tools/briefing.py --titles-only "topic"      # Filtered titles
-python3 ~/.copilot/tools/briefing.py "task" --wing ui --room settings  # Filter by wing/room
-python3 ~/.copilot/tools/briefing.py "task" --min-confidence 0.7       # High-quality entries only
+sk briefing "your task description"    # Compact ~500 tokens
+sk briefing "your task" --full         # Full detail ~3K tokens
+sk briefing --auto                     # Auto-detect from git/plan
+sk briefing --wakeup                   # Ultra-compact ~170 tokens for session start
+sk briefing --titles-only              # Index only ~10 tok/entry — progressive disclosure
+sk briefing --titles-only "topic"      # Filtered titles
+sk briefing "task" --wing ui --room settings  # Filter by wing/room
+sk briefing "task" --min-confidence 0.7       # High-quality entries only
+# fallback: python3 ~/.copilot/tools/briefing.py <args>
 ```
 
 Output includes: relevant mistakes to avoid, patterns to follow, related past work.
@@ -60,7 +61,8 @@ Output includes: relevant mistakes to avoid, patterns to follow, related past wo
 When dispatching tentacle agents, prefer the bundle-first structured recall path:
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py swarm <name> --briefing
+sk tentacle swarm <name> --briefing
+# fallback: python3 ~/.copilot/tools/tentacle.py swarm <name> --briefing
 ```
 
 This materializes `.octogent/tentacles/<name>/bundle/` by default, keeps the dispatch prompt
@@ -75,63 +77,67 @@ For manual compatibility and ad hoc non-tentacle prompts, inject context directl
 
 ```bash
 python3 ~/.copilot/tools/briefing.py "task description" --for-subagent
+# (--for-subagent is also available via: sk briefing "task description" --for-subagent)
 ```
 
 This outputs a compact `[KNOWLEDGE CONTEXT]` block (~200 tokens) designed to be
 embedded directly into prompts. Example manual workflow:
 
-1. Run `briefing.py "fix Docker networking" --for-subagent` → get context block
+1. Run `sk briefing "fix Docker networking" --for-subagent` → get context block
 2. Prepend the context block to the sub-agent's prompt
 3. Sub-agent now knows past mistakes/patterns without querying KB directly
 
 ### 2. Search
 
 ```bash
-python3 ~/.copilot/tools/query-session.py "search terms"              # Compact results
-python3 ~/.copilot/tools/query-session.py "docker error" --verbose    # Full content
-python3 ~/.copilot/tools/query-session.py "deployment error" --semantic            # Compact semantic output
-python3 ~/.copilot/tools/query-session.py "deployment error" --semantic --verbose  # Shows feedback bias only when non-zero
-python3 ~/.copilot/tools/query-session.py "spring" --source copilot   # Filter by agent
-python3 ~/.copilot/tools/query-session.py "gradle" --type research    # Filter by doc type
+sk query "search terms"              # Compact results
+sk query "docker error" --verbose    # Full content
+sk query "deployment error" --semantic            # Compact semantic output
+sk query "deployment error" --semantic --verbose  # Shows feedback bias only when non-zero
+sk query "spring" --source copilot   # Filter by agent
+sk query "gradle" --type research    # Filter by doc type
+# fallback: python3 ~/.copilot/tools/query-session.py <args>
 ```
 
 ### 3. Drill Down (use entry IDs from search/briefing results)
 
 ```bash
-python3 ~/.copilot/tools/query-session.py --detail <id>     # Full content of one entry
-python3 ~/.copilot/tools/query-session.py --context <id>    # Entry + same-session entries
-python3 ~/.copilot/tools/query-session.py --related <id>    # Entry + graph connections
+sk query --detail <id>     # Full content of one entry
+sk query --context <id>    # Entry + same-session entries
+sk query --related <id>    # Entry + graph connections
+# fallback: python3 ~/.copilot/tools/query-session.py <flag> <id>
 ```
 
-`query-session.py --detail <id>` writes stateless `detail_open` telemetry:
+`sk query --detail <id>` writes stateless `detail_open` telemetry:
 - found entry → `hit_count=1`, `selected_entry_ids=[id]`
 - missing entry → `hit_count=0`, `selected_entry_ids=[]`
 
 ### 4. Browse by Category
 
 ```bash
-python3 ~/.copilot/tools/query-session.py --mistakes    # Past errors and how they were fixed
-python3 ~/.copilot/tools/query-session.py --patterns    # Reusable best practices
-python3 ~/.copilot/tools/query-session.py --decisions   # Architecture/design choices
-python3 ~/.copilot/tools/query-session.py --tools       # Tool configs and usage notes
+sk query --mistakes    # Past errors and how they were fixed
+sk query --patterns    # Reusable best practices
+sk query --decisions   # Architecture/design choices
+sk query --tools       # Tool configs and usage notes
 ```
 
 ### 4b. Recall Telemetry Stats
 
 ```bash
-python3 ~/.copilot/tools/knowledge-health.py --recall
-python3 ~/.copilot/tools/knowledge-health.py --recall --json
+sk index health --recall
+sk index health --recall --json
+# fallback: python3 ~/.copilot/tools/knowledge-health.py --recall [--json]
 ```
 
 - `recall_events` is lean telemetry (counts/IDs/output size only), not verbose output logging.
-- Default `query-session.py "query"` telemetry aggregates the full emitted surface
+- Default `sk query "query"` telemetry aggregates the full emitted surface
   (primary search + `sessions_fts` + knowledge-entry blocks).
 - `--recall` outputs recall-only stats (text or JSON). No browse UI / contextual summary / provider rerank scope here.
 
 ### 5. Knowledge Graph
 
 ```bash
-python3 ~/.copilot/tools/query-session.py --graph "topic"   # Visual: entries + connections
+sk query --graph "topic"   # Visual: entries + connections
 ```
 
 Shows how knowledge entries relate to each other:
@@ -140,42 +146,44 @@ Shows how knowledge entries relate to each other:
 - **SAME_SESSION** — entries discovered together in one session
 - **SAME_TOPIC** — same topic tracked across multiple sessions
 
-### 6. Record Knowledge (learn.py)
+### 6. Record Knowledge
 
 ```bash
 # 7 observation types
-python3 ~/.copilot/tools/learn.py --mistake "Title"   "What went wrong and fix"         --tags "tag1,tag2"
-python3 ~/.copilot/tools/learn.py --pattern "Title"   "What works well / best practice" --tags "tag1"
-python3 ~/.copilot/tools/learn.py --decision "Title"  "Architecture decision rationale" --tags "tag1"
-python3 ~/.copilot/tools/learn.py --tool "Title"      "Tool/config that was useful"     --tags "tag1"
-python3 ~/.copilot/tools/learn.py --feature "Title"   "New feature implementation"      --tags "tag1"
-python3 ~/.copilot/tools/learn.py --refactor "Title"  "Code improvement description"    --tags "tag1"
-python3 ~/.copilot/tools/learn.py --discovery "Title" "Codebase finding or insight"     --tags "tag1"
+sk learn --mistake "Title"   "What went wrong and fix"         --tags "tag1,tag2"
+sk learn --pattern "Title"   "What works well / best practice" --tags "tag1"
+sk learn --decision "Title"  "Architecture decision rationale" --tags "tag1"
+sk learn --tool "Title"      "Tool/config that was useful"     --tags "tag1"
+sk learn --feature "Title"   "New feature implementation"      --tags "tag1"
+sk learn --refactor "Title"  "Code improvement description"    --tags "tag1"
+sk learn --discovery "Title" "Codebase finding or insight"     --tags "tag1"
 
 # Structured facts (discrete, verifiable statements)
-python3 ~/.copilot/tools/learn.py --pattern "Title" "Description" \
+sk learn --pattern "Title" "Description" \
   --fact "max retries is 3" --fact "timeout is 30s"
 
 # Palace categorization (wing/room)
-python3 ~/.copilot/tools/learn.py --mistake "Title" "Description" --wing ui --room settings
+sk learn --mistake "Title" "Description" --wing ui --room settings
 
 # Knowledge graph relations
-python3 ~/.copilot/tools/learn.py --relate "ScreenA" "navigates_to" "ScreenB"
-python3 ~/.copilot/tools/learn.py --relate "ComponentX" "uses" "ThemeToken"
+sk learn --relate "ScreenA" "navigates_to" "ScreenB"
+sk learn --relate "ComponentX" "uses" "ThemeToken"
 
 # Bulk import / view
-python3 ~/.copilot/tools/learn.py --from-file notes.md    # Bulk import from markdown
-python3 ~/.copilot/tools/learn.py --list                   # List recent entries
-python3 ~/.copilot/tools/learn.py --stats                  # Knowledge base statistics
+sk learn --from-file notes.md    # Bulk import from markdown
+sk learn --list                   # List recent entries
+sk learn --stats                  # Knowledge base statistics
+# fallback: python3 ~/.copilot/tools/learn.py <args>
 ```
 
 ### 7. Auto-Update Tools
 
 ```bash
-python3 ~/.copilot/tools/auto-update-tools.py              # Auto-update (24h cooldown)
-python3 ~/.copilot/tools/auto-update-tools.py --force       # Force update now
-python3 ~/.copilot/tools/auto-update-tools.py --status      # Show version info
-python3 ~/.copilot/tools/auto-update-tools.py --doctor      # Health check
+sk update              # Auto-update (24h cooldown)
+sk update --force       # Force update now
+sk update --status      # Show version info
+sk update --doctor      # Health check
+# fallback: python3 ~/.copilot/tools/auto-update-tools.py <args>
 ```
 
 ### 8. Optional Sync Runtime (local-first)
@@ -184,41 +192,43 @@ Use these only when sync replication is needed. Local `knowledge.db` remains pri
 
 ```bash
 # Single connection string in ~/.copilot/tools/sync-config.json
-python3 ~/.copilot/tools/sync-config.py --setup https://gateway.example.com
-python3 ~/.copilot/tools/sync-config.py --setup-env SYNC_GATEWAY_URL
-python3 ~/.copilot/tools/sync-config.py --status
-python3 ~/.copilot/tools/sync-config.py --status --json
-python3 ~/.copilot/tools/sync-config.py --get
-python3 ~/.copilot/tools/sync-config.py --clear
+sk sync config --setup https://gateway.example.com
+sk sync config --setup-env SYNC_GATEWAY_URL
+sk sync config --status
+sk sync config --status --json
+sk sync config --get
+sk sync config --clear
 
 # Local-first runtime + diagnostics
-python3 ~/.copilot/tools/sync-daemon.py --once
-python3 ~/.copilot/tools/sync-daemon.py --daemon
-python3 ~/.copilot/tools/sync-daemon.py --interval 30
-python3 ~/.copilot/tools/sync-daemon.py --push-only
-python3 ~/.copilot/tools/sync-daemon.py --pull-only
-python3 ~/.copilot/tools/sync-status.py --json
-python3 ~/.copilot/tools/sync-status.py --watch-status --json
-python3 ~/.copilot/tools/sync-status.py --health-check --json
-python3 ~/.copilot/tools/sync-status.py --audit --json
-python3 ~/.copilot/tools/auto-update-tools.py --restart-watch
-python3 ~/.copilot/tools/auto-update-tools.py --watch-status
-python3 ~/.copilot/tools/auto-update-tools.py --health-check
-python3 ~/.copilot/tools/auto-update-tools.py --audit-runtime
+sk sync run --once
+sk sync run --daemon
+sk sync run --interval 30
+sk sync run --push-only
+sk sync run --pull-only
+sk sync status --json
+sk sync status --watch-status --json
+sk sync status --health-check --json
+sk sync status --audit --json
+sk update --restart-watch
+sk update --watch-status
+sk update --health-check
+sk update --audit-runtime
+# fallback: python3 ~/.copilot/tools/sync-config.py / sync-daemon.py / sync-status.py / auto-update-tools.py
 ```
 
 If no `connection_string` is configured, daemon sync remains local-only/idle.
 Daemon runtime is hardened for backlog catch-up: adaptive per-cycle limits, multi-page pull in one cycle, and post-pull targeted refresh of `knowledge_fts` / `ke_fts`.
-`sync-config.py --setup` expects an HTTP(S) gateway URL (not a raw Postgres/libSQL DSN).
+`sk sync config --setup` expects an HTTP(S) gateway URL (not a raw Postgres/libSQL DSN).
 `sync-gateway.py` is a **reference/mock** contract surface in this repo (not production authority).
 Default provider rollout recommendation: Neon (backing Postgres) + Railway (thin gateway host), while preserving the same HTTP gateway contract.
 
 ### 9. Trend Scout operations (scheduled, not hook-driven)
 
 ```bash
-python3 ~/.copilot/tools/trend-scout.py --search-only
-python3 ~/.copilot/tools/trend-scout.py --dry-run --limit 1 --force
-python3 ~/.copilot/tools/trend-scout.py --limit 1 --force
+sk scout run --search-only
+sk scout run --dry-run --limit 1 --force
+sk scout run --limit 1 --force
+# fallback: python3 ~/.copilot/tools/trend-scout.py <args>
 ```
 
 - Trend Scout creates **or updates** marker-linked issues.
@@ -240,15 +250,15 @@ python3 ~/.copilot/tools/trend-scout.py --limit 1 --force
 ## Workflow Example
 
 ```
-1. briefing.py "fix Docker compose networking"
+1. sk briefing "fix Docker compose networking"
    → shows 2 past mistakes about Docker DNS, 1 pattern about compose networks
 
-2. query-session.py --detail 2045
+2. sk query --detail 2045
    → reads the full mistake: was using wrong network driver
 
 3. Apply the fix using the pattern from the briefing
 
-4. learn.py --pattern "Docker DNS Fix" "Use bridge network with explicit DNS" \
+4. sk learn --pattern "Docker DNS Fix" "Use bridge network with explicit DNS" \
      --fact "compose DNS uses service names" --wing infrastructure --room docker
 ```
 
@@ -257,14 +267,14 @@ User: "I need to add retry logic to the payment service. Where should I start?"
 
 1. Run briefing before touching anything:
    ```
-   python3 ~/.copilot/tools/briefing.py "add retry logic payment service" --auto --compact
+   sk briefing "add retry logic payment service" --auto --compact
    ```
    → Output surfaces a past mistake: "Exponential backoff not applied to idempotent endpoints"
    and a pattern: "Use tenacity library with max_attempts=3, wait=wait_exponential(min=1, max=10)"
 
 2. Drill into the pattern entry shown in results:
    ```
-   python3 ~/.copilot/tools/query-session.py --detail 1842
+   sk query --detail 1842
    ```
    → Full entry: exact tenacity config that worked in the order service
 
@@ -272,7 +282,7 @@ User: "I need to add retry logic to the payment service. Where should I start?"
 
 4. Record what was learned:
    ```
-   python3 ~/.copilot/tools/learn.py --pattern "Payment retry with tenacity" \
+   sk learn --pattern "Payment retry with tenacity" \
      "Use tenacity with max_attempts=3, wait_exponential(min=1, max=10) on POST /charge" \
      --fact "idempotency key required on retry" --wing backend --room payments
    ```
@@ -283,7 +293,7 @@ User: "Getting 'SSL: CERTIFICATE_VERIFY_FAILED' on CI — has this come up befor
 
 1. Search for the error message:
    ```
-   python3 ~/.copilot/tools/query-session.py "SSL CERTIFICATE_VERIFY_FAILED"
+   sk query "SSL CERTIFICATE_VERIFY_FAILED"
    ```
    → Finds a past mistake entry explaining that the corporate proxy strips certs and the fix
    was to set `REQUESTS_CA_BUNDLE` to the internal CA bundle path.
@@ -292,7 +302,7 @@ User: "Getting 'SSL: CERTIFICATE_VERIFY_FAILED' on CI — has this come up befor
 
 3. If it was a new variant, record it:
    ```
-   python3 ~/.copilot/tools/learn.py --mistake "SSL verify failed behind proxy" \
+   sk learn --mistake "SSL verify failed behind proxy" \
      "Corporate proxy strips SSL — set REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt" \
      --tags "ssl,ci,proxy" --wing devops --room ci
    ```
@@ -301,7 +311,8 @@ User: "Getting 'SSL: CERTIFICATE_VERIFY_FAILED' on CI — has this come up befor
 ## Semantic Search (if embeddings configured)
 
 ```bash
-python3 ~/.copilot/tools/query-session.py "deployment error" --semantic
+sk query "deployment error" --semantic
+# fallback: python3 ~/.copilot/tools/query-session.py "deployment error" --semantic
 ```
 
 Works with meaning, not just keywords. Requires API key setup via `embed.py --setup`.

--- a/templates/copilot-instructions.md
+++ b/templates/copilot-instructions.md
@@ -49,10 +49,10 @@ Chi tiết nằm trong `~/.github/instructions/`:
 - Sync dùng mô hình local-first: local `knowledge.db` vẫn là nguồn đọc chính.
 - Cấu hình chỉ có **một** `connection_string` trong `~/.copilot/tools/sync-config.json`.
 - Lệnh runtime/diagnostics:
-  - `python3 ~/.copilot/tools/sync-config.py --setup <url>|--setup-env <ENV_VAR>|--status|--status --json|--get|--clear`
-  - `python3 ~/.copilot/tools/sync-daemon.py --once|--daemon|--interval <seconds>|--push-only|--pull-only`
-  - `python3 ~/.copilot/tools/sync-status.py [--json]|--watch-status [--json]|--health-check [--json]|--audit [--json]`
-  - `python3 ~/.copilot/tools/auto-update-tools.py --restart-watch|--watch-status|--health-check|--audit-runtime`
+  - `sk sync config --setup <url>|--setup-env <ENV_VAR>|--status|--status --json|--get|--clear` (fallback: `python3 ~/.copilot/tools/sync-config.py ...`)
+  - `sk sync run --once|--daemon|--interval <seconds>|--push-only|--pull-only` (fallback: `python3 ~/.copilot/tools/sync-daemon.py ...`)
+  - `sk sync status [--json]|--watch-status [--json]|--health-check [--json]|--audit [--json]` (fallback: `python3 ~/.copilot/tools/sync-status.py ...`)
+  - `sk update --restart-watch|--watch-status|--health-check|--audit-runtime` (fallback: `python3 ~/.copilot/tools/auto-update-tools.py ...`)
 - Không có `connection_string` ⇒ sync daemon local-only/idle (không fail cứng).
 - Hardening runtime: daemon tự tăng giới hạn sync khi backlog lớn, pull nhiều page trong một cycle, và refresh `knowledge_fts` / `ke_fts` ngay sau pull apply.
 - `sync-gateway.py` chỉ là **reference/mock** contract surface (`/sync/push`, `/sync/pull`, `/healthz`), không phải production authority.

--- a/templates/session-knowledge.instructions.md
+++ b/templates/session-knowledge.instructions.md
@@ -12,14 +12,15 @@ Use the lightest fetch that covers the task complexity:
 
 ```bash
 # Trivial tasks (rename, formatting, single-line fix) — skip or ultra-compact
-python3 ~/.copilot/tools/briefing.py --wakeup          # ~170 tokens, titles only
+sk briefing --wakeup          # ~170 tokens, titles only
 
 # Moderate tasks (bug fix, small feature) — compact is usually enough
-python3 ~/.copilot/tools/briefing.py --auto --compact  # ~500 tokens, top results
+sk briefing --auto --compact  # ~500 tokens, top results
 
 # Complex or unfamiliar tasks — request full detail only after compact reveals a hit
-python3 ~/.copilot/tools/query-session.py --detail <id>  # Expand one entry by ID
-python3 ~/.copilot/tools/briefing.py "task" --full       # Full detail ~3K tokens
+sk query --detail <id>  # Expand one entry by ID
+sk briefing "task" --full       # Full detail ~3K tokens
+# fallback: python3 ~/.copilot/tools/briefing.py <args> / python3 ~/.copilot/tools/query-session.py <args>
 ```
 
 Read the output before acting. It surfaces past mistakes and proven patterns.
@@ -29,7 +30,8 @@ Read the output before acting. It surfaces past mistakes and proven patterns.
 When dispatching tentacle agents, prefer the structured recall path in `tentacle.py`:
 
 ```bash
-python3 ~/.copilot/tools/tentacle.py swarm <name> --briefing
+sk tentacle swarm <name> --briefing
+# fallback: python3 ~/.copilot/tools/tentacle.py swarm <name> --briefing
 ```
 
 This injects bounded `[KNOWLEDGE EVIDENCE]` by trying `briefing.py --task <id> --json`
@@ -42,34 +44,36 @@ keeps category buckets in `entries.<category>[]`. Drilldown may add
 
 ```bash
 # 1. Create tentacle
-python3 ~/.copilot/tools/tentacle.py create <name> --scope "<paths>" --desc "<desc>" --briefing --skill <skill-name>
+sk tentacle create <name> --scope "<paths>" --desc "<desc>" --briefing --skill <skill-name>
 
 # 2. Add todos
-python3 ~/.copilot/tools/tentacle.py todo <name> add "<task>"
+sk tentacle todo <name> add "<task>"
 
 # 3. (Optional) Prepare isolated worktree + pre-warm bundle before dispatch
-python3 ~/.copilot/tools/tentacle.py worktree <name> prepare
-python3 ~/.copilot/tools/tentacle.py bundle <name> --worktree
+sk tentacle worktree <name> prepare
+sk tentacle bundle <name> --worktree
 
 # 4. Dispatch (bundle is default; --worktree surfaces isolated repo path too)
-python3 ~/.copilot/tools/tentacle.py swarm <name> --agent-type general-purpose --model claude-sonnet-4.6 --briefing --worktree
-python3 ~/.copilot/tools/tentacle.py dispatch <name> --briefing --worktree
+sk tentacle swarm <name> --agent-type general-purpose --model claude-sonnet-4.6 --briefing --worktree
+sk tentacle dispatch <name> --briefing --worktree
 
 # 5. Operator monitoring (read-only)
-python3 ~/.copilot/tools/tentacle.py status
+sk tentacle status
 
 # 6. Verify, record learnings, close (orchestrator only)
-python3 ~/.copilot/tools/tentacle.py verify <name> "python3 test_fixes.py" --label "tests"
-python3 ~/.copilot/tools/tentacle.py handoff <name> "summary" --learn
-python3 ~/.copilot/tools/tentacle.py complete <name>   # marks done, clears marker, auto-learns
-python3 ~/.copilot/tools/tentacle.py worktree <name> cleanup
+sk tentacle verify <name> "python3 test_fixes.py" --label "tests"
+sk tentacle handoff <name> "summary" --learn
+sk tentacle complete <name>   # marks done, clears marker, auto-learns
+sk tentacle worktree <name> cleanup
+# fallback: python3 ~/.copilot/tools/tentacle.py <subcommand> <args>
 ```
 
 For manual compatibility or ad hoc non-tentacle prompts, inject compact context directly:
 
 ```bash
 # Manual compatibility path — compact and directly injectable
-python3 ~/.copilot/tools/briefing.py "task description" --for-subagent
+sk briefing "task description" --for-subagent
+# fallback: python3 ~/.copilot/tools/briefing.py "task description" --for-subagent
 ```
 
 Include output verbatim in the sub-agent prompt under a `## Past Knowledge` section.
@@ -87,33 +91,34 @@ When sync is configured, keep guidance aligned to shipped behavior:
 
 ```bash
 # one connection_string in ~/.copilot/tools/sync-config.json
-python3 ~/.copilot/tools/sync-config.py --setup <https://gateway>
-python3 ~/.copilot/tools/sync-config.py --setup-env SYNC_GATEWAY_URL
-python3 ~/.copilot/tools/sync-config.py --status
-python3 ~/.copilot/tools/sync-config.py --status --json
-python3 ~/.copilot/tools/sync-config.py --clear
-python3 ~/.copilot/tools/sync-config.py --get
+sk sync config --setup <https://gateway>
+sk sync config --setup-env SYNC_GATEWAY_URL
+sk sync config --status
+sk sync config --status --json
+sk sync config --clear
+sk sync config --get
 
 # local-first runtime + diagnostics
-python3 ~/.copilot/tools/sync-daemon.py --once
-python3 ~/.copilot/tools/sync-daemon.py --daemon
-python3 ~/.copilot/tools/sync-daemon.py --interval 30
-python3 ~/.copilot/tools/sync-daemon.py --push-only
-python3 ~/.copilot/tools/sync-daemon.py --pull-only
-python3 ~/.copilot/tools/sync-status.py --json
-python3 ~/.copilot/tools/sync-status.py --watch-status --json
-python3 ~/.copilot/tools/sync-status.py --health-check --json
-python3 ~/.copilot/tools/sync-status.py --audit --json
-python3 ~/.copilot/tools/auto-update-tools.py --restart-watch
-python3 ~/.copilot/tools/auto-update-tools.py --watch-status
-python3 ~/.copilot/tools/auto-update-tools.py --health-check
-python3 ~/.copilot/tools/auto-update-tools.py --audit-runtime
+sk sync run --once
+sk sync run --daemon
+sk sync run --interval 30
+sk sync run --push-only
+sk sync run --pull-only
+sk sync status --json
+sk sync status --watch-status --json
+sk sync status --health-check --json
+sk sync status --audit --json
+sk update --restart-watch
+sk update --watch-status
+sk update --health-check
+sk update --audit-runtime
+# fallback: python3 ~/.copilot/tools/sync-config.py / sync-daemon.py / sync-status.py / auto-update-tools.py
 ```
 
 - Missing `connection_string` means local-only idle sync (not fatal).
 - Runtime hardening: daemon auto-adjusts per-cycle limits on backlog, consumes multiple pull pages per cycle, and refreshes touched `knowledge_fts` / `ke_fts` rows after pull apply.
 - `sync-gateway.py` is **reference/mock only** in this repo.
-- `sync-config.py --setup` accepts an HTTP(S) gateway URL, not a raw Postgres/libSQL DSN.
+- `sk sync config --setup` accepts an HTTP(S) gateway URL, not a raw Postgres/libSQL DSN.
 - Default provider rollout recommendation: Neon (backing Postgres) + Railway (thin gateway host), while keeping the same HTTP gateway contract.
 - Browse sync status is read-only: `/healthz` → `sync_status_endpoint: "/api/sync/status"`.
 
@@ -122,9 +127,10 @@ python3 ~/.copilot/tools/auto-update-tools.py --audit-runtime
 Use Trend Scout as explicit/scheduled automation, not an interactive hook:
 
 ```bash
-python3 ~/.copilot/tools/trend-scout.py --search-only
-python3 ~/.copilot/tools/trend-scout.py --dry-run --limit 1 --force
-python3 ~/.copilot/tools/trend-scout.py --limit 1 --force
+sk scout run --search-only
+sk scout run --dry-run --limit 1 --force
+sk scout run --limit 1 --force
+# fallback: python3 ~/.copilot/tools/trend-scout.py <args>
 ```
 
 - It creates or updates marker-linked issues in the target repo.
@@ -134,15 +140,16 @@ python3 ~/.copilot/tools/trend-scout.py --limit 1 --force
 ## Recall Telemetry (Phase 5)
 
 ```bash
-python3 ~/.copilot/tools/knowledge-health.py --recall
-python3 ~/.copilot/tools/knowledge-health.py --recall --json
+sk index health --recall
+sk index health --recall --json
+# fallback: python3 ~/.copilot/tools/knowledge-health.py --recall [--json]
 ```
 
 - `recall_events` is lean telemetry only (counts/IDs/output size), not verbose output logging.
-- `query-session.py --detail <id>` is stateless telemetry:
+- `sk query --detail <id>` is stateless telemetry:
   - found entry → `detail_open` with `hit_count=1`, `selected_entry_ids=[id]`
   - missing entry → `detail_open` with `hit_count=0`, `selected_entry_ids=[]`
-- default `query-session.py "query"` telemetry aggregates the full emitted search surface
+- default `sk query "query"` telemetry aggregates the full emitted search surface
   (primary search block + `sessions_fts` block + knowledge-entry block).
 - If `recall_events` is unavailable on an older DB, recall commands still run (best-effort telemetry).
 - Browse UI, contextual summaries, and provider rerank are outside this telemetry scope.
@@ -152,10 +159,11 @@ python3 ~/.copilot/tools/knowledge-health.py --recall --json
 Record what you learned (choose the most specific type):
 
 ```bash
-python3 ~/.copilot/tools/learn.py --mistake "Title"   "Root cause and fix"  --tags "module,tech" --wing <wing> --room <room>
-python3 ~/.copilot/tools/learn.py --pattern "Title"   "What works well"     --tags "module,tech" --wing <wing> --room <room>
-python3 ~/.copilot/tools/learn.py --feature "Title"   "What was built"      --tags "module,tech" --wing <wing> --room <room>
-python3 ~/.copilot/tools/learn.py --discovery "Title" "Codebase insight"    --tags "module,tech" --wing <wing> --room <room>
+sk learn --mistake "Title"   "Root cause and fix"  --tags "module,tech" --wing <wing> --room <room>
+sk learn --pattern "Title"   "What works well"     --tags "module,tech" --wing <wing> --room <room>
+sk learn --feature "Title"   "What was built"      --tags "module,tech" --wing <wing> --room <room>
+sk learn --discovery "Title" "Codebase insight"    --tags "module,tech" --wing <wing> --room <room>
+# fallback: python3 ~/.copilot/tools/learn.py <type> <args>
 ```
 
 ## Rules

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -1901,6 +1901,97 @@ import shutil as _shutil
 _shutil.rmtree(str(_goal_tmp), ignore_errors=True)
 
 
+
+
+# ─── SK Launcher pipeline integration ────────────────────────────────────────────────────────
+
+print("\n🚀  SK Launcher pipeline")
+
+import importlib.util as _ilu_sk
+_sk_spec = _ilu_sk.spec_from_file_location("auto_update_sk", REPO / "auto-update-tools.py")
+_sk_aut = _ilu_sk.module_from_spec(_sk_spec)
+_saved_sk_argv = sys.argv[:]
+sys.argv = [str(REPO / "auto-update-tools.py")]
+try:
+    _sk_spec.loader.exec_module(_sk_aut)
+finally:
+    sys.argv = _saved_sk_argv
+
+import unittest.mock as _sk_mock
+
+_sk_refresh_calls = []
+
+
+def _sk_fake_changes(files: list) -> dict:
+    """Helper: simulate classify_changes by faking git diff output."""
+    with _sk_mock.patch.object(_sk_aut, "_git_output", return_value="\n".join(files)):
+        return _sk_aut.classify_changes("aaa", "bbb")
+
+
+# Sk1: classify_changes sets sk_launcher=True for sk.py, and refresh would be called
+with _sk_mock.patch.object(_sk_aut, "refresh_sk_launcher", side_effect=lambda: _sk_refresh_calls.append(1)):
+    _sk_changes = _sk_fake_changes(["sk.py"])
+    test("Sk1: classify_changes sets sk_launcher=True for sk.py",
+         _sk_changes.get("sk_launcher") is True,
+         "got " + repr(_sk_changes.get("sk_launcher")))
+    if _sk_changes.get("sk_launcher"):
+        _sk_aut.refresh_sk_launcher()
+    test("Sk1: refresh_sk_launcher invoked when sk_launcher=True",
+         len(_sk_refresh_calls) == 1,
+         f"call count: {len(_sk_refresh_calls)}")
+
+_sk_refresh_calls.clear()
+
+# Sk2: classify_changes sk_launcher=False for unrelated files
+with _sk_mock.patch.object(_sk_aut, "refresh_sk_launcher", side_effect=lambda: _sk_refresh_calls.append(1)):
+    _sk_changes2 = _sk_fake_changes(["watch-sessions.py"])
+    test("Sk2: classify_changes sk_launcher=False for unrelated change",
+         _sk_changes2.get("sk_launcher") is False,
+         "got " + repr(_sk_changes2.get("sk_launcher")))
+    if _sk_changes2.get("sk_launcher"):
+        _sk_aut.refresh_sk_launcher()
+    test("Sk2: refresh_sk_launcher NOT called when sk_launcher=False",
+         len(_sk_refresh_calls) == 0,
+         f"unexpected call count: {len(_sk_refresh_calls)}")
+
+# Sk3: instruction template changes trigger managed global-instructions refresh
+_sk_instruction_calls = []
+with _sk_mock.patch.object(_sk_aut, "refresh_global_instructions", side_effect=lambda: _sk_instruction_calls.append(1)):
+    _sk_changes3 = _sk_fake_changes(["templates/copilot-instructions.md"])
+    test("Sk3: classify_changes detects global instruction refresh",
+         bool(_sk_changes3.get("global_instructions")),
+         "got " + repr(_sk_changes3.get("global_instructions")))
+    if _sk_changes3.get("global_instructions"):
+        _sk_aut.refresh_global_instructions()
+    test("Sk3: refresh_global_instructions invoked when instruction templates change",
+         len(_sk_instruction_calls) == 1,
+         f"call count: {len(_sk_instruction_calls)}")
+
+# Sk4: hook config changes trigger managed hook refresh
+_sk_hook_calls = []
+with _sk_mock.patch.object(_sk_aut, "refresh_global_hooks", side_effect=lambda: _sk_hook_calls.append(1)):
+    _sk_changes4 = _sk_fake_changes(["hooks/hooks.json"])
+    test("Sk4: classify_changes detects managed hook refresh",
+         bool(_sk_changes4.get("managed_hooks")),
+         "got " + repr(_sk_changes4.get("managed_hooks")))
+    if _sk_changes4.get("managed_hooks"):
+        _sk_aut.refresh_global_hooks()
+    test("Sk4: refresh_global_hooks invoked when hook config changes",
+         len(_sk_hook_calls) == 1,
+         f"call count: {len(_sk_hook_calls)}")
+
+# Sk5: refresh_sk_launcher handles missing install.py gracefully
+_orig_td_sk = _sk_aut.TOOLS_DIR
+_sk_aut.TOOLS_DIR = REPO / ".test-scratch" / "nonexistent-dir"
+try:
+    try:
+        _sk_aut.refresh_sk_launcher()
+        test("Sk5: refresh_sk_launcher is safe when install.py missing", True)
+    except Exception as _e_sk:
+        test("Sk5: refresh_sk_launcher is safe when install.py missing", False, str(_e_sk))
+finally:
+    _sk_aut.TOOLS_DIR = _orig_td_sk
+
 # ─── Summary ────────────────────────────────────────────────────────────
 
 print(f"\n{'='*50}")

--- a/tests/test_auto_update_coverage.py
+++ b/tests/test_auto_update_coverage.py
@@ -66,6 +66,7 @@ REQUIRED_PATTERNS = [
     "hooks/rules/",
     "scripts/",
     ".github/workflows/",
+    ".github/hooks/",
     "skills/",
     "launchd/",
     "templates/",
@@ -102,6 +103,7 @@ cases = [
     ("browse/",       ["browse/core.py"],         "browse"),
     ("providers/",    ["providers/base.py"],       "providers"),
     ("hooks/rules/",  ["hooks/rules/lint.py"],     "hooks_rules"),
+    (".github/hooks/", [".github/hooks/hooks.json"], "github_hooks"),
     ("scripts/",      ["scripts/check.sh"],        "scripts"),
     (".github/workflows/", [".github/workflows/ci.yml"], "workflows"),
 ]
@@ -118,6 +120,26 @@ test("classify_changes still detects skills/",
      bool(result.get("skills")), f"skills={result.get('skills')!r}")
 test("classify_changes still detects launchd/",
      bool(result.get("launchd")), f"launchd={result.get('launchd')!r}")
+
+result_instructions = _fake_changes(["templates/copilot-instructions.md"])
+test("classify_changes detects global instruction template refresh",
+     bool(result_instructions.get("global_instructions")),
+     f"global_instructions={result_instructions.get('global_instructions')!r}")
+
+result_session_instructions = _fake_changes(["templates/session-knowledge.instructions.md"])
+test("classify_changes detects session-knowledge instruction refresh",
+     bool(result_session_instructions.get("global_instructions")),
+     f"global_instructions={result_session_instructions.get('global_instructions')!r}")
+
+result_managed_hooks = _fake_changes(["hooks/hooks.json"])
+test("classify_changes detects managed hooks refresh from hooks/",
+     bool(result_managed_hooks.get("managed_hooks")),
+     f"managed_hooks={result_managed_hooks.get('managed_hooks')!r}")
+
+result_legacy_hooks = _fake_changes([".github/hooks/hooks.json"])
+test("classify_changes detects managed hooks refresh from .github/hooks/",
+     bool(result_legacy_hooks.get("managed_hooks")),
+     f"managed_hooks={result_legacy_hooks.get('managed_hooks')!r}")
 
 
 # ─── 3. --list-coverage subcommand ──────────────────────────────────────────
@@ -289,6 +311,35 @@ with _mock2.patch("shutil.which") as _mw:
 test("#22: _pnpm_cmd returns ['pnpm'] when neither found (FileNotFoundError expected)",
      result_neither == ["pnpm"],
      f"got {result_neither!r}")
+
+
+# ─── SK Launcher coverage ───────────────────────────────────────────────────
+
+print("\n🚀  SK Launcher coverage")
+
+# COVERAGE_MANIFEST must have a 'Launcher' category (or a path containing bin/)
+all_covered = [pat for entries in _aut.COVERAGE_MANIFEST.values() for pat, _ in entries]
+test("COVERAGE_MANIFEST covers ~/.copilot/bin/ launcher dir",
+     any("bin" in pat for pat in all_covered),
+     f"covered paths: {all_covered}")
+
+# classify_changes() must return sk_launcher=True for sk.py changes
+result_sk = _fake_changes(["sk.py"])
+test("classify_changes sk_launcher=True when sk.py changed",
+     result_sk.get("sk_launcher") is True,
+     f"got sk_launcher={result_sk.get('sk_launcher')!r}")
+
+# classify_changes() must return sk_launcher=True for install.py changes
+result_inst = _fake_changes(["install.py"])
+test("classify_changes sk_launcher=True when install.py changed",
+     result_inst.get("sk_launcher") is True,
+     f"got sk_launcher={result_inst.get('sk_launcher')!r}")
+
+# classify_changes() must return sk_launcher=False for unrelated changes
+result_unrel = _fake_changes(["watch-sessions.py", "migrate.py", "docs/README.md"])
+test("classify_changes sk_launcher=False for unrelated files",
+     result_unrel.get("sk_launcher") is False,
+     f"got sk_launcher={result_unrel.get('sk_launcher')!r}")
 
 
 # ─── Summary ────────────────────────────────────────────────────────────────

--- a/tests/test_install_wave3.py
+++ b/tests/test_install_wave3.py
@@ -17,6 +17,7 @@ Run: python3 tests/test_install_wave3.py
 """
 
 import importlib.util
+import builtins
 import json
 import os
 import sys
@@ -250,6 +251,8 @@ test("TOOL_FILES contains build-session-index.py", "build-session-index.py" in _
 test("TOOL_FILES contains briefing.py", "briefing.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains watch-sessions.py", "watch-sessions.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains install.py", "install.py" in _install.TOOL_FILES)
+test("TOOL_FILES contains sk.py", "sk.py" in _install.TOOL_FILES)
+test("SUPPORT_FILES contains pyproject.toml", "pyproject.toml" in _install.SUPPORT_FILES)
 
 # MINIMAL_SKILL_MD sanity
 skill_md = _install.MINIMAL_SKILL_MD
@@ -258,6 +261,225 @@ test("MINIMAL_SKILL_MD contains name field", "name: session-knowledge" in skill_
 test("MINIMAL_SKILL_MD contains description", "description:" in skill_md)
 test("MINIMAL_SKILL_MD contains H1 title", "# Session Knowledge" in skill_md)
 test("MINIMAL_SKILL_MD mentions briefing.py", "briefing.py" in skill_md)
+
+
+# ── 9. Editable install uninstall guard ───────────────────────────────────────
+
+print("\n🧷 Editable install guard")
+
+
+class _FakeDist:
+    def __init__(self, name: str, direct_url_text: str | None):
+        self.metadata = {"Name": name}
+        self._direct_url_text = direct_url_text
+
+    def read_text(self, filename: str) -> str | None:
+        if filename == "direct_url.json":
+            return self._direct_url_text
+        return None
+
+
+original_distributions = _install.metadata.distributions
+editable_source = (SCRATCH / "editable-source").resolve()
+editable_source.mkdir(exist_ok=True)
+other_source = (SCRATCH / "other-source").resolve()
+other_source.mkdir(exist_ok=True)
+
+editable_direct_url = json.dumps({
+    "url": editable_source.as_uri(),
+    "dir_info": {"editable": True},
+})
+other_direct_url = json.dumps({
+    "url": other_source.as_uri(),
+    "dir_info": {"editable": True},
+})
+non_editable_direct_url = json.dumps({
+    "url": editable_source.as_uri(),
+    "dir_info": {"editable": False},
+})
+
+try:
+    _install.metadata.distributions = lambda: [_FakeDist("copilot-session-knowledge", editable_direct_url)]
+    detected = _install._matching_editable_install_source_dir(editable_source)
+    test("matching editable install detected", detected == editable_source)
+
+    _install.metadata.distributions = lambda: [_FakeDist("copilot-session-knowledge", other_direct_url)]
+    ignored_other = _install._matching_editable_install_source_dir(editable_source)
+    test("editable install in different source dir ignored", ignored_other is None)
+
+    _install.metadata.distributions = lambda: [_FakeDist("copilot-session-knowledge", non_editable_direct_url)]
+    ignored_non_editable = _install._matching_editable_install_source_dir(editable_source)
+    test("non-editable install ignored", ignored_non_editable is None)
+finally:
+    _install.metadata.distributions = original_distributions
+
+original_input = builtins.input
+original_match = _install._matching_editable_install_source_dir
+prompted = {"called": False}
+
+try:
+    builtins.input = lambda _prompt="": prompted.__setitem__("called", True) or "n"
+    _install._matching_editable_install_source_dir = lambda target_dir=None: editable_source
+    uninstall_rc = _install.uninstall()
+    test("uninstall blocks before confirmation when editable install detected", not prompted["called"])
+    test("blocked uninstall returns nonzero", uninstall_rc == 1)
+finally:
+    builtins.input = original_input
+    _install._matching_editable_install_source_dir = original_match
+
+
+# ── SK Launcher helpers ───────────────────────────────────────────────────────
+
+print("\n🚀  SK Launcher")
+
+import stat as _stat
+
+_SK_HOME = SCRATCH / "sk-launcher-home"
+_SK_HOME.mkdir(parents=True, exist_ok=True)
+_SK_BIN = _SK_HOME / ".copilot" / "bin"
+_SK_BIN.mkdir(parents=True, exist_ok=True)
+
+# Patch HOME + SK_LAUNCHER_DIR so launcher tests stay inside scratch space.
+_orig_home = _install.HOME
+_orig_sk_dir = _install.SK_LAUNCHER_DIR
+_orig_shell = os.environ.get("SHELL")
+_install.HOME = _SK_HOME
+_install.SK_LAUNCHER_DIR = _SK_BIN
+os.environ["SHELL"] = "/bin/zsh"
+
+try:
+    # install_sk_launcher() creates the script
+    result = _install.install_sk_launcher(quiet=True)
+    test("install_sk_launcher returns True on fresh install", result is True)
+
+    scripts = _install._sk_launcher_script_paths()
+    any_exist = any((_SK_BIN / p.name).exists() for p in scripts)
+    test("launcher script created in SK_LAUNCHER_DIR", any_exist)
+
+    # Content check: must reference sk.py
+    for p in scripts:
+        patched = _SK_BIN / p.name
+        if patched.exists():
+            content = patched.read_text(encoding="utf-8")
+            test("launcher content references sk.py", "sk.py" in content)
+            if os.name != "nt":
+                mode = os.stat(patched).st_mode
+                test("POSIX launcher script is executable", bool(mode & _stat.S_IXUSR))
+            break
+
+    profile_path = _SK_HOME / ".zshrc"
+    test("install_sk_launcher creates preferred shell profile when missing", profile_path.exists())
+    if profile_path.exists():
+        profile_content = profile_path.read_text(encoding="utf-8")
+        test("launcher PATH marker added to shell profile",
+             _install._SK_PATH_MARKER_START in profile_content)
+        test("launcher PATH export references SK_LAUNCHER_DIR",
+             str(_install.SK_LAUNCHER_DIR) in profile_content)
+
+    # Idempotency: second call returns False (already installed)
+    result2 = _install.install_sk_launcher(quiet=True)
+    test("install_sk_launcher returns False when already current", result2 is False)
+
+    # uninstall_sk_launcher() removes script
+    removed = _install.uninstall_sk_launcher(quiet=True)
+    test("uninstall_sk_launcher reports removals", removed > 0)
+    still_exists = any((_SK_BIN / p.name).exists() for p in scripts)
+    test("uninstall_sk_launcher removes launcher script", not still_exists)
+    if profile_path.exists():
+        cleaned_content = profile_path.read_text(encoding="utf-8")
+        test("uninstall_sk_launcher removes PATH marker from profile",
+             _install._SK_PATH_MARKER_START not in cleaned_content)
+
+    # uninstall safe when file missing (idempotent)
+    try:
+        removed_again = _install.uninstall_sk_launcher(quiet=True)
+        test("uninstall_sk_launcher is safe when files missing", True)
+        test("uninstall_sk_launcher returns 0 when already absent", removed_again == 0)
+    except Exception as _e:
+        test("uninstall_sk_launcher is safe when files missing", False, str(_e))
+
+finally:
+    _install.HOME = _orig_home
+    _install.SK_LAUNCHER_DIR = _orig_sk_dir
+    if _orig_shell is None:
+        os.environ.pop("SHELL", None)
+    else:
+        os.environ["SHELL"] = _orig_shell
+
+
+# ── _sk_launcher_content ──────────────────────────────────────────────────────
+
+print("\n📄  _sk_launcher_content")
+
+try:
+    content_auto = _install._sk_launcher_content()
+    test("launcher content references sk.py", "sk.py" in content_auto)
+    if os.name == "nt":
+        test("windows launcher references sk.py", "sk.py" in content_auto)
+    else:
+        test("posix launcher starts with shebang", content_auto.startswith("#!/"))
+        test("posix launcher passes args",
+             '"$@"' in content_auto or "$@" in content_auto)
+except Exception as _e:
+    test("_sk_launcher_content raises no exception", False, str(_e))
+    test("launcher content references sk.py", False, "function failed")
+    test("launcher passes args", False, "function failed")
+
+
+# ── Windows PATH helper normalization ─────────────────────────────────────────
+
+print("\n🪟 Windows launcher PATH helpers")
+
+
+class _FakeWinreg:
+    HKEY_CURRENT_USER = object()
+    KEY_READ = 1
+    KEY_WRITE = 2
+    REG_EXPAND_SZ = 2
+
+    def __init__(self, path_value: str):
+        self.path_value = path_value
+        self.last_written = None
+
+    def OpenKey(self, *_args):
+        return "fake-key"
+
+    def QueryValueEx(self, _key, _name):
+        return self.path_value, self.REG_EXPAND_SZ
+
+    def SetValueEx(self, _key, _name, _reserved, _kind, value):
+        self.last_written = value
+        self.path_value = value
+
+    def CloseKey(self, _key):
+        return None
+
+
+_orig_sk_dir_windows = _install.SK_LAUNCHER_DIR
+_orig_winreg = sys.modules.get("winreg")
+_install.SK_LAUNCHER_DIR = Path(r"C:\Users\tester\.copilot\bin")
+sys.modules["winreg"] = _FakeWinreg(
+    r"C:\Users\tester\.copilot\bin\;C:\Windows\System32",
+)
+
+try:
+    _install._inject_launcher_path_windows(quiet=True)
+    fake_winreg = sys.modules["winreg"]
+    test("windows PATH add avoids duplicate launcher entry with trailing slash",
+         fake_winreg.last_written is None)
+
+    removed_windows = _install._remove_launcher_path_windows(quiet=True)
+    test("windows PATH remove matches launcher entry with trailing slash",
+         removed_windows is True)
+    test("windows PATH remove preserves remaining entries",
+         fake_winreg.path_value == r"C:\Windows\System32",
+         fake_winreg.path_value)
+finally:
+    _install.SK_LAUNCHER_DIR = _orig_sk_dir_windows
+    if _orig_winreg is None:
+        sys.modules.pop("winreg", None)
+    else:
+        sys.modules["winreg"] = _orig_winreg
 
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+test_sk_cli.py — Focused tests for sk.py dispatcher.
+
+Covers:
+  - --help exits 0 and prints usage
+  - --version exits 0 and prints version string
+  - known direct commands route to the right script (subprocess stub)
+  - known grouped namespace commands route correctly
+  - unknown command exits 2 and prints error message
+  - group with no subcommand exits 0 and prints available subs
+
+Run: python3 tests/test_sk_cli.py
+"""
+
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+TOOLS_DIR = Path(__file__).parent.parent
+SK_PATH = TOOLS_DIR / "sk.py"
+
+
+def _load_sk():
+    spec = importlib.util.spec_from_file_location("sk", SK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+sk = _load_sk()
+
+
+class TestSkHelp(unittest.TestCase):
+    def test_help_short_flag(self):
+        with patch("builtins.print") as mock_print:
+            rc = sk.main(["-h"])
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("sk", output)
+        self.assertIn("briefing", output)
+
+    def test_help_long_flag(self):
+        with patch("builtins.print") as mock_print:
+            rc = sk.main(["--help"])
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("query", output)
+
+    def test_no_args_shows_help(self):
+        with patch("builtins.print"):
+            rc = sk.main([])
+        self.assertEqual(rc, 0)
+
+
+class TestSkVersion(unittest.TestCase):
+    def test_version_long(self):
+        with patch("builtins.print") as mock_print:
+            rc = sk.main(["--version"])
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("sk", output)
+        self.assertIn(sk.__version__, output)
+
+    def test_version_short(self):
+        with patch("builtins.print") as mock_print:
+            rc = sk.main(["-V"])
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn(sk.__version__, output)
+
+
+class TestSkDirectCommands(unittest.TestCase):
+    """Verify that direct commands call _run with the correct script."""
+
+    def _assert_routes(self, cmd: str, expected_script: str, extra: list[str] | None = None):
+        extra = extra or []
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main([cmd] + extra)
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with(expected_script, extra)
+
+    def test_briefing(self):
+        self._assert_routes("briefing", "briefing.py", ["--auto"])
+
+    def test_query(self):
+        self._assert_routes("query", "query-session.py", ["some query"])
+
+    def test_learn(self):
+        self._assert_routes("learn", "learn.py")
+
+    def test_tentacle(self):
+        self._assert_routes("tentacle", "tentacle.py", ["list"])
+
+    def test_install(self):
+        self._assert_routes("install", "install.py")
+
+    def test_setup(self):
+        self._assert_routes("setup", "setup-project.py")
+
+    def test_update(self):
+        self._assert_routes("update", "auto-update-tools.py")
+
+    def test_browse(self):
+        self._assert_routes("browse", "browse.py")
+
+    def test_benchmark(self):
+        self._assert_routes("benchmark", "benchmark.py")
+
+    def test_retro(self):
+        self._assert_routes("retro", "retro.py")
+
+    def test_heal(self):
+        self._assert_routes("heal", "copilot-cli-healer.py")
+
+
+class TestSkGroupedCommands(unittest.TestCase):
+    """Verify that grouped namespace commands route to the right script."""
+
+    def _assert_group_routes(self, group: str, sub: str, expected_script: str, extra: list[str] | None = None):
+        extra = extra or []
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main([group, sub] + extra)
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with(expected_script, extra)
+
+    # index group
+    def test_index_build(self):
+        self._assert_group_routes("index", "build", "build-session-index.py")
+
+    def test_index_extract(self):
+        self._assert_group_routes("index", "extract", "extract-knowledge.py")
+
+    def test_index_migrate(self):
+        self._assert_group_routes("index", "migrate", "migrate.py")
+
+    def test_index_status(self):
+        self._assert_group_routes("index", "status", "index-status.py")
+
+    def test_index_health(self):
+        self._assert_group_routes("index", "health", "knowledge-health.py")
+
+    def test_index_embed(self):
+        self._assert_group_routes("index", "embed", "embed.py")
+
+    # sync group
+    def test_sync_run(self):
+        self._assert_group_routes("sync", "run", "sync-daemon.py")
+
+    def test_sync_config(self):
+        self._assert_group_routes("sync", "config", "sync-config.py")
+
+    def test_sync_status(self):
+        self._assert_group_routes("sync", "status", "sync-status.py")
+
+    def test_sync_gateway(self):
+        self._assert_group_routes("sync", "gateway", "sync-gateway.py")
+
+    def test_sync_merge(self):
+        self._assert_group_routes("sync", "merge", "sync-knowledge.py")
+
+    # checkpoint group
+    def test_checkpoint_save(self):
+        self._assert_group_routes("checkpoint", "save", "checkpoint-save.py")
+
+    def test_checkpoint_restore(self):
+        self._assert_group_routes("checkpoint", "restore", "checkpoint-restore.py")
+
+    def test_checkpoint_diff(self):
+        self._assert_group_routes("checkpoint", "diff", "checkpoint-diff.py")
+
+    # profile group
+    def test_profile_build(self):
+        self._assert_group_routes("profile", "build", "profile-builder.py")
+
+    def test_profile_import(self):
+        self._assert_group_routes("profile", "import", "profile-import.py")
+
+    def test_profile_export(self):
+        self._assert_group_routes("profile", "export", "profile-export.py")
+
+    # context group
+    def test_context_project(self):
+        self._assert_group_routes("context", "project", "project-context.py")
+
+    def test_context_map(self):
+        self._assert_group_routes("context", "map", "codebase-map.py")
+
+    # scout group
+    def test_scout_run(self):
+        self._assert_group_routes("scout", "run", "trend-scout.py")
+
+    def test_scout_config(self):
+        self._assert_group_routes("scout", "config", "scout-config.py")
+
+    def test_scout_status(self):
+        self._assert_group_routes("scout", "status", "scout-status.py")
+
+
+class TestSkErrorCases(unittest.TestCase):
+    def test_unknown_command_returns_2(self):
+        with patch("builtins.print"):
+            rc = sk.main(["nonexistent-command"])
+        self.assertEqual(rc, 2)
+
+    def test_unknown_subcommand_returns_2(self):
+        with patch("builtins.print"):
+            rc = sk.main(["index", "no-such-sub"])
+        self.assertEqual(rc, 2)
+
+    def test_group_help_shows_subcommands(self):
+        with patch("builtins.print") as mock_print:
+            rc = sk.main(["index", "--help"])
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("build", output)
+
+    def test_group_no_sub_shows_usage(self):
+        with patch("builtins.print") as mock_print:
+            rc = sk.main(["sync"])
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("run", output)
+
+    def test_missing_script_returns_2(self):
+        """_run should return 2 when the target script does not exist."""
+        rc = sk._run("does-not-exist.py", [])
+        self.assertEqual(rc, 2)
+
+    def test_resolve_tools_dir_honors_env_override(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"SK_TOOLS_DIR": tmpdir}, clear=False):
+                tools_dir, from_env = sk._resolve_tools_dir()
+        self.assertEqual(tools_dir, Path(tmpdir).resolve())
+        self.assertTrue(from_env)
+
+    def test_missing_checkout_shows_editable_install_hint(self):
+        temp_dir = Path(tempfile.mkdtemp(prefix="sk-missing-tools-"))
+        try:
+            with patch.object(sk, "_resolve_tools_dir", return_value=(temp_dir, False)):
+                with patch("builtins.print") as mock_print:
+                    rc = sk._run("briefing.py", [])
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+        self.assertEqual(rc, 2)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("pip install -e", output)
+        self.assertIn("SK_TOOLS_DIR", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- auto-provision a managed cross-platform `sk` launcher during install
- refresh the launcher plus managed global instructions/hooks during `sk update`
- migrate docs, templates, and skills to `sk`-first guidance with direct-script fallbacks
- cover the rollout with focused install/auto-update/CLI regression tests

## Notes
- branch isolates the verified `sk` rollout and leaves unrelated local `browse-ui` worktree conflict state untouched
- verified with focused `sk` rollout gates plus the previously green full-suite run in the source checkout