### PR TITLE
feat(tentacle): extend goal resume options

### DIFF
--- a/docs/AGENT-RULES.md
+++ b/docs/AGENT-RULES.md
@@ -169,7 +169,7 @@ When acting as an orchestrator with an active goal, the lifecycle is iterative, 
    sk tentacle goal eval --decision continue   # or: complete | pause | abandon
    # fallback: python3 ~/.copilot/tools/tentacle.py goal eval ...
    ```
-   For automated retries with stall detection, use `goal verify-loop` instead of (or after) `goal criteria check`. It re-runs verification commands up to `--max-retries` times and detects stalls (identical repeated failures). On `--escalate`, it marks the goal `needs-human` and prints advisory recovery steps — fix the underlying issues, then run `goal resume` to re-activate the goal before retrying:
+   For automated retries with stall detection, use `goal verify-loop` instead of (or after) `goal criteria check`. It re-runs verification commands up to `--max-retries` times and detects stalls (identical repeated failures). On `--escalate`, it marks the goal `needs-human` and prints advisory recovery steps — fix the underlying issues, then run `goal resume` to re-activate the goal before retrying. If blocked or ambiguous tentacles need to be cleared at the same time, pass `--reset-failed` (resets every BLOCKED/AMBIGUOUS tentacle to idle) or `--from-iteration N` (rewinds the iteration counter to N and resets all tentacles assigned to that iteration or later). Success-criteria pass/fail state is preserved in both cases.
    ```bash
    sk tentacle goal verify-loop [--id sc-1] [--max-retries 3] [--retry-delay 10] [--timeout 60] [--escalate]
    # fallback: python3 ~/.copilot/tools/tentacle.py goal verify-loop ...

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -588,11 +588,43 @@ sk tentacle goal link <tentacle-name>
 sk tentacle goal eval [--decision continue|pause|complete|abandon] [--notes "..."]
 
 # Resume a paused or abandoned goal
-sk tentacle goal resume
+sk tentacle goal resume [--reset-failed] [--from-iteration N]
 
 # Summarize iteration state and advise on the next step
 sk tentacle goal next-iter
 ```
+
+### Resume with state reset
+
+`goal resume` re-activates a paused, abandoned, or `needs-human` goal. Two optional flags let
+operators reset tentacle state at the same time:
+
+```bash
+# Reset every BLOCKED and AMBIGUOUS tentacle back to idle so it can be re-dispatched
+sk tentacle goal resume --reset-failed
+# fallback: python3 ~/.copilot/tools/tentacle.py goal resume --reset-failed
+
+# Rewind the goal to iteration N and reset all tentacles assigned to iteration >= N
+sk tentacle goal resume --from-iteration N
+# fallback: python3 ~/.copilot/tools/tentacle.py goal resume --from-iteration N
+
+# Combine both: rewind and clear any remaining BLOCKED/AMBIGUOUS tentacles in one step
+sk tentacle goal resume --from-iteration N --reset-failed
+```
+
+**`--reset-failed`** — any tentacle whose `terminal_status` is `BLOCKED` or `AMBIGUOUS` has its
+status reset to `idle` and its terminal state cleared. Tentacles that completed with `DONE` are
+not touched.
+
+**`--from-iteration N`** — the goal's iteration counter is rewound to N, and every tentacle
+whose `goal_iteration` is >= N is reset to `idle`. Use this to re-run an entire wave when later
+work reveals that an earlier iteration's output is wrong. N must be between 1 and the current
+iteration (inclusive).
+
+Both flags can be used together in one command. In all cases:
+
+- Success-criteria pass/fail state is preserved — `goal resume` does not clear or re-run criteria.
+- Evaluation history is not truncated.
 
 ### Success criteria
 

--- a/tentacle.py
+++ b/tentacle.py
@@ -2189,7 +2189,11 @@ def _cmd_goal_resume(args, tentacles: Path) -> None:
                 t_meta = json.loads(meta_path.read_text(encoding="utf-8"))
             except Exception:
                 continue
-            t_iter = t_meta.get("goal_iteration") or t_meta.get("iteration") or 1
+            raw_iter = t_meta.get("goal_iteration") or t_meta.get("iteration") or 1
+            try:
+                t_iter = int(raw_iter)
+            except (TypeError, ValueError):
+                t_iter = 1
             t_terminal = t_meta.get("terminal_status")
             needs_rewind = from_iteration is not None and t_iter >= from_iteration
             needs_reset_failed = reset_failed and t_terminal in {"BLOCKED", "AMBIGUOUS"}

--- a/tentacle.py
+++ b/tentacle.py
@@ -2150,6 +2150,21 @@ def _cmd_goal_resume(args, tentacles: Path) -> None:
         print("ERROR: No goal initialized. Run `tentacle.py goal init` first.", file=sys.stderr)
         sys.exit(1)
 
+    reset_failed = getattr(args, "reset_failed", False)
+    from_iteration = getattr(args, "from_iteration", None)
+
+    current_iter = state.get("iteration", 1)
+    tentacle_names = state.get("tentacles", [])
+
+    # Validate --from-iteration bounds before making any changes.
+    if from_iteration is not None:
+        if from_iteration < 1 or from_iteration > current_iter:
+            print(
+                f"ERROR: --from-iteration {from_iteration} is out of bounds (valid range: 1–{current_iter}).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
     prev_status = state.get("status", "unknown")
     state["status"] = GOAL_STATUS_ACTIVE
     state["resumed_at"] = datetime.now(timezone.utc).isoformat()
@@ -2160,11 +2175,52 @@ def _cmd_goal_resume(args, tentacles: Path) -> None:
         state.pop("needs_human_reason", None)
         state.pop("needs_human_failing_criteria", None)
         state.pop("needs_human_at", None)
+
+    pending_meta_writes: list[tuple[Path, dict]] = []
+    rewound_names: set[str] = set()
+    reset_failed_names: set[str] = set()
+    if from_iteration is not None or reset_failed:
+        for name in tentacle_names:
+            t_dir = tentacles / name
+            meta_path = t_dir / "meta.json"
+            if not meta_path.exists():
+                continue
+            try:
+                t_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            t_iter = t_meta.get("goal_iteration") or t_meta.get("iteration") or 1
+            t_terminal = t_meta.get("terminal_status")
+            needs_rewind = from_iteration is not None and t_iter >= from_iteration
+            needs_reset_failed = reset_failed and t_terminal in {"BLOCKED", "AMBIGUOUS"}
+            if not (needs_rewind or needs_reset_failed):
+                continue
+            t_meta["status"] = "idle"
+            t_meta.pop("terminal_status", None)
+            t_meta.pop("completed_at", None)
+            pending_meta_writes.append((meta_path, t_meta))
+            if needs_rewind:
+                rewound_names.add(name)
+            if needs_reset_failed:
+                reset_failed_names.add(name)
+
+    if from_iteration is not None:
+        state["iteration"] = from_iteration
+
     _goal_write(tentacles, state)
+
+    for meta_path, t_meta in pending_meta_writes:
+        meta_path.write_text(json.dumps(t_meta, indent=2) + "\n", encoding="utf-8")
+
+    if from_iteration is not None:
+        print(f"⏪ Rewound to iteration {from_iteration} (was {current_iter}); reset {len(rewound_names)} tentacle(s).")
+
+    if reset_failed:
+        print(f"🔁 Reset {len(reset_failed_names)} BLOCKED/AMBIGUOUS tentacle(s) to idle.")
 
     print(f"🔄 Goal '{state.get('title', '?')}' resumed (was: {prev_status})")
     print(f"   Iteration: {state.get('iteration', 1)}")
-    print(f"   Linked tentacles: {len(state.get('tentacles', []))}")
+    print(f"   Linked tentacles: {len(tentacle_names)}")
 
 
 def _cmd_goal_criteria(args, tentacles: Path) -> None:
@@ -4208,7 +4264,22 @@ def main():
     p_goal_eval.add_argument("--notes", default="", help="Optional notes for this evaluation")
 
     # goal resume
-    p_goal_sub.add_parser("resume", help="Resume a paused/abandoned goal (set status=active)")
+    p_goal_resume = p_goal_sub.add_parser("resume", help="Resume a paused/abandoned goal (set status=active)")
+    p_goal_resume.add_argument(
+        "--reset-failed",
+        dest="reset_failed",
+        action="store_true",
+        default=False,
+        help="Reset tentacles with BLOCKED or AMBIGUOUS terminal_status back to idle",
+    )
+    p_goal_resume.add_argument(
+        "--from-iteration",
+        dest="from_iteration",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Rewind goal to iteration N, resetting tentacles assigned to iteration >= N",
+    )
 
     # goal criteria
     p_goal_criteria = p_goal_sub.add_parser("criteria", help="Manage success criteria: add / check / list")

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -741,17 +741,17 @@ class TestGoalResume(unittest.TestCase):
     def test_reset_failed_preserves_done_tentacle(self):
         """--reset-failed must NOT touch a DONE tentacle."""
         self._link_tentacle_with_meta("t-done", terminal_status="DONE")
-        # Manually set its status to done so the fixture is realistic.
+        # Manually set its status to completed so the fixture matches the real lifecycle values.
         meta_path = self.tentacles / "t-done" / "meta.json"
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
-        meta["status"] = "done"
+        meta["status"] = "completed"
         meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
         self._pause_goal()
         args = _fake_args(goal_action="resume", reset_failed=True, from_iteration=None)
         with patch("builtins.print"):
             T._cmd_goal_resume(args, self.tentacles)
         meta = self._read_meta("t-done")
-        self.assertEqual(meta["status"], "done", "DONE tentacle must not be reset by --reset-failed")
+        self.assertEqual(meta["status"], "completed", "DONE tentacle must not be reset by --reset-failed")
         self.assertEqual(meta["terminal_status"], "DONE")
 
     def test_reset_failed_preserves_regressed_tentacle(self):
@@ -787,6 +787,25 @@ class TestGoalResume(unittest.TestCase):
             T._cmd_goal_resume(args, self.tentacles)
         state = T._goal_load(self.tentacles)
         self.assertEqual(state["iteration"], 2)
+
+    def test_from_iteration_accepts_string_goal_iteration_metadata(self):
+        """String goal_iteration metadata must be normalized before numeric rewind comparisons."""
+        self._link_tentacle_with_meta("t-string-iter", goal_iteration="2")
+        meta_path = self.tentacles / "t-string-iter" / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["status"] = "completed"
+        meta["terminal_status"] = "DONE"
+        meta["completed_at"] = "2026-01-01T00:00:00Z"
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        with patch("builtins.print"):
+            T._cmd_goal_eval(_fake_args(goal_action="eval", decision="continue", notes=""), self.tentacles)
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", from_iteration=2, reset_failed=False)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        meta = self._read_meta("t-string-iter")
+        self.assertEqual(meta["status"], "idle")
+        self.assertNotIn("terminal_status", meta)
 
     def test_from_iteration_resets_tentacles_at_or_after_n(self):
         """--from-iteration N must reset tentacles whose goal_iteration >= N to idle."""

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -692,6 +692,229 @@ class TestGoalResume(unittest.TestCase):
         state = T._goal_load(self.tentacles)
         self.assertEqual(state["status"], T.GOAL_STATUS_ACTIVE)
 
+    # ------------------------------------------------------------------
+    # Issue #139 regressions: --reset-failed and --from-iteration
+    # ------------------------------------------------------------------
+
+    def _link_tentacle_with_meta(self, name: str, terminal_status: str | None = None, goal_iteration: int = 1) -> Path:
+        """Create a tentacle, add it to the goal's tentacles list, and stamp meta fields."""
+        t_dir = _make_tentacle(name, self.tentacles)
+        # Write goal_iteration and optional terminal_status into meta.json.
+        meta_path = t_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["goal_iteration"] = goal_iteration
+        if terminal_status is not None:
+            meta["terminal_status"] = terminal_status
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        # Register tentacle in the goal state.
+        state = T._goal_load(self.tentacles)
+        if name not in state.setdefault("tentacles", []):
+            state["tentacles"].append(name)
+        T._goal_write(self.tentacles, state)
+        return t_dir
+
+    def _read_meta(self, name: str) -> dict:
+        return json.loads((self.tentacles / name / "meta.json").read_text(encoding="utf-8"))
+
+    def test_reset_failed_resets_blocked_tentacle(self):
+        """--reset-failed must flip a BLOCKED tentacle back to idle."""
+        self._link_tentacle_with_meta("t-blocked", terminal_status="BLOCKED")
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", reset_failed=True, from_iteration=None)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        meta = self._read_meta("t-blocked")
+        self.assertEqual(meta["status"], "idle")
+        self.assertNotIn("terminal_status", meta)
+
+    def test_reset_failed_resets_ambiguous_tentacle(self):
+        """--reset-failed must flip an AMBIGUOUS tentacle back to idle."""
+        self._link_tentacle_with_meta("t-ambiguous", terminal_status="AMBIGUOUS")
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", reset_failed=True, from_iteration=None)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        meta = self._read_meta("t-ambiguous")
+        self.assertEqual(meta["status"], "idle")
+        self.assertNotIn("terminal_status", meta)
+
+    def test_reset_failed_preserves_done_tentacle(self):
+        """--reset-failed must NOT touch a DONE tentacle."""
+        self._link_tentacle_with_meta("t-done", terminal_status="DONE")
+        # Manually set its status to done so the fixture is realistic.
+        meta_path = self.tentacles / "t-done" / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["status"] = "done"
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", reset_failed=True, from_iteration=None)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        meta = self._read_meta("t-done")
+        self.assertEqual(meta["status"], "done", "DONE tentacle must not be reset by --reset-failed")
+        self.assertEqual(meta["terminal_status"], "DONE")
+
+    def test_reset_failed_preserves_regressed_tentacle(self):
+        """--reset-failed must NOT touch a REGRESSED tentacle."""
+        self._link_tentacle_with_meta("t-regressed", terminal_status="REGRESSED")
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", reset_failed=True, from_iteration=None)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        meta = self._read_meta("t-regressed")
+        self.assertEqual(meta["terminal_status"], "REGRESSED")
+
+    def test_reset_failed_preserves_toobig_tentacle(self):
+        """--reset-failed must NOT touch a TOO_BIG tentacle."""
+        self._link_tentacle_with_meta("t-toobig", terminal_status="TOO_BIG")
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", reset_failed=True, from_iteration=None)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        meta = self._read_meta("t-toobig")
+        self.assertEqual(meta["terminal_status"], "TOO_BIG")
+
+    def test_from_iteration_rewinds_iteration_counter(self):
+        """--from-iteration N must set state['iteration'] back to N."""
+        # Advance to iteration 3 via two continue evals.
+        for _ in range(2):
+            with patch("builtins.print"):
+                T._cmd_goal_eval(_fake_args(goal_action="eval", decision="continue", notes=""), self.tentacles)
+        # Now pause and resume rewinding to iter 2.
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", from_iteration=2, reset_failed=False)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["iteration"], 2)
+
+    def test_from_iteration_resets_tentacles_at_or_after_n(self):
+        """--from-iteration N must reset tentacles whose goal_iteration >= N to idle."""
+        self._link_tentacle_with_meta("t-iter2", goal_iteration=2)
+        self._link_tentacle_with_meta("t-iter3", goal_iteration=3)
+        for name in ("t-iter2", "t-iter3"):
+            meta_path = self.tentacles / name / "meta.json"
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            meta["status"] = "completed"
+            meta["terminal_status"] = "DONE"
+            meta["completed_at"] = "2026-01-01T00:00:00Z"
+            meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        # Advance goal to iteration 3.
+        for _ in range(2):
+            with patch("builtins.print"):
+                T._cmd_goal_eval(_fake_args(goal_action="eval", decision="continue", notes=""), self.tentacles)
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", from_iteration=2, reset_failed=False)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        self.assertEqual(self._read_meta("t-iter2")["status"], "idle")
+        self.assertEqual(self._read_meta("t-iter3")["status"], "idle")
+        self.assertNotIn("terminal_status", self._read_meta("t-iter2"))
+        self.assertNotIn("terminal_status", self._read_meta("t-iter3"))
+
+    def test_from_iteration_preserves_tentacles_before_n(self):
+        """--from-iteration N must NOT reset tentacles whose goal_iteration < N."""
+        self._link_tentacle_with_meta("t-iter1", goal_iteration=1)
+        meta_path = self.tentacles / "t-iter1" / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["status"] = "completed"
+        meta["terminal_status"] = "DONE"
+        meta["completed_at"] = "2026-01-01T00:00:00Z"
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        # Advance goal to iteration 2.
+        with patch("builtins.print"):
+            T._cmd_goal_eval(_fake_args(goal_action="eval", decision="continue", notes=""), self.tentacles)
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", from_iteration=2, reset_failed=False)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        self.assertEqual(
+            self._read_meta("t-iter1")["status"],
+            "completed",
+            "Tentacle from iteration 1 must not be reset when rewinding to iteration 2",
+        )
+        self.assertEqual(self._read_meta("t-iter1")["terminal_status"], "DONE")
+
+    def test_eval_history_preserved_after_reset_failed(self):
+        """--reset-failed must not truncate eval_history."""
+        with patch("builtins.print"):
+            T._cmd_goal_eval(_fake_args(goal_action="eval", decision="continue", notes=""), self.tentacles)
+        self._pause_goal()
+        history_before = T._goal_load(self.tentacles)["eval_history"]
+        self.assertGreater(len(history_before), 0)
+        args = _fake_args(goal_action="resume", reset_failed=True, from_iteration=None)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        history_after = T._goal_load(self.tentacles)["eval_history"]
+        self.assertEqual(len(history_after), len(history_before), "eval_history must be preserved by --reset-failed")
+
+    def test_eval_history_preserved_after_from_iteration(self):
+        """--from-iteration N must not truncate eval_history."""
+        with patch("builtins.print"):
+            T._cmd_goal_eval(_fake_args(goal_action="eval", decision="continue", notes=""), self.tentacles)
+        self._pause_goal()
+        # Capture history length after all evals (before the resume).
+        history_before = T._goal_load(self.tentacles)["eval_history"]
+        self.assertGreater(len(history_before), 0)
+        args = _fake_args(goal_action="resume", from_iteration=1, reset_failed=False)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        history_after = T._goal_load(self.tentacles)["eval_history"]
+        self.assertEqual(len(history_after), len(history_before), "eval_history must be preserved by --from-iteration")
+
+    def test_success_criteria_status_preserved_after_reset_failed(self):
+        """--reset-failed must not alter success_criteria pass/fail state."""
+        state = T._goal_load(self.tentacles)
+        state["success_criteria"] = [{"id": "sc-1", "description": "Tests pass", "status": "verified"}]
+        T._goal_write(self.tentacles, state)
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", reset_failed=True, from_iteration=None)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(
+            state["success_criteria"][0]["status"],
+            "verified",
+            "success_criteria status must be preserved by --reset-failed",
+        )
+
+    def test_success_criteria_status_preserved_after_from_iteration(self):
+        """--from-iteration N must not alter success_criteria pass/fail state."""
+        state = T._goal_load(self.tentacles)
+        state["success_criteria"] = [{"id": "sc-1", "description": "Tests pass", "status": "verified"}]
+        T._goal_write(self.tentacles, state)
+        with patch("builtins.print"):
+            T._cmd_goal_eval(_fake_args(goal_action="eval", decision="continue", notes=""), self.tentacles)
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", from_iteration=1, reset_failed=False)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(
+            state["success_criteria"][0]["status"],
+            "verified",
+            "success_criteria status must be preserved by --from-iteration",
+        )
+
+    def test_from_iteration_out_of_bounds_low_exits(self):
+        """--from-iteration 0 must exit with code 1 (below valid range)."""
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", from_iteration=0, reset_failed=False)
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_resume(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_from_iteration_out_of_bounds_high_exits(self):
+        """--from-iteration N > current iteration must exit with code 1."""
+        # Goal starts at iteration=1, so from_iteration=2 is out of bounds.
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", from_iteration=99, reset_failed=False)
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_resume(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+
 
 # ---------------------------------------------------------------------------
 # Tests for _cmd_goal_criteria


### PR DESCRIPTION
## Summary
- add `goal resume --reset-failed` and `goal resume --from-iteration N`
- preserve success criteria and append-only eval history while resetting only the intended tentacle state
- add resume-option regressions and operator docs for the new flags

## Verification
- python -m py_compile tentacle.py tests/test_tentacle_goal.py
- python -m ruff check tentacle.py tests/test_tentacle_goal.py
- python -m ruff format --check tentacle.py tests/test_tentacle_goal.py
- python test_security.py
- python test_fixes.py
- python -m unittest discover -s tests -p "test_tentacle*.py"
- python tentacle.py goal resume --help
- real `--session-dir` smoke for `goal resume --reset-failed` and `goal resume --from-iteration 2`

Closes #139