### PR TITLE
fix(tentacle): address PR 142 review followups

### DIFF
--- a/docs/AGENT-RULES.md
+++ b/docs/AGENT-RULES.md
@@ -169,7 +169,7 @@ When acting as an orchestrator with an active goal, the lifecycle is iterative, 
    sk tentacle goal eval --decision continue   # or: complete | pause | abandon
    # fallback: python3 ~/.copilot/tools/tentacle.py goal eval ...
    ```
-   For automated retries with stall detection, use `goal verify-loop` instead of (or after) `criteria check`. It re-runs verification commands up to `--max-retries` times and detects stalls (identical repeated failures). On `--escalate`, it marks the goal `needs-human` and prints advisory recovery steps — fix the underlying issues, then run `goal resume` to re-activate the goal before retrying:
+   For automated retries with stall detection, use `goal verify-loop` instead of (or after) `goal criteria check`. It re-runs verification commands up to `--max-retries` times and detects stalls (identical repeated failures). On `--escalate`, it marks the goal `needs-human` and prints advisory recovery steps — fix the underlying issues, then run `goal resume` to re-activate the goal before retrying:
    ```bash
    sk tentacle goal verify-loop [--id sc-1] [--max-retries 3] [--retry-delay 10] [--timeout 60] [--escalate]
    # fallback: python3 ~/.copilot/tools/tentacle.py goal verify-loop ...

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -641,6 +641,9 @@ sk tentacle goal verify-loop --id sc-1
 # Override retry/timeout limits
 sk tentacle goal verify-loop --max-retries 5 --retry-delay 30 --timeout 120
 
+# Run once with no retries (--max-retries 0)
+sk tentacle goal verify-loop --max-retries 0
+
 # On stall or retry exhaustion, mark goal needs-human and print advisory next steps
 sk tentacle goal verify-loop --escalate
 ```

--- a/tentacle.py
+++ b/tentacle.py
@@ -1760,6 +1760,17 @@ def _positive_int_arg(value: str) -> int:
     return parsed
 
 
+def _nonneg_int_arg(value: str) -> int:
+    """Argparse type that accepts non-negative integers (0 or more)."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError("must be a non-negative integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return parsed
+
+
 def _validate_goal_budget_value(value: int | None, flag_name: str) -> int | None:
     """Reject zero/negative budget values even when commands are called directly in-process."""
     if value is None:
@@ -2143,6 +2154,12 @@ def _cmd_goal_resume(args, tentacles: Path) -> None:
     state["status"] = GOAL_STATUS_ACTIVE
     state["resumed_at"] = datetime.now(timezone.utc).isoformat()
     state["updated_at"] = datetime.now(timezone.utc).isoformat()
+    # Clear stale needs-human metadata when resuming from needs-human state.
+    # Success-criteria pass/fail state is preserved intentionally.
+    if prev_status == GOAL_STATUS_NEEDS_HUMAN:
+        state.pop("needs_human_reason", None)
+        state.pop("needs_human_failing_criteria", None)
+        state.pop("needs_human_at", None)
     _goal_write(tentacles, state)
 
     print(f"🔄 Goal '{state.get('title', '?')}' resumed (was: {prev_status})")
@@ -2449,7 +2466,8 @@ def _cmd_goal_verify_loop(args, tentacles: Path) -> None:
 
     criteria: list = state.get("success_criteria", [])
     check_id = getattr(args, "id", None)
-    max_retries = getattr(args, "max_retries", 3) or 3
+    _raw_retries = getattr(args, "max_retries", None)
+    max_retries = _raw_retries if _raw_retries is not None else 3
     retry_delay = getattr(args, "retry_delay", 10) or 10
     timeout = getattr(args, "timeout", 60) or 60
     escalate = getattr(args, "escalate", False)
@@ -2493,7 +2511,8 @@ def _cmd_goal_verify_loop(args, tentacles: Path) -> None:
                 {
                     "id": cid,
                     "exit_code": exit_code,
-                    "output_snippet": output[:200],
+                    "output_hash": hashlib.sha256(output.encode()).hexdigest()[:16],
+                    "output_len": len(output),
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             )
@@ -4264,9 +4283,9 @@ def main():
     p_goal_verify.add_argument(
         "--max-retries",
         dest="max_retries",
-        type=_positive_int_arg,
-        default=3,
-        help="Maximum number of retry attempts after the initial run (default: 3)",
+        type=_nonneg_int_arg,
+        default=None,
+        help="Maximum number of retry attempts after the initial run (default: 3; 0 means one run, no retries)",
     )
     p_goal_verify.add_argument(
         "--retry-delay",

--- a/tentacle.py
+++ b/tentacle.py
@@ -2507,12 +2507,13 @@ def _cmd_goal_verify_loop(args, tentacles: Path) -> None:
             ran_any = True
             print(f"  Running [{cid}]: {cmd_str[:60]}...")
             exit_code, output = _goal_criteria_run_one(c, cwd, timeout)
+            output_bytes = output.encode("utf-8", errors="replace")
             attempt_results.append(
                 {
                     "id": cid,
                     "exit_code": exit_code,
-                    "output_hash": hashlib.sha256(output.encode()).hexdigest()[:16],
-                    "output_len": len(output),
+                    "output_hash": hashlib.sha256(output_bytes).hexdigest()[:16],
+                    "output_len": len(output_bytes),
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             )

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -16,6 +16,7 @@ Tests cover:
 Runs in-process using a temp subdirectory. Does NOT write to /tmp.
 """
 
+import hashlib
 import json
 import os
 import sys
@@ -2133,6 +2134,8 @@ class TestGoalVerifyLoop(unittest.TestCase):
         output into goal state.  Each per-result record must store a truncated
         SHA-256 hash (output_hash) and the byte count (output_len) instead.
         """
+        output_text = "sensitive-output-e🙂"
+        output_bytes = output_text.encode("utf-8")
         args = _fake_args(
             goal_action="verify-loop",
             id=None,
@@ -2141,7 +2144,7 @@ class TestGoalVerifyLoop(unittest.TestCase):
             timeout=30,
             escalate=False,
         )
-        with patch("tentacle._goal_criteria_run_one", return_value=(1, "sensitive-output-content")):
+        with patch("tentacle._goal_criteria_run_one", return_value=(1, output_text)):
             with patch("time.sleep"):
                 with patch("builtins.print"):
                     with self.assertRaises(SystemExit):
@@ -2155,6 +2158,8 @@ class TestGoalVerifyLoop(unittest.TestCase):
                 self.assertIn("output_hash", result, "Each result must carry output_hash")
                 self.assertIn("output_len", result, "Each result must carry output_len")
                 self.assertNotIn("output_snippet", result, "Raw output_snippet must not be stored in history")
+                self.assertEqual(result["output_len"], len(output_bytes))
+                self.assertEqual(result["output_hash"], hashlib.sha256(output_bytes).hexdigest()[:16])
 
     # ------------------------------------------------------------------
     # CLI / parser plumbing

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -1604,8 +1604,6 @@ class TestGoalVerifyLoop(unittest.TestCase):
 
         Two identical failures followed by a passing attempt must NOT trigger
         stall — the loop must reach attempt 3 and return successfully.
-
-        This test will FAIL until the stall threshold is corrected to >= 3.
         """
         results = [(1, "repeated error"), (1, "repeated error"), (0, "success")]
         call_count = [0]
@@ -2062,6 +2060,101 @@ class TestGoalVerifyLoop(unittest.TestCase):
         sc2 = next(c for c in state["success_criteria"] if c["id"] == "sc-2")
         self.assertEqual(sc1["status"], "verified")
         self.assertEqual(sc2["status"], "unverified", "sc-2 must be untouched when --id=sc-1")
+
+    # ------------------------------------------------------------------
+    # PR #142 follow-up regressions
+    # ------------------------------------------------------------------
+
+    def test_resume_clears_needs_human_metadata(self):
+        """Resume from needs-human must remove stale needs_human_* fields.
+
+        After escalation the goal carries needs_human_reason,
+        needs_human_failing_criteria, and needs_human_at.  Those fields must be
+        deleted when the goal is resumed so a subsequent verify-loop sees a
+        clean slate and does not carry stale escalation context.
+        """
+        state = T._goal_load(self.tentacles)
+        state["status"] = T.GOAL_STATUS_NEEDS_HUMAN
+        state["needs_human_reason"] = "stall"
+        state["needs_human_failing_criteria"] = ["sc-1"]
+        state["needs_human_at"] = datetime.now(timezone.utc).isoformat()
+        T._goal_write(self.tentacles, state)
+
+        args = _fake_args(goal_action="resume")
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_ACTIVE)
+        self.assertNotIn("needs_human_reason", state, "needs_human_reason must be cleared on resume")
+        self.assertNotIn(
+            "needs_human_failing_criteria", state, "needs_human_failing_criteria must be cleared on resume"
+        )
+        self.assertNotIn("needs_human_at", state, "needs_human_at must be cleared on resume")
+
+    def test_max_retries_zero_means_single_attempt(self):
+        """--max-retries 0 must run exactly one attempt (no retries).
+
+        Before the fix, ``getattr(args, "max_retries", 3) or 3`` treated 0 as
+        falsy and silently fell back to 3 extra retries (4 total).  The
+        corrected logic must treat 0 as explicit: one initial run, then stop.
+        """
+        call_count = [0]
+
+        def _mock_run(c, cwd, timeout=60):
+            call_count[0] += 1
+            return (1, "still failing")
+
+        args = _fake_args(
+            goal_action="verify-loop",
+            id=None,
+            max_retries=0,
+            retry_delay=1,
+            timeout=30,
+            escalate=False,
+        )
+        with patch("tentacle._goal_criteria_run_one", side_effect=_mock_run):
+            with patch("time.sleep"):
+                with patch("builtins.print"):
+                    with self.assertRaises(SystemExit) as cm:
+                        T._cmd_goal_verify_loop(args, self.tentacles)
+
+        self.assertEqual(cm.exception.code, 1)
+        self.assertEqual(
+            call_count[0],
+            1,
+            "--max-retries 0 must produce exactly 1 attempt; the or-3 fallback bug would give 4",
+        )
+
+    def test_verify_loop_history_stores_hash_not_raw_output(self):
+        """verify_loop_history entries must carry output_hash/output_len, not output_snippet.
+
+        Persisting raw output snippets can leak large or sensitive command
+        output into goal state.  Each per-result record must store a truncated
+        SHA-256 hash (output_hash) and the byte count (output_len) instead.
+        """
+        args = _fake_args(
+            goal_action="verify-loop",
+            id=None,
+            max_retries=0,
+            retry_delay=1,
+            timeout=30,
+            escalate=False,
+        )
+        with patch("tentacle._goal_criteria_run_one", return_value=(1, "sensitive-output-content")):
+            with patch("time.sleep"):
+                with patch("builtins.print"):
+                    with self.assertRaises(SystemExit):
+                        T._cmd_goal_verify_loop(args, self.tentacles)
+
+        state = T._goal_load(self.tentacles)
+        history = state.get("verify_loop_history", [])
+        self.assertTrue(history, "verify_loop_history must have at least one entry after a run")
+        for entry in history:
+            for result in entry.get("results", []):
+                self.assertIn("output_hash", result, "Each result must carry output_hash")
+                self.assertIn("output_len", result, "Each result must carry output_len")
+                self.assertNotIn("output_snippet", result, "Raw output_snippet must not be stored in history")
 
     # ------------------------------------------------------------------
     # CLI / parser plumbing


### PR DESCRIPTION
## Summary
- clear stale `needs-human` metadata on `goal resume`
- treat `--max-retries 0` as one initial run with no retries and stop persisting raw verify-loop output into `goal.json`
- add regressions and docs updates for the PR #142 review follow-ups

## Verification
- python -m py_compile tentacle.py tests/test_tentacle_goal.py
- python -m ruff check tentacle.py tests/test_tentacle_goal.py
- python -m ruff format --check tentacle.py tests/test_tentacle_goal.py
- python test_security.py
- python test_fixes.py
- python -m unittest discover -s tests -p "test_tentacle*.py"
- python tentacle.py goal verify-loop --help
- real `--session-dir` smoke for `--max-retries 0`, `--escalate`, and `goal resume`

Closes #143