### PR TITLE
feat(tentacle): finish goal success criteria flow

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -578,6 +578,15 @@ sk tentacle goal init --title "Implement auth" [--desc "..."] [--force] \
   [--max-iterations N] [--max-tentacles N] [--timeout MINUTES]
 # fallback: python3 ~/.copilot/tools/tentacle.py goal init --title "Implement auth"
 
+# Create a goal with optional initial success criteria (alias for goal init + criteria add)
+sk tentacle goal create --title "Implement auth" [--desc "..."] [--force] \
+  [--max-iterations N] [--max-tentacles N] [--timeout MINUTES] \
+  [--criterion '{"description":"tests pass","verification_command":"pytest"}'] \
+  [--criterion '{"id":"sc-docs","description":"docs build","verification_command":"mkdocs build"}']
+# fallback: python3 ~/.copilot/tools/tentacle.py goal create --title "Implement auth" --criterion '...'
+# --criterion is repeatable; each value must be a JSON object with optional keys:
+#   id, description, verification_command
+
 # Check current goal text, or dry-run a proposed title/description before init
 sk tentacle goal validate [--title "Implement auth"] [--desc "..."] [--format text|json]
 # fallback: python3 ~/.copilot/tools/tentacle.py goal validate --title "Implement auth"
@@ -704,11 +713,32 @@ Both flags can be used together in one command. In all cases:
 sk tentacle goal criteria add --desc "All 186 tests pass" --id sc-1 \
   [--verify-cmd "python3 run_all_tests.py"]
 
-# Run verify commands for all criteria (or one by --id) and record pass/fail
+# Run verify commands for all criteria (or one by --id) and record pass/fail + evidence
 sk tentacle goal criteria check [--id sc-1] [--timeout 60]
+
+# Single-pass alias: run all criteria verification once (alias for goal criteria check)
+sk tentacle goal verify [--id sc-1] [--timeout 60]
+# fallback: python3 ~/.copilot/tools/tentacle.py goal verify
 
 # List all criteria and their current status
 sk tentacle goal criteria list
+```
+
+After `goal verify` (or `goal criteria check`) runs, each criterion in `goal.json` is updated
+with `status` (`verified` or `failed`), a timestamp (`verified_at` / `failed_at`), and the
+`evidence` field containing the first 500 characters of the command's combined stdout+stderr output.
+
+`goal.json` criterion schema (each entry in `success_criteria`):
+
+```json
+{
+  "id": "sc-1",
+  "description": "All 186 tests pass",
+  "verification_command": "python3 run_all_tests.py",
+  "status": "verified",
+  "verified_at": "2026-05-11T10:00:00+00:00",
+  "evidence": "186 passed in 7.55s\n"
+}
 ```
 
 ### Gates
@@ -812,8 +842,8 @@ re-activate the goal before re-running `goal verify-loop`.
 ### Typical orchestrator cycle
 
 ```
-goal init → goal dispatch → handoffs collected
-  → goal gate pass / goal criteria check → goal eval --decision continue
+goal create --title "..." [--criterion JSON] ... → goal dispatch → handoffs collected
+  → goal verify / goal gate pass → goal eval --decision continue
   → (new wave if goal unmet) → goal eval --decision complete → git commit + close
 
 Human gate path:

--- a/tentacle.py
+++ b/tentacle.py
@@ -22,6 +22,7 @@ Usage:
     python3 ~/.copilot/tools/tentacle.py complete <name> [--no-learn]
     python3 ~/.copilot/tools/tentacle.py delete <name>
     python3 ~/.copilot/tools/tentacle.py goal init --title <title> [--desc <desc>] [--force] [--max-iterations N] [--max-tentacles N] [--timeout MINUTES]
+    python3 ~/.copilot/tools/tentacle.py goal create --title <title> [--desc <desc>] [--force] [--max-iterations N] [--max-tentacles N] [--timeout MINUTES] [--criterion JSON] ...
     python3 ~/.copilot/tools/tentacle.py goal validate [--title <title>] [--desc <desc>] [--format text|json]
     python3 ~/.copilot/tools/tentacle.py goal status [--format text|json]
     python3 ~/.copilot/tools/tentacle.py goal dispatch [--concurrency N] [--format text|json]
@@ -31,6 +32,7 @@ Usage:
     python3 ~/.copilot/tools/tentacle.py goal criteria add --desc <desc> [--id <id>] [--verify-cmd <cmd>]
     python3 ~/.copilot/tools/tentacle.py goal criteria check [--id <id>] [--timeout <secs>]
     python3 ~/.copilot/tools/tentacle.py goal criteria list
+    python3 ~/.copilot/tools/tentacle.py goal verify [--id <id>] [--timeout <secs>]
     python3 ~/.copilot/tools/tentacle.py goal gate pass <gate-id> [--reason <text>]
     python3 ~/.copilot/tools/tentacle.py goal gate fail <gate-id> [--reason <text>]
     python3 ~/.copilot/tools/tentacle.py goal gate add <gate-id> [--desc <desc>]
@@ -2521,6 +2523,93 @@ def _cmd_goal_init(args, tentacles: Path) -> None:
     print("   Tip: link tentacles with `tentacle.py goal link <tentacle-name>`")
 
 
+def _cmd_goal_create(args, tentacles: Path) -> None:
+    """Create a new goal with optional initial success criteria (alias for goal init + criteria add).
+
+    Accepts all the same arguments as ``goal init``.  If one or more
+    ``--criterion`` values are supplied they are parsed as JSON objects with
+    optional keys ``id``, ``description``, and ``verification_command``, then
+    added to the newly created goal.
+
+    Example::
+
+        tentacle.py goal create --title "Ship v2" \\
+            --criterion '{"description":"tests pass","verification_command":"pytest"}' \\
+            --criterion '{"id":"sc-docs","description":"docs build"}'
+    """
+    import types as _types
+
+    # Validate ALL criteria before any write so that an invalid later value
+    # cannot leave a partial goal (with some criteria but not others) on disk.
+    raw_criteria: list[str] = getattr(args, "criterion", None) or []
+    parsed_criteria: list[dict] = []
+    for raw in raw_criteria:
+        try:
+            c = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            print(
+                f"ERROR: --criterion value is not valid JSON: {raw!r}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not isinstance(c, dict):
+            print(
+                f"ERROR: --criterion value must be a JSON object, got: {type(c).__name__}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        parsed_criteria.append(c)
+
+    # Prevalidate criterion IDs: reject duplicate explicit IDs and explicit/auto
+    # collisions before any write so no partial goal.json can survive ID conflicts.
+    # Simulate the same assignment logic used by _cmd_goal_criteria "add":
+    #   auto-ID = f"sc-{running_count + 1}" where running_count tracks added criteria.
+    seen_ids: set[str] = set()
+    running_count = 0
+    for c in parsed_criteria:
+        effective_id: str = c.get("id") or f"sc-{running_count + 1}"
+        if effective_id in seen_ids:
+            print(
+                f"ERROR: --criterion IDs would collide: '{effective_id}' appears more than once "
+                f"(check explicit 'id' fields and auto-generated sc-N IDs).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        seen_ids.add(effective_id)
+        running_count += 1
+
+    # All criteria are valid and IDs are unique — safe to create the goal now.
+    _cmd_goal_init(args, tentacles)
+
+    for c in parsed_criteria:
+        add_args = _types.SimpleNamespace(
+            goal_action="criteria",
+            criteria_action="add",
+            desc=c.get("description", ""),
+            id=c.get("id", None),
+            verify_cmd=c.get("verification_command", ""),
+        )
+        _cmd_goal_criteria(add_args, tentacles)
+
+
+def _cmd_goal_verify(args, tentacles: Path) -> None:
+    """Run all success criteria verification commands (alias for ``goal criteria check``).
+
+    Delegates directly to :func:`_cmd_goal_criteria` with ``criteria_action``
+    set to ``"check"``, so all persistence and exit-code semantics are identical
+    to ``goal criteria check``.
+    """
+    import types as _types
+
+    check_args = _types.SimpleNamespace(
+        goal_action="criteria",
+        criteria_action="check",
+        id=getattr(args, "id", None),
+        timeout=getattr(args, "timeout", 60) or 60,
+    )
+    _cmd_goal_criteria(check_args, tentacles)
+
+
 def _cmd_goal_validate(args, tentacles: Path) -> None:
     """Check goal title/description length against the soft/hard text budget."""
     source = _goal_validate_input_source(args, tentacles)
@@ -3202,13 +3291,13 @@ def _cmd_goal_criteria(args, tentacles: Path) -> None:
                 verified_at = datetime.now(timezone.utc).isoformat()
                 c["status"] = "verified"
                 c["verified_at"] = verified_at
-                criterion_updates[str(c.get("id", "?"))] = {"status": "verified", "verified_at": verified_at}
+                criterion_updates[str(c.get("id", "?"))] = {"status": "verified", "verified_at": verified_at, "evidence": output}
                 print(f"  ✅ [{c.get('id', '?')}] PASSED")
             else:
                 failed_at = datetime.now(timezone.utc).isoformat()
                 c["status"] = "failed"
                 c["failed_at"] = failed_at
-                criterion_updates[str(c.get("id", "?"))] = {"status": "failed", "failed_at": failed_at}
+                criterion_updates[str(c.get("id", "?"))] = {"status": "failed", "failed_at": failed_at, "evidence": output}
                 print(f"  ❌ [{c.get('id', '?')}] FAILED (exit={exit_code})")
                 for line in output.strip().splitlines()[:5]:
                     print(f"     {line}")
@@ -3232,6 +3321,8 @@ def _cmd_goal_criteria(args, tentacles: Path) -> None:
                     criterion["verified_at"] = update["verified_at"]
                 if "failed_at" in update:
                     criterion["failed_at"] = update["failed_at"]
+                if "evidence" in update:
+                    criterion["evidence"] = update["evidence"]
             state["updated_at"] = datetime.now(timezone.utc).isoformat()
             _goal_write(tentacles, state)
             all_verified = all(c.get("status") == "verified" for c in criteria)
@@ -3680,7 +3771,7 @@ def _cmd_goal_verify_loop(args, tentacles: Path) -> None:
                 verified_at = datetime.now(timezone.utc).isoformat()
                 c["status"] = "verified"
                 c["verified_at"] = verified_at
-                criterion_updates[str(cid)] = {"status": "verified", "verified_at": verified_at}
+                criterion_updates[str(cid)] = {"status": "verified", "verified_at": verified_at, "evidence": output}
                 print(f"  ✅ [{cid}] PASSED")
                 last_failure_hashes.pop(cid, None)
                 stall_counts.pop(cid, None)
@@ -3688,7 +3779,7 @@ def _cmd_goal_verify_loop(args, tentacles: Path) -> None:
                 failed_at = datetime.now(timezone.utc).isoformat()
                 c["status"] = "failed"
                 c["failed_at"] = failed_at
-                criterion_updates[str(cid)] = {"status": "failed", "failed_at": failed_at}
+                criterion_updates[str(cid)] = {"status": "failed", "failed_at": failed_at, "evidence": output}
                 print(f"  ❌ [{cid}] FAILED (exit={exit_code})")
                 for line in output.strip().splitlines()[:5]:
                     print(f"     {line}")
@@ -3733,6 +3824,8 @@ def _cmd_goal_verify_loop(args, tentacles: Path) -> None:
                     criterion["verified_at"] = update["verified_at"]
                 if "failed_at" in update:
                     criterion["failed_at"] = update["failed_at"]
+                if "evidence" in update:
+                    criterion["evidence"] = update["evidence"]
             persisted_state["updated_at"] = datetime.now(timezone.utc).isoformat()
             _goal_write(tentacles, persisted_state)
 
@@ -3779,13 +3872,15 @@ def _cmd_goal_verify_loop(args, tentacles: Path) -> None:
 
 
 def cmd_goal(args):
-    """Dispatch goal sub-commands: init / validate / status / dispatch / link / eval / resume / criteria / gate / budget / next-iter / verify-loop."""
+    """Dispatch goal sub-commands: init / create / validate / status / dispatch / link / eval / resume / criteria / gate / budget / next-iter / verify / verify-loop."""
     tentacles = get_tentacles_dir(args.session_dir)
     sub = args.goal_action
 
     try:
         if sub == "init":
             _cmd_goal_init(args, tentacles)
+        elif sub == "create":
+            _cmd_goal_create(args, tentacles)
         elif sub == "validate":
             _cmd_goal_validate(args, tentacles)
         elif sub == "status":
@@ -3806,6 +3901,8 @@ def cmd_goal(args):
             _cmd_goal_budget(args, tentacles)
         elif sub == "next-iter":
             _cmd_goal_next_iter(args, tentacles)
+        elif sub == "verify":
+            _cmd_goal_verify(args, tentacles)
         elif sub == "verify-loop":
             _cmd_goal_verify_loop(args, tentacles)
         else:
@@ -5411,7 +5508,7 @@ def main():
     # goal subcommand
     p_goal = sub.add_parser(
         "goal",
-        help="Orchestrator-level goal loop: init/validate/status/dispatch/link/eval/resume/criteria/gate/budget/next-iter",
+        help="Orchestrator-level goal loop: init/create/validate/status/dispatch/link/eval/resume/criteria/verify/gate/budget/next-iter/verify-loop",
     )
     p_goal_sub = p_goal.add_subparsers(dest="goal_action", required=True)
 
@@ -5441,6 +5538,48 @@ def main():
         default=None,
         help="Budget: timeout in minutes (positive integer)",
     )
+
+    # goal create (alias for goal init + optional --criterion entries)
+    p_goal_create = p_goal_sub.add_parser(
+        "create",
+        help="Create a new goal.json (alias for goal init) with optional initial success criteria",
+    )
+    p_goal_create.add_argument("--title", default="Unnamed Goal", help="Short title for this goal")
+    p_goal_create.add_argument("--desc", default="", help="Optional description")
+    p_goal_create.add_argument("--force", action="store_true", help="Overwrite existing goal.json")
+    p_goal_create.add_argument(
+        "--max-iterations",
+        dest="max_iterations",
+        type=_positive_int_arg,
+        default=None,
+        help="Budget: max loop iterations (positive integer)",
+    )
+    p_goal_create.add_argument(
+        "--max-tentacles",
+        dest="max_tentacles",
+        type=_positive_int_arg,
+        default=None,
+        help="Budget: max tentacle count (positive integer)",
+    )
+    p_goal_create.add_argument(
+        "--timeout",
+        dest="timeout",
+        type=_positive_int_arg,
+        default=None,
+        help="Budget: timeout in minutes (positive integer)",
+    )
+    p_goal_create.add_argument(
+        "--criterion",
+        dest="criterion",
+        action="append",
+        default=[],
+        metavar="JSON",
+        help=(
+            'Add a success criterion as a JSON object, e.g. \'{"description":"tests pass",'
+            '"verification_command":"pytest"}\'. Repeatable.'
+        ),
+    )
+
 
     # goal validate
     p_goal_validate = p_goal_sub.add_parser("validate", help="Check goal title/description length")
@@ -5606,6 +5745,24 @@ def main():
     p_goal_sub.add_parser(
         "next-iter",
         help="Summarise iteration state and advise on the next goal-loop step",
+    )
+
+    # goal verify (single-pass alias for goal criteria check)
+    p_goal_verify_simple = p_goal_sub.add_parser(
+        "verify",
+        help="Run all success criteria verification commands once (alias for goal criteria check)",
+    )
+    p_goal_verify_simple.add_argument(
+        "--id",
+        default=None,
+        dest="id",
+        help="Check only the criterion with this ID (default: all criteria)",
+    )
+    p_goal_verify_simple.add_argument(
+        "--timeout",
+        type=_positive_int_arg,
+        default=60,
+        help="Per-command timeout in seconds (default: 60)",
     )
 
     # goal verify-loop

--- a/tentacle.py
+++ b/tentacle.py
@@ -2558,6 +2558,14 @@ def _cmd_goal_create(args, tentacles: Path) -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
+        for _field in ("id", "description", "verification_command"):
+            _val = c.get(_field)
+            if _val is not None and not isinstance(_val, str):
+                print(
+                    f"ERROR: --criterion field '{_field}' must be a string, got: {type(_val).__name__} ({_val!r})",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
         parsed_criteria.append(c)
 
     # Prevalidate criterion IDs: reject duplicate explicit IDs and explicit/auto
@@ -3291,13 +3299,21 @@ def _cmd_goal_criteria(args, tentacles: Path) -> None:
                 verified_at = datetime.now(timezone.utc).isoformat()
                 c["status"] = "verified"
                 c["verified_at"] = verified_at
-                criterion_updates[str(c.get("id", "?"))] = {"status": "verified", "verified_at": verified_at, "evidence": output}
+                criterion_updates[str(c.get("id", "?"))] = {
+                    "status": "verified",
+                    "verified_at": verified_at,
+                    "evidence": output,
+                }
                 print(f"  ✅ [{c.get('id', '?')}] PASSED")
             else:
                 failed_at = datetime.now(timezone.utc).isoformat()
                 c["status"] = "failed"
                 c["failed_at"] = failed_at
-                criterion_updates[str(c.get("id", "?"))] = {"status": "failed", "failed_at": failed_at, "evidence": output}
+                criterion_updates[str(c.get("id", "?"))] = {
+                    "status": "failed",
+                    "failed_at": failed_at,
+                    "evidence": output,
+                }
                 print(f"  ❌ [{c.get('id', '?')}] FAILED (exit={exit_code})")
                 for line in output.strip().splitlines()[:5]:
                     print(f"     {line}")
@@ -5579,7 +5595,6 @@ def main():
             '"verification_command":"pytest"}\'. Repeatable.'
         ),
     )
-
 
     # goal validate
     p_goal_validate = p_goal_sub.add_parser("validate", help="Check goal title/description length")

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -1352,6 +1352,422 @@ class TestGoalCriteria(unittest.TestCase):
                 T._cmd_goal_criteria(args, self.tentacles)
         self.assertEqual(cm.exception.code, 1)
 
+    def test_criteria_check_persists_evidence_on_pass(self):
+        state = T._goal_load(self.tentacles)
+        state["success_criteria"] = [
+            {
+                "id": "sc-ev",
+                "description": "Outputs hello",
+                "verification_command": _py_inline('print("hello")'),
+                "status": "unverified",
+            }
+        ]
+        T._goal_write(self.tentacles, state)
+        args = _fake_args(goal_action="criteria", criteria_action="check", id=None, timeout=30)
+        with patch("builtins.print"):
+            T._cmd_goal_criteria(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        criterion = state["success_criteria"][0]
+        self.assertEqual(criterion["status"], "verified")
+        self.assertIn("evidence", criterion)
+        self.assertIn("hello", criterion["evidence"])
+
+    def test_criteria_check_persists_evidence_on_fail(self):
+        state = T._goal_load(self.tentacles)
+        state["success_criteria"] = [
+            {
+                "id": "sc-ef",
+                "description": "Fails with output",
+                "verification_command": _py_inline('import sys; sys.stderr.write("boom"); sys.exit(1)'),
+                "status": "unverified",
+            }
+        ]
+        T._goal_write(self.tentacles, state)
+        args = _fake_args(goal_action="criteria", criteria_action="check", id=None, timeout=30)
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit):
+                T._cmd_goal_criteria(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        criterion = state["success_criteria"][0]
+        self.assertEqual(criterion["status"], "failed")
+        self.assertIn("evidence", criterion)
+        self.assertIn("boom", criterion["evidence"])
+
+
+# ---------------------------------------------------------------------------
+# Tests for _cmd_goal_create (issue #130 exact surface)
+# ---------------------------------------------------------------------------
+
+
+class TestGoalCreate(unittest.TestCase):
+    def setUp(self):
+        self.base = SCRATCH_DIR / "create"
+        _, self.tentacles = _make_octogent(self.base)
+
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    def test_create_without_criteria_creates_goal(self):
+        args = _fake_args(
+            title="Create Test",
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=[],
+        )
+        with patch("builtins.print"):
+            T._cmd_goal_create(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertIsNotNone(state)
+        self.assertEqual(state["title"], "Create Test")
+        self.assertEqual(state["success_criteria"], [])
+
+    def test_create_with_criteria_adds_them(self):
+        args = _fake_args(
+            title="Goal With Criteria",
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=[
+                '{"description": "first criterion", "verification_command": "echo 1"}',
+                '{"id": "sc-custom", "description": "custom id criterion", "verification_command": "echo 2"}',
+            ],
+        )
+        with patch("builtins.print"):
+            T._cmd_goal_create(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(len(state["success_criteria"]), 2)
+        self.assertEqual(state["success_criteria"][0]["description"], "first criterion")
+        self.assertEqual(state["success_criteria"][0]["status"], "unverified")
+        self.assertEqual(state["success_criteria"][1]["id"], "sc-custom")
+
+    def test_create_criterion_schema_has_required_fields(self):
+        args = _fake_args(
+            title="Schema Check",
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=['{"description": "test desc", "verification_command": "echo ok"}'],
+        )
+        with patch("builtins.print"):
+            T._cmd_goal_create(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        c = state["success_criteria"][0]
+        self.assertIn("id", c)
+        self.assertIn("description", c)
+        self.assertIn("verification_command", c)
+        self.assertIn("status", c)
+        self.assertEqual(c["status"], "unverified")
+
+    def test_create_invalid_json_criterion_exits(self):
+        args = _fake_args(
+            title="Bad JSON",
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=["not-valid-json"],
+        )
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_create(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_create_non_object_criterion_exits(self):
+        args = _fake_args(
+            title="Non-object",
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=["[1, 2, 3]"],
+        )
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_create(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_create_invalid_later_criterion_leaves_no_partial_goal(self):
+        """Regression: invalid later --criterion must not leave partial goal state on disk.
+
+        Before the fix, _cmd_goal_create wrote goal.json (via _cmd_goal_init) and
+        the first valid criterion before encountering the invalid second criterion,
+        leaving an incomplete goal on disk.  After the fix, all criteria are validated
+        before any write, so the goal file must not exist on failure.
+        """
+        args = _fake_args(
+            title="Partial Write Test",
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=[
+                '{"description": "valid first criterion"}',
+                "NOT_VALID_JSON",  # second criterion is intentionally bad
+            ],
+        )
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_create(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+        # The goal file must NOT exist — no partial state was written.
+        goal_file = self.tentacles / "goal.json"
+        self.assertFalse(
+            goal_file.exists(),
+            "goal.json must not exist after validation failure (partial-write bug).",
+        )
+
+    def test_create_non_object_later_criterion_leaves_no_partial_goal(self):
+        """Regression: non-object later --criterion must not leave partial goal state on disk."""
+        args = _fake_args(
+            title="Partial Write Non-Object",
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=[
+                '{"description": "valid criterion"}',
+                "[1, 2, 3]",  # valid JSON but not an object
+            ],
+        )
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_create(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+        goal_file = self.tentacles / "goal.json"
+        self.assertFalse(
+            goal_file.exists(),
+            "goal.json must not exist after non-object criterion failure (partial-write bug).",
+        )
+
+    def test_create_duplicate_explicit_ids_exits_before_write(self):
+        """Regression: two --criterion values with the same explicit 'id' must be rejected
+        before any goal write so no partial goal.json is left on disk."""
+        args = _fake_args(
+            title="Dup Explicit IDs",
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=[
+                '{"id": "sc-dup", "description": "first"}',
+                '{"id": "sc-dup", "description": "second"}',
+            ],
+        )
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_create(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+        goal_file = self.tentacles / "goal.json"
+        self.assertFalse(
+            goal_file.exists(),
+            "goal.json must not exist when duplicate explicit IDs are supplied.",
+        )
+
+    def test_create_explicit_id_collides_with_auto_exits_before_write(self):
+        """Regression: an explicit 'id' that would collide with an auto-generated sc-N
+        must be rejected before any goal write so no partial goal.json is left on disk.
+
+        With three criteria where criterion[0] has no ID (auto -> sc-1), criterion[1]
+        has explicit id 'sc-1', the second criterion collides with the first auto-ID."""
+        args = _fake_args(
+            title="Auto-Explicit Collision",
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=[
+                '{"description": "auto sc-1"}',
+                '{"id": "sc-1", "description": "explicit sc-1 collides with auto"}',
+            ],
+        )
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_create(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+        goal_file = self.tentacles / "goal.json"
+        self.assertFalse(
+            goal_file.exists(),
+            "goal.json must not exist when an explicit ID collides with an auto-generated ID.",
+        )
+
+    def test_create_explicit_id_forces_auto_collision_with_later_entry(self):
+        """Regression: explicit sc-2 in position[0] must collide with the auto-generated
+        sc-2 that would be assigned to position[1] (because running_count==1 after the
+        first criterion is counted)."""
+        args = _fake_args(
+            title="Explicit Forces Auto Collision",
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=[
+                '{"id": "sc-2", "description": "explicit sc-2 at position 0"}',
+                '{"description": "auto sc-2 at position 1"}',
+            ],
+        )
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_create(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+        goal_file = self.tentacles / "goal.json"
+        self.assertFalse(
+            goal_file.exists(),
+            "goal.json must not exist when an explicit ID forces a later auto-ID collision.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests for _cmd_goal_verify (issue #130 exact surface)
+# ---------------------------------------------------------------------------
+
+
+class TestGoalVerify(unittest.TestCase):
+    def setUp(self):
+        self.base = SCRATCH_DIR / "verify"
+        _, self.tentacles = _make_octogent(self.base)
+        _init_goal(self.tentacles, title="Verify Goal")
+
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    def test_verify_passes_all_criteria(self):
+        state = T._goal_load(self.tentacles)
+        state["success_criteria"] = [
+            {
+                "id": "sc-v1",
+                "description": "Pass",
+                "verification_command": _py_inline("import sys; sys.exit(0)"),
+                "status": "unverified",
+            }
+        ]
+        T._goal_write(self.tentacles, state)
+        args = _fake_args(goal_action="verify", id=None, timeout=30)
+        with patch("builtins.print"):
+            T._cmd_goal_verify(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["success_criteria"][0]["status"], "verified")
+
+    def test_verify_fails_and_exits_1(self):
+        state = T._goal_load(self.tentacles)
+        state["success_criteria"] = [
+            {
+                "id": "sc-v2",
+                "description": "Fail",
+                "verification_command": _py_inline("raise SystemExit(1)"),
+                "status": "unverified",
+            }
+        ]
+        T._goal_write(self.tentacles, state)
+        args = _fake_args(goal_action="verify", id=None, timeout=30)
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_verify(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["success_criteria"][0]["status"], "failed")
+
+    def test_verify_persists_evidence(self):
+        state = T._goal_load(self.tentacles)
+        state["success_criteria"] = [
+            {
+                "id": "sc-v3",
+                "description": "Outputs something",
+                "verification_command": _py_inline('print("evidence-output")'),
+                "status": "unverified",
+            }
+        ]
+        T._goal_write(self.tentacles, state)
+        args = _fake_args(goal_action="verify", id=None, timeout=30)
+        with patch("builtins.print"):
+            T._cmd_goal_verify(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        c = state["success_criteria"][0]
+        self.assertIn("evidence", c)
+        self.assertIn("evidence-output", c["evidence"])
+
+    def test_verify_no_goal_exits(self):
+        T._goal_path(self.tentacles).unlink()
+        args = _fake_args(goal_action="verify", id=None, timeout=30)
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_verify(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_verify_filter_by_id(self):
+        state = T._goal_load(self.tentacles)
+        state["success_criteria"] = [
+            {
+                "id": "sc-a",
+                "description": "A",
+                "verification_command": _py_inline("raise SystemExit(0)"),
+                "status": "unverified",
+            },
+            {
+                "id": "sc-b",
+                "description": "B",
+                "verification_command": _py_inline("raise SystemExit(0)"),
+                "status": "unverified",
+            },
+        ]
+        T._goal_write(self.tentacles, state)
+        args = _fake_args(goal_action="verify", id="sc-a", timeout=30)
+        with patch("builtins.print"):
+            T._cmd_goal_verify(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["success_criteria"][0]["status"], "verified")
+        self.assertEqual(state["success_criteria"][1]["status"], "unverified")
+
+    def test_verify_negative_timeout_rejected_by_parser(self):
+        """goal verify --timeout must reject negative values (uses _positive_int_arg)."""
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, str(TOOLS_DIR / "tentacle.py"), "goal", "verify", "--timeout", "-5"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        # argparse exits with code 2 for argument type errors
+        self.assertEqual(result.returncode, 2, f"Expected exit 2 for negative timeout, got {result.returncode}")
+        self.assertIn("positive integer", result.stderr, "Error message must mention 'positive integer'")
+
+    def test_verify_zero_timeout_rejected_by_parser(self):
+        """goal verify --timeout must reject zero (uses _positive_int_arg, which requires >0)."""
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, str(TOOLS_DIR / "tentacle.py"), "goal", "verify", "--timeout", "0"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        self.assertEqual(result.returncode, 2, f"Expected exit 2 for zero timeout, got {result.returncode}")
+        self.assertIn("positive integer", result.stderr, "Error message must mention 'positive integer'")
+
 
 # ---------------------------------------------------------------------------
 # Tests for _cmd_goal_gate
@@ -2866,6 +3282,36 @@ class TestGoalVerifyLoop(unittest.TestCase):
         )
         combined = result.stdout + result.stderr
         for flag in ("--max-retries", "--escalate", "--retry-delay", "--timeout", "--id"):
+            self.assertIn(flag, combined, f"Parser must expose '{flag}'")
+
+    def test_parser_registers_goal_create_with_expected_flags(self):
+        """CLI parser must expose goal create with --title, --desc, --criterion, --force."""
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, str(TOOLS_DIR / "tentacle.py"), "goal", "create", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        combined = result.stdout + result.stderr
+        self.assertEqual(result.returncode, 0, f"goal create --help failed:\n{combined}")
+        for flag in ("--title", "--desc", "--criterion", "--force"):
+            self.assertIn(flag, combined, f"Parser must expose '{flag}'")
+
+    def test_parser_registers_goal_verify_with_expected_flags(self):
+        """CLI parser must expose goal verify with --id and --timeout."""
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, str(TOOLS_DIR / "tentacle.py"), "goal", "verify", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        combined = result.stdout + result.stderr
+        self.assertEqual(result.returncode, 0, f"goal verify --help failed:\n{combined}")
+        for flag in ("--id", "--timeout"):
             self.assertIn(flag, combined, f"Parser must expose '{flag}'")
 
 

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -1639,6 +1639,85 @@ class TestGoalCreate(unittest.TestCase):
             "goal.json must not exist when an explicit ID forces a later auto-ID collision.",
         )
 
+    # ------------------------------------------------------------------
+    # PR follow-up: non-string criterion field values must be rejected
+    # ------------------------------------------------------------------
+
+    def _non_string_field_args(self, title: str, criterion_json: str):
+        return _fake_args(
+            title=title,
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=[criterion_json],
+        )
+
+    def test_create_non_string_description_exits(self):
+        """Regression (PR #152): non-string 'description' must be rejected before any write."""
+        args = self._non_string_field_args("Bad desc type", '{"description": 123}')
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_create(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertFalse(
+            (self.tentacles / "goal.json").exists(),
+            "goal.json must not be written when description is not a string.",
+        )
+
+    def test_create_non_string_id_exits(self):
+        """Regression (PR #152): non-string 'id' must be rejected before any write."""
+        args = self._non_string_field_args("Bad id type", '{"id": 42, "description": "ok"}')
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_create(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertFalse(
+            (self.tentacles / "goal.json").exists(),
+            "goal.json must not be written when id is not a string.",
+        )
+
+    def test_create_non_string_verification_command_exits(self):
+        """Regression (PR #152): non-string 'verification_command' must be rejected before any write."""
+        args = self._non_string_field_args(
+            "Bad cmd type",
+            '{"description": "ok", "verification_command": ["echo", "hello"]}',
+        )
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_create(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertFalse(
+            (self.tentacles / "goal.json").exists(),
+            "goal.json must not be written when verification_command is not a string.",
+        )
+
+    def test_create_non_string_later_criterion_leaves_no_partial_goal(self):
+        """Regression (PR #152): non-string field in a later criterion must not leave partial state."""
+        args = _fake_args(
+            title="Partial Non-String",
+            desc="",
+            force=False,
+            max_iterations=None,
+            max_tentacles=None,
+            timeout=None,
+            goal_action="create",
+            criterion=[
+                '{"description": "valid first criterion"}',
+                '{"description": 999}',  # second: non-string description
+            ],
+        )
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_create(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertFalse(
+            (self.tentacles / "goal.json").exists(),
+            "goal.json must not exist after non-string field failure in a later criterion.",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests for _cmd_goal_verify (issue #130 exact surface)


### PR DESCRIPTION
## Summary
- add exact `goal create` and `goal verify` surfaces without breaking existing commands
- persist success-criteria evidence and harden create-time validation against malformed and colliding criterion IDs
- reject invalid `goal verify --timeout` values and sync focused docs/tests

Closes #130