### PR TITLE
feat(sk): add buglog export command

### DIFF
--- a/buglog-export.py
+++ b/buglog-export.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+buglog-export.py — Export mistake entries as a git-friendly BUGLOG.
+
+Reads mistake-category knowledge entries from the session knowledge DB and
+emits a deterministic Markdown or JSON document suitable for committing as
+BUGLOG.md or piping to other tools.
+
+Usage:
+    python buglog-export.py                          # Markdown to stdout (default)
+    python buglog-export.py --format json            # JSON to stdout
+    python buglog-export.py --output BUGLOG.md       # Write Markdown to file
+    python buglog-export.py --output bugs.json --format json
+    python buglog-export.py --limit 100              # Max entries (default: 200)
+    python buglog-export.py --tags docker,ci         # Filter by tag (any match)
+    python buglog-export.py --min-confidence 0.7     # Minimum confidence threshold
+
+Output contracts:
+  Markdown — human-readable, git-diff friendly, no ANSI escapes, deterministic
+             ordering (confidence DESC, id ASC).
+  JSON     — machine-readable envelope:
+             {"generated_at": ISO8601, "entry_count": N, "entries": [...]}
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+SESSION_STATE = Path.home() / ".copilot" / "session-state"
+DB_PATH = SESSION_STATE / "knowledge.db"
+
+
+def _get_db() -> sqlite3.Connection:
+    if not DB_PATH.exists():
+        print(
+            f"Error: knowledge database not found at {DB_PATH}\n"
+            "Run 'python build-session-index.py' then 'python extract-knowledge.py' first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    db = sqlite3.connect(str(DB_PATH))
+    db.row_factory = sqlite3.Row
+    return db
+
+
+def _fetch_mistakes(
+    db: sqlite3.Connection,
+    limit: int,
+    tags_filter: list[str],
+    min_confidence: float,
+) -> list[dict]:
+    """Return mistake entries as dicts, deterministically ordered.
+
+    LIMIT is applied after Python-side tag filtering so --tags + --limit
+    always returns the top-N *matching* entries, not a pre-truncated set.
+    Fixes: SQL LIMIT before tag filtering caused false-negatives when matching
+    entries ranked below the LIMIT cutoff by confidence (issue #90).
+    """
+    # Omit LIMIT from SQL when tag filtering is active; apply it after filtering.
+    # When no tag filter is requested, push LIMIT into SQL for efficiency.
+    sql = """
+        SELECT id, title, content, tags, confidence, session_id, occurrence_count,
+               COALESCE(wing, '') AS wing, COALESCE(room, '') AS room,
+               COALESCE(source, 'copilot') AS source
+        FROM knowledge_entries
+        WHERE category = 'mistake'
+          AND confidence >= ?
+        ORDER BY confidence DESC, id ASC
+    """
+    if tags_filter:
+        params: tuple = (min_confidence,)
+    else:
+        sql += "\nLIMIT ?"
+        params = (min_confidence, limit)
+
+    try:
+        rows = db.execute(sql, params).fetchall()
+    except sqlite3.OperationalError as exc:
+        print(f"Error querying database: {exc}", file=sys.stderr)
+        return []
+
+    entries = [dict(r) for r in rows]
+
+    if tags_filter:
+        lower_tags = [t.lower() for t in tags_filter]
+        entries = [
+            e for e in entries
+            if any(t in (e.get("tags") or "").lower() for t in lower_tags)
+        ]
+
+    # Apply limit after filtering so --limit counts filtered rows, not raw DB rows.
+    return entries[:limit]
+
+
+def _render_markdown(entries: list[dict], generated_at: str) -> str:
+    lines: list[str] = []
+    lines.append("# BUGLOG — Mistake Entries\n")
+    lines.append(f"<!-- generated: {generated_at} | entries: {len(entries)} -->\n")
+
+    if not entries:
+        lines.append("*No mistake entries found.*\n")
+        return "\n".join(lines)
+
+    for i, e in enumerate(entries, 1):
+        lines.append(f"## {i}. {e['title']}\n")
+        meta: list[str] = []
+        if e.get("tags"):
+            meta.append(f"- **Tags**: `{e['tags']}`")
+        meta.append(f"- **Confidence**: {e['confidence']:.2f}")
+        if e.get("occurrence_count", 1) > 1:
+            meta.append(f"- **Occurrences**: {e['occurrence_count']}")
+        if e.get("wing"):
+            room_part = f" / {e['room']}" if e.get("room") else ""
+            meta.append(f"- **Domain**: {e['wing']}{room_part}")
+        meta.append(f"- **Session**: `{(e.get('session_id') or '')[:8]}...`")
+        lines.extend(meta)
+        lines.append("")
+        content = (e.get("content") or "").strip()
+        if content:
+            lines.append(content)
+        lines.append("")
+        lines.append("---\n")
+
+    return "\n".join(lines)
+
+
+def _render_json(entries: list[dict], generated_at: str) -> str:
+    payload = {
+        "generated_at": generated_at,
+        "entry_count": len(entries),
+        "entries": entries,
+    }
+    return json.dumps(payload, indent=2, ensure_ascii=False, default=str)
+
+
+def _write_output(text: str, output_path: Path | None) -> None:
+    if output_path is None:
+        try:
+            print(text)
+        except UnicodeEncodeError:
+            sys.stdout.buffer.write(text.encode("utf-8"))
+            sys.stdout.buffer.write(b"\n")
+        return
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(text, encoding="utf-8")
+    print(f"Written {len(text)} chars to {output_path}", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="buglog-export",
+        description="Export mistake knowledge entries as a git-friendly BUGLOG.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="FILE",
+        default=None,
+        help="Write output to FILE instead of stdout",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        metavar="N",
+        help="Maximum number of entries to export (default: 200)",
+    )
+    parser.add_argument(
+        "--tags",
+        default=None,
+        metavar="TAG[,TAG...]",
+        help="Filter entries by tag (comma-separated, any-match)",
+    )
+    parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=0.0,
+        metavar="FLOAT",
+        help="Minimum confidence threshold (0.0–1.0, default: 0.0)",
+    )
+    args = parser.parse_args(argv)
+
+    tags_filter = [t.strip() for t in args.tags.split(",")] if args.tags else []
+    output_path = Path(args.output) if args.output else None
+
+    db = _get_db()
+    try:
+        entries = _fetch_mistakes(db, args.limit, tags_filter, args.min_confidence)
+    finally:
+        db.close()
+
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    if args.format == "json":
+        text = _render_json(entries, generated_at)
+    else:
+        text = _render_markdown(entries, generated_at)
+
+    _write_output(text, output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/buglog-export.py
+++ b/buglog-export.py
@@ -91,20 +91,22 @@ def _fetch_mistakes(
     entries = [dict(r) for r in rows]
 
     if tags_filter:
-        lower_tags = [t.lower() for t in tags_filter]
+        lower_tags = {t.lower() for t in tags_filter}
         entries = [
             e for e in entries
-            if any(t in (e.get("tags") or "").lower() for t in lower_tags)
+            if {tok.strip().lower() for tok in (e.get("tags") or "").split(",") if tok.strip()} & lower_tags
         ]
 
     # Apply limit after filtering so --limit counts filtered rows, not raw DB rows.
     return entries[:limit]
 
 
-def _render_markdown(entries: list[dict], generated_at: str) -> str:
+def _render_markdown(entries: list[dict]) -> str:
     lines: list[str] = []
     lines.append("# BUGLOG — Mistake Entries\n")
-    lines.append(f"<!-- generated: {generated_at} | entries: {len(entries)} -->\n")
+    # Omit timestamp from the comment so repeated runs on unchanged data produce
+    # identical output — a requirement for git-diff-friendly / deterministic output.
+    lines.append(f"<!-- entries: {len(entries)} -->\n")
 
     if not entries:
         lines.append("*No mistake entries found.*\n")
@@ -195,7 +197,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    tags_filter = [t.strip() for t in args.tags.split(",")] if args.tags else []
+    if args.limit <= 0:
+        parser.error(f"--limit must be a positive integer, got {args.limit}")
+    if not (0.0 <= args.min_confidence <= 1.0):
+        parser.error(f"--min-confidence must be between 0.0 and 1.0, got {args.min_confidence}")
+
+    # Filter empty tokens so `--tags docker,` or `--tags ,` do not silently
+    # disable filtering by injecting an empty string that matches everything.
+    tags_filter = [t.strip() for t in args.tags.split(",") if t.strip()] if args.tags else []
     output_path = Path(args.output) if args.output else None
 
     db = _get_db()
@@ -209,7 +218,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.format == "json":
         text = _render_json(entries, generated_at)
     else:
-        text = _render_markdown(entries, generated_at)
+        text = _render_markdown(entries)
 
     _write_output(text, output_path)
     return 0

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -40,17 +40,26 @@ sk export-buglog                                 # Markdown to stdout
 sk export-buglog --format json                   # JSON to stdout
 sk export-buglog --output BUGLOG.md              # Write Markdown to BUGLOG.md
 sk export-buglog --output bugs.json --format json # Write JSON to file
-sk export-buglog --limit 50                      # Cap at 50 entries (default: 200)
-sk export-buglog --tags docker,ci                # Filter by tag (any match)
-sk export-buglog --min-confidence 0.7            # High-quality entries only
+sk export-buglog --limit 50                      # Cap at 50 entries (default: 200, must be ≥ 1)
+sk export-buglog --tags docker,ci                # Filter by tag (exact token match, comma-separated)
+sk export-buglog --min-confidence 0.7            # High-quality entries only (range: 0.0–1.0)
 sk buglog                                        # Markdown to stdout (alias)
 sk buglog --format json                          # JSON to stdout (alias)
 sk buglog --output BUGLOG.md                     # Write Markdown to BUGLOG.md (alias)
 sk buglog --output bugs.json --format json       # Write JSON to file (alias)
-sk buglog --limit 50                             # Cap at 50 entries (default: 200)
-sk buglog --tags docker,ci                       # Filter by tag (any match)
-sk buglog --min-confidence 0.7                   # High-quality entries only
+sk buglog --limit 50                             # Cap at 50 entries (default: 200, must be ≥ 1)
+sk buglog --tags docker,ci                       # Filter by tag (exact token match, comma-separated)
+sk buglog --min-confidence 0.7                   # High-quality entries only (range: 0.0–1.0)
 ```
+
+**`--tags` semantics:** each token in the comma-separated list is matched against the entry's
+tag tokens exactly (whole-token, case-insensitive). A query of `--tags doc` will **not** match
+entries tagged `docker`; use `--tags docker` for that. Trailing commas and empty tokens are ignored.
+
+**`--limit`:** must be a positive integer (≥ 1). Applied after tag filtering so `--tags + --limit`
+always returns the top-N *matching* entries. Errors with exit code 2 if ≤ 0.
+
+**`--min-confidence`:** float in [0.0, 1.0]. Errors with exit code 2 if out of range.
 
 JSON envelope:
 ```json
@@ -58,6 +67,7 @@ JSON envelope:
 ```
 
 Ordering is deterministic: `confidence DESC, id ASC` — stable for git diffs.
+Markdown output omits a run-timestamp so repeated exports on unchanged data produce identical output.
 
 ### `sk index` — knowledge index lifecycle
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -21,7 +21,32 @@ sk browse --port 8080 --token TOKEN      # → browse.py
 sk benchmark record                      # → benchmark.py
 sk retro                                 # → retro.py
 sk heal                                  # → copilot-cli-healer.py
+sk buglog                                # → buglog-export.py  (Markdown to stdout)
+sk buglog --format json                  # → buglog-export.py  (JSON to stdout)
+sk buglog --output BUGLOG.md             # → buglog-export.py  (write Markdown to file)
 ```
+
+### `sk buglog` — BUGLOG export
+
+Export mistake-category knowledge entries as a deterministic, git-friendly document.
+Useful for committing a `BUGLOG.md` to a repo or piping to downstream tools.
+
+```bash
+sk buglog                                        # Markdown to stdout
+sk buglog --format json                          # JSON to stdout
+sk buglog --output BUGLOG.md                     # Write Markdown to BUGLOG.md
+sk buglog --output bugs.json --format json       # Write JSON to file
+sk buglog --limit 50                             # Cap at 50 entries (default: 200)
+sk buglog --tags docker,ci                       # Filter by tag (any match)
+sk buglog --min-confidence 0.7                   # High-quality entries only
+```
+
+JSON envelope:
+```json
+{"generated_at": "2024-01-01T00:00:00Z", "entry_count": 5, "entries": [...]}
+```
+
+Ordering is deterministic: `confidence DESC, id ASC` — stable for git diffs.
 
 ### `sk index` — knowledge index lifecycle
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -21,21 +21,32 @@ sk browse --port 8080 --token TOKEN      # → browse.py
 sk benchmark record                      # → benchmark.py
 sk retro                                 # → retro.py
 sk heal                                  # → copilot-cli-healer.py
-sk buglog                                # → buglog-export.py  (Markdown to stdout)
+sk export-buglog                         # → buglog-export.py  (Markdown to stdout)
+sk export-buglog --format json           # → buglog-export.py  (JSON to stdout)
+sk export-buglog --output BUGLOG.md      # → buglog-export.py  (write Markdown to file)
+sk buglog                                # → buglog-export.py  (alias for export-buglog)
 sk buglog --format json                  # → buglog-export.py  (JSON to stdout)
 sk buglog --output BUGLOG.md             # → buglog-export.py  (write Markdown to file)
 ```
 
-### `sk buglog` — BUGLOG export
+### `sk export-buglog` — BUGLOG export
 
 Export mistake-category knowledge entries as a deterministic, git-friendly document.
 Useful for committing a `BUGLOG.md` to a repo or piping to downstream tools.
+`sk buglog` is an alias for `sk export-buglog` (backward-compatible).
 
 ```bash
-sk buglog                                        # Markdown to stdout
-sk buglog --format json                          # JSON to stdout
-sk buglog --output BUGLOG.md                     # Write Markdown to BUGLOG.md
-sk buglog --output bugs.json --format json       # Write JSON to file
+sk export-buglog                                 # Markdown to stdout
+sk export-buglog --format json                   # JSON to stdout
+sk export-buglog --output BUGLOG.md              # Write Markdown to BUGLOG.md
+sk export-buglog --output bugs.json --format json # Write JSON to file
+sk export-buglog --limit 50                      # Cap at 50 entries (default: 200)
+sk export-buglog --tags docker,ci                # Filter by tag (any match)
+sk export-buglog --min-confidence 0.7            # High-quality entries only
+sk buglog                                        # Markdown to stdout (alias)
+sk buglog --format json                          # JSON to stdout (alias)
+sk buglog --output BUGLOG.md                     # Write Markdown to BUGLOG.md (alias)
+sk buglog --output bugs.json --format json       # Write JSON to file (alias)
 sk buglog --limit 50                             # Cap at 50 entries (default: 200)
 sk buglog --tags docker,ci                       # Filter by tag (any match)
 sk buglog --min-confidence 0.7                   # High-quality entries only

--- a/sk.py
+++ b/sk.py
@@ -18,6 +18,7 @@ Usage:
     sk retro    [<args>...]       Run retro.py
     sk heal     [<args>...]       Run copilot-cli-healer.py
     sk watch    [<args>...]       Run watch-sessions.py
+    sk buglog   [<args>...]       Run buglog-export.py
     sk hooks    run|list|<event>  Run hooks/hook_runner.py
 
     sk index  build|extract|migrate|status|health|embed [<args>...]
@@ -64,6 +65,7 @@ _DIRECT: dict[str, str] = {
     "retro": "retro.py",
     "heal": "copilot-cli-healer.py",
     "watch": "watch-sessions.py",
+    "buglog": "buglog-export.py",
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}

--- a/sk.py
+++ b/sk.py
@@ -18,7 +18,8 @@ Usage:
     sk retro    [<args>...]       Run retro.py
     sk heal     [<args>...]       Run copilot-cli-healer.py
     sk watch    [<args>...]       Run watch-sessions.py
-    sk buglog   [<args>...]       Run buglog-export.py
+    sk export-buglog [<args>...]  Run buglog-export.py
+    sk buglog   [<args>...]       Run buglog-export.py (alias for export-buglog)
     sk hooks    run|list|<event>  Run hooks/hook_runner.py
 
     sk index  build|extract|migrate|status|health|embed [<args>...]
@@ -65,7 +66,8 @@ _DIRECT: dict[str, str] = {
     "retro": "retro.py",
     "heal": "copilot-cli-healer.py",
     "watch": "watch-sessions.py",
-    "buglog": "buglog-export.py",
+    "export-buglog": "buglog-export.py",
+    "buglog": "buglog-export.py",  # alias for export-buglog (backward compat)
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -679,6 +679,132 @@ class TestBuglogTagFilterSemantics(unittest.TestCase):
             db.close()
         self.assertEqual(len(results), 2, "Without tags, limit=2 should return exactly 2 entries")
 
+    def test_exact_tag_matching_no_false_positive(self):
+        """Substring 'doc' must NOT match the tag 'docker' — exact token matching required.
+
+        Regression: old code used ``t in tags_string.lower()`` which caused
+        'doc' to match 'docker,ci' because 'doc' is a substring of 'docker'.
+        """
+        db = self._make_db()
+        try:
+            results = self.buglog._fetch_mistakes(
+                db, limit=200, tags_filter=["doc"], min_confidence=0.0
+            )
+        finally:
+            db.close()
+        titles = [r["title"] for r in results]
+        self.assertNotIn(
+            "Docker mistake",
+            titles,
+            "Tag 'doc' must NOT match entry tagged 'docker' — exact token match required",
+        )
+        self.assertEqual(results, [], "No entries carry the exact tag 'doc'")
+
+    def test_empty_tag_tokens_are_ignored(self):
+        """Empty items from trailing commas in --tags must not disable filtering.
+
+        'docker,' splits to ['docker', ''] — the empty string matches every
+        entry ('' in any_string is True), effectively disabling the filter.
+        The fix strips empty tokens before tag matching.
+        """
+        # Simulate what main() does after parsing '--tags docker,'
+        raw_tags = "docker,"
+        tags_filter = [t.strip() for t in raw_tags.split(",") if t.strip()]
+        self.assertEqual(tags_filter, ["docker"], "Empty token must be stripped from tags_filter")
+
+        db = self._make_db()
+        try:
+            results = self.buglog._fetch_mistakes(
+                db, limit=200, tags_filter=tags_filter, min_confidence=0.0
+            )
+        finally:
+            db.close()
+        # Only the docker-tagged entry should be returned, not all 4 entries.
+        titles = [r["title"] for r in results]
+        self.assertEqual(
+            titles,
+            ["Docker mistake"],
+            "Trailing comma in tags must not disable filtering (empty token bug)",
+        )
+
+    def test_markdown_output_has_no_timestamp(self):
+        """Markdown comment must not contain a timestamp — it would break git-diff determinism.
+
+        The docstring promises 'git-diff friendly' / 'deterministic' output.
+        A timestamp that changes every run defeats this contract.
+        """
+        entries = [
+            {"id": 1, "title": "T", "content": "C", "tags": "x", "confidence": 0.9,
+             "session_id": "abc12345", "occurrence_count": 1, "wing": "", "room": "", "source": "copilot"}
+        ]
+        md = self.buglog._render_markdown(entries)
+        # Must not contain any timestamp pattern like 2024-01-01T00:00:00Z
+        import re
+        self.assertIsNone(
+            re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", md),
+            "Markdown output must not contain a timestamp (breaks git-diff determinism)",
+        )
+        # Entry count IS deterministic and should be present
+        self.assertIn("entries: 1", md)
+
+
+class TestBuglogArgValidation(unittest.TestCase):
+    """Tests for --limit and --min-confidence input validation in buglog-export.py."""
+
+    BUGLOG_PATH = TOOLS_DIR / "buglog-export.py"
+
+    @classmethod
+    def setUpClass(cls):
+        if not cls.BUGLOG_PATH.exists():
+            raise unittest.SkipTest(
+                "buglog-export.py not present — skipping arg-validation tests"
+            )
+        spec = importlib.util.spec_from_file_location("buglog_export_val", cls.BUGLOG_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        cls.buglog = mod
+
+    def _call_main(self, argv):
+        """Call main() and return (exit_code, stderr_output).  Patches _get_db to avoid needing a real DB."""
+        import io
+        from unittest.mock import patch, MagicMock
+        fake_db = MagicMock()
+        fake_db.execute.return_value.fetchall.return_value = []
+        stderr_capture = io.StringIO()
+        try:
+            with patch.object(self.buglog, "_get_db", return_value=fake_db), \
+                 patch("sys.stderr", stderr_capture):
+                rc = self.buglog.main(argv)
+            return rc, stderr_capture.getvalue()
+        except SystemExit as exc:
+            return exc.code, stderr_capture.getvalue()
+
+    def test_limit_zero_rejected(self):
+        """--limit 0 must be rejected with exit code 2."""
+        rc, _ = self._call_main(["--limit", "0"])
+        self.assertEqual(rc, 2, "--limit 0 must exit with code 2")
+
+    def test_limit_negative_rejected(self):
+        """--limit -1 must be rejected (would produce entries[:-1] = all-but-last)."""
+        rc, _ = self._call_main(["--limit", "-1"])
+        self.assertEqual(rc, 2, "--limit -1 must exit with code 2")
+
+    def test_min_confidence_above_one_rejected(self):
+        """--min-confidence 1.5 is out of range [0.0, 1.0] and must be rejected."""
+        rc, _ = self._call_main(["--min-confidence", "1.5"])
+        self.assertEqual(rc, 2, "--min-confidence 1.5 must exit with code 2")
+
+    def test_min_confidence_negative_rejected(self):
+        """--min-confidence -0.1 is out of range and must be rejected."""
+        rc, _ = self._call_main(["--min-confidence", "-0.1"])
+        self.assertEqual(rc, 2, "--min-confidence -0.1 must exit with code 2")
+
+    def test_valid_limit_and_confidence_accepted(self):
+        """Valid values must not trigger an error."""
+        rc, _ = self._call_main(["--limit", "50", "--min-confidence", "0.5"])
+        self.assertEqual(rc, 0, "Valid --limit and --min-confidence must succeed")
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -127,6 +127,15 @@ class TestSkDirectCommands(unittest.TestCase):
     def test_watch(self):
         self._assert_routes("watch", "watch-sessions.py")
 
+    def test_export_buglog(self):
+        self._assert_routes("export-buglog", "buglog-export.py")
+
+    def test_export_buglog_with_format_flag(self):
+        self._assert_routes("export-buglog", "buglog-export.py", ["--format", "json"])
+
+    def test_export_buglog_with_output_flag(self):
+        self._assert_routes("export-buglog", "buglog-export.py", ["--output", "BUGLOG.md"])
+
     def test_buglog(self):
         self._assert_routes("buglog", "buglog-export.py")
 

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -16,6 +16,7 @@ Run: python3 tests/test_sk_cli.py
 import importlib.util
 import os
 import shutil
+import sqlite3
 import sys
 import tempfile
 import unittest
@@ -125,6 +126,15 @@ class TestSkDirectCommands(unittest.TestCase):
 
     def test_watch(self):
         self._assert_routes("watch", "watch-sessions.py")
+
+    def test_buglog(self):
+        self._assert_routes("buglog", "buglog-export.py")
+
+    def test_buglog_with_format_flag(self):
+        self._assert_routes("buglog", "buglog-export.py", ["--format", "json"])
+
+    def test_buglog_with_output_flag(self):
+        self._assert_routes("buglog", "buglog-export.py", ["--output", "BUGLOG.md"])
 
 
 class TestSkHooksCompat(unittest.TestCase):
@@ -483,5 +493,183 @@ class TestSkNativeFeaturePreconditions(unittest.TestCase):
         )
 
 
+
+class TestBuglogTagFilterSemantics(unittest.TestCase):
+    """Regression tests for issue #90: --limit must apply after --tags filtering.
+
+    The original bug: SQL LIMIT ran before Python-side tag filtering.  When all
+    entries with a matching tag ranked below the LIMIT cutoff (by confidence),
+    they were silently excluded — a false-negative that the caller had no way to
+    detect.
+
+    Fix: fetch without LIMIT when tags are active, filter, then slice to limit.
+    """
+
+    BUGLOG_PATH = TOOLS_DIR / "buglog-export.py"
+
+    @classmethod
+    def setUpClass(cls):
+        if not cls.BUGLOG_PATH.exists():
+            raise unittest.SkipTest(
+                "buglog-export.py not present — skipping filter-semantics tests"
+            )
+        spec = importlib.util.spec_from_file_location("buglog_export", cls.BUGLOG_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        cls.buglog = mod
+
+    def _make_db(self) -> sqlite3.Connection:
+        """In-memory DB with 3 high-confidence untagged rows + 1 low-confidence tagged row."""
+        db = sqlite3.connect(":memory:")
+        db.row_factory = sqlite3.Row
+        db.execute("""
+            CREATE TABLE knowledge_entries (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                content TEXT,
+                tags TEXT,
+                confidence REAL,
+                session_id TEXT,
+                occurrence_count INTEGER DEFAULT 1,
+                category TEXT DEFAULT 'mistake',
+                wing TEXT,
+                room TEXT,
+                source TEXT DEFAULT 'copilot'
+            )
+        """)
+        # Three entries WITHOUT the target tag at high confidence (ranked 1-3).
+        for i in range(3):
+            db.execute(
+                "INSERT INTO knowledge_entries "
+                "(id, title, content, tags, confidence, session_id, category) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'mistake')",
+                (i + 1, f"High entry {i+1}", f"Content {i+1}", "python,database",
+                 1.0 - i * 0.01, f"sess-{i+1}"),
+            )
+        # One entry WITH the target tag at lower confidence (ranked 4th — below limit=3).
+        db.execute(
+            "INSERT INTO knowledge_entries "
+            "(id, title, content, tags, confidence, session_id, category) "
+            "VALUES (?, ?, ?, ?, ?, ?, 'mistake')",
+            (4, "Docker mistake", "Docker content", "docker,ci", 0.5, "sess-docker"),
+        )
+        db.commit()
+        return db
+
+    def test_limit_truncates_before_tag_filter_reproduces_false_negative(self):
+        """Reproduce the false-negative: old behaviour returned 0 matching rows.
+
+        With limit=3 applied in SQL before tag filtering, the 'docker' entry
+        (ranked 4th) is never fetched, so the tag filter finds nothing.
+        This test directly demonstrates the pre-fix failure path.
+        """
+        db = self._make_db()
+        try:
+            # Simulate old (broken) logic: LIMIT in SQL before Python tag filter.
+            sql = """
+                SELECT id, title, content, tags, confidence, session_id, occurrence_count,
+                       COALESCE(wing, '') AS wing, COALESCE(room, '') AS room,
+                       COALESCE(source, 'copilot') AS source
+                FROM knowledge_entries
+                WHERE category = 'mistake'
+                  AND confidence >= 0.0
+                ORDER BY confidence DESC, id ASC
+                LIMIT 3
+            """
+            rows = db.execute(sql).fetchall()
+            entries = [dict(r) for r in rows]
+            # Apply tag filter after truncated fetch — this is the buggy path.
+            filtered = [e for e in entries if "docker" in (e.get("tags") or "").lower()]
+            # False-negative: the docker entry was excluded by LIMIT before filtering.
+            self.assertEqual(
+                filtered, [],
+                "Reproducer: old LIMIT-first logic produces an empty result (false-negative)",
+            )
+        finally:
+            db.close()
+
+    def test_fetch_mistakes_with_tags_applies_limit_after_filter(self):
+        """Fixed _fetch_mistakes: --limit applies after tag filtering, not before.
+
+        With limit=3 and tags=['docker'], the function should return the docker
+        entry even though it ranks 4th by confidence — because LIMIT is now
+        applied only after the tag filter narrows the result set.
+        """
+        db = self._make_db()
+        try:
+            results = self.buglog._fetch_mistakes(
+                db, limit=3, tags_filter=["docker"], min_confidence=0.0
+            )
+        finally:
+            db.close()
+        titles = [r["title"] for r in results]
+        self.assertIn(
+            "Docker mistake",
+            titles,
+            "--limit should not truncate before tag filtering (issue #90 regression)",
+        )
+        self.assertEqual(len(results), 1, "Only the docker-tagged entry should match")
+
+    def test_fetch_mistakes_limit_respected_after_filter(self):
+        """When multiple tagged entries exist, limit is honoured after filtering."""
+        db = sqlite3.connect(":memory:")
+        db.row_factory = sqlite3.Row
+        db.execute("""
+            CREATE TABLE knowledge_entries (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                content TEXT,
+                tags TEXT,
+                confidence REAL,
+                session_id TEXT,
+                occurrence_count INTEGER DEFAULT 1,
+                category TEXT DEFAULT 'mistake',
+                wing TEXT,
+                room TEXT,
+                source TEXT DEFAULT 'copilot'
+            )
+        """)
+        # 5 high-confidence untagged entries.
+        for i in range(5):
+            db.execute(
+                "INSERT INTO knowledge_entries "
+                "(id, title, content, tags, confidence, session_id, category) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'mistake')",
+                (i + 1, f"Top {i+1}", "body", "python", 1.0 - i * 0.01, f"s{i}"),
+            )
+        # 3 low-confidence tagged entries.
+        for j in range(3):
+            db.execute(
+                "INSERT INTO knowledge_entries "
+                "(id, title, content, tags, confidence, session_id, category) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'mistake')",
+                (100 + j, f"Docker {j}", "body", "docker", 0.3 - j * 0.01, f"d{j}"),
+            )
+        db.commit()
+        try:
+            # limit=2 with tags=['docker'] — should return the 2 highest-confidence docker entries.
+            results = self.buglog._fetch_mistakes(
+                db, limit=2, tags_filter=["docker"], min_confidence=0.0
+            )
+        finally:
+            db.close()
+        self.assertEqual(len(results), 2, "limit=2 should cap filtered results at 2")
+        self.assertTrue(
+            all("docker" in (r.get("tags") or "").lower() for r in results),
+            "All returned entries must match the docker tag",
+        )
+
+    def test_fetch_mistakes_no_tags_uses_sql_limit(self):
+        """Without --tags, LIMIT is pushed into SQL (efficiency path); result count is correct."""
+        db = self._make_db()
+        try:
+            results = self.buglog._fetch_mistakes(
+                db, limit=2, tags_filter=[], min_confidence=0.0
+            )
+        finally:
+            db.close()
+        self.assertEqual(len(results), 2, "Without tags, limit=2 should return exactly 2 entries")
+
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- add `buglog-export.py` for git-friendly markdown/json buglog exports
- wire the feature into `sk.py` and document the usage surface
- fix tag-filter limit semantics and cover the exported CLI path with regression tests

## Evidence
- `python -m py_compile buglog-export.py sk.py query-session.py`
- `python tests/test_sk_cli.py`
- `python buglog-export.py --limit 2 --output TMPFILE.md`
- `python buglog-export.py --format json --limit 2 --output TMPFILE.json`

Closes #90