### PR TITLE
feat(tentacle): add per-iteration goal mapping

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,7 +68,7 @@ recovery hints. None of these scripts are candidates for deletion as a consequen
 | `mcp-server.py` | Read-only MCP stdio JSON-RPC surface for `briefing` and `query_session` |
 | `watch-sessions.py` | File watcher; triggers incremental re-indexing |
 | `learn.py` | Manual knowledge entry |
-| `tentacle.py` | Multi-agent orchestration (create → todo → bundle → swarm → complete) + orchestrator goal loop (`goal init/status/link/eval/resume/criteria/gate/budget/next-iter/verify-loop`). `sk tentacle goal …` routes here via Rust pass-through — no Rust code change is needed when adding new `goal` subcommands. |
+| `tentacle.py` | Multi-agent orchestration (create → todo → bundle → swarm → complete) + orchestrator goal loop (`goal init/status/link/eval/resume/criteria/gate/budget/next-iter/verify-loop`). `goal.json` now keeps both the legacy flat `tentacles` list and a structured per-iteration `iterations` map so status/history queries can answer which tentacles belonged to each iteration without breaking older readers. `sk tentacle goal …` routes here via Rust pass-through — no Rust code change is needed when adding new `goal` subcommands. |
 | `embed.py` | Optional semantic search via embedding APIs (OpenAI, Fireworks, etc.) with TF-IDF fallback |
 | `claude-adapter.py` | Parses Claude Code JSONL sessions into the common DB format |
 | `sync-knowledge.py` | Merges `knowledge.db` files across environments (Windows ↔ WSL); MAX confidence semantics |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -594,6 +594,31 @@ sk tentacle goal resume [--reset-failed] [--from-iteration N]
 sk tentacle goal next-iter
 ```
 
+`goal.json` keeps a backward-compatible flat `tentacles` list and a structured `iterations`
+map. Each iteration bucket records its own tentacles plus lifecycle metadata:
+
+```json
+{
+  "tentacles": ["iter1-worker", "iter2-worker"],
+  "iterations": {
+    "1": {
+      "tentacles": ["iter1-worker"],
+      "started_at": "2026-05-11T06:00:00+00:00",
+      "completed_at": "2026-05-11T06:10:00+00:00",
+      "eval_decision": "continue"
+    },
+    "2": {
+      "tentacles": ["iter2-worker"],
+      "started_at": "2026-05-11T06:10:00+00:00"
+    }
+  }
+}
+```
+
+`goal status` text output now prints an iteration map, and `goal status --format json`
+returns the same `iterations` object. Use that JSON when you need to answer questions like
+"which tentacles were linked in iteration 2?" without guessing from current tentacle meta.
+
 ### Resume with state reset
 
 `goal resume` re-activates a paused, abandoned, or `needs-human` goal. Two optional flags let
@@ -617,9 +642,11 @@ status reset to `idle` and its terminal state cleared. Tentacles that completed 
 not touched.
 
 **`--from-iteration N`** — the goal's iteration counter is rewound to N, and every tentacle
-whose `goal_iteration` is >= N is reset to `idle`. Use this to re-run an entire wave when later
-work reveals that an earlier iteration's output is wrong. N must be between 1 and the current
-iteration (inclusive).
+whose `goal_iteration` is >= N is reset to `idle`. The structured `iterations` map keeps the
+tentacle membership for each iteration, but the rewound iteration and any later iteration have
+their stored eval decision cleared so the loop can run again cleanly. Use this to re-run an
+entire wave when later work reveals that an earlier iteration's output is wrong. N must be
+between 1 and the current iteration (inclusive).
 
 Both flags can be used together in one command. In all cases:
 

--- a/tentacle.py
+++ b/tentacle.py
@@ -1787,11 +1787,8 @@ def _goal_iteration_entry(iterations: dict, iteration: int | str, *, started_at:
         for name in tentacle_names:
             if isinstance(name, str) and name and name not in normalized_names:
                 normalized_names.append(name)
-    entry: dict = {"tentacles": normalized_names}
-    for field in ("started_at", "completed_at", "eval_decision"):
-        value = raw_entry.get(field)
-        if value:
-            entry[field] = value
+    entry: dict = dict(raw_entry)
+    entry["tentacles"] = normalized_names
     if started_at and not entry.get("started_at"):
         entry["started_at"] = started_at
     iterations[key] = entry
@@ -2103,16 +2100,17 @@ def _cmd_goal_init(args, tentacles: Path) -> None:
     if timeout_minutes is not None:
         budget["timeout_minutes"] = timeout_minutes
 
+    now_iso = datetime.now(timezone.utc).isoformat()
     state = {
         "goal_id": goal_id,
         "title": title,
         "description": desc,
-        "created_at": datetime.now(timezone.utc).isoformat(),
-        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "created_at": now_iso,
+        "updated_at": now_iso,
         "status": GOAL_STATUS_ACTIVE,
         "iteration": 1,
         "tentacles": [],
-        "iterations": {"1": {"tentacles": [], "started_at": datetime.now(timezone.utc).isoformat()}},
+        "iterations": {"1": {"tentacles": [], "started_at": now_iso}},
         "eval_history": [],
         "success_criteria": [],
         "gates": [],

--- a/tentacle.py
+++ b/tentacle.py
@@ -1745,14 +1745,172 @@ def _goal_path(tentacles_dir: Path) -> Path:
     return tentacles_dir.parent / GOAL_STATE_FILENAME
 
 
+def _goal_current_iteration(state: dict) -> int:
+    """Return the current goal iteration as a positive integer."""
+    try:
+        current = int(state.get("iteration", 1))
+    except (TypeError, ValueError):
+        current = 1
+    return max(1, current)
+
+
+def _goal_iteration_key(iteration: int | str | None) -> str:
+    """Normalize an iteration identifier to the goal.json string-key format."""
+    try:
+        parsed = int(iteration)
+    except (TypeError, ValueError):
+        parsed = 1
+    return str(max(1, parsed))
+
+
+def _goal_sorted_iteration_keys(iterations: dict) -> list[str]:
+    """Sort iteration keys numerically when possible, then lexically as fallback."""
+
+    def _sort_key(raw_key: str) -> tuple[int, int | str]:
+        try:
+            return (0, int(raw_key))
+        except (TypeError, ValueError):
+            return (1, str(raw_key))
+
+    return sorted(iterations.keys(), key=_sort_key)
+
+
+def _goal_iteration_entry(iterations: dict, iteration: int | str, *, started_at: str | None = None) -> dict:
+    """Return a normalized per-iteration entry, creating it when needed."""
+    key = _goal_iteration_key(iteration)
+    raw_entry = iterations.get(key)
+    if not isinstance(raw_entry, dict):
+        raw_entry = {}
+    tentacle_names = raw_entry.get("tentacles")
+    normalized_names: list[str] = []
+    if isinstance(tentacle_names, list):
+        for name in tentacle_names:
+            if isinstance(name, str) and name and name not in normalized_names:
+                normalized_names.append(name)
+    entry: dict = {"tentacles": normalized_names}
+    for field in ("started_at", "completed_at", "eval_decision"):
+        value = raw_entry.get(field)
+        if value:
+            entry[field] = value
+    if started_at and not entry.get("started_at"):
+        entry["started_at"] = started_at
+    iterations[key] = entry
+    return entry
+
+
+def _goal_build_iterations_from_legacy(state: dict) -> dict[str, dict]:
+    """Reconstruct per-iteration metadata from the legacy flat goal shape."""
+    current_iter = _goal_current_iteration(state)
+    created_at = state.get("created_at")
+    iterations: dict[str, dict] = {}
+    if created_at:
+        _goal_iteration_entry(iterations, 1, started_at=created_at)
+    else:
+        _goal_iteration_entry(iterations, current_iter)
+
+    for eval_entry in state.get("eval_history") or []:
+        iter_no = _goal_current_iteration({"iteration": eval_entry.get("iteration", 1)})
+        entry = _goal_iteration_entry(iterations, iter_no)
+        if eval_entry.get("blocked_by_gates"):
+            continue
+        decision = eval_entry.get("decision")
+        if decision not in GOAL_EVAL_DECISIONS:
+            continue
+        evaluated_at = eval_entry.get("evaluated_at")
+        if evaluated_at:
+            entry["completed_at"] = evaluated_at
+        entry["eval_decision"] = decision
+        if decision == "continue":
+            _goal_iteration_entry(iterations, iter_no + 1, started_at=evaluated_at)
+
+    _goal_iteration_entry(iterations, current_iter)
+    if created_at:
+        _goal_iteration_entry(iterations, 1, started_at=created_at)
+    return iterations
+
+
+def _goal_sync_iterations(state: dict, tentacles_dir: Path | None = None) -> dict:
+    """Keep the structured iteration map and legacy flat tentacle list in sync."""
+    current_iter = _goal_current_iteration(state)
+    state["iteration"] = current_iter
+    created_at = state.get("created_at")
+
+    raw_iterations = state.get("iterations")
+    if isinstance(raw_iterations, dict):
+        iterations: dict[str, dict] = {}
+        for raw_key in _goal_sorted_iteration_keys(raw_iterations):
+            started_at = created_at if _goal_iteration_key(raw_key) == "1" else None
+            normalized_key = _goal_iteration_key(raw_key)
+            existing = raw_iterations.get(raw_key)
+            iterations[normalized_key] = existing if isinstance(existing, dict) else {}
+            _goal_iteration_entry(iterations, normalized_key, started_at=started_at)
+    else:
+        iterations = _goal_build_iterations_from_legacy(state)
+
+    if not iterations:
+        iterations = {_goal_iteration_key(current_iter): {"tentacles": []}}
+    if created_at:
+        _goal_iteration_entry(iterations, 1, started_at=created_at)
+    _goal_iteration_entry(iterations, current_iter)
+
+    legacy_flat: list[str] = []
+    for name in state.get("tentacles") or []:
+        if isinstance(name, str) and name and name not in legacy_flat:
+            legacy_flat.append(name)
+
+    for name in legacy_flat:
+        if any(name in entry.get("tentacles", []) for entry in iterations.values()):
+            continue
+        assigned_iter = current_iter
+        if tentacles_dir is not None:
+            meta_path = tentacles_dir / name / "meta.json"
+            if meta_path.exists():
+                try:
+                    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+                except Exception:
+                    meta = {}
+                assigned_iter = _goal_current_iteration(
+                    {"iteration": meta.get("goal_iteration") or meta.get("iteration") or current_iter}
+                )
+        entry = _goal_iteration_entry(
+            iterations,
+            assigned_iter,
+            started_at=created_at if assigned_iter == 1 else None,
+        )
+        if name not in entry["tentacles"]:
+            entry["tentacles"].append(name)
+
+    flattened: list[str] = []
+    for key in _goal_sorted_iteration_keys(iterations):
+        entry = _goal_iteration_entry(iterations, key, started_at=created_at if key == "1" else None)
+        for name in entry["tentacles"]:
+            if name not in flattened:
+                flattened.append(name)
+
+    state["iterations"] = iterations
+    state["tentacles"] = flattened
+    return state
+
+
+def _goal_iteration_tentacles(state: dict, iteration: int | str) -> list[str]:
+    """Return the tentacles recorded for a specific iteration."""
+    iterations = state.get("iterations") or {}
+    entry = iterations.get(_goal_iteration_key(iteration)) or {}
+    names = entry.get("tentacles") or []
+    return [name for name in names if isinstance(name, str) and name]
+
+
 def _goal_load(tentacles_dir: Path) -> dict:
     """Load goal.json; return empty dict if missing or malformed."""
     gp = _goal_path(tentacles_dir)
     if gp.exists():
         try:
-            return json.loads(gp.read_text(encoding="utf-8"))
+            state = json.loads(gp.read_text(encoding="utf-8"))
         except Exception:
             return {}
+        if not isinstance(state, dict):
+            return {}
+        return _goal_sync_iterations(state, tentacles_dir)
     return {}
 
 
@@ -1760,6 +1918,7 @@ def _goal_write(tentacles_dir: Path, state: dict) -> None:
     """Write goal.json (orchestrator-only state; no concurrent writers expected)."""
     gp = _goal_path(tentacles_dir)
     gp.parent.mkdir(parents=True, exist_ok=True)
+    _goal_sync_iterations(state, tentacles_dir)
     gp.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 
 
@@ -1812,7 +1971,7 @@ def _validate_goal_budget_value(value: int | None, flag_name: str) -> int | None
 def _goal_budget_status(state: dict) -> dict:
     """Return a dict summarising current budget consumption vs limits."""
     budget = state.get("budget") or {}
-    current_iter = state.get("iteration", 1)
+    current_iter = _goal_current_iteration(state)
     max_iters = budget.get("max_iterations")
     max_tentacles = budget.get("max_tentacles")
     timeout_minutes = budget.get("timeout_minutes")
@@ -1953,6 +2112,7 @@ def _cmd_goal_init(args, tentacles: Path) -> None:
         "status": GOAL_STATUS_ACTIVE,
         "iteration": 1,
         "tentacles": [],
+        "iterations": {"1": {"tentacles": [], "started_at": datetime.now(timezone.utc).isoformat()}},
         "eval_history": [],
         "success_criteria": [],
         "gates": [],
@@ -1995,21 +2155,40 @@ def _cmd_goal_status(args, tentacles: Path) -> None:
             print(f"     {line}")
 
     tentacle_names = state.get("tentacles", [])
+    iteration_map = state.get("iterations") or {}
     if tentacle_names:
-        print(f"\n   Linked tentacles ({len(tentacle_names)}):")
-        for name in tentacle_names:
-            t_dir = tentacles / name
-            if t_dir.exists():
-                t_meta_path = t_dir / "meta.json"
-                try:
-                    t_meta = json.loads(t_meta_path.read_text(encoding="utf-8")) if t_meta_path.exists() else {}
-                except Exception:
-                    t_meta = {}
-                t_status = t_meta.get("status", "unknown")
-                t_iter = t_meta.get("goal_iteration") or t_meta.get("iteration", "?")
-                print(f"     - {name} [{t_status}] iter={t_iter}")
-            else:
-                print(f"     - {name} [missing]")
+        print(
+            f"\n   Linked tentacles: {len(tentacle_names)} total across "
+            f"{len(iteration_map) if iteration_map else 1} iteration(s)"
+        )
+        print("   Iteration map:")
+        for iter_key in _goal_sorted_iteration_keys(iteration_map):
+            entry = iteration_map.get(iter_key) or {}
+            header_bits: list[str] = []
+            if _goal_iteration_key(iter_key) == _goal_iteration_key(state.get("iteration", 1)):
+                header_bits.append("current")
+            if entry.get("eval_decision"):
+                header_bits.append(str(entry["eval_decision"]))
+            header = f"     Iteration {iter_key}"
+            if header_bits:
+                header += f" ({', '.join(header_bits)})"
+            print(header)
+            iter_names = _goal_iteration_tentacles(state, iter_key)
+            if not iter_names:
+                print("       - (no tentacles linked)")
+                continue
+            for name in iter_names:
+                t_dir = tentacles / name
+                if t_dir.exists():
+                    t_meta_path = t_dir / "meta.json"
+                    try:
+                        t_meta = json.loads(t_meta_path.read_text(encoding="utf-8")) if t_meta_path.exists() else {}
+                    except Exception:
+                        t_meta = {}
+                    t_status = t_meta.get("status", "unknown")
+                    print(f"       - {name} [{t_status}]")
+                else:
+                    print(f"       - {name} [missing]")
     else:
         print("\n   No tentacles linked yet. Use `tentacle.py goal link <name>`.")
 
@@ -2078,12 +2257,19 @@ def _cmd_goal_link(args, tentacles: Path) -> None:
         sys.exit(1)
 
     linked: list = state.setdefault("tentacles", [])
-    already_linked = tentacle_name in linked
-    if not already_linked:
+    if tentacle_name not in linked:
         linked.append(tentacle_name)
     goal_id = state.get("goal_id", "")
     goal_name = state.get("title", "")
-    iteration = state.get("iteration", 1)
+    iteration = _goal_current_iteration(state)
+    iter_entry = _goal_iteration_entry(
+        state.setdefault("iterations", {}),
+        iteration,
+        started_at=state.get("created_at") if iteration == 1 else None,
+    )
+    already_linked = tentacle_name in iter_entry["tentacles"]
+    if not already_linked:
+        iter_entry["tentacles"].append(tentacle_name)
 
     # Stamp goal metadata into tentacle meta.json.
     meta_path = t_dir / "meta.json"
@@ -2125,7 +2311,7 @@ def _cmd_goal_eval(args, tentacles: Path) -> None:
         sys.exit(1)
 
     notes = getattr(args, "notes", "") or ""
-    current_iter = state.get("iteration", 1)
+    current_iter = _goal_current_iteration(state)
     current_status = state.get("status", GOAL_STATUS_ACTIVE)
     if current_status in {
         GOAL_STATUS_COMPLETED,
@@ -2219,11 +2405,18 @@ def _cmd_goal_eval(args, tentacles: Path) -> None:
         state.pop("awaiting_gate_id", None)
         state.pop("awaiting_gate_reason", None)
 
+    evaluated_at = datetime.now(timezone.utc).isoformat()
+    current_iter_entry = _goal_iteration_entry(
+        state.setdefault("iterations", {}),
+        current_iter,
+        started_at=state.get("created_at") if current_iter == 1 else None,
+    )
+
     eval_entry: dict = {
         "iteration": current_iter,
         "decision": decision,
         "notes": notes,
-        "evaluated_at": datetime.now(timezone.utc).isoformat(),
+        "evaluated_at": evaluated_at,
     }
     # Snapshot gate/criteria status at eval time for auditability.
     gates = state.get("gates") or []
@@ -2237,10 +2430,13 @@ def _cmd_goal_eval(args, tentacles: Path) -> None:
 
     history: list = state.setdefault("eval_history", [])
     history.append(eval_entry)
+    current_iter_entry["eval_decision"] = decision
+    current_iter_entry["completed_at"] = evaluated_at
 
     if decision == "continue":
         state["status"] = GOAL_STATUS_ACTIVE
         state["iteration"] = current_iter + 1
+        _goal_iteration_entry(state.setdefault("iterations", {}), current_iter + 1, started_at=evaluated_at)
         print(f"▶  Eval: continuing — advancing to iteration {current_iter + 1}")
     elif decision == "pause":
         state["status"] = GOAL_STATUS_PAUSED
@@ -2274,8 +2470,9 @@ def _cmd_goal_resume(args, tentacles: Path) -> None:
     reset_failed = getattr(args, "reset_failed", False)
     from_iteration = getattr(args, "from_iteration", None)
 
-    current_iter = state.get("iteration", 1)
+    current_iter = _goal_current_iteration(state)
     tentacle_names = state.get("tentacles", [])
+    iteration_map = state.setdefault("iterations", {})
 
     # Validate --from-iteration bounds before making any changes.
     if from_iteration is not None:
@@ -2335,6 +2532,20 @@ def _cmd_goal_resume(args, tentacles: Path) -> None:
 
     if from_iteration is not None:
         state["iteration"] = from_iteration
+        resumed_at = state["resumed_at"]
+        for raw_key in _goal_sorted_iteration_keys(iteration_map):
+            iter_no = _goal_current_iteration({"iteration": raw_key})
+            entry = _goal_iteration_entry(
+                iteration_map, iter_no, started_at=state.get("created_at") if iter_no == 1 else None
+            )
+            if iter_no < from_iteration:
+                continue
+            entry.pop("completed_at", None)
+            entry.pop("eval_decision", None)
+            if iter_no == from_iteration:
+                entry["started_at"] = resumed_at
+            elif iter_no > from_iteration:
+                entry.pop("started_at", None)
 
     _goal_write(tentacles, state)
 
@@ -2692,8 +2903,8 @@ def _cmd_goal_next_iter(args, tentacles: Path) -> None:
         sys.exit(1)
 
     bs = _goal_budget_status(state)
-    current_iter = state.get("iteration", 1)
-    tentacle_names = state.get("tentacles", [])
+    current_iter = _goal_current_iteration(state)
+    tentacle_names = _goal_iteration_tentacles(state, current_iter)
 
     print(f"🔄 Goal loop: '{state.get('title', '?')}' — iteration {current_iter}")
     if bs["max_iterations"] is not None:
@@ -2714,9 +2925,6 @@ def _cmd_goal_next_iter(args, tentacles: Path) -> None:
         try:
             t_meta = json.loads(meta_path.read_text(encoding="utf-8"))
         except Exception:
-            continue
-        t_iter = t_meta.get("goal_iteration") or t_meta.get("iteration") or 1
-        if t_iter != current_iter:
             continue
         terminal = t_meta.get("terminal_status")
         t_status = t_meta.get("status", "idle")

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -318,6 +318,9 @@ class TestGoalInit(unittest.TestCase):
         self.assertIn("goal_id", state)
         self.assertIn("created_at", state)
         self.assertEqual(state["tentacles"], [])
+        self.assertIn("iterations", state)
+        self.assertEqual(state["iterations"]["1"]["tentacles"], [])
+        self.assertIn("started_at", state["iterations"]["1"])
         self.assertEqual(state["success_criteria"], [])
         self.assertEqual(state["gates"], [])
 
@@ -412,6 +415,7 @@ class TestGoalStatus(unittest.TestCase):
         data = json.loads("\n".join(captured))
         self.assertEqual(data["title"], "JSON Goal")
         self.assertIn("goal_id", data)
+        self.assertEqual(data["iterations"]["1"]["tentacles"], [])
 
     def test_status_shows_budget_when_set(self):
         _init_goal(self.tentacles, max_iterations=3)
@@ -460,6 +464,36 @@ class TestGoalStatus(unittest.TestCase):
         self.assertIn("broken-meta", combined)
         self.assertIn("[unknown]", combined)
 
+    def test_status_shows_per_iteration_tentacles(self):
+        _make_tentacle("alpha", self.tentacles, goal_iteration=1)
+        _make_tentacle("beta", self.tentacles, goal_iteration=2)
+        state = _init_goal(self.tentacles, title="Iter Status")
+        state["iteration"] = 2
+        state["tentacles"] = ["alpha", "beta"]
+        state["iterations"] = {
+            "1": {
+                "tentacles": ["alpha"],
+                "started_at": state["created_at"],
+                "completed_at": state["updated_at"],
+                "eval_decision": "continue",
+            },
+            "2": {
+                "tentacles": ["beta"],
+                "started_at": state["updated_at"],
+            },
+        }
+        T._goal_write(self.tentacles, state)
+        captured = []
+        args = _fake_args(goal_action="status", format="text")
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(" ".join(str(x) for x in a))):
+            T._cmd_goal_status(args, self.tentacles)
+        combined = "\n".join(captured)
+        self.assertIn("Iteration map", combined)
+        self.assertIn("Iteration 1", combined)
+        self.assertIn("Iteration 2", combined)
+        self.assertIn("alpha", combined)
+        self.assertIn("beta", combined)
+
 
 # ---------------------------------------------------------------------------
 # Tests for _cmd_goal_link
@@ -482,6 +516,7 @@ class TestGoalLink(unittest.TestCase):
             T._cmd_goal_link(args, self.tentacles)
         state = T._goal_load(self.tentacles)
         self.assertIn("alpha", state["tentacles"])
+        self.assertIn("alpha", state["iterations"]["1"]["tentacles"])
 
     def test_link_stamps_goal_id_into_tentacle_meta(self):
         goal_id = T._goal_load(self.tentacles)["goal_id"]
@@ -499,6 +534,18 @@ class TestGoalLink(unittest.TestCase):
             T._cmd_goal_link(args, self.tentacles)
         state = T._goal_load(self.tentacles)
         self.assertEqual(state["tentacles"].count("alpha"), 1)
+        self.assertEqual(state["iterations"]["1"]["tentacles"].count("alpha"), 1)
+
+    def test_link_preserves_previous_iteration_membership(self):
+        args = _fake_args(goal_action="link", tentacle_name="alpha")
+        with patch("builtins.print"):
+            T._cmd_goal_link(args, self.tentacles)
+            T._cmd_goal_eval(_fake_args(goal_action="eval", decision="continue", notes="iter 1 done"), self.tentacles)
+            T._cmd_goal_link(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["tentacles"].count("alpha"), 1)
+        self.assertIn("alpha", state["iterations"]["1"]["tentacles"])
+        self.assertIn("alpha", state["iterations"]["2"]["tentacles"])
 
     def test_link_recovers_from_malformed_tentacle_meta(self):
         (self.tentacles / "alpha" / "meta.json").write_text("{not-json", encoding="utf-8")
@@ -525,6 +572,27 @@ class TestGoalLink(unittest.TestCase):
             with self.assertRaises(SystemExit) as cm:
                 T._cmd_goal_link(args, self.tentacles)
         self.assertEqual(cm.exception.code, 1)
+
+    def test_load_backfills_iterations_from_legacy_flat_state(self):
+        _make_tentacle("legacy-alpha", self.tentacles, goal_iteration=1)
+        state = T._goal_load(self.tentacles)
+        state["title"] = "Legacy Goal"
+        state.pop("iterations", None)
+        state["iteration"] = 2
+        state["tentacles"] = ["legacy-alpha"]
+        state["eval_history"] = [
+            {
+                "iteration": 1,
+                "decision": "continue",
+                "notes": "iter 1 done",
+                "evaluated_at": "2026-01-01T00:00:00+00:00",
+            }
+        ]
+        T._goal_path(self.tentacles).write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+        loaded = T._goal_load(self.tentacles)
+        self.assertEqual(loaded["iterations"]["1"]["tentacles"], ["legacy-alpha"])
+        self.assertEqual(loaded["iterations"]["1"]["eval_decision"], "continue")
+        self.assertIn("2", loaded["iterations"])
 
 
 # ---------------------------------------------------------------------------
@@ -1343,6 +1411,65 @@ class TestGoalNextIter(unittest.TestCase):
         text = self._captured()
         self.assertIn("wip-t", text)
 
+    def test_only_current_iteration_tentacles_are_shown(self):
+        old_dir = _make_tentacle("old-t", self.tentacles, status="completed", goal_iteration=1)
+        new_dir = _make_tentacle("new-t", self.tentacles, status="active", goal_iteration=2)
+        state = T._goal_load(self.tentacles)
+        state["iteration"] = 2
+        state["tentacles"] = ["old-t", "new-t"]
+        state["iterations"] = {
+            "1": {
+                "tentacles": ["old-t"],
+                "started_at": state["created_at"],
+                "completed_at": state["updated_at"],
+                "eval_decision": "continue",
+            },
+            "2": {
+                "tentacles": ["new-t"],
+                "started_at": state["updated_at"],
+            },
+        }
+        T._goal_write(self.tentacles, state)
+        old_meta = json.loads((old_dir / "meta.json").read_text(encoding="utf-8"))
+        old_meta["terminal_status"] = "DONE"
+        old_meta["goal_iteration"] = 1
+        (old_dir / "meta.json").write_text(json.dumps(old_meta, indent=2) + "\n", encoding="utf-8")
+        new_meta = json.loads((new_dir / "meta.json").read_text(encoding="utf-8"))
+        new_meta["goal_iteration"] = 2
+        (new_dir / "meta.json").write_text(json.dumps(new_meta, indent=2) + "\n", encoding="utf-8")
+        text = self._captured()
+        self.assertIn("new-t", text)
+        self.assertNotIn("old-t", text)
+
+    def test_rewound_iteration_uses_iteration_map_not_stale_meta_iteration(self):
+        carry_dir = _make_tentacle("carry-t", self.tentacles, status="active", goal_iteration=2)
+        state = T._goal_load(self.tentacles)
+        state["iteration"] = 2
+        state["tentacles"] = ["carry-t"]
+        state["iterations"] = {
+            "1": {
+                "tentacles": ["carry-t"],
+                "started_at": state["created_at"],
+                "completed_at": state["updated_at"],
+                "eval_decision": "continue",
+            },
+            "2": {
+                "tentacles": ["carry-t"],
+                "started_at": state["updated_at"],
+            },
+        }
+        T._goal_write(self.tentacles, state)
+        meta = json.loads((carry_dir / "meta.json").read_text(encoding="utf-8"))
+        meta["goal_iteration"] = 2
+        (carry_dir / "meta.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+        args = _fake_args(goal_action="resume", reset_failed=False, from_iteration=1)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+
+        text = self._captured()
+        self.assertIn("carry-t", text)
+
     def test_shows_pending_gates(self):
         state = T._goal_load(self.tentacles)
         state["gates"] = [{"id": "G1", "description": "Gate one", "status": "pending"}]
@@ -1387,8 +1514,20 @@ class TestGoalNextIter(unittest.TestCase):
     def test_tentacle_from_previous_iteration_not_counted(self):
         t_dir = _make_tentacle("old-t", self.tentacles, status="completed")
         state = T._goal_load(self.tentacles)
-        state["tentacles"] = ["old-t"]
         state["iteration"] = 2
+        state["tentacles"] = ["old-t"]
+        state["iterations"] = {
+            "1": {
+                "tentacles": ["old-t"],
+                "started_at": state["created_at"],
+                "completed_at": state["updated_at"],
+                "eval_decision": "continue",
+            },
+            "2": {
+                "tentacles": [],
+                "started_at": state["updated_at"],
+            },
+        }
         T._goal_write(self.tentacles, state)
         meta = json.loads((t_dir / "meta.json").read_text(encoding="utf-8"))
         meta["goal_iteration"] = 1  # iteration 1, not current (2)
@@ -2589,7 +2728,9 @@ class TestGoalHumanGate(unittest.TestCase):
         T._goal_write(self.tentacles, state)
 
         with patch("builtins.print"):
-            T._cmd_goal_gate(_fake_args(goal_action="gate", gate_action="pass", gate_id="HGPASS", reason=""), self.tentacles)
+            T._cmd_goal_gate(
+                _fake_args(goal_action="gate", gate_action="pass", gate_id="HGPASS", reason=""), self.tentacles
+            )
 
         state = T._goal_load(self.tentacles)
         self.assertEqual(state["status"], T.GOAL_STATUS_ACTIVE)
@@ -2759,7 +2900,10 @@ class TestGoalHumanGate(unittest.TestCase):
         T._goal_write(self.tentacles, state)
 
         with patch("builtins.print"):
-            T._cmd_goal_gate(_fake_args(goal_action="gate", gate_action="fail", gate_id="HGFAIL", reason="legacy fail"), self.tentacles)
+            T._cmd_goal_gate(
+                _fake_args(goal_action="gate", gate_action="fail", gate_id="HGFAIL", reason="legacy fail"),
+                self.tentacles,
+            )
 
         state = T._goal_load(self.tentacles)
         gate = next(g for g in state["gates"] if g["id"] == "HGFAIL")
@@ -2800,7 +2944,10 @@ class TestGoalHumanGate(unittest.TestCase):
         T._goal_write(self.tentacles, state)
 
         with patch("builtins.print"):
-            T._cmd_goal_gate(_fake_args(goal_action="gate", gate_action="fail", gate_id="HGFAIL1", reason="legacy fail"), self.tentacles)
+            T._cmd_goal_gate(
+                _fake_args(goal_action="gate", gate_action="fail", gate_id="HGFAIL1", reason="legacy fail"),
+                self.tentacles,
+            )
 
         state = T._goal_load(self.tentacles)
         self.assertEqual(state["status"], T.GOAL_STATUS_AWAITING_GATE)
@@ -2902,7 +3049,9 @@ class TestGoalHumanGate(unittest.TestCase):
 
         # Approve the gate.
         with patch("builtins.print"):
-            T._cmd_goal_gate(_fake_args(goal_action="gate", gate_action="approve", gate_id="APV", reason=""), self.tentacles)
+            T._cmd_goal_gate(
+                _fake_args(goal_action="gate", gate_action="approve", gate_id="APV", reason=""), self.tentacles
+            )
 
         # Now eval should succeed — status was awaiting-gate, gate is now approved.
         with patch("builtins.print"):
@@ -2941,9 +3090,7 @@ class TestGoalHumanGate(unittest.TestCase):
         state["status"] = T.GOAL_STATUS_AWAITING_GATE
         state["awaiting_gate_id"] = "REJST"
         state["awaiting_gate_reason"] = "Tests still red"
-        state["gates"] = [
-            {"id": "REJST", "description": "", "status": "rejected", "reason": "Tests still red"}
-        ]
+        state["gates"] = [{"id": "REJST", "description": "", "status": "rejected", "reason": "Tests still red"}]
         T._goal_write(self.tentacles, state)
 
         captured = []
@@ -3001,7 +3148,9 @@ class TestGoalHumanGate(unittest.TestCase):
         T._goal_write(self.tentacles, state)
 
         with patch("builtins.print"):
-            T._cmd_goal_eval(_fake_args(goal_action="eval", decision="pause", notes="pause after review"), self.tentacles)
+            T._cmd_goal_eval(
+                _fake_args(goal_action="eval", decision="pause", notes="pause after review"), self.tentacles
+            )
 
         state = T._goal_load(self.tentacles)
         self.assertEqual(state["status"], T.GOAL_STATUS_PAUSED)
@@ -3025,7 +3174,9 @@ class TestGoalHumanGate(unittest.TestCase):
         T._goal_write(self.tentacles, state)
 
         with patch("builtins.print"):
-            T._cmd_goal_eval(_fake_args(goal_action="eval", decision="abandon", notes="abandon after review"), self.tentacles)
+            T._cmd_goal_eval(
+                _fake_args(goal_action="eval", decision="abandon", notes="abandon after review"), self.tentacles
+            )
 
         state = T._goal_load(self.tentacles)
         self.assertEqual(state["status"], T.GOAL_STATUS_ABANDONED)
@@ -3108,21 +3259,27 @@ class TestGoalHumanGate(unittest.TestCase):
 
         # Approve G1 → should roll to G2.
         with patch("builtins.print"):
-            T._cmd_goal_gate(_fake_args(goal_action="gate", gate_action="approve", gate_id="G1", reason=""), self.tentacles)
+            T._cmd_goal_gate(
+                _fake_args(goal_action="gate", gate_action="approve", gate_id="G1", reason=""), self.tentacles
+            )
         state = T._goal_load(self.tentacles)
         self.assertEqual(state["status"], T.GOAL_STATUS_AWAITING_GATE)
         self.assertEqual(state["awaiting_gate_id"], "G2")
 
         # Approve G2 → should roll to G3.
         with patch("builtins.print"):
-            T._cmd_goal_gate(_fake_args(goal_action="gate", gate_action="approve", gate_id="G2", reason=""), self.tentacles)
+            T._cmd_goal_gate(
+                _fake_args(goal_action="gate", gate_action="approve", gate_id="G2", reason=""), self.tentacles
+            )
         state = T._goal_load(self.tentacles)
         self.assertEqual(state["status"], T.GOAL_STATUS_AWAITING_GATE)
         self.assertEqual(state["awaiting_gate_id"], "G3")
 
         # Approve G3 → all clear, goal is active.
         with patch("builtins.print"):
-            T._cmd_goal_gate(_fake_args(goal_action="gate", gate_action="approve", gate_id="G3", reason=""), self.tentacles)
+            T._cmd_goal_gate(
+                _fake_args(goal_action="gate", gate_action="approve", gate_id="G3", reason=""), self.tentacles
+            )
         state = T._goal_load(self.tentacles)
         self.assertEqual(state["status"], T.GOAL_STATUS_ACTIVE)
         self.assertNotIn("awaiting_gate_id", state)

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -321,8 +321,18 @@ class TestGoalInit(unittest.TestCase):
         self.assertIn("iterations", state)
         self.assertEqual(state["iterations"]["1"]["tentacles"], [])
         self.assertIn("started_at", state["iterations"]["1"])
+        self.assertEqual(state["iterations"]["1"]["started_at"], state["created_at"])
         self.assertEqual(state["success_criteria"], [])
         self.assertEqual(state["gates"], [])
+
+    def test_iteration_entry_round_trip_preserves_unknown_fields(self):
+        state = _init_goal(self.tentacles, title="Future Fields")
+        state["iterations"]["1"]["owner"] = "alice"
+        state["iterations"]["1"]["notes"] = {"kind": "future-proof"}
+        T._goal_write(self.tentacles, state)
+        loaded = T._goal_load(self.tentacles)
+        self.assertEqual(loaded["iterations"]["1"]["owner"], "alice")
+        self.assertEqual(loaded["iterations"]["1"]["notes"], {"kind": "future-proof"})
 
     def test_budget_fields_stored_when_provided(self):
         state = _init_goal(self.tentacles, max_iterations=5, max_tentacles=4, timeout=120)

--- a/tests/test_tentacle_runtime.py
+++ b/tests/test_tentacle_runtime.py
@@ -6496,6 +6496,7 @@ class TestGoalLoopRuntimeFlow(unittest.TestCase):
         self._goal_link("link-worker")
         data = self._status_json()
         self.assertIn("link-worker", data["tentacles"])
+        self.assertIn("link-worker", data["iterations"]["1"]["tentacles"])
 
     def test_runtime_criteria_full_check_cycle(self):
         """Add criteria → check → verify all pass → confirm in status."""
@@ -6607,6 +6608,10 @@ class TestGoalLoopRuntimeFlow(unittest.TestCase):
         self.assertEqual(len(data["eval_history"]), 2)
         self.assertIn("iter1-worker", data["tentacles"])
         self.assertIn("iter2-worker", data["tentacles"])
+        self.assertEqual(data["iterations"]["1"]["tentacles"], ["iter1-worker"])
+        self.assertEqual(data["iterations"]["1"]["eval_decision"], "continue")
+        self.assertEqual(data["iterations"]["2"]["tentacles"], ["iter2-worker"])
+        self.assertEqual(data["iterations"]["2"]["eval_decision"], "complete")
 
     def test_runtime_budget_status_json_reflects_real_state(self):
         """Budget status must accurately reflect current iteration vs limit."""
@@ -6675,6 +6680,7 @@ class TestGoalLoopRuntimeFlow(unittest.TestCase):
             "status",
             "iteration",
             "tentacles",
+            "iterations",
             "eval_history",
             "success_criteria",
             "gates",


### PR DESCRIPTION
## Summary
- add a backward-compatible `iterations` map to `goal.json` while keeping the legacy flat `tentacles` list mirrored
- show per-iteration tentacle history in `goal status` and drive `goal next-iter` and rewind behavior from that map
- add regression coverage plus plain-language docs for iteration queries and legacy-state backfill

## Testing
- `python -m ruff format --check tentacle.py tests/test_tentacle_goal.py tests/test_tentacle_runtime.py`
- `python -m ruff check tentacle.py tests/test_tentacle_goal.py tests/test_tentacle_runtime.py`
- `python -m pytest tests/test_tentacle_goal.py tests/test_tentacle_runtime.py -q`
- `python test_fixes.py`
- real CLI smoke for `goal init`, `goal link`, `goal eval`, `goal status`, `goal resume`, and `goal next-iter`

Closes #137