### PR TITLE
feat(tentacle): add goal loop auto-continuation

### DIFF
--- a/tentacle.py
+++ b/tentacle.py
@@ -4271,8 +4271,227 @@ def _cmd_goal_coverage(args, tentacles: Path) -> None:
         print("\n  No success criteria defined. Add criteria with `goal criteria add`.")
 
 
+# ---------------------------------------------------------------------------
+# Goal loop helpers (issue #129)
+# ---------------------------------------------------------------------------
+
+
+def _goal_loop_record_eval(tentacles: Path, decision: str, current_iter: int, notes: str) -> None:
+    """Record a loop-driven eval entry in goal state (internal helper, no gate/warning checks)."""
+    evaluated_at = datetime.now(timezone.utc).isoformat()
+
+    def _apply(state: dict) -> None:
+        eval_entry: dict = {
+            "iteration": current_iter,
+            "decision": decision,
+            "notes": notes,
+            "evaluated_at": evaluated_at,
+            "source": "goal-loop",
+        }
+        state.setdefault("eval_history", []).append(eval_entry)
+        iter_entry = _goal_iteration_entry(state.setdefault("iterations", {}), current_iter)
+        iter_entry["eval_decision"] = decision
+        iter_entry["completed_at"] = evaluated_at
+        if decision == "complete":
+            state["status"] = GOAL_STATUS_COMPLETED
+            state["completed_at"] = evaluated_at
+        elif decision == "continue":
+            state["status"] = GOAL_STATUS_ACTIVE
+            state["iteration"] = current_iter + 1
+            _goal_iteration_entry(
+                state.setdefault("iterations", {}),
+                current_iter + 1,
+                started_at=evaluated_at,
+            )
+        state["updated_at"] = evaluated_at
+
+    _goal_transact(tentacles, _apply)
+
+
+def _goal_loop_mark_budget_limited(tentacles: Path, current_iter: int, reason: str) -> None:
+    """Mark goal as budget_limited and record in eval_history."""
+    marked_at = datetime.now(timezone.utc).isoformat()
+
+    def _apply(state: dict) -> None:
+        state["status"] = GOAL_STATUS_BUDGET_LIMITED
+        state["budget_limited_at"] = marked_at
+        state["budget_limited_reason"] = reason
+        eval_entry: dict = {
+            "iteration": current_iter,
+            "decision": "budget_limited",
+            "notes": f"goal-loop: {reason}",
+            "evaluated_at": marked_at,
+            "source": "goal-loop",
+        }
+        state.setdefault("eval_history", []).append(eval_entry)
+        # Stamp per-iteration metadata consistently with other eval decisions.
+        iter_entry = _goal_iteration_entry(state.setdefault("iterations", {}), current_iter)
+        iter_entry["eval_decision"] = "budget_limited"
+        iter_entry["completed_at"] = marked_at
+        state["updated_at"] = marked_at
+
+    _goal_transact(tentacles, _apply)
+    print(f"\n⚠️  Goal marked '{GOAL_STATUS_BUDGET_LIMITED}': {reason}")
+    print("   Run `goal resume` then `goal loop` to continue.")
+
+
+def _cmd_goal_loop(args, tentacles: Path) -> None:
+    """
+    Auto-continuation goal loop: verify criteria → eval continue/complete/budget_limited.
+
+    Each step:
+    1. Check goal status — stop if already terminal or needs-human.
+    2. Check budget (iteration/tentacle/timeout) — stop and mark budget_limited if exceeded.
+    3. Check blocking gates — stop and set awaiting-gate status if any gate blocks.
+    4. Run success criteria verification commands.
+    5. All criteria pass → eval complete.
+    6. Criteria fail, goal iteration budget reached → mark budget_limited.
+    7. Criteria fail, budget OK → eval continue (advance iteration) and repeat.
+    """
+    max_steps: int | None = getattr(args, "max_iterations", None)
+    criterion_timeout: int = getattr(args, "timeout", 60) or 60
+
+    state = _goal_load(tentacles)
+    if not state:
+        print(
+            "ERROR: No goal initialized. Run `tentacle.py goal init` first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    _terminal = {GOAL_STATUS_COMPLETED, GOAL_STATUS_ABANDONED, GOAL_STATUS_BUDGET_LIMITED}
+    current_status = state.get("status", GOAL_STATUS_ACTIVE)
+    if current_status in _terminal:
+        print(f"ℹ️  Goal is already '{current_status}' — nothing to loop.")
+        return
+    if current_status == GOAL_STATUS_NEEDS_HUMAN:
+        print(f"ℹ️  Goal is '{current_status}' — resolve issues and run `goal resume` first.")
+        return
+
+    git_root = find_git_root()
+    cwd = str(git_root) if git_root else str(Path.cwd())
+
+    step = 0
+    print(
+        f"🔄 goal loop: '{state.get('title', '?')}' "
+        f"— max_steps={max_steps if max_steps is not None else 'unlimited (governed by budget)'}"
+    )
+
+    while True:
+        step += 1
+
+        # Reload state fresh each step.
+        state = _goal_load(tentacles)
+        if not state:
+            print("ERROR: Goal state disappeared during loop.", file=sys.stderr)
+            sys.exit(1)
+
+        current_status = state.get("status", GOAL_STATUS_ACTIVE)
+        if current_status in _terminal:
+            print(f"\n   Goal reached '{current_status}' — loop complete.")
+            break
+        if current_status == GOAL_STATUS_NEEDS_HUMAN:
+            print(f"\n🚨 Goal is '{current_status}' — loop stopped. Resolve and `goal resume`.")
+            break
+
+        current_iter = _goal_current_iteration(state)
+        print(f"\n   Step {step} — iteration {current_iter}")
+
+        # 1. Budget check.
+        bs = _goal_budget_status(state)
+        if bs["over_budget"]:
+            over_reasons = []
+            if bs["over_iterations"]:
+                over_reasons.append(f"iterations {current_iter}>{bs['max_iterations']}")
+            if bs["over_tentacles"]:
+                over_reasons.append(f"tentacles {bs['tentacle_count']}>{bs['max_tentacles']}")
+            if bs["over_timeout"]:
+                over_reasons.append(f"timeout {bs['elapsed_minutes']}m>{bs['timeout_minutes']}m")
+            reason = "; ".join(over_reasons) or "budget exceeded"
+            _goal_loop_mark_budget_limited(tentacles, current_iter, reason)
+            break
+
+        # 2. max_steps guard for this loop invocation.
+        if max_steps is not None and step > max_steps:
+            reason = f"loop max_steps={max_steps} reached"
+            _goal_loop_mark_budget_limited(tentacles, current_iter, reason)
+            break
+
+        # 3. Gate check.
+        blocking = _goal_gates_blocking(state)
+        if blocking:
+            blocked_at = datetime.now(timezone.utc).isoformat()
+            gate_ids = [g.get("id", "?") for g in blocking]
+            primary = blocking[0]
+            primary_id = primary.get("id", "?")
+            primary_reason = primary.get("reason") or (
+                f"Gate '{primary_id}' is {primary.get('status', 'pending')}"
+            )
+
+            def _apply_gate_block(s: dict, _gate_ids=gate_ids, _iter=current_iter, _at=blocked_at, _pid=primary_id, _pr=primary_reason) -> None:
+                eval_entry: dict = {
+                    "iteration": _iter,
+                    "decision": "continue",
+                    "notes": f"goal-loop: blocked by gate(s) {_gate_ids}",
+                    "evaluated_at": _at,
+                    "blocked_by_gates": _gate_ids,
+                    "source": "goal-loop",
+                }
+                s.setdefault("eval_history", []).append(eval_entry)
+                s["status"] = GOAL_STATUS_AWAITING_GATE
+                s["awaiting_gate_id"] = _pid
+                s["awaiting_gate_reason"] = _pr
+                s["updated_at"] = _at
+
+            _goal_transact(tentacles, _apply_gate_block)
+            print(f"   ⛔ {len(blocking)} gate(s) blocking progress:")
+            for g in blocking:
+                g_st = g.get("status", "pending")
+                icon = "❌" if g_st == "rejected" else "⬜"
+                print(f"      {icon} [{g.get('id', '?')}] {g.get('description', '')[:60]} — {g_st}")
+            print(f"   Goal status set to '{GOAL_STATUS_AWAITING_GATE}'. Approve gate(s) with `goal gate approve <id>` then re-run `goal loop`.")
+            break
+
+        # 4. Run success criteria.
+        runnable = [c for c in (state.get("success_criteria") or []) if c.get("verification_command", "")]
+        if not runnable:
+            print("   ℹ️  No success criteria with verification_command set — auto-advancing.")
+        all_passed = bool(runnable)
+        for c in runnable:
+            cid = c.get("id", "?")
+            exit_code, output = _goal_criteria_run_one(c, cwd, timeout=criterion_timeout)
+            if exit_code == 0:
+                print(f"      ✅ [{cid}] passed")
+            else:
+                print(f"      ❌ [{cid}] failed (exit={exit_code})")
+                for line in output.strip().splitlines()[:3]:
+                    print(f"         {line}")
+                all_passed = False
+
+        # 5. Decide.
+        if all_passed:
+            _goal_loop_record_eval(tentacles, "complete", current_iter, "goal-loop: all criteria verified")
+            print(f"\n✅ Goal complete at iteration {current_iter} (step {step}).")
+            break
+
+        # Check goal's own iteration budget before continuing.
+        goal_max_iters = (state.get("budget") or {}).get("max_iterations")
+        if goal_max_iters is not None and current_iter >= goal_max_iters:
+            reason = f"iteration {current_iter} reached goal max_iterations={goal_max_iters}"
+            _goal_loop_mark_budget_limited(tentacles, current_iter, reason)
+            break
+
+        _goal_loop_record_eval(
+            tentacles,
+            "continue",
+            current_iter,
+            f"goal-loop: step {step}, criteria not yet met",
+        )
+        print(f"   ▶  Advancing to iteration {current_iter + 1}...")
+
+
 def cmd_goal(args):
-    """Dispatch goal sub-commands: init / create / validate / status / dispatch / link / eval / resume / criteria / gate / budget / next-iter / verify / verify-loop / coverage."""
+    """Dispatch goal sub-commands: init / create / validate / status / dispatch / link / eval / resume / criteria / gate / budget / next-iter / verify / verify-loop / coverage / loop."""
     tentacles = get_tentacles_dir(args.session_dir)
     sub = args.goal_action
 
@@ -4309,6 +4528,8 @@ def cmd_goal(args):
             _cmd_goal_verify_loop(args, tentacles)
         elif sub == "coverage":
             _cmd_goal_coverage(args, tentacles)
+        elif sub == "loop":
+            _cmd_goal_loop(args, tentacles)
         else:
             print(f"ERROR: Unknown goal action '{sub}'", file=sys.stderr)
             sys.exit(1)
@@ -5973,7 +6194,7 @@ def main():
     # goal subcommand
     p_goal = sub.add_parser(
         "goal",
-        help="Orchestrator-level goal loop: init/create/validate/status/dispatch/link/eval/resume/criteria/verify/gate/budget/next-iter/verify-loop/coverage",
+        help="Orchestrator-level goal loop: init/create/validate/status/dispatch/link/eval/resume/criteria/verify/gate/budget/next-iter/verify-loop/coverage/loop",
     )
     p_goal_sub = p_goal.add_subparsers(dest="goal_action", required=True)
 
@@ -6298,6 +6519,32 @@ def main():
         choices=["text", "json"],
         default="text",
         help="Output format: text (default) or json",
+    )
+
+    # goal loop
+    p_goal_loop = p_goal_sub.add_parser(
+        "loop",
+        help=(
+            "Auto-continuation loop: verify criteria → eval continue/complete/budget_limited. "
+            "Stops when goal is complete, budget exceeded, or gates block."
+        ),
+    )
+    p_goal_loop.add_argument(
+        "--max-iterations",
+        dest="max_iterations",
+        type=_positive_int_arg,
+        default=None,
+        help=(
+            "Maximum loop steps for this invocation — marks goal budget_limited when exceeded. "
+            "Defaults to unlimited (governed by goal budget)."
+        ),
+    )
+    p_goal_loop.add_argument(
+        "--timeout",
+        dest="timeout",
+        type=_positive_int_arg,
+        default=60,
+        help="Per-criterion verification timeout in seconds (default: 60)",
     )
 
     args = parser.parse_args()

--- a/tentacle.py
+++ b/tentacle.py
@@ -4424,11 +4424,11 @@ def _cmd_goal_loop(args, tentacles: Path) -> None:
             gate_ids = [g.get("id", "?") for g in blocking]
             primary = blocking[0]
             primary_id = primary.get("id", "?")
-            primary_reason = primary.get("reason") or (
-                f"Gate '{primary_id}' is {primary.get('status', 'pending')}"
-            )
+            primary_reason = primary.get("reason") or (f"Gate '{primary_id}' is {primary.get('status', 'pending')}")
 
-            def _apply_gate_block(s: dict, _gate_ids=gate_ids, _iter=current_iter, _at=blocked_at, _pid=primary_id, _pr=primary_reason) -> None:
+            def _apply_gate_block(
+                s: dict, _gate_ids=gate_ids, _iter=current_iter, _at=blocked_at, _pid=primary_id, _pr=primary_reason
+            ) -> None:
                 eval_entry: dict = {
                     "iteration": _iter,
                     "decision": "continue",
@@ -4449,7 +4449,9 @@ def _cmd_goal_loop(args, tentacles: Path) -> None:
                 g_st = g.get("status", "pending")
                 icon = "❌" if g_st == "rejected" else "⬜"
                 print(f"      {icon} [{g.get('id', '?')}] {g.get('description', '')[:60]} — {g_st}")
-            print(f"   Goal status set to '{GOAL_STATUS_AWAITING_GATE}'. Approve gate(s) with `goal gate approve <id>` then re-run `goal loop`.")
+            print(
+                f"   Goal status set to '{GOAL_STATUS_AWAITING_GATE}'. Approve gate(s) with `goal gate approve <id>` then re-run `goal loop`."
+            )
             break
 
         # 4. Run success criteria.

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -5263,5 +5263,281 @@ class TestGoalCoverageUnit(unittest.TestCase):
         )
 
 
+# ---------------------------------------------------------------------------
+# Goal loop helpers and tests (issue #129)
+# ---------------------------------------------------------------------------
+
+
+def _run_loop(tentacles, *, max_iterations=None, timeout=60) -> None:
+    """Helper: invoke _cmd_goal_loop with fake args."""
+    args = _fake_args(
+        goal_action="loop",
+        max_iterations=max_iterations,
+        timeout=timeout,
+    )
+    with patch("builtins.print"):
+        T._cmd_goal_loop(args, tentacles)
+
+
+class TestGoalLoopConstants(unittest.TestCase):
+    """Verify the budget_limited status constant exists and is distinct."""
+
+    def test_budget_limited_constant_is_string(self):
+        self.assertIsInstance(T.GOAL_STATUS_BUDGET_LIMITED, str)
+
+    def test_budget_limited_distinct_from_others(self):
+        others = {
+            T.GOAL_STATUS_ACTIVE,
+            T.GOAL_STATUS_PAUSED,
+            T.GOAL_STATUS_COMPLETED,
+            T.GOAL_STATUS_ABANDONED,
+            T.GOAL_STATUS_NEEDS_HUMAN,
+            T.GOAL_STATUS_AWAITING_GATE,
+        }
+        self.assertNotIn(T.GOAL_STATUS_BUDGET_LIMITED, others)
+
+
+class TestGoalLoop(unittest.TestCase):
+    def setUp(self):
+        self.base = SCRATCH_DIR / "loop"
+        _, self.tentacles = _make_octogent(self.base)
+        _init_goal(self.tentacles, title="Loop Goal", max_iterations=10)
+
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    # -- helpers --
+
+    def _add_passing_criterion(self, cid: str = "sc-pass") -> None:
+        """Add a criterion whose verification command always exits 0."""
+        state = T._goal_load(self.tentacles)
+        state.setdefault("success_criteria", []).append(
+            {
+                "id": cid,
+                "description": "always passes",
+                "status": "pending",
+                "verification_command": _py_inline("raise SystemExit(0)"),
+            }
+        )
+        T._goal_write(self.tentacles, state)
+
+    def _add_failing_criterion(self, cid: str = "sc-fail") -> None:
+        """Add a criterion whose verification command always exits 1."""
+        state = T._goal_load(self.tentacles)
+        state.setdefault("success_criteria", []).append(
+            {
+                "id": cid,
+                "description": "always fails",
+                "status": "pending",
+                "verification_command": _py_inline("raise SystemExit(1)"),
+            }
+        )
+        T._goal_write(self.tentacles, state)
+
+    # -- tests --
+
+    def test_loop_marks_complete_when_all_criteria_pass(self):
+        self._add_passing_criterion()
+        _run_loop(self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_COMPLETED)
+
+    def test_loop_records_complete_eval_in_history(self):
+        self._add_passing_criterion()
+        _run_loop(self.tentacles)
+        state = T._goal_load(self.tentacles)
+        history = state.get("eval_history", [])
+        last = history[-1]
+        self.assertEqual(last["decision"], "complete")
+        self.assertEqual(last["source"], "goal-loop")
+
+    def test_loop_marks_budget_limited_when_max_steps_exceeded(self):
+        self._add_failing_criterion()
+        _run_loop(self.tentacles, max_iterations=1)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_BUDGET_LIMITED)
+
+    def test_budget_limited_records_eval_history_entry(self):
+        self._add_failing_criterion()
+        _run_loop(self.tentacles, max_iterations=1)
+        state = T._goal_load(self.tentacles)
+        last = state["eval_history"][-1]
+        self.assertEqual(last["decision"], "budget_limited")
+        self.assertEqual(last["source"], "goal-loop")
+
+    def test_budget_limited_state_has_timestamp_and_reason(self):
+        self._add_failing_criterion()
+        _run_loop(self.tentacles, max_iterations=1)
+        state = T._goal_load(self.tentacles)
+        self.assertIn("budget_limited_at", state)
+        self.assertIn("budget_limited_reason", state)
+
+    def test_loop_records_continue_eval_before_budget_limited(self):
+        """Failing criteria → continue recorded → then budget_limited on next step."""
+        self._add_failing_criterion()
+        _run_loop(self.tentacles, max_iterations=2)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_BUDGET_LIMITED)
+        decisions = [e["decision"] for e in state.get("eval_history", [])]
+        self.assertIn("continue", decisions)
+        self.assertIn("budget_limited", decisions)
+
+    def test_loop_advances_iteration_on_continue(self):
+        """After a continue eval the iteration counter must increment."""
+        _rmtree(SCRATCH_DIR)
+        _, self.tentacles = _make_octogent(self.base)
+        _init_goal(self.tentacles, title="Loop Goal", max_iterations=10)
+        self._add_failing_criterion()
+        _run_loop(self.tentacles, max_iterations=2)
+        state = T._goal_load(self.tentacles)
+        # iteration should have advanced at least once (from 1)
+        current_iter = T._goal_current_iteration(state)
+        self.assertGreaterEqual(current_iter, 2)
+
+    def test_loop_exits_immediately_when_already_complete(self):
+        """Loop should exit without error if goal is already completed."""
+        state = T._goal_load(self.tentacles)
+        state["status"] = T.GOAL_STATUS_COMPLETED
+        T._goal_write(self.tentacles, state)
+        _run_loop(self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_COMPLETED)
+
+    def test_loop_exits_immediately_when_budget_limited(self):
+        state = T._goal_load(self.tentacles)
+        state["status"] = T.GOAL_STATUS_BUDGET_LIMITED
+        T._goal_write(self.tentacles, state)
+        _run_loop(self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_BUDGET_LIMITED)
+
+    def test_loop_exits_immediately_when_abandoned(self):
+        state = T._goal_load(self.tentacles)
+        state["status"] = T.GOAL_STATUS_ABANDONED
+        T._goal_write(self.tentacles, state)
+        _run_loop(self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_ABANDONED)
+
+    def test_loop_stops_when_goal_iteration_budget_reached(self):
+        """Goal with max_iterations=2 and failing criteria → budget_limited at iter 2."""
+        _rmtree(SCRATCH_DIR)
+        _, tentacles = _make_octogent(self.base)
+        _init_goal(tentacles, title="Budget Goal", max_iterations=2)
+        args = _fake_args(goal_action="loop", max_iterations=None, timeout=60)
+        state = T._goal_load(tentacles)
+        state.setdefault("success_criteria", []).append(
+            {
+                "id": "sc1",
+                "description": "fails",
+                "status": "pending",
+                "verification_command": _py_inline("raise SystemExit(1)"),
+            }
+        )
+        T._goal_write(tentacles, state)
+        with patch("builtins.print"):
+            T._cmd_goal_loop(args, tentacles)
+        state = T._goal_load(tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_BUDGET_LIMITED)
+
+    def test_loop_stops_at_blocking_gate(self):
+        """A pending gate should stop the loop and set status to awaiting-gate."""
+        state = T._goal_load(self.tentacles)
+        state["gates"] = [{"id": "G1", "description": "gate", "status": "pending"}]
+        T._goal_write(self.tentacles, state)
+        self._add_passing_criterion()
+        _run_loop(self.tentacles)
+        state = T._goal_load(self.tentacles)
+        # Gate blocking must transition goal to awaiting-gate (not stay active).
+        self.assertEqual(state["status"], T.GOAL_STATUS_AWAITING_GATE)
+        # eval_history must contain a blocked_by_gates entry.
+        history = state.get("eval_history", [])
+        blocked_entries = [e for e in history if e.get("blocked_by_gates")]
+        self.assertTrue(blocked_entries, "expected an eval_history entry with blocked_by_gates")
+        self.assertIn("G1", blocked_entries[0]["blocked_by_gates"])
+        # awaiting_gate_id must be set.
+        self.assertEqual(state.get("awaiting_gate_id"), "G1")
+
+    def test_loop_exits_when_no_goal_initialized(self):
+        _, empty_tentacles = _make_octogent(SCRATCH_DIR / "empty")
+        args = _fake_args(goal_action="loop", max_iterations=None, timeout=60)
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_loop(args, empty_tentacles)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_resume_clears_budget_limited_fields(self):
+        """After goal resume from budget_limited, budget_limited_* fields must be gone."""
+        state = T._goal_load(self.tentacles)
+        state["status"] = T.GOAL_STATUS_BUDGET_LIMITED
+        state["budget_limited_at"] = "2026-01-01T00:00:00Z"
+        state["budget_limited_reason"] = "max_steps=1 reached"
+        T._goal_write(self.tentacles, state)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(
+                _fake_args(goal_action="resume", reset_failed=False, from_iteration=None),
+                self.tentacles,
+            )
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_ACTIVE)
+        self.assertNotIn("budget_limited_at", state)
+        self.assertNotIn("budget_limited_reason", state)
+
+    def test_eval_blocked_on_budget_limited_goal(self):
+        """Direct eval on a budget_limited goal must exit with error."""
+        state = T._goal_load(self.tentacles)
+        state["status"] = T.GOAL_STATUS_BUDGET_LIMITED
+        T._goal_write(self.tentacles, state)
+        args = _fake_args(goal_action="eval", decision="continue", notes="")
+        with patch("builtins.print"):
+            with self.assertRaises(SystemExit) as cm:
+                T._cmd_goal_eval(args, self.tentacles)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_loop_no_criteria_auto_advances_until_budget(self):
+        """Goal with no verifiable criteria auto-continues until budget or max_steps."""
+        _rmtree(SCRATCH_DIR)
+        _, tentacles = _make_octogent(self.base)
+        _init_goal(tentacles, title="No Criteria", max_iterations=3)
+        _run_loop(tentacles, max_iterations=2)
+        state = T._goal_load(tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_BUDGET_LIMITED)
+
+    def test_loop_budget_limited_stamps_iter_metadata(self):
+        """budget_limited transition must stamp eval_decision/completed_at on the iteration entry."""
+        self._add_failing_criterion()
+        _run_loop(self.tentacles, max_iterations=1)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_BUDGET_LIMITED)
+        iterations = state.get("iterations", {})
+        has_budget_decision = any(
+            v.get("eval_decision") == "budget_limited"
+            for v in iterations.values()
+            if isinstance(v, dict)
+        )
+        self.assertTrue(has_budget_decision, "expected an iteration entry with eval_decision='budget_limited'")
+        budget_entry = next(
+            v for v in iterations.values()
+            if isinstance(v, dict) and v.get("eval_decision") == "budget_limited"
+        )
+        self.assertIn("completed_at", budget_entry)
+
+    def test_loop_gate_block_records_awaiting_gate_state(self):
+        """Gate blocking in goal loop must write awaiting-gate status and eval_history entry."""
+        state = T._goal_load(self.tentacles)
+        state["gates"] = [{"id": "G2", "description": "security gate", "status": "pending"}]
+        T._goal_write(self.tentacles, state)
+        self._add_passing_criterion()
+        _run_loop(self.tentacles)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_AWAITING_GATE)
+        self.assertEqual(state.get("awaiting_gate_id"), "G2")
+        self.assertIn("awaiting_gate_reason", state)
+        history = state.get("eval_history", [])
+        blocked = [e for e in history if e.get("blocked_by_gates")]
+        self.assertEqual(len(blocked), 1)
+        self.assertIn("G2", blocked[0]["blocked_by_gates"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `tentacle.py goal loop` auto-continuation command on top of the current goal infrastructure
- record eval-history entries for loop decisions, gate-block awaiting-gate transitions, and budget-limited iteration metadata
- cover loop behavior and CLI wiring with goal/runtime tests while preserving newer main-side goal commands

## Scope note
- This PR implements the **criteria-verification / evaluation continuation loop**.
- Full tentacle dispatch-and-wait orchestration remains follow-up work and is **not** claimed by this PR.

## Evidence
- `python -m py_compile tentacle.py`
- `python tests/test_tentacle_goal.py`
- `python tests/test_tentacle_runtime.py`
- `python tentacle.py goal --help`

Refs #129