### PR TITLE
feat: add dream-score ranking for knowledge promotion

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -69,6 +69,28 @@ JSON envelope:
 Ordering is deterministic: `confidence DESC, id ASC` — stable for git diffs.
 Markdown output omits a run-timestamp so repeated exports on unchanged data produce identical output.
 
+### `sk dream` — dream-score ranking for knowledge promotion
+
+Computes a weighted dream-score for each knowledge entry using recall telemetry
+(`entry_recall_stats`) and concept tags (`entry_concept_tags`). Scores are
+persisted in `entry_dream_scores` (local-only, never synced).
+
+```bash
+sk dream                    # Score all entries, persist, show top 20
+sk dream --dry-run          # List top candidates without persisting scores
+sk dream --dry-run --top 10 --json          # Top-10 as JSON (no persist)
+sk dream --min-score 0.5 --min-recall 1     # Relaxed gate thresholds
+sk dream --w-frequency 0.3 --w-relevance 0.4 \
+         --w-diversity 0.1 --w-recency 0.1 \
+         --w-consolidation 0.05 --w-conceptual 0.05  # Custom weights
+sk dream --db /path/to/knowledge.db         # Custom DB path
+```
+
+Gate (default): `score >= 0.75 AND recall_count >= 3 AND unique_queries >= 2`.
+
+See [docs/concepts/dreaming.md](concepts/dreaming.md) for the full formula, signal
+normalization, and out-of-scope future phases (#160, #161, #162).
+
 ### `sk index` — knowledge index lifecycle
 
 ```bash

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -1,0 +1,121 @@
+# Dreaming — Knowledge Promotion via Dream-Score Ranking
+
+> Issue #159 · Depends on: #157 (recall telemetry), #158 (concept tags)
+
+## What is a Dream-Score?
+
+A *dream-score* is a weighted composite signal (0–1) that ranks each knowledge
+entry by its promotion readiness. Entries that exceed the configured **gate**
+thresholds are promotion candidates — they have been recalled often, from
+diverse queries, have associated concept tags, and were recently accessed.
+
+The name "Dreaming" is borrowed from neuroscience: the system periodically
+"dreams" over its memory, surfaces the most valuable entries, and marks them
+for promotion to higher-priority surfaces such as `MEMORY.md`.
+
+## Score Formula
+
+```
+dream_score = w_frequency    * signal_frequency
+            + w_relevance    * signal_relevance
+            + w_diversity    * signal_diversity
+            + w_recency      * signal_recency
+            + w_consolidation * signal_consolidation
+            + w_conceptual   * signal_conceptual
+```
+
+### Signals
+
+| Signal | Source | Normalization |
+|---|---|---|
+| `frequency` | `entry_recall_stats.recall_count` | `min(count / 100, 1.0)` |
+| `relevance` | `entry_recall_stats.unique_queries` | `min(queries / 50, 1.0)` |
+| `diversity` | `COUNT(entry_concept_tags)` | `min(tags / 10, 1.0)` |
+| `recency` | `entry_recall_stats.last_recalled_at` | Exponential decay, half-life 30 days |
+| `consolidation` | `knowledge_entries.confidence × occurrence_count` | `confidence × min(occ/20, 1.0)` |
+| `conceptual` | `entry_concept_tags` exists | `1.0` if any tag, else `0.0` |
+
+### Weight Overrides
+
+Use `--w-<signal>` flags to supply custom weights.  If the supplied weights sum
+to more than 1.0, `dream.py` **automatically renormalizes** them so the total is
+exactly 1.0 and emits a warning to stderr.  This keeps the dream-score bounded
+to `[0, 1]` and preserves the meaning of the default gate threshold (`0.75`).
+
+### Default Weights
+
+Derived from OpenClaw `extensions/memory-core/src/short-term-promotion.ts`:
+
+| Weight | Default |
+|---|---|
+| `frequency` | 0.24 |
+| `relevance` | 0.30 |
+| `diversity` | 0.15 |
+| `recency` | 0.15 |
+| `consolidation` | 0.10 |
+| `conceptual` | 0.06 |
+
+## Gate Thresholds
+
+An entry **passes the gate** when all three conditions hold:
+
+| Condition | Default |
+|---|---|
+| `dream_score >= min_score` | `0.75` |
+| `recall_count >= min_recall` | `3` |
+| `unique_queries >= min_queries` | `2` |
+
+## Persistence
+
+Scores are written to `entry_dream_scores` (migration v20):
+
+```sql
+CREATE TABLE entry_dream_scores (
+    entry_id          INTEGER PRIMARY KEY,
+    score             REAL    NOT NULL DEFAULT 0.0,
+    signal_frequency  REAL    DEFAULT 0.0,
+    signal_relevance  REAL    DEFAULT 0.0,
+    signal_diversity  REAL    DEFAULT 0.0,
+    signal_recency    REAL    DEFAULT 0.0,
+    signal_consolidation REAL DEFAULT 0.0,
+    signal_conceptual REAL    DEFAULT 0.0,
+    passes_gate       INTEGER NOT NULL DEFAULT 0,
+    scored_at         TEXT    DEFAULT (datetime('now'))
+);
+```
+
+`entry_dream_scores` is **`local_only`** — it is never synced to remote replicas
+because scores are computed from local telemetry and can be regenerated on any
+machine.
+
+## CLI Usage
+
+```bash
+# Score all entries, persist results, show top 20
+sk dream
+
+# Dry-run: score and list without persisting
+sk dream --dry-run
+
+# Show top 10 candidates as JSON
+sk dream --dry-run --top 10 --json
+
+# Override gate thresholds
+sk dream --min-score 0.5 --min-recall 1 --min-queries 1
+
+# Override weights
+sk dream --w-frequency 0.3 --w-relevance 0.4 --w-diversity 0.1 \
+         --w-recency 0.1 --w-consolidation 0.05 --w-conceptual 0.05
+
+# Point at a different database
+sk dream --db /path/to/knowledge.db
+```
+
+## Out of Scope (future issues)
+
+- **#160** Promotion executor: writing gate-passing entries to `MEMORY.md`.
+- **#161** Scheduling: periodic automatic dream runs.
+- **#162** Cross-replica score merging / collaborative dreaming.
+
+These phases are intentionally excluded from the `dream.py` implementation.
+`dream.py` computes and persists scores; the promotion action lives elsewhere.

--- a/dream.py
+++ b/dream.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""
+dream.py — Dream-score ranking for knowledge promotion (issue #159).
+
+Computes a weighted dream-score for each knowledge entry using recall
+telemetry (entry_recall_stats) and concept tags (entry_concept_tags).
+Entries that pass configurable gates are candidates for promotion.
+
+Usage:
+    python dream.py                     # Score all entries, persist, show top-20
+    python dream.py --dry-run           # Score and list top-N without persisting
+    python dream.py --top 10            # Show top-N candidates
+    python dream.py --json              # JSON output
+    python dream.py --min-score 0.75    # Override gate min score
+    python dream.py --min-recall 3      # Override gate min recall count
+    python dream.py --min-queries 2     # Override gate min unique queries
+
+    # Override weights (if they sum > 1.0, they are automatically renormalized to sum=1.0)
+    python dream.py --w-frequency 0.24 --w-relevance 0.30 --w-diversity 0.15 \
+                    --w-recency 0.15 --w-consolidation 0.10 --w-conceptual 0.06
+
+Score formula (6 weighted signals, each normalized to [0, 1]):
+    dream_score = w_frequency   * signal_frequency
+                + w_relevance   * signal_relevance
+                + w_diversity   * signal_diversity
+                + w_recency     * signal_recency
+                + w_consolidation * signal_consolidation
+                + w_conceptual  * signal_conceptual
+
+Gate: entry passes if dream_score >= min_score
+                  AND recall_count >= min_recall
+                  AND unique_queries >= min_queries
+
+Default weights (from OpenClaw extensions/memory-core/src/short-term-promotion.ts):
+    frequency=0.24, relevance=0.30, diversity=0.15,
+    recency=0.15, consolidation=0.10, conceptual=0.06
+
+Default gates:
+    min_score=0.75, min_recall=3, min_queries=2
+"""
+
+import argparse
+import json
+import math
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+SESSION_STATE = Path.home() / ".copilot" / "session-state"
+DB_PATH = SESSION_STATE / "knowledge.db"
+
+# Default weights (must sum ≤ 1.0)
+DEFAULT_WEIGHTS = {
+    "frequency": 0.24,
+    "relevance": 0.30,
+    "diversity": 0.15,
+    "recency": 0.15,
+    "consolidation": 0.10,
+    "conceptual": 0.06,
+}
+
+# Default gate thresholds
+DEFAULT_MIN_SCORE = 0.75
+DEFAULT_MIN_RECALL = 3
+DEFAULT_MIN_QUERIES = 2
+
+# Normalization caps
+_RECALL_CAP = 100.0  # recall_count above this → saturates at 1.0
+_QUERIES_CAP = 50.0  # unique_queries above this → saturates at 1.0
+_TAGS_CAP = 10.0  # tag count above this → saturates at 1.0
+_RECENCY_HALFLIFE_DAYS = 30.0  # recency half-life: 30 days → signal 0.5
+
+
+def _open_db(db_path: Path) -> sqlite3.Connection:
+    if not db_path.exists():
+        print(f"dream: database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _ensure_dream_scores_table(conn: sqlite3.Connection) -> None:
+    """Create entry_dream_scores if it doesn't exist (idempotent)."""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS entry_dream_scores (
+            entry_id INTEGER PRIMARY KEY,
+            score REAL NOT NULL DEFAULT 0.0,
+            signal_frequency REAL DEFAULT 0.0,
+            signal_relevance REAL DEFAULT 0.0,
+            signal_diversity REAL DEFAULT 0.0,
+            signal_recency REAL DEFAULT 0.0,
+            signal_consolidation REAL DEFAULT 0.0,
+            signal_conceptual REAL DEFAULT 0.0,
+            passes_gate INTEGER NOT NULL DEFAULT 0,
+            scored_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_eds_score ON entry_dream_scores(score DESC);
+        CREATE INDEX IF NOT EXISTS idx_eds_passes_gate ON entry_dream_scores(passes_gate);
+    """)
+    conn.commit()
+
+
+def _days_since(iso_str: str | None) -> float:
+    """Return days elapsed since iso_str (UTC), or very large number if missing.
+
+    Naive timestamps (no timezone suffix, e.g. written by briefing.py as
+    ``YYYY-MM-DDTHH:MM:SS``) are treated as UTC so they are not silently zeroed.
+    """
+    if not iso_str:
+        return 9999.0
+    try:
+        ts = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+        if ts.tzinfo is None:
+            # briefing.py writes timestamps without a timezone suffix; treat as UTC.
+            ts = ts.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        diff = now - ts
+        return max(0.0, diff.total_seconds() / 86400.0)
+    except (ValueError, TypeError):
+        return 9999.0
+
+
+def _sig_recency(days: float) -> float:
+    """Exponential decay: 1.0 at 0 days, 0.5 at half-life days."""
+    return math.exp(-math.log(2.0) * days / _RECENCY_HALFLIFE_DAYS)
+
+
+def _normalize(value: float, cap: float) -> float:
+    """Linear normalization capped at cap, result in [0, 1]."""
+    return min(1.0, max(0.0, value / cap)) if cap > 0 else 0.0
+
+
+def compute_score(
+    recall_count: int,
+    recall_days: int,
+    unique_queries: int,
+    last_recalled_at: str | None,
+    tag_count: int,
+    confidence: float,
+    occurrence_count: int,
+    weights: dict,
+) -> dict:
+    """
+    Compute dream-score signals and weighted total.
+
+    Returns a dict with signal_* floats and 'score'.
+    """
+    sig_freq = _normalize(recall_count, _RECALL_CAP)
+    sig_rel = _normalize(unique_queries, _QUERIES_CAP)
+    sig_div = _normalize(tag_count, _TAGS_CAP)
+    sig_rec = _sig_recency(_days_since(last_recalled_at))
+    # consolidation: confidence * capped recurrence
+    sig_con = float(confidence or 0.0) * _normalize(occurrence_count, 20.0)
+    sig_con = min(1.0, max(0.0, sig_con))
+    sig_cpt = 1.0 if tag_count > 0 else 0.0
+
+    w = weights
+    score = (
+        w["frequency"] * sig_freq
+        + w["relevance"] * sig_rel
+        + w["diversity"] * sig_div
+        + w["recency"] * sig_rec
+        + w["consolidation"] * sig_con
+        + w["conceptual"] * sig_cpt
+    )
+    return {
+        "signal_frequency": round(sig_freq, 6),
+        "signal_relevance": round(sig_rel, 6),
+        "signal_diversity": round(sig_div, 6),
+        "signal_recency": round(sig_rec, 6),
+        "signal_consolidation": round(sig_con, 6),
+        "signal_conceptual": round(sig_cpt, 6),
+        "score": round(score, 6),
+    }
+
+
+def fetch_entries(conn: sqlite3.Connection) -> list[dict]:
+    """Fetch all knowledge entries joined with recall stats and tag counts."""
+    cur = conn.execute("""
+        SELECT
+            ke.id              AS entry_id,
+            ke.title           AS title,
+            ke.category        AS category,
+            ke.confidence      AS confidence,
+            ke.occurrence_count AS occurrence_count,
+            COALESCE(ers.recall_count,   0) AS recall_count,
+            COALESCE(ers.recall_days,    0) AS recall_days,
+            COALESCE(ers.unique_queries, 0) AS unique_queries,
+            ers.last_recalled_at            AS last_recalled_at,
+            COALESCE(tc.tag_count,       0) AS tag_count
+        FROM knowledge_entries ke
+        LEFT JOIN entry_recall_stats ers ON ers.entry_id = ke.id
+        LEFT JOIN (
+            SELECT entry_id, COUNT(*) AS tag_count
+            FROM entry_concept_tags
+            GROUP BY entry_id
+        ) tc ON tc.entry_id = ke.id
+    """)
+    cols = [desc[0] for desc in cur.description]
+    return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+
+
+def run_scoring(
+    conn: sqlite3.Connection,
+    weights: dict,
+    min_score: float,
+    min_recall: int,
+    min_queries: int,
+    dry_run: bool,
+    top_n: int,
+    as_json: bool,
+) -> int:
+    """Run dream-score computation, persist (unless dry_run), and report."""
+    _ensure_dream_scores_table(conn)
+    entries = fetch_entries(conn)
+
+    results = []
+    for entry in entries:
+        sig = compute_score(
+            recall_count=int(entry["recall_count"] or 0),
+            recall_days=int(entry["recall_days"] or 0),
+            unique_queries=int(entry["unique_queries"] or 0),
+            last_recalled_at=entry.get("last_recalled_at"),
+            tag_count=int(entry["tag_count"] or 0),
+            confidence=float(entry["confidence"] or 1.0),
+            occurrence_count=int(entry["occurrence_count"] or 1),
+            weights=weights,
+        )
+        passes_gate = (
+            sig["score"] >= min_score
+            and int(entry["recall_count"] or 0) >= min_recall
+            and int(entry["unique_queries"] or 0) >= min_queries
+        )
+        rec = {
+            "entry_id": entry["entry_id"],
+            "title": entry["title"],
+            "category": entry["category"],
+            "recall_count": int(entry["recall_count"] or 0),
+            "unique_queries": int(entry["unique_queries"] or 0),
+            "tag_count": int(entry["tag_count"] or 0),
+            "passes_gate": passes_gate,
+            **sig,
+        }
+        results.append(rec)
+
+    # Sort by score descending
+    results.sort(key=lambda r: r["score"], reverse=True)
+
+    # Persist unless dry-run
+    if not dry_run:
+        now_str = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        conn.executemany(
+            """
+            INSERT INTO entry_dream_scores
+                (entry_id, score,
+                 signal_frequency, signal_relevance, signal_diversity,
+                 signal_recency, signal_consolidation, signal_conceptual,
+                 passes_gate, scored_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(entry_id) DO UPDATE SET
+                score = excluded.score,
+                signal_frequency = excluded.signal_frequency,
+                signal_relevance = excluded.signal_relevance,
+                signal_diversity = excluded.signal_diversity,
+                signal_recency = excluded.signal_recency,
+                signal_consolidation = excluded.signal_consolidation,
+                signal_conceptual = excluded.signal_conceptual,
+                passes_gate = excluded.passes_gate,
+                scored_at = excluded.scored_at
+            """,
+            [
+                (
+                    r["entry_id"],
+                    r["score"],
+                    r["signal_frequency"],
+                    r["signal_relevance"],
+                    r["signal_diversity"],
+                    r["signal_recency"],
+                    r["signal_consolidation"],
+                    r["signal_conceptual"],
+                    1 if r["passes_gate"] else 0,
+                    now_str,
+                )
+                for r in results
+            ],
+        )
+        conn.commit()
+
+    # Top-N slice
+    top = results[:top_n]
+    candidates = [r for r in results if r["passes_gate"]]
+    gate_count = len(candidates)
+
+    if as_json:
+        output = {
+            "total_entries": len(results),
+            "gate_count": gate_count,
+            "dry_run": dry_run,
+            "weights": weights,
+            "gates": {
+                "min_score": min_score,
+                "min_recall": min_recall,
+                "min_queries": min_queries,
+            },
+            "top": top,
+        }
+        print(json.dumps(output, indent=2))
+        return 0
+
+    # Human output
+    mode = "[DRY RUN — not persisted]" if dry_run else "[persisted]"
+    print(f"Dream Score Report {mode}")
+    print(f"  Entries scored  : {len(results)}")
+    print(f"  Gate candidates : {gate_count}  (score>={min_score}, recall>={min_recall}, queries>={min_queries})")
+    print(f"  Showing top     : {min(top_n, len(results))}")
+    print()
+    if not top:
+        print("  (no entries)")
+        return 0
+    header = f"  {'#':>3}  {'Score':>6}  {'Rc':>4}  {'Uq':>4}  {'Tg':>4}  {'Gate':>5}  Title"
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for i, r in enumerate(top, 1):
+        gate_mark = "✓" if r["passes_gate"] else " "
+        title = (r["title"] or "")[:60]
+        print(
+            f"  {i:>3}.  {r['score']:>6.3f}  {r['recall_count']:>4}  "
+            f"{r['unique_queries']:>4}  {r['tag_count']:>4}  {gate_mark:>5}  {title}"
+        )
+    return 0
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="dream",
+        description="Dream-score ranking for knowledge promotion (issue #159).",
+    )
+    p.add_argument("--dry-run", action="store_true", help="List top-N candidates without persisting scores to DB.")
+    p.add_argument("--top", type=int, default=20, metavar="N", help="Show top-N entries (default: 20).")
+    p.add_argument("--json", action="store_true", dest="as_json", help="Emit JSON output.")
+    p.add_argument(
+        "--db",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Path to knowledge.db (default: ~/.copilot/session-state/knowledge.db).",
+    )
+
+    # Gate overrides
+    g = p.add_argument_group("gate thresholds")
+    g.add_argument(
+        "--min-score",
+        type=float,
+        default=DEFAULT_MIN_SCORE,
+        metavar="SCORE",
+        help=f"Min dream score to pass gate (default: {DEFAULT_MIN_SCORE}).",
+    )
+    g.add_argument(
+        "--min-recall",
+        type=int,
+        default=DEFAULT_MIN_RECALL,
+        metavar="N",
+        help=f"Min recall count to pass gate (default: {DEFAULT_MIN_RECALL}).",
+    )
+    g.add_argument(
+        "--min-queries",
+        type=int,
+        default=DEFAULT_MIN_QUERIES,
+        metavar="N",
+        help=f"Min unique queries to pass gate (default: {DEFAULT_MIN_QUERIES}).",
+    )
+
+    # Weight overrides
+    w = p.add_argument_group("weight overrides")
+    w.add_argument(
+        "--w-frequency",
+        type=float,
+        default=DEFAULT_WEIGHTS["frequency"],
+        metavar="W",
+        help=f"Frequency weight (default: {DEFAULT_WEIGHTS['frequency']}).",
+    )
+    w.add_argument(
+        "--w-relevance",
+        type=float,
+        default=DEFAULT_WEIGHTS["relevance"],
+        metavar="W",
+        help=f"Relevance weight (default: {DEFAULT_WEIGHTS['relevance']}).",
+    )
+    w.add_argument(
+        "--w-diversity",
+        type=float,
+        default=DEFAULT_WEIGHTS["diversity"],
+        metavar="W",
+        help=f"Diversity weight (default: {DEFAULT_WEIGHTS['diversity']}).",
+    )
+    w.add_argument(
+        "--w-recency",
+        type=float,
+        default=DEFAULT_WEIGHTS["recency"],
+        metavar="W",
+        help=f"Recency weight (default: {DEFAULT_WEIGHTS['recency']}).",
+    )
+    w.add_argument(
+        "--w-consolidation",
+        type=float,
+        default=DEFAULT_WEIGHTS["consolidation"],
+        metavar="W",
+        help=f"Consolidation weight (default: {DEFAULT_WEIGHTS['consolidation']}).",
+    )
+    w.add_argument(
+        "--w-conceptual",
+        type=float,
+        default=DEFAULT_WEIGHTS["conceptual"],
+        metavar="W",
+        help=f"Conceptual weight (default: {DEFAULT_WEIGHTS['conceptual']}).",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+
+    db_path = Path(args.db) if args.db else DB_PATH
+
+    weights = {
+        "frequency": args.w_frequency,
+        "relevance": args.w_relevance,
+        "diversity": args.w_diversity,
+        "recency": args.w_recency,
+        "consolidation": args.w_consolidation,
+        "conceptual": args.w_conceptual,
+    }
+
+    # Validate weights: each must be non-negative; renormalize if sum > 1.0
+    for k, v in weights.items():
+        if v < 0.0:
+            print(f"dream: weight --w-{k} must be >= 0 (got {v})", file=sys.stderr)
+            return 2
+    total_w = sum(weights.values())
+    if total_w > 1.0 + 1e-9:
+        weights = {k: v / total_w for k, v in weights.items()}
+        print(
+            f"dream: warning: weights summed to {total_w:.4f} > 1.0; renormalized to sum=1.0",
+            file=sys.stderr,
+        )
+
+    if args.top < 1:
+        print("dream: --top must be >= 1", file=sys.stderr)
+        return 2
+
+    conn = _open_db(db_path)
+    try:
+        return run_scoring(
+            conn=conn,
+            weights=weights,
+            min_score=args.min_score,
+            min_recall=args.min_recall,
+            min_queries=args.min_queries,
+            dry_run=args.dry_run,
+            top_n=args.top,
+            as_json=args.as_json,
+        )
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dream.py
+++ b/dream.py
@@ -78,6 +78,9 @@ _TAGS_CAP = 10.0  # tag count above this â†’ saturates at 1.0
 _RECENCY_HALFLIFE_DAYS = 30.0  # recency half-life: 30 days â†’ signal 0.5
 
 
+_REQUIRED_TABLES = ("knowledge_entries", "entry_recall_stats", "entry_concept_tags")
+
+
 def _open_db(db_path: Path) -> sqlite3.Connection:
     if not db_path.exists():
         print(f"dream: database not found: {db_path}", file=sys.stderr)
@@ -85,6 +88,19 @@ def _open_db(db_path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     return conn
+
+
+def _check_required_tables(conn: sqlite3.Connection) -> None:
+    """Exit with a friendly error if required tables are missing (unmigrated DB)."""
+    existing = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    missing = [t for t in _REQUIRED_TABLES if t not in existing]
+    if missing:
+        print(
+            f"dream: database is missing required table(s): {', '.join(missing)}\n"
+            f"  Run `sk index migrate` (or `python migrate.py`) to apply migrations.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 def _ensure_dream_scores_table(conn: sqlite3.Connection) -> None:
@@ -219,6 +235,7 @@ def run_scoring(
     as_json: bool,
 ) -> int:
     """Run dream-score computation, persist (unless dry_run), and report."""
+    _check_required_tables(conn)
     _ensure_dream_scores_table(conn)
     entries = fetch_entries(conn)
 

--- a/dream.py
+++ b/dream.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-dream.py — Dream-score ranking for knowledge promotion (issue #159).
+dream.py â€” Dream-score ranking for knowledge promotion (issue #159).
 
 Computes a weighted dream-score for each knowledge entry using recall
 telemetry (entry_recall_stats) and concept tags (entry_concept_tags).
@@ -56,7 +56,7 @@ if os.name == "nt":
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
 DB_PATH = SESSION_STATE / "knowledge.db"
 
-# Default weights (must sum ≤ 1.0)
+# Default weights (must sum â‰¤ 1.0)
 DEFAULT_WEIGHTS = {
     "frequency": 0.24,
     "relevance": 0.30,
@@ -72,10 +72,10 @@ DEFAULT_MIN_RECALL = 3
 DEFAULT_MIN_QUERIES = 2
 
 # Normalization caps
-_RECALL_CAP = 100.0  # recall_count above this → saturates at 1.0
-_QUERIES_CAP = 50.0  # unique_queries above this → saturates at 1.0
-_TAGS_CAP = 10.0  # tag count above this → saturates at 1.0
-_RECENCY_HALFLIFE_DAYS = 30.0  # recency half-life: 30 days → signal 0.5
+_RECALL_CAP = 100.0  # recall_count above this â†’ saturates at 1.0
+_QUERIES_CAP = 50.0  # unique_queries above this â†’ saturates at 1.0
+_TAGS_CAP = 10.0  # tag count above this â†’ saturates at 1.0
+_RECENCY_HALFLIFE_DAYS = 30.0  # recency half-life: 30 days â†’ signal 0.5
 
 
 def _open_db(db_path: Path) -> sqlite3.Connection:
@@ -316,7 +316,7 @@ def run_scoring(
         return 0
 
     # Human output
-    mode = "[DRY RUN — not persisted]" if dry_run else "[persisted]"
+    mode = "[DRY RUN â€” not persisted]" if dry_run else "[persisted]"
     print(f"Dream Score Report {mode}")
     print(f"  Entries scored  : {len(results)}")
     print(f"  Gate candidates : {gate_count}  (score>={min_score}, recall>={min_recall}, queries>={min_queries})")
@@ -329,7 +329,7 @@ def run_scoring(
     print(header)
     print("  " + "-" * (len(header) - 2))
     for i, r in enumerate(top, 1):
-        gate_mark = "✓" if r["passes_gate"] else " "
+        gate_mark = "âœ“" if r["passes_gate"] else " "
         title = (r["title"] or "")[:60]
         print(
             f"  {i:>3}.  {r['score']:>6.3f}  {r['recall_count']:>4}  "
@@ -449,6 +449,19 @@ def main(argv: list[str] | None = None) -> int:
         weights = {k: v / total_w for k, v in weights.items()}
         print(
             f"dream: warning: weights summed to {total_w:.4f} > 1.0; renormalized to sum=1.0",
+            file=sys.stderr,
+        )
+        total_w = 1.0
+
+    # Warn when the gate is structurally unreachable: maximum achievable score
+    # equals sum(weights) because each signal is in [0, 1].  If that ceiling is
+    # below min_score, gate_count will always be zero with no other indication.
+    if total_w < args.min_score - 1e-9:
+        print(
+            f"dream: warning: weights sum to {total_w:.4f}, which is below --min-score "
+            f"{args.min_score:.4f}; the maximum achievable dream score is {total_w:.4f} "
+            f"so no entry can ever pass the score gate. "
+            f"Lower --min-score or increase the weights.",
             file=sys.stderr,
         )
 

--- a/migrate.py
+++ b/migrate.py
@@ -158,6 +158,7 @@ def _seed_sync_table_policies(db: sqlite3.Connection):
         ("embedding_meta", "local_only", ""),
         ("tfidf_model", "local_only", ""),
         ("entry_concept_tags", "local_only", ""),
+        ("entry_dream_scores", "local_only", ""),
     ]
     db.executemany(
         """
@@ -743,6 +744,27 @@ if __name__ == "__main__":
                 )""",
                 "CREATE INDEX IF NOT EXISTS idx_ect_entry ON entry_concept_tags(entry_id)",
                 "CREATE INDEX IF NOT EXISTS idx_ect_tag ON entry_concept_tags(tag)",
+            ],
+        ),
+        (
+            20,
+            "dream_scores",
+            [
+                # Persisted dream-score per knowledge entry (issue #159, local_only).
+                """CREATE TABLE IF NOT EXISTS entry_dream_scores (
+                    entry_id INTEGER PRIMARY KEY,
+                    score REAL NOT NULL DEFAULT 0.0,
+                    signal_frequency REAL DEFAULT 0.0,
+                    signal_relevance REAL DEFAULT 0.0,
+                    signal_diversity REAL DEFAULT 0.0,
+                    signal_recency REAL DEFAULT 0.0,
+                    signal_consolidation REAL DEFAULT 0.0,
+                    signal_conceptual REAL DEFAULT 0.0,
+                    passes_gate INTEGER NOT NULL DEFAULT 0,
+                    scored_at TEXT DEFAULT (datetime('now'))
+                )""",
+                "CREATE INDEX IF NOT EXISTS idx_eds_score ON entry_dream_scores(score DESC)",
+                "CREATE INDEX IF NOT EXISTS idx_eds_passes_gate ON entry_dream_scores(passes_gate)",
             ],
         ),
     ]

--- a/sk-rust/src/sync/schema.rs
+++ b/sk-rust/src/sync/schema.rs
@@ -80,6 +80,8 @@ pub const DEFAULT_SYNC_TABLE_POLICIES: &[(&str, &str, &str)] = &[
     ("embeddings", "local_only", ""),
     ("embedding_meta", "local_only", ""),
     ("tfidf_model", "local_only", ""),
+    ("entry_concept_tags", "local_only", ""),
+    ("entry_dream_scores", "local_only", ""),
 ];
 
 pub const REQUIRED_SYNC_TABLES: &[&str] = &[

--- a/sk.py
+++ b/sk.py
@@ -20,6 +20,7 @@ Usage:
     sk watch    [<args>...]       Run watch-sessions.py
     sk export-buglog [<args>...]  Run buglog-export.py
     sk buglog   [<args>...]       Run buglog-export.py (alias for export-buglog)
+    sk dream    [<args>...]       Run dream.py
     sk hooks    run|list|<event>  Run hooks/hook_runner.py
 
     sk index  build|extract|migrate|status|health|embed|tag [<args>...]
@@ -68,6 +69,7 @@ _DIRECT: dict[str, str] = {
     "watch": "watch-sessions.py",
     "export-buglog": "buglog-export.py",
     "buglog": "buglog-export.py",  # alias for export-buglog (backward compat)
+    "dream": "dream.py",
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}
@@ -197,9 +199,7 @@ def _run_hooks(extra_args: list[str]) -> int:
 
 
 def _print_help() -> None:
-    direct_list = "  " + "\n  ".join(
-        f"sk {cmd:<12} → {script}" for cmd, script in _DIRECT.items()
-    )
+    direct_list = "  " + "\n  ".join(f"sk {cmd:<12} → {script}" for cmd, script in _DIRECT.items())
     print(
         f"sk {__version__} — copilot-session-knowledge unified CLI\n"
         "\nDirect commands:\n"
@@ -243,8 +243,7 @@ def main(argv: list[str] | None = None) -> int:
         if sub not in _GROUPS[cmd]:
             subs = list(_GROUPS[cmd].keys())
             print(
-                f"sk {cmd}: unknown subcommand '{sub}'. "
-                f"Choose from: {', '.join(subs)}",
+                f"sk {cmd}: unknown subcommand '{sub}'. Choose from: {', '.join(subs)}",
                 file=sys.stderr,
             )
             return 2

--- a/sync-daemon.py
+++ b/sync-daemon.py
@@ -123,6 +123,8 @@ DEFAULT_SYNC_TABLE_POLICIES = [
     ("embeddings", "local_only", ""),
     ("embedding_meta", "local_only", ""),
     ("tfidf_model", "local_only", ""),
+    ("entry_concept_tags", "local_only", ""),
+    ("entry_dream_scores", "local_only", ""),
 ]
 
 REQUIRED_SYNC_TABLES = {

--- a/tests/test_dream_score.py
+++ b/tests/test_dream_score.py
@@ -744,6 +744,96 @@ def _test_weights_renormalized_via_cli():
 _test_weights_renormalized_via_cli()
 
 
+# ─── 12. Regression: low-sum weights make gate unreachable ────────────────────
+
+print("\n\u26a0\ufe0f  Regression — low-sum weights (gate unreachable)")
+
+
+def _test_low_sum_weights_warning():
+    """When total weight < min_score, the gate can never be satisfied.
+
+    main() must emit a clear stderr diagnostic instead of silently returning
+    gate_count=0 with no explanation.
+    """
+    db_path, conn = _make_db(
+        entries=[{"title": "LowWeightEntry", "confidence": 1.0, "occurrence_count": 20}],
+        recall_stats=[
+            {
+                "entry_id": 1,
+                "recall_count": 100,
+                "unique_queries": 50,
+                "last_recalled_at": "2025-01-01T00:00:00Z",
+            }
+        ],
+        tags=[{"entry_id": 1, "tag": "python"}],
+    )
+    conn.close()
+
+    import io
+
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+    sys.stdout = io.StringIO()
+    sys.stderr = io.StringIO()
+    try:
+        # weights sum = 0.10 + 0.05 = 0.15, far below default min_score=0.75
+        rc = dream.main(
+            [
+                "--json",
+                "--dry-run",
+                "--db",
+                db_path,
+                "--w-frequency",
+                "0.10",
+                "--w-relevance",
+                "0.05",
+                "--w-diversity",
+                "0.00",
+                "--w-recency",
+                "0.00",
+                "--w-consolidation",
+                "0.00",
+                "--w-conceptual",
+                "0.00",
+            ]
+        )
+        stdout_out = sys.stdout.getvalue()
+        stderr_out = sys.stderr.getvalue()
+    finally:
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+    test("low-sum weights: returns 0 (not an error exit)", rc == 0, f"rc={rc}")
+    test(
+        "low-sum weights: stderr warns gate is unreachable",
+        "max" in stderr_out and "min-score" in stderr_out,
+        f"stderr={stderr_out!r}",
+    )
+    try:
+        data = json.loads(stdout_out)
+        test(
+            "low-sum weights: gate_count=0 (gate is unreachable)",
+            data.get("gate_count") == 0,
+            f"gate_count={data.get('gate_count')}",
+        )
+        top = data.get("top", [])
+        if top:
+            test(
+                "low-sum weights: max score <= weight sum (0.15)",
+                top[0]["score"] <= 0.15 + 1e-9,
+                f"score={top[0]['score']}",
+            )
+    except json.JSONDecodeError as exc:
+        test("low-sum weights: JSON parseable", False, str(exc))
+
+
+_test_low_sum_weights_warning()
+
+
 # ─── Summary ─────────────────────────────────────────────────────────────────
 
 print(f"\n{'=' * 50}")

--- a/tests/test_dream_score.py
+++ b/tests/test_dream_score.py
@@ -834,8 +834,106 @@ def _test_low_sum_weights_warning():
 _test_low_sum_weights_warning()
 
 
-# ─── Summary ─────────────────────────────────────────────────────────────────
+# ─── 13. Unmigrated DB — missing required tables ────────────────────────────
 
+print("\n🚫 Unmigrated DB — missing required tables")
+
+
+def _test_unmigrated_db_bare_exits_cleanly():
+    """A completely bare DB (no tables) must yield a clean nonzero exit, not a traceback."""
+    fd, db_path = tempfile.mkstemp(suffix=".db", prefix="dream_test_bare_")
+    os.close(fd)
+
+    import io
+
+    old_stderr = sys.stderr
+    sys.stderr = io.StringIO()
+    exited_code = None
+    main_rc = None
+    try:
+        try:
+            main_rc = dream.main(["--db", db_path, "--dry-run", "--json"])
+        except SystemExit as exc:
+            exited_code = exc.code
+        stderr_out = sys.stderr.getvalue()
+    finally:
+        sys.stderr = old_stderr
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+    if exited_code is not None:
+        test("bare DB: exits with code 1", exited_code == 1, f"code={exited_code}")
+    else:
+        test("bare DB: returns nonzero", main_rc not in (None, 0), f"rc={main_rc}")
+
+    test(
+        "bare DB: stderr mentions missing table(s)",
+        "missing" in stderr_out and ("knowledge_entries" in stderr_out or "required" in stderr_out),
+        f"stderr={stderr_out!r}",
+    )
+    test(
+        "bare DB: stderr hints to run migrate",
+        "migrate" in stderr_out,
+        f"stderr={stderr_out!r}",
+    )
+
+
+_test_unmigrated_db_bare_exits_cleanly()
+
+
+def _test_partial_schema_db_exits_cleanly():
+    """A DB with only knowledge_entries (no recall/tags tables) must exit cleanly."""
+    fd, db_path = tempfile.mkstemp(suffix=".db", prefix="dream_test_partial_")
+    os.close(fd)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE knowledge_entries (id INTEGER PRIMARY KEY, title TEXT, category TEXT, confidence REAL, occurrence_count INTEGER)"
+    )
+    conn.commit()
+    conn.close()
+
+    import io
+
+    old_stderr = sys.stderr
+    sys.stderr = io.StringIO()
+    exited_code = None
+    main_rc = None
+    try:
+        try:
+            main_rc = dream.main(["--db", db_path, "--dry-run", "--json"])
+        except SystemExit as exc:
+            exited_code = exc.code
+        stderr_out = sys.stderr.getvalue()
+    finally:
+        sys.stderr = old_stderr
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+    if exited_code is not None:
+        test("partial schema DB: exits with code 1", exited_code == 1, f"code={exited_code}")
+    else:
+        test("partial schema DB: returns nonzero", main_rc not in (None, 0), f"rc={main_rc}")
+
+    test(
+        "partial schema: stderr names a missing table",
+        "entry_recall_stats" in stderr_out or "entry_concept_tags" in stderr_out,
+        f"stderr={stderr_out!r}",
+    )
+    test(
+        "partial schema: stderr hints to run migrate",
+        "migrate" in stderr_out,
+        f"stderr={stderr_out!r}",
+    )
+
+
+_test_partial_schema_db_exits_cleanly()
+
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
 print(f"\n{'=' * 50}")
 print(f"  PASS: {PASS}  FAIL: {FAIL}")
 print(f"{'=' * 50}")

--- a/tests/test_dream_score.py
+++ b/tests/test_dream_score.py
@@ -1,0 +1,753 @@
+#!/usr/bin/env python3
+"""
+tests/test_dream_score.py — Tests for dream.py scoring (issue #159).
+
+Covers:
+  - Score calculation for all 6 signals
+  - Weighted sum computation
+  - Gate logic (min_score, min_recall, min_queries)
+  - --dry-run: scores not persisted to DB
+  - Normal run: scores persisted to entry_dream_scores
+  - --json output structure
+  - --top N slicing
+  - Weight validation (negative weight → exit 2)
+  - Edge cases: empty DB, entry with no recall stats, entry with no tags
+
+Run: python3 tests/test_dream_score.py
+"""
+
+import importlib.util
+import json
+import math
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+TOOLS_DIR = Path(__file__).parent.parent
+DREAM_PY = TOOLS_DIR / "dream.py"
+
+PASS = 0
+FAIL = 0
+
+
+def test(name: str, passed: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if passed:
+        PASS += 1
+        print(f"  ✅ {name}")
+    else:
+        FAIL += 1
+        print(f"  ❌ {name}" + (f": {detail}" if detail else ""))
+
+
+def _load_dream():
+    spec = importlib.util.spec_from_file_location("dream_mod", str(DREAM_PY))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+dream = _load_dream()
+
+_DB_SCHEMA = """
+    CREATE TABLE IF NOT EXISTS knowledge_entries (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL DEFAULT '',
+        category TEXT NOT NULL DEFAULT 'pattern',
+        title TEXT NOT NULL DEFAULT '',
+        content TEXT NOT NULL DEFAULT '',
+        confidence REAL DEFAULT 1.0,
+        occurrence_count INTEGER DEFAULT 1,
+        stable_id TEXT,
+        tags TEXT DEFAULT ''
+    );
+    CREATE TABLE IF NOT EXISTS entry_recall_stats (
+        entry_id INTEGER PRIMARY KEY,
+        recall_count INTEGER NOT NULL DEFAULT 0,
+        recall_days INTEGER NOT NULL DEFAULT 0,
+        unique_queries INTEGER NOT NULL DEFAULT 0,
+        first_recalled_at TEXT,
+        last_recalled_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS entry_concept_tags (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        entry_id INTEGER NOT NULL,
+        tag TEXT NOT NULL,
+        source TEXT NOT NULL DEFAULT 'auto',
+        tagged_at TEXT DEFAULT (datetime('now')),
+        UNIQUE(entry_id, tag)
+    );
+"""
+
+
+def _make_db(entries=None, recall_stats=None, tags=None) -> tuple[str, sqlite3.Connection]:
+    fd, db_path = tempfile.mkstemp(suffix=".db", prefix="dream_test_")
+    os.close(fd)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_DB_SCHEMA)
+    conn.commit()
+    if entries:
+        for e in entries:
+            conn.execute(
+                "INSERT INTO knowledge_entries "
+                "(session_id, category, title, content, confidence, occurrence_count) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    e.get("session_id", "s1"),
+                    e.get("category", "pattern"),
+                    e.get("title", "T"),
+                    e.get("content", "C"),
+                    e.get("confidence", 1.0),
+                    e.get("occurrence_count", 1),
+                ),
+            )
+    if recall_stats:
+        for r in recall_stats:
+            conn.execute(
+                "INSERT INTO entry_recall_stats "
+                "(entry_id, recall_count, recall_days, unique_queries, last_recalled_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    r["entry_id"],
+                    r.get("recall_count", 0),
+                    r.get("recall_days", 0),
+                    r.get("unique_queries", 0),
+                    r.get("last_recalled_at"),
+                ),
+            )
+    if tags:
+        for t in tags:
+            conn.execute(
+                "INSERT OR IGNORE INTO entry_concept_tags (entry_id, tag) VALUES (?, ?)",
+                (t["entry_id"], t["tag"]),
+            )
+    conn.commit()
+    return db_path, conn
+
+
+def _cleanup(db_path: str, conn: sqlite3.Connection) -> None:
+    conn.close()
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+# ─── 1. Unit tests: compute_score signals ───────────────────────────────────
+
+print("\n🧮 compute_score — signal calculations")
+
+W = dream.DEFAULT_WEIGHTS
+
+
+def _score(**kwargs):
+    defaults = dict(
+        recall_count=0,
+        recall_days=0,
+        unique_queries=0,
+        last_recalled_at=None,
+        tag_count=0,
+        confidence=1.0,
+        occurrence_count=1,
+        weights=W,
+    )
+    defaults.update(kwargs)
+    return dream.compute_score(**defaults)
+
+
+def _test_signal_zero_recall():
+    s = _score(recall_count=0, unique_queries=0, tag_count=0)
+    # frequency=0, relevance=0, diversity=0, conceptual=0
+    # recency: last_recalled_at=None → days=9999 → ~0
+    # consolidation: confidence=1 * normalize(1,20)=0.05
+    test("signal_frequency=0 when recall_count=0", s["signal_frequency"] == 0.0, f"got {s['signal_frequency']}")
+    test("signal_relevance=0 when unique_queries=0", s["signal_relevance"] == 0.0, f"got {s['signal_relevance']}")
+    test("signal_diversity=0 when tag_count=0", s["signal_diversity"] == 0.0, f"got {s['signal_diversity']}")
+    test("signal_conceptual=0 when tag_count=0", s["signal_conceptual"] == 0.0, f"got {s['signal_conceptual']}")
+    test("signal_recency≈0 when last_recalled_at=None", s["signal_recency"] < 0.01, f"got {s['signal_recency']}")
+
+
+_test_signal_zero_recall()
+
+
+def _test_signal_max_caps():
+    s = _score(recall_count=1000, unique_queries=1000, tag_count=100)
+    test("signal_frequency=1.0 at recall_count cap", s["signal_frequency"] == 1.0, f"got {s['signal_frequency']}")
+    test("signal_relevance=1.0 at unique_queries cap", s["signal_relevance"] == 1.0, f"got {s['signal_relevance']}")
+    test("signal_diversity=1.0 at tag_count cap", s["signal_diversity"] == 1.0, f"got {s['signal_diversity']}")
+    test("signal_conceptual=1.0 when tag_count>0", s["signal_conceptual"] == 1.0, f"got {s['signal_conceptual']}")
+
+
+_test_signal_max_caps()
+
+
+def _test_signal_recency():
+    # Recency at half-life should be ~0.5
+    from datetime import datetime, timedelta, timezone
+
+    halflife_ago = (datetime.now(timezone.utc) - timedelta(days=dream._RECENCY_HALFLIFE_DAYS)).isoformat()
+    s = _score(last_recalled_at=halflife_ago)
+    test("signal_recency≈0.5 at half-life", abs(s["signal_recency"] - 0.5) < 0.02, f"got {s['signal_recency']}")
+
+    # Very recent recall → ~1.0
+    recent = datetime.now(timezone.utc).isoformat()
+    s2 = _score(last_recalled_at=recent)
+    test("signal_recency≈1.0 for just-recalled entry", s2["signal_recency"] > 0.99, f"got {s2['signal_recency']}")
+
+
+_test_signal_recency()
+
+
+def _test_consolidation():
+    # confidence=1.0, occurrence_count=20 → sig_con = 1.0 * 1.0 = 1.0
+    s = _score(confidence=1.0, occurrence_count=20, recall_count=0, unique_queries=0)
+    test(
+        "signal_consolidation=1.0 at max occurrence",
+        s["signal_consolidation"] == 1.0,
+        f"got {s['signal_consolidation']}",
+    )
+    # confidence=0.5, occurrence_count=10 → sig_con = 0.5 * 0.5 = 0.25
+    s2 = _score(confidence=0.5, occurrence_count=10, recall_count=0, unique_queries=0)
+    test(
+        "signal_consolidation=0.25 for conf=0.5, occ=10",
+        abs(s2["signal_consolidation"] - 0.25) < 0.01,
+        f"got {s2['signal_consolidation']}",
+    )
+
+
+_test_consolidation()
+
+
+def _test_weighted_sum():
+    # With all signals = 1.0, score = sum(weights) = 1.0 (default weights sum to 1.0)
+    total_w = sum(W.values())
+    from datetime import datetime, timezone
+
+    s = _score(
+        recall_count=1000,
+        unique_queries=1000,
+        tag_count=100,
+        confidence=1.0,
+        occurrence_count=20,
+        last_recalled_at=datetime.now(timezone.utc).isoformat(),
+    )
+    test(
+        "score ≈ sum(weights) when all signals=1.0",
+        abs(s["score"] - total_w) < 0.02,
+        f"score={s['score']}, total_w={total_w}",
+    )
+
+
+_test_weighted_sum()
+
+
+# ─── 2. Gate logic ──────────────────────────────────────────────────────────
+
+print("\n🔒 Gate logic")
+
+
+def _test_gate():
+    db_path, conn = _make_db(
+        entries=[
+            {"title": "Entry A", "confidence": 1.0, "occurrence_count": 5},
+            {"title": "Entry B", "confidence": 0.1, "occurrence_count": 1},
+        ],
+        recall_stats=[
+            # Entry 1: passes gate (high recall, many queries, recent)
+            {"entry_id": 1, "recall_count": 10, "unique_queries": 5, "last_recalled_at": "2025-01-01T00:00:00Z"},
+            # Entry 2: fails gate (low recall)
+            {"entry_id": 2, "recall_count": 1, "unique_queries": 1, "last_recalled_at": None},
+        ],
+        tags=[
+            {"entry_id": 1, "tag": "python"},
+            {"entry_id": 1, "tag": "testing"},
+        ],
+    )
+    import io
+
+    old_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        rc = dream.run_scoring(
+            conn=conn,
+            weights=W,
+            min_score=0.0,  # permissive score gate
+            min_recall=3,  # recall gate
+            min_queries=2,  # queries gate
+            dry_run=True,
+            top_n=20,
+            as_json=True,
+        )
+        output = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old_stdout
+    _cleanup(db_path, conn)
+
+    test("gate run returns 0", rc == 0, f"got {rc}")
+    data = json.loads(output)
+    test("total_entries=2", data["total_entries"] == 2, str(data))
+    # Entry 1 has recall_count=10>=3 AND unique_queries=5>=2 AND score>0
+    # Entry 2 fails recall gate (1 < 3) and queries gate (1 < 2)
+    test("gate_count=1 (only Entry A passes)", data["gate_count"] == 1, f"gate_count={data['gate_count']}")
+    top = data["top"]
+    passing = [r for r in top if r["passes_gate"]]
+    test("Entry A passes gate", len(passing) == 1 and passing[0]["title"] == "Entry A", str(passing))
+
+
+_test_gate()
+
+
+# ─── 3. Persistence ─────────────────────────────────────────────────────────
+
+print("\n💾 Persistence — scores written to entry_dream_scores")
+
+
+def _test_persist():
+    db_path, conn = _make_db(
+        entries=[{"title": "X", "confidence": 0.9, "occurrence_count": 3}],
+        recall_stats=[
+            {"entry_id": 1, "recall_count": 5, "unique_queries": 3, "last_recalled_at": "2025-06-01T00:00:00Z"},
+        ],
+        tags=[{"entry_id": 1, "tag": "sql"}],
+    )
+    import io
+
+    old_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        rc = dream.run_scoring(
+            conn=conn,
+            weights=W,
+            min_score=dream.DEFAULT_MIN_SCORE,
+            min_recall=dream.DEFAULT_MIN_RECALL,
+            min_queries=dream.DEFAULT_MIN_QUERIES,
+            dry_run=False,
+            top_n=20,
+            as_json=True,
+        )
+    finally:
+        sys.stdout = old_stdout
+    test("persist run returns 0", rc == 0, f"rc={rc}")
+    row = conn.execute("SELECT score, passes_gate FROM entry_dream_scores WHERE entry_id=1").fetchone()
+    test("entry_dream_scores row written for entry 1", row is not None, "row is None")
+    if row:
+        test("score is float > 0", isinstance(row[0], float) and row[0] > 0, f"score={row[0]}")
+    _cleanup(db_path, conn)
+
+
+_test_persist()
+
+
+def _test_dry_run_no_persist():
+    db_path, conn = _make_db(
+        entries=[{"title": "Y", "confidence": 1.0, "occurrence_count": 1}],
+    )
+    import io
+
+    old_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        dream.run_scoring(
+            conn=conn,
+            weights=W,
+            min_score=0.0,
+            min_recall=0,
+            min_queries=0,
+            dry_run=True,
+            top_n=20,
+            as_json=True,
+        )
+    finally:
+        sys.stdout = old_stdout
+    row = conn.execute("SELECT COUNT(*) FROM entry_dream_scores").fetchone()
+    # Table may not even exist when dry_run=True (we still create it, but no rows)
+    test("dry_run: no rows persisted", row[0] == 0, f"count={row[0]}")
+    _cleanup(db_path, conn)
+
+
+_test_dry_run_no_persist()
+
+
+# ─── 4. JSON output ─────────────────────────────────────────────────────────
+
+print("\n📄 JSON output structure")
+
+
+def _test_json_structure():
+    db_path, conn = _make_db(
+        entries=[
+            {"title": "Alpha", "confidence": 1.0, "occurrence_count": 2},
+            {"title": "Beta", "confidence": 0.5, "occurrence_count": 1},
+        ],
+        recall_stats=[
+            {"entry_id": 1, "recall_count": 8, "unique_queries": 4, "last_recalled_at": "2025-05-01T00:00:00Z"},
+        ],
+    )
+    import io
+
+    old_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        rc = dream.run_scoring(
+            conn=conn,
+            weights=W,
+            min_score=0.0,
+            min_recall=0,
+            min_queries=0,
+            dry_run=True,
+            top_n=5,
+            as_json=True,
+        )
+        output = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old_stdout
+    _cleanup(db_path, conn)
+
+    test("json run returns 0", rc == 0, f"rc={rc}")
+    try:
+        data = json.loads(output)
+        test("json output is valid JSON", True)
+    except json.JSONDecodeError as e:
+        test("json output is valid JSON", False, str(e))
+        return
+
+    for key in ("total_entries", "gate_count", "dry_run", "weights", "gates", "top"):
+        test(f"json has '{key}' key", key in data, f"keys={list(data)}")
+    test("total_entries=2", data.get("total_entries") == 2)
+    if data.get("top"):
+        top_item = data["top"][0]
+        for sig in (
+            "score",
+            "signal_frequency",
+            "signal_relevance",
+            "signal_diversity",
+            "signal_recency",
+            "signal_consolidation",
+            "signal_conceptual",
+            "passes_gate",
+            "entry_id",
+            "title",
+            "category",
+        ):
+            test(f"top item has '{sig}'", sig in top_item, f"keys={list(top_item)}")
+
+
+_test_json_structure()
+
+
+# ─── 5. --top N slicing ─────────────────────────────────────────────────────
+
+print("\n🔢 --top N slicing")
+
+
+def _test_top_n():
+    # Create 5 entries, ask for top 3
+    db_path, conn = _make_db(
+        entries=[{"title": f"E{i}"} for i in range(5)],
+    )
+    import io
+
+    old_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        dream.run_scoring(
+            conn=conn,
+            weights=W,
+            min_score=0.0,
+            min_recall=0,
+            min_queries=0,
+            dry_run=True,
+            top_n=3,
+            as_json=True,
+        )
+        output = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old_stdout
+    _cleanup(db_path, conn)
+    data = json.loads(output)
+    test("top_n=3 returns at most 3 items", len(data["top"]) <= 3, f"got {len(data['top'])}")
+    test("total_entries=5 regardless of top_n", data["total_entries"] == 5, f"got {data['total_entries']}")
+
+
+_test_top_n()
+
+
+# ─── 6. CLI main() routing ──────────────────────────────────────────────────
+
+print("\n🚦 CLI main() routing")
+
+
+def _test_cli_dry_run():
+    db_path, conn = _make_db(
+        entries=[{"title": "CLI-test"}],
+    )
+    conn.close()
+    import io
+
+    old_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        rc = dream.main(["--dry-run", "--json", "--db", db_path])
+        output = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old_stdout
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+    test("main --dry-run --json returns 0", rc == 0, f"rc={rc}")
+    try:
+        data = json.loads(output)
+        test("--dry-run sets dry_run=True in JSON", data.get("dry_run") is True, str(data.get("dry_run")))
+    except json.JSONDecodeError:
+        test("CLI JSON is parseable", False, output[:200])
+
+
+_test_cli_dry_run()
+
+
+def _test_cli_invalid_weight():
+    import io
+
+    old_stderr = sys.stderr
+    sys.stderr = io.StringIO()
+    try:
+        rc = dream.main(["--w-frequency", "-0.1", "--db", "nonexistent_test.db"])
+    finally:
+        sys.stderr = old_stderr
+    test("negative weight → exit 2", rc == 2, f"rc={rc}")
+
+
+_test_cli_invalid_weight()
+
+
+def _test_cli_invalid_top():
+    import io
+
+    old_stderr = sys.stderr
+    sys.stderr = io.StringIO()
+    try:
+        rc = dream.main(["--top", "0", "--db", "nonexistent_test.db"])
+    finally:
+        sys.stderr = old_stderr
+    test("--top 0 → exit 2", rc == 2, f"rc={rc}")
+
+
+_test_cli_invalid_top()
+
+
+# ─── 7. Empty DB ────────────────────────────────────────────────────────────
+
+print("\n📭 Empty DB")
+
+
+def _test_empty_db():
+    db_path, conn = _make_db()
+    import io
+
+    old_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        rc = dream.run_scoring(
+            conn=conn,
+            weights=W,
+            min_score=0.0,
+            min_recall=0,
+            min_queries=0,
+            dry_run=True,
+            top_n=10,
+            as_json=True,
+        )
+        output = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old_stdout
+    _cleanup(db_path, conn)
+    test("empty DB returns 0", rc == 0, f"rc={rc}")
+    data = json.loads(output)
+    test("empty DB: total_entries=0", data.get("total_entries") == 0)
+    test("empty DB: gate_count=0", data.get("gate_count") == 0)
+
+
+_test_empty_db()
+
+
+# ─── 8. _ensure_dream_scores_table idempotency ──────────────────────────────
+
+print("\n🔄 _ensure_dream_scores_table idempotency")
+
+
+def _test_idempotent_table():
+    db_path, conn = _make_db()
+    try:
+        dream._ensure_dream_scores_table(conn)
+        dream._ensure_dream_scores_table(conn)
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+        test("entry_dream_scores table created", "entry_dream_scores" in tables, str(tables))
+    except Exception as e:
+        test("_ensure_dream_scores_table idempotent", False, str(e))
+    finally:
+        _cleanup(db_path, conn)
+
+
+_test_idempotent_table()
+
+
+# ─── 9. fetch_entries handles missing recall stats gracefully ────────────────
+
+print("\n🕳️ fetch_entries — missing recall stats")
+
+
+def _test_fetch_no_recall():
+    db_path, conn = _make_db(
+        entries=[{"title": "No recall entry", "confidence": 0.8, "occurrence_count": 2}],
+    )
+    try:
+        entries = dream.fetch_entries(conn)
+        test("fetch_entries returns 1 entry", len(entries) == 1, str(entries))
+        e = entries[0]
+        test("recall_count=0 for entry with no recall stats", e["recall_count"] == 0, f"got {e['recall_count']}")
+        test("unique_queries=0 for entry with no recall stats", e["unique_queries"] == 0, f"got {e['unique_queries']}")
+        test("tag_count=0 for entry with no tags", e["tag_count"] == 0, f"got {e['tag_count']}")
+    finally:
+        _cleanup(db_path, conn)
+
+
+_test_fetch_no_recall()
+
+
+# ─── 10. Regression: naive timestamps must not zero recency signal ───────────
+
+print("\n🕐 Regression — naive timestamp handling")
+
+
+def _test_days_since_naive_timestamp():
+    """_days_since() must handle timestamps written by briefing.py without timezone suffix."""
+    # briefing.py writes 'YYYY-MM-DDTHH:MM:SS' — no 'Z', no '+00:00'
+    naive_ts = "2025-01-01T12:00:00"
+    days = dream._days_since(naive_ts)
+    test("naive timestamp: days_since < 9999", days < 9999.0, f"got {days} (expected real days, not sentinel)")
+    test("naive timestamp: days_since > 0", days > 0, f"got {days}")
+    sig = dream._sig_recency(days)
+    test("naive timestamp: recency signal > 0", sig > 0.0, f"got {sig}")
+
+    # Timezone-aware and naive parsing of the same moment must agree (within 1 s)
+    aware_ts = "2025-01-01T12:00:00+00:00"
+    diff = abs(dream._days_since(naive_ts) - dream._days_since(aware_ts))
+    test("naive and aware timestamps yield same days_since", diff < 0.00002, f"diff={diff} days")
+
+
+_test_days_since_naive_timestamp()
+
+
+def _test_recency_not_zeroed_for_naive_last_recalled():
+    """compute_score must return a real recency signal for naive timestamps from briefing.py."""
+    s = _score(last_recalled_at="2025-06-01T00:00:00")  # no timezone suffix
+    test(
+        "recency signal > 0 for naive timestamp (not zeroed)",
+        s["signal_recency"] > 0.0,
+        f"got {s['signal_recency']}",
+    )
+    test(
+        "recency signal < 1.0 for past naive timestamp",
+        s["signal_recency"] < 1.0,
+        f"got {s['signal_recency']}",
+    )
+
+
+_test_recency_not_zeroed_for_naive_last_recalled()
+
+
+# ─── 11. Regression: weight renormalization must cap scores at ≤ 1.0 ─────────
+
+print("\n⚖️  Regression — weight renormalization")
+
+
+def _test_weights_renormalized_via_cli():
+    """When weights sum > 1.0, main() must renormalize so scores stay <= 1.0."""
+    db_path, conn = _make_db(
+        entries=[{"title": "R", "confidence": 1.0, "occurrence_count": 20}],
+        recall_stats=[
+            {
+                "entry_id": 1,
+                "recall_count": 100,
+                "unique_queries": 50,
+                "last_recalled_at": "2025-01-01T00:00:00Z",
+            }
+        ],
+        tags=[{"entry_id": 1, "tag": "python"}],
+    )
+    conn.close()
+
+    import io
+
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+    sys.stdout = io.StringIO()
+    sys.stderr = io.StringIO()
+    try:
+        rc = dream.main(
+            [
+                "--json",
+                "--dry-run",
+                "--db",
+                db_path,
+                # weights sum = 2.0 (all doubled)
+                "--w-frequency",
+                "0.48",
+                "--w-relevance",
+                "0.60",
+                "--w-diversity",
+                "0.30",
+                "--w-recency",
+                "0.30",
+                "--w-consolidation",
+                "0.20",
+                "--w-conceptual",
+                "0.12",
+            ]
+        )
+        output = sys.stdout.getvalue()
+        stderr_out = sys.stderr.getvalue()
+    finally:
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+    test("overweight CLI: returns 0", rc == 0, f"rc={rc}")
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError as e:
+        test("overweight CLI: JSON parseable", False, str(e))
+        return
+    top = data["top"]
+    test("overweight CLI: has top entry", len(top) == 1, f"len={len(top)}")
+    if top:
+        test(
+            "overweight CLI: score <= 1.0 after renorm",
+            top[0]["score"] <= 1.001,
+            f"score={top[0]['score']}",
+        )
+    test("overweight CLI: renorm warning emitted", "renormalized" in stderr_out, f"stderr={stderr_out!r}")
+
+
+_test_weights_renormalized_via_cli()
+
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+print(f"\n{'=' * 50}")
+print(f"  PASS: {PASS}  FAIL: {FAIL}")
+print(f"{'=' * 50}")
+if FAIL:
+    sys.exit(1)

--- a/tests/test_memory_contract.py
+++ b/tests/test_memory_contract.py
@@ -21,8 +21,8 @@ Run:
     python3 test_memory_contract.py
 """
 
-import importlib.util
 import hashlib
+import importlib.util
 import io
 import json
 import os
@@ -205,6 +205,26 @@ _DB_SCHEMA = """
         query_hash TEXT NOT NULL,
         PRIMARY KEY (entry_id, query_hash)
     );
+    CREATE TABLE IF NOT EXISTS entry_concept_tags (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        entry_id INTEGER NOT NULL,
+        tag TEXT NOT NULL,
+        source TEXT NOT NULL DEFAULT 'auto',
+        tagged_at TEXT DEFAULT (datetime('now')),
+        UNIQUE(entry_id, tag)
+    );
+    CREATE TABLE IF NOT EXISTS entry_dream_scores (
+        entry_id INTEGER PRIMARY KEY,
+        score REAL NOT NULL DEFAULT 0.0,
+        signal_frequency REAL DEFAULT 0.0,
+        signal_relevance REAL DEFAULT 0.0,
+        signal_diversity REAL DEFAULT 0.0,
+        signal_recency REAL DEFAULT 0.0,
+        signal_consolidation REAL DEFAULT 0.0,
+        signal_conceptual REAL DEFAULT 0.0,
+        passes_gate INTEGER NOT NULL DEFAULT 0,
+        scored_at TEXT DEFAULT (datetime('now'))
+    );
 """
 
 
@@ -239,6 +259,7 @@ def with_test_db(fn):
 
 # ─── Helper: capture stdout ─────────────────────────────────────────────────
 
+
 class _CapStdout:
     """Context manager capturing sys.stdout for the duration of the block."""
 
@@ -264,22 +285,27 @@ def _test_quiet_mode(db_path):
     sys.stderr = captured_stderr
     with _CapStdout() as cap:
         entry_id = _learn.add_entry(
-            "pattern", "Quiet mode test", "Content for quiet mode test.",
-            task_id="memory-contract", affected_files=["briefing.py"],
-            quiet=True, skip_gate=True
+            "pattern",
+            "Quiet mode test",
+            "Content for quiet mode test.",
+            task_id="memory-contract",
+            affected_files=["briefing.py"],
+            quiet=True,
+            skip_gate=True,
         )
     sys.stderr = old_stderr
     stderr_text = captured_stderr.getvalue()
     stdout_text = cap.getvalue()
 
-    test("add_entry quiet=True: returns valid id",
-         isinstance(entry_id, int) and entry_id > 0, f"got {entry_id!r}")
-    test("add_entry quiet=True: human text goes to stderr",
-         "Added new pattern" in stderr_text,
-         f"stderr={stderr_text!r}")
-    test("add_entry quiet=True: stdout is clean (no human text)",
-         "Added new" not in stdout_text and "Updated" not in stdout_text,
-         f"stdout had: {stdout_text!r}")
+    test("add_entry quiet=True: returns valid id", isinstance(entry_id, int) and entry_id > 0, f"got {entry_id!r}")
+    test(
+        "add_entry quiet=True: human text goes to stderr", "Added new pattern" in stderr_text, f"stderr={stderr_text!r}"
+    )
+    test(
+        "add_entry quiet=True: stdout is clean (no human text)",
+        "Added new" not in stdout_text and "Updated" not in stdout_text,
+        f"stdout had: {stdout_text!r}",
+    )
 
 
 _test_quiet_mode()
@@ -295,12 +321,16 @@ def _test_learn_json(db_path):
     _learn.DB_PATH = Path(db_path)
     old_argv = sys.argv
     sys.argv = [
-        "learn.py", "--pattern",
+        "learn.py",
+        "--pattern",
         "JSON contract test pattern",
         "Verifying that --json emits structured output.",
-        "--task", "memory-contract",
-        "--file", "briefing.py",
-        "--file", "learn.py",
+        "--task",
+        "memory-contract",
+        "--file",
+        "briefing.py",
+        "--file",
+        "learn.py",
         "--skip-gate",
         "--json",
     ]
@@ -323,21 +353,32 @@ def _test_learn_json(db_path):
 
     test("learn.py --json: stdout is valid JSON", json_valid)
     test("learn.py --json: has 'id' field", "id" in data, f"keys={list(data)}")
-    test("learn.py --json: 'id' is positive int",
-         isinstance(data.get("id"), int) and data["id"] > 0, f"id={data.get('id')!r}")
-    test("learn.py --json: has 'status' field (added|updated)",
-         data.get("status") in ("added", "updated"), f"status={data.get('status')!r}")
-    test("learn.py --json: 'category' matches",
-         data.get("category") == "pattern", f"category={data.get('category')!r}")
-    test("learn.py --json: 'task_id' preserved",
-         data.get("task_id") == "memory-contract",
-         f"task_id={data.get('task_id')!r}")
-    test("learn.py --json: 'affected_files' is a list",
-         isinstance(data.get("affected_files"), list),
-         f"type={type(data.get('affected_files'))}")
-    test("learn.py --json: 'affected_files' contains both files",
-         set(data.get("affected_files", [])) == {"briefing.py", "learn.py"},
-         f"files={data.get('affected_files')!r}")
+    test(
+        "learn.py --json: 'id' is positive int",
+        isinstance(data.get("id"), int) and data["id"] > 0,
+        f"id={data.get('id')!r}",
+    )
+    test(
+        "learn.py --json: has 'status' field (added|updated)",
+        data.get("status") in ("added", "updated"),
+        f"status={data.get('status')!r}",
+    )
+    test("learn.py --json: 'category' matches", data.get("category") == "pattern", f"category={data.get('category')!r}")
+    test(
+        "learn.py --json: 'task_id' preserved",
+        data.get("task_id") == "memory-contract",
+        f"task_id={data.get('task_id')!r}",
+    )
+    test(
+        "learn.py --json: 'affected_files' is a list",
+        isinstance(data.get("affected_files"), list),
+        f"type={type(data.get('affected_files'))}",
+    )
+    test(
+        "learn.py --json: 'affected_files' contains both files",
+        set(data.get("affected_files", [])) == {"briefing.py", "learn.py"},
+        f"files={data.get('affected_files')!r}",
+    )
 
 
 _test_learn_json()
@@ -353,7 +394,8 @@ def _test_learn_human(db_path):
     _learn.DB_PATH = Path(db_path)
     old_argv = sys.argv
     sys.argv = [
-        "learn.py", "--pattern",
+        "learn.py",
+        "--pattern",
         "Human path test",
         "Verifying the human CLI still works without --json.",
         "--skip-gate",
@@ -366,15 +408,12 @@ def _test_learn_human(db_path):
     sys.argv = old_argv
     output = cap.getvalue()
 
-    test("learn.py (no --json): 'Done.' printed",
-         "Done." in output, f"got: {output!r}")
-    test("learn.py (no --json): 'Recording pattern...' printed",
-         "Recording pattern" in output, f"got: {output!r}")
+    test("learn.py (no --json): 'Done.' printed", "Done." in output, f"got: {output!r}")
+    test("learn.py (no --json): 'Recording pattern...' printed", "Recording pattern" in output, f"got: {output!r}")
     # Ensure it's NOT JSON
     try:
         json.loads(output.strip())
-        test("learn.py (no --json): output is NOT pure JSON", False,
-             "stdout parsed as JSON — human mode broken")
+        test("learn.py (no --json): output is NOT pure JSON", False, "stdout parsed as JSON — human mode broken")
     except json.JSONDecodeError:
         test("learn.py (no --json): output is NOT pure JSON", True)
 
@@ -393,8 +432,11 @@ def _test_export_json_types(db_path):
     _qs.DB_PATH = Path(db_path)
     rows = [
         {
-            "id": 1, "category": "pattern", "title": "T",
-            "content": "C", "confidence": 0.8,
+            "id": 1,
+            "category": "pattern",
+            "title": "T",
+            "content": "C",
+            "confidence": 0.8,
             "affected_files": '["briefing.py","learn.py"]',
             "facts": '["use parameterized SQL"]',
             "task_id": "memory-contract",
@@ -415,14 +457,22 @@ def _test_export_json_types(db_path):
         test("_export_json: result is a list", isinstance(data, list))
         item = data[0] if data else {}
         af = item.get("affected_files")
-        test("_export_json: affected_files is list (not str)",
-             isinstance(af, list), f"type={type(af).__name__}, val={af!r}")
-        test("_export_json: affected_files contains expected files",
-             isinstance(af, list) and "briefing.py" in af,
-             f"got: {af!r}")
+        test(
+            "_export_json: affected_files is list (not str)",
+            isinstance(af, list),
+            f"type={type(af).__name__}, val={af!r}",
+        )
+        test(
+            "_export_json: affected_files contains expected files",
+            isinstance(af, list) and "briefing.py" in af,
+            f"got: {af!r}",
+        )
         facts = item.get("facts")
-        test("_export_json: facts is list (not str)",
-             isinstance(facts, list), f"type={type(facts).__name__}, val={facts!r}")
+        test(
+            "_export_json: facts is list (not str)",
+            isinstance(facts, list),
+            f"type={type(facts).__name__}, val={facts!r}",
+        )
     finally:
         _qs.DB_PATH = orig_db_path
 
@@ -441,51 +491,86 @@ def _test_qs_task_json(db_path):
     db = sqlite3.connect(db_path)
     db.row_factory = sqlite3.Row
     import time as _time
+
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
-    doc_id = db.execute("""
+    doc_id = db.execute(
+        """
         INSERT INTO documents
             (session_id, doc_type, seq, title, file_path, indexed_at)
         VALUES (?, ?, ?, ?, ?, ?)
-    """, ("test-session-01", "checkpoint", 3, "Checkpoint for task export test",
-          "checkpoints/003-task-export.md", now)).lastrowid
-    db.execute("""
+    """,
+        ("test-session-01", "checkpoint", 3, "Checkpoint for task export test", "checkpoints/003-task-export.md", now),
+    ).lastrowid
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (category, title, content, confidence, session_id, task_id,
              affected_files, facts, occurrence_count, first_seen, last_seen,
              document_id, source_section, source_file, start_line, end_line,
              code_language, code_snippet)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, ("pattern", "Task export test", "Content of task export test.",
-           0.8, "test-session-01", "memory-contract",
-          '["briefing.py","query-session.py"]', '[]', now, now,
-          doc_id, "technical_details", "src/query_session.py", 101, 118,
-          "python", "def show_by_task(task_id):\n    return task_id"))
+    """,
+        (
+            "pattern",
+            "Task export test",
+            "Content of task export test.",
+            0.8,
+            "test-session-01",
+            "memory-contract",
+            '["briefing.py","query-session.py"]',
+            "[]",
+            now,
+            now,
+            doc_id,
+            "technical_details",
+            "src/query_session.py",
+            101,
+            118,
+            "python",
+            "def show_by_task(task_id):\n    return task_id",
+        ),
+    )
     main_id = db.execute("SELECT last_insert_rowid()").fetchone()[0]
-    rel1 = db.execute("""
+    rel1 = db.execute(
+        """
         INSERT INTO knowledge_entries (session_id, category, title, content, confidence, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?)
-    """, ("test-session-01", "pattern", "Related high confidence", "r1", 0.7, now, now)).lastrowid
-    rel2 = db.execute("""
+    """,
+        ("test-session-01", "pattern", "Related high confidence", "r1", 0.7, now, now),
+    ).lastrowid
+    rel2 = db.execute(
+        """
         INSERT INTO knowledge_entries (session_id, category, title, content, confidence, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?)
-    """, ("test-session-01", "mistake", "Related top confidence", "r2", 0.7, now, now)).lastrowid
-    rel3 = db.execute("""
+    """,
+        ("test-session-01", "mistake", "Related top confidence", "r2", 0.7, now, now),
+    ).lastrowid
+    rel3 = db.execute(
+        """
         INSERT INTO knowledge_entries (session_id, category, title, content, confidence, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?)
-    """, ("test-session-01", "tool", "Related low confidence", "r3", 0.7, now, now)).lastrowid
-    rel4 = db.execute("""
+    """,
+        ("test-session-01", "tool", "Related low confidence", "r3", 0.7, now, now),
+    ).lastrowid
+    rel4 = db.execute(
+        """
         INSERT INTO knowledge_entries (session_id, category, title, content, confidence, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?)
-    """, ("test-session-01", "decision", "Related tie confidence", "r4", 0.7, now, now)).lastrowid
-    db.executemany("""
+    """,
+        ("test-session-01", "decision", "Related tie confidence", "r4", 0.7, now, now),
+    ).lastrowid
+    db.executemany(
+        """
         INSERT INTO knowledge_relations (source_id, target_id, relation_type, confidence)
         VALUES (?, ?, ?, ?)
-    """, [
-        (main_id, rel1, "RELATED", 0.80),
-        (main_id, rel2, "RELATED", 0.95),
-        (main_id, rel3, "RELATED", 0.20),
-        (main_id, rel4, "RELATED", 0.80),
-    ])
+    """,
+        [
+            (main_id, rel1, "RELATED", 0.80),
+            (main_id, rel2, "RELATED", 0.95),
+            (main_id, rel3, "RELATED", 0.20),
+            (main_id, rel4, "RELATED", 0.80),
+        ],
+    )
     db.commit()
     db.close()
 
@@ -508,13 +593,21 @@ def _test_qs_task_json(db_path):
         return
 
     # Non-empty path must return same object shape as empty path: {task_id, entries}
-    test("--task --export json: result is an object (not bare list)", isinstance(data, dict),
-         f"type={type(data).__name__}")
-    test("--task --export json: has 'task_id' key",
-         isinstance(data, dict) and "task_id" in data, f"keys={list(data) if isinstance(data, dict) else 'N/A'}")
-    test("--task --export json: 'entries' is a list",
-         isinstance(data, dict) and isinstance(data.get("entries"), list),
-         f"entries type={type(data.get('entries')) if isinstance(data, dict) else 'N/A'}")
+    test(
+        "--task --export json: result is an object (not bare list)",
+        isinstance(data, dict),
+        f"type={type(data).__name__}",
+    )
+    test(
+        "--task --export json: has 'task_id' key",
+        isinstance(data, dict) and "task_id" in data,
+        f"keys={list(data) if isinstance(data, dict) else 'N/A'}",
+    )
+    test(
+        "--task --export json: 'entries' is a list",
+        isinstance(data, dict) and isinstance(data.get("entries"), list),
+        f"entries type={type(data.get('entries')) if isinstance(data, dict) else 'N/A'}",
+    )
     if not isinstance(data, dict):
         return
     entries = data.get("entries", [])
@@ -523,38 +616,46 @@ def _test_qs_task_json(db_path):
         return
     item = entries[0]
     af = item.get("affected_files")
-    test("--task --export json: affected_files is list",
-         isinstance(af, list), f"type={type(af).__name__}")
-    test("--task --export json: task_id field present",
-         "task_id" in item, f"keys={list(item)}")
+    test("--task --export json: affected_files is list", isinstance(af, list), f"type={type(af).__name__}")
+    test("--task --export json: task_id field present", "task_id" in item, f"keys={list(item)}")
     src_doc = item.get("source_document")
-    test("--task --export json: source_document is object",
-         isinstance(src_doc, dict), f"type={type(src_doc).__name__}")
-    test("--task --export json: source_document carries checkpoint provenance",
-         isinstance(src_doc, dict)
-         and src_doc.get("doc_type") == "checkpoint"
-         and src_doc.get("section") == "technical_details",
-         f"source_document={src_doc!r}")
-    test("--task --export json: code location handles included",
-         item.get("source_file") == "src/query_session.py"
-         and item.get("start_line") == 101
-         and item.get("end_line") == 118,
-         f"location=({item.get('source_file')!r}, {item.get('start_line')!r}, {item.get('end_line')!r})")
-    test("--task --export json: code snippet handles included",
-         item.get("code_language") == "python"
-         and "def show_by_task" in (item.get("code_snippet") or ""),
-         f"code=({item.get('code_language')!r}, {item.get('code_snippet')!r})")
+    test("--task --export json: source_document is object", isinstance(src_doc, dict), f"type={type(src_doc).__name__}")
+    test(
+        "--task --export json: source_document carries checkpoint provenance",
+        isinstance(src_doc, dict)
+        and src_doc.get("doc_type") == "checkpoint"
+        and src_doc.get("section") == "technical_details",
+        f"source_document={src_doc!r}",
+    )
+    test(
+        "--task --export json: code location handles included",
+        item.get("source_file") == "src/query_session.py"
+        and item.get("start_line") == 101
+        and item.get("end_line") == 118,
+        f"location=({item.get('source_file')!r}, {item.get('start_line')!r}, {item.get('end_line')!r})",
+    )
+    test(
+        "--task --export json: code snippet handles included",
+        item.get("code_language") == "python" and "def show_by_task" in (item.get("code_snippet") or ""),
+        f"code=({item.get('code_language')!r}, {item.get('code_snippet')!r})",
+    )
     valid_states = {"fresh", "drifted", "missing", "unknown"}
-    test("--task --export json: snippet_freshness is canonical enum",
-         item.get("snippet_freshness") in valid_states,
-         f"snippet_freshness={item.get('snippet_freshness')!r}")
+    test(
+        "--task --export json: snippet_freshness is canonical enum",
+        item.get("snippet_freshness") in valid_states,
+        f"snippet_freshness={item.get('snippet_freshness')!r}",
+    )
     related_ids = item.get("related_entry_ids", [])
-    test("--task --export json: related_entry_ids is JSON int list",
-         isinstance(related_ids, list) and all(isinstance(x, int) for x in related_ids),
-         f"related_entry_ids={related_ids!r}")
-    test("--task --export json: related_entry_ids capped and confidence-ranked",
-         related_ids == [int(rel2), int(rel1), int(rel4)],
-         f"related_entry_ids={related_ids!r}, expected={[int(rel2), int(rel1), int(rel4)]!r}")
+    test(
+        "--task --export json: related_entry_ids is JSON int list",
+        isinstance(related_ids, list) and all(isinstance(x, int) for x in related_ids),
+        f"related_entry_ids={related_ids!r}",
+    )
+    test(
+        "--task --export json: related_entry_ids capped and confidence-ranked",
+        related_ids == [int(rel2), int(rel1), int(rel4)],
+        f"related_entry_ids={related_ids!r}, expected={[int(rel2), int(rel1), int(rel4)]!r}",
+    )
 
 
 _test_qs_task_json()
@@ -570,15 +671,28 @@ def _test_qs_file_json(db_path):
     db = sqlite3.connect(db_path)
     db.row_factory = sqlite3.Row
     import time as _time
+
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (category, title, content, confidence, session_id, task_id,
              affected_files, facts, occurrence_count, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
-    """, ("mistake", "File export test", "Content of file export test.",
-          0.9, "test-session-02", "memory-contract",
-          '["briefing.py"]', '[]', now, now))
+    """,
+        (
+            "mistake",
+            "File export test",
+            "Content of file export test.",
+            0.9,
+            "test-session-02",
+            "memory-contract",
+            '["briefing.py"]',
+            "[]",
+            now,
+            now,
+        ),
+    )
     db.commit()
     db.close()
 
@@ -605,8 +719,7 @@ def _test_qs_file_json(db_path):
         test("--file --export json: entry returned", False, "empty")
         return
     af = data[0].get("affected_files")
-    test("--file --export json: affected_files is list",
-         isinstance(af, list), f"type={type(af).__name__}")
+    test("--file --export json: affected_files is list", isinstance(af, list), f"type={type(af).__name__}")
 
 
 _test_qs_file_json()
@@ -621,15 +734,28 @@ print("\n🔍 query-session.py — --module --export json contract")
 def _test_qs_module_json(db_path):
     db = sqlite3.connect(db_path)
     import time as _time
+
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (category, title, content, confidence, session_id, task_id,
              affected_files, facts, occurrence_count, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
-    """, ("discovery", "Module export test",
-          "This mentions briefing.py in the content for module search.",
-          0.7, "test-session-03", "", '[]', '[]', now, now))
+    """,
+        (
+            "discovery",
+            "Module export test",
+            "This mentions briefing.py in the content for module search.",
+            0.7,
+            "test-session-03",
+            "",
+            "[]",
+            "[]",
+            now,
+            now,
+        ),
+    )
     db.commit()
     db.close()
 
@@ -666,26 +792,46 @@ print("\n📋 briefing.py — --task --json contract")
 def _test_briefing_task_json(db_path):
     db = sqlite3.connect(db_path)
     import time as _time
+
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
-    doc_id = db.execute("""
+    doc_id = db.execute(
+        """
         INSERT INTO documents
             (session_id, doc_type, seq, title, file_path, indexed_at)
         VALUES (?, ?, ?, ?, ?, ?)
-    """, ("test-session-04", "checkpoint", 9, "Briefing JSON source document",
-          "checkpoints/009-briefing-json.md", now)).lastrowid
-    db.execute("""
+    """,
+        ("test-session-04", "checkpoint", 9, "Briefing JSON source document", "checkpoints/009-briefing-json.md", now),
+    ).lastrowid
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (category, title, content, confidence, session_id, task_id,
              affected_files, facts, tags, occurrence_count, first_seen, last_seen,
              document_id, source_section, source_file, start_line, end_line,
              code_language, code_snippet)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, ("pattern", "Briefing JSON test pattern",
-          "Testing machine-readable briefing output.",
-           0.8, "test-session-04", "memory-contract",
-          '["briefing.py","learn.py"]', '[]', "test", now, now,
-          doc_id, "implementation", "briefing.py", 1740, 1769,
-          "python", "json_tagged = [{\"source_document\": _source_document_from_row(r)}]"))
+    """,
+        (
+            "pattern",
+            "Briefing JSON test pattern",
+            "Testing machine-readable briefing output.",
+            0.8,
+            "test-session-04",
+            "memory-contract",
+            '["briefing.py","learn.py"]',
+            "[]",
+            "test",
+            now,
+            now,
+            doc_id,
+            "implementation",
+            "briefing.py",
+            1740,
+            1769,
+            "python",
+            'json_tagged = [{"source_document": _source_document_from_row(r)}]',
+        ),
+    )
     db.commit()
     db.close()
 
@@ -696,56 +842,75 @@ def _test_briefing_task_json(db_path):
         data = json.loads(result)
         test("generate_task_briefing(fmt='json'): valid JSON", True)
     except json.JSONDecodeError as e:
-        test("generate_task_briefing(fmt='json'): valid JSON", False,
-             f"{e}; got: {result[:200]!r}")
+        test("generate_task_briefing(fmt='json'): valid JSON", False, f"{e}; got: {result[:200]!r}")
         return
 
-    test("generate_task_briefing(fmt='json'): 'task_id' field",
-         data.get("task_id") == "memory-contract",
-         f"task_id={data.get('task_id')!r}")
-    test("generate_task_briefing(fmt='json'): 'tagged_entries' is list",
-         isinstance(data.get("tagged_entries"), list),
-         f"type={type(data.get('tagged_entries'))}")
-    test("generate_task_briefing(fmt='json'): 'related_entries' is list",
-         isinstance(data.get("related_entries"), list),
-         f"type={type(data.get('related_entries'))}")
-    test("generate_task_briefing(fmt='json'): 'generated_at' field",
-         "generated_at" in data, f"keys={list(data)}")
-    test("generate_task_briefing(fmt='json'): 'total_entries' is int",
-         isinstance(data.get("total_entries"), int),
-         f"total_entries={data.get('total_entries')!r}")
+    test(
+        "generate_task_briefing(fmt='json'): 'task_id' field",
+        data.get("task_id") == "memory-contract",
+        f"task_id={data.get('task_id')!r}",
+    )
+    test(
+        "generate_task_briefing(fmt='json'): 'tagged_entries' is list",
+        isinstance(data.get("tagged_entries"), list),
+        f"type={type(data.get('tagged_entries'))}",
+    )
+    test(
+        "generate_task_briefing(fmt='json'): 'related_entries' is list",
+        isinstance(data.get("related_entries"), list),
+        f"type={type(data.get('related_entries'))}",
+    )
+    test("generate_task_briefing(fmt='json'): 'generated_at' field", "generated_at" in data, f"keys={list(data)}")
+    test(
+        "generate_task_briefing(fmt='json'): 'total_entries' is int",
+        isinstance(data.get("total_entries"), int),
+        f"total_entries={data.get('total_entries')!r}",
+    )
 
     if data.get("tagged_entries"):
         entry = data["tagged_entries"][0]
         af = entry.get("affected_files")
-        test("generate_task_briefing(fmt='json'): entry.affected_files is list",
-             isinstance(af, list), f"type={type(af).__name__}, val={af!r}")
-        test("generate_task_briefing(fmt='json'): entry.affected_files correct",
-             set(af) == {"briefing.py", "learn.py"} if isinstance(af, list) else False,
-             f"got: {af!r}")
-        test("generate_task_briefing(fmt='json'): entry has 'confidence'",
-             "confidence" in entry, f"keys={list(entry)}")
+        test(
+            "generate_task_briefing(fmt='json'): entry.affected_files is list",
+            isinstance(af, list),
+            f"type={type(af).__name__}, val={af!r}",
+        )
+        test(
+            "generate_task_briefing(fmt='json'): entry.affected_files correct",
+            set(af) == {"briefing.py", "learn.py"} if isinstance(af, list) else False,
+            f"got: {af!r}",
+        )
+        test("generate_task_briefing(fmt='json'): entry has 'confidence'", "confidence" in entry, f"keys={list(entry)}")
         src_doc = entry.get("source_document")
-        test("generate_task_briefing(fmt='json'): entry.source_document shape",
-             isinstance(src_doc, dict) and "section" in src_doc and "doc_type" in src_doc,
-             f"source_document={src_doc!r}")
-        test("generate_task_briefing(fmt='json'): entry code-location fields",
-             entry.get("source_file") == "briefing.py"
-             and entry.get("start_line") == 1740
-             and entry.get("end_line") == 1769,
-             f"location=({entry.get('source_file')!r}, {entry.get('start_line')!r}, {entry.get('end_line')!r})")
-        test("generate_task_briefing(fmt='json'): entry code-snippet fields",
-             entry.get("code_language") == "python"
-             and "source_document" in (entry.get("code_snippet") or ""),
-             f"code=({entry.get('code_language')!r}, {entry.get('code_snippet')!r})")
+        test(
+            "generate_task_briefing(fmt='json'): entry.source_document shape",
+            isinstance(src_doc, dict) and "section" in src_doc and "doc_type" in src_doc,
+            f"source_document={src_doc!r}",
+        )
+        test(
+            "generate_task_briefing(fmt='json'): entry code-location fields",
+            entry.get("source_file") == "briefing.py"
+            and entry.get("start_line") == 1740
+            and entry.get("end_line") == 1769,
+            f"location=({entry.get('source_file')!r}, {entry.get('start_line')!r}, {entry.get('end_line')!r})",
+        )
+        test(
+            "generate_task_briefing(fmt='json'): entry code-snippet fields",
+            entry.get("code_language") == "python" and "source_document" in (entry.get("code_snippet") or ""),
+            f"code=({entry.get('code_language')!r}, {entry.get('code_snippet')!r})",
+        )
         valid_states = {"fresh", "drifted", "missing", "unknown"}
-        test("generate_task_briefing(fmt='json'): entry snippet_freshness enum",
-             entry.get("snippet_freshness") in valid_states,
-             f"snippet_freshness={entry.get('snippet_freshness')!r}")
+        test(
+            "generate_task_briefing(fmt='json'): entry snippet_freshness enum",
+            entry.get("snippet_freshness") in valid_states,
+            f"snippet_freshness={entry.get('snippet_freshness')!r}",
+        )
         rel_ids = entry.get("related_entry_ids", [])
-        test("generate_task_briefing(fmt='json'): entry related_entry_ids is int list",
-             isinstance(rel_ids, list) and all(isinstance(x, int) for x in rel_ids) and len(rel_ids) <= 3,
-             f"related_entry_ids={rel_ids!r}")
+        test(
+            "generate_task_briefing(fmt='json'): entry related_entry_ids is int list",
+            isinstance(rel_ids, list) and all(isinstance(x, int) for x in rel_ids) and len(rel_ids) <= 3,
+            f"related_entry_ids={rel_ids!r}",
+        )
 
 
 _test_briefing_task_json()
@@ -760,31 +925,47 @@ print("\n📋 briefing.py — --task text mode preserved")
 def _test_briefing_task_text(db_path):
     db = sqlite3.connect(db_path)
     import time as _time
+
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (category, title, content, confidence, session_id, task_id,
              affected_files, facts, tags, occurrence_count, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
-    """, ("mistake", "Briefing text mode test",
-          "Verifying text path is still human-readable.",
-          0.75, "test-session-05", "memory-contract",
-          '[]', '[]', "", now, now))
+    """,
+        (
+            "mistake",
+            "Briefing text mode test",
+            "Verifying text path is still human-readable.",
+            0.75,
+            "test-session-05",
+            "memory-contract",
+            "[]",
+            "[]",
+            "",
+            now,
+            now,
+        ),
+    )
     db.commit()
     db.close()
 
     _briefing.DB_PATH = Path(db_path)
     result = _briefing.generate_task_briefing("memory-contract", limit=30, fmt="text")
 
-    test("generate_task_briefing(fmt='text'): returns str",
-         isinstance(result, str))
-    test("generate_task_briefing(fmt='text'): contains task_id",
-         "memory-contract" in result, f"result={result[:100]!r}")
+    test("generate_task_briefing(fmt='text'): returns str", isinstance(result, str))
+    test(
+        "generate_task_briefing(fmt='text'): contains task_id", "memory-contract" in result, f"result={result[:100]!r}"
+    )
     # Ensure it's NOT JSON
     try:
         json.loads(result.strip())
-        test("generate_task_briefing(fmt='text'): output is NOT JSON", False,
-             "text mode output parsed as JSON — human mode broken")
+        test(
+            "generate_task_briefing(fmt='text'): output is NOT JSON",
+            False,
+            "text mode output parsed as JSON — human mode broken",
+        )
     except json.JSONDecodeError:
         test("generate_task_briefing(fmt='text'): output is NOT JSON", True)
 
@@ -801,8 +982,7 @@ print("\n🔍 query-session.py — --task --export json (empty task)")
 def _test_qs_task_json_empty(db_path):
     _qs.DB_PATH = Path(db_path)
     old_argv = sys.argv
-    sys.argv = ["query-session.py", "--task", "nonexistent-task-xyz",
-                "--export", "json"]
+    sys.argv = ["query-session.py", "--task", "nonexistent-task-xyz", "--export", "json"]
     with _CapStdout() as cap:
         try:
             _qs.main()
@@ -814,13 +994,14 @@ def _test_qs_task_json_empty(db_path):
     try:
         data = json.loads(output)
         test("--task --export json (empty): valid JSON for missing task", True)
-        test("--task --export json (empty): has 'task_id' key",
-             "task_id" in data, f"keys={list(data)}")
-        test("--task --export json (empty): entries is empty list",
-             data.get("entries") == [], f"entries={data.get('entries')!r}")
+        test("--task --export json (empty): has 'task_id' key", "task_id" in data, f"keys={list(data)}")
+        test(
+            "--task --export json (empty): entries is empty list",
+            data.get("entries") == [],
+            f"entries={data.get('entries')!r}",
+        )
     except json.JSONDecodeError as e:
-        test("--task --export json (empty): valid JSON for missing task",
-             False, f"{e}; got: {output!r}")
+        test("--task --export json (empty): valid JSON for missing task", False, f"{e}; got: {output!r}")
 
 
 _test_qs_task_json_empty()
@@ -836,25 +1017,45 @@ def _test_qs_detail_phase3_surfaces(db_path):
     db = sqlite3.connect(db_path)
     db.row_factory = sqlite3.Row
     import time as _time
+
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
-    doc_id = db.execute("""
+    doc_id = db.execute(
+        """
         INSERT INTO documents
             (session_id, doc_type, seq, title, file_path, indexed_at)
         VALUES (?, ?, ?, ?, ?, ?)
-    """, ("test-session-detail", "checkpoint", 7, "Detail view source",
-          "checkpoints/007-detail.md", now)).lastrowid
-    db.execute("""
+    """,
+        ("test-session-detail", "checkpoint", 7, "Detail view source", "checkpoints/007-detail.md", now),
+    ).lastrowid
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (category, title, content, confidence, session_id, task_id,
              affected_files, facts, occurrence_count, first_seen, last_seen,
              document_id, source_section, source_file, start_line, end_line,
              code_language, code_snippet)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, ("pattern", "Detail rendering test", "Detail body for rendered contract.",
-          0.91, "test-session-detail", "memory-contract",
-          '["query-session.py"]', '[]', now, now,
-          doc_id, "technical_details", "query-session.py", 740, 760,
-          "python", "def show_detail(entry_id: int):\n    print('detail')"))
+    """,
+        (
+            "pattern",
+            "Detail rendering test",
+            "Detail body for rendered contract.",
+            0.91,
+            "test-session-detail",
+            "memory-contract",
+            '["query-session.py"]',
+            "[]",
+            now,
+            now,
+            doc_id,
+            "technical_details",
+            "query-session.py",
+            740,
+            760,
+            "python",
+            "def show_detail(entry_id: int):\n    print('detail')",
+        ),
+    )
     entry_id = db.execute("SELECT last_insert_rowid()").fetchone()[0]
     db.commit()
     db.close()
@@ -866,20 +1067,26 @@ def _test_qs_detail_phase3_surfaces(db_path):
 
     test("--detail renders provenance label", "Provenance:" in output, f"output={output[:300]!r}")
     test("--detail renders code location label", "Code location:" in output, f"output={output[:300]!r}")
-    test("--detail renders snippet freshness label",
-         "Snippet freshness:" in output, f"output={output[:300]!r}")
-    test("--detail renders language-tagged snippet heading",
-         "Code snippet (python):" in output, f"output={output[:400]!r}")
+    test("--detail renders snippet freshness label", "Snippet freshness:" in output, f"output={output[:300]!r}")
+    test(
+        "--detail renders language-tagged snippet heading",
+        "Code snippet (python):" in output,
+        f"output={output[:400]!r}",
+    )
     test("--detail renders snippet body", "def show_detail" in output, f"output={output[:400]!r}")
     code_loc_idx = output.find("Code location:")
     freshness_idx = output.find("Snippet freshness:")
     snippet_idx = output.find("Code snippet (python):")
-    test("--detail freshness line appears after code location",
-         code_loc_idx != -1 and freshness_idx != -1 and code_loc_idx < freshness_idx,
-         f"indices code_location={code_loc_idx}, freshness={freshness_idx}")
-    test("--detail freshness line appears before snippet block",
-         freshness_idx != -1 and snippet_idx != -1 and freshness_idx < snippet_idx,
-         f"indices freshness={freshness_idx}, snippet={snippet_idx}")
+    test(
+        "--detail freshness line appears after code location",
+        code_loc_idx != -1 and freshness_idx != -1 and code_loc_idx < freshness_idx,
+        f"indices code_location={code_loc_idx}, freshness={freshness_idx}",
+    )
+    test(
+        "--detail freshness line appears before snippet block",
+        freshness_idx != -1 and snippet_idx != -1 and freshness_idx < snippet_idx,
+        f"indices freshness={freshness_idx}, snippet={snippet_idx}",
+    )
 
 
 _test_qs_detail_phase3_surfaces()
@@ -907,11 +1114,9 @@ def _test_qs_file_json_empty(db_path):
     try:
         data = json.loads(output)
         test("--file --export json (empty): valid JSON", True)
-        test("--file --export json (empty): result is empty list",
-             data == [], f"got: {data!r}")
+        test("--file --export json (empty): result is empty list", data == [], f"got: {data!r}")
     except json.JSONDecodeError as e:
-        test("--file --export json (empty): valid JSON", False,
-             f"{e}; got: {output!r}")
+        test("--file --export json (empty): valid JSON", False, f"{e}; got: {output!r}")
 
 
 _test_qs_file_json_empty()
@@ -939,11 +1144,9 @@ def _test_qs_module_json_empty(db_path):
     try:
         data = json.loads(output)
         test("--module --export json (empty): valid JSON", True)
-        test("--module --export json (empty): result is empty list",
-             data == [], f"got: {data!r}")
+        test("--module --export json (empty): result is empty list", data == [], f"got: {data!r}")
     except json.JSONDecodeError as e:
-        test("--module --export json (empty): valid JSON", False,
-             f"{e}; got: {output!r}")
+        test("--module --export json (empty): valid JSON", False, f"{e}; got: {output!r}")
 
 
 _test_qs_module_json_empty()
@@ -980,18 +1183,23 @@ def _test_qs_diff_json_no_changes():
     try:
         data = json.loads(output)
         test("--diff --export json (no changes): valid JSON", True)
-        test("--diff --export json (no changes): has 'changed_files' key",
-             isinstance(data, dict) and "changed_files" in data,
-             f"keys={list(data) if isinstance(data, dict) else 'N/A'}")
-        test("--diff --export json (no changes): 'changed_files' is empty list",
-             isinstance(data, dict) and data.get("changed_files") == [],
-             f"changed_files={data.get('changed_files')!r}")
-        test("--diff --export json (no changes): 'entries' is empty list",
-             isinstance(data, dict) and data.get("entries") == [],
-             f"entries={data.get('entries')!r}")
+        test(
+            "--diff --export json (no changes): has 'changed_files' key",
+            isinstance(data, dict) and "changed_files" in data,
+            f"keys={list(data) if isinstance(data, dict) else 'N/A'}",
+        )
+        test(
+            "--diff --export json (no changes): 'changed_files' is empty list",
+            isinstance(data, dict) and data.get("changed_files") == [],
+            f"changed_files={data.get('changed_files')!r}",
+        )
+        test(
+            "--diff --export json (no changes): 'entries' is empty list",
+            isinstance(data, dict) and data.get("entries") == [],
+            f"entries={data.get('entries')!r}",
+        )
     except json.JSONDecodeError as e:
-        test("--diff --export json (no changes): valid JSON", False,
-             f"{e}; got: {output!r}")
+        test("--diff --export json (no changes): valid JSON", False, f"{e}; got: {output!r}")
 
 
 _test_qs_diff_json_no_changes()
@@ -1019,11 +1227,9 @@ def _test_show_knowledge_operational_error_json():
     try:
         data = json.loads(output)
         test("show_knowledge OperationalError --export json: valid JSON", True)
-        test("show_knowledge OperationalError --export json: is empty list",
-             data == [], f"got: {data!r}")
+        test("show_knowledge OperationalError --export json: is empty list", data == [], f"got: {data!r}")
     except json.JSONDecodeError as e:
-        test("show_knowledge OperationalError --export json: valid JSON", False,
-             f"{e}; got: {output!r}")
+        test("show_knowledge OperationalError --export json: valid JSON", False, f"{e}; got: {output!r}")
 
 
 _test_show_knowledge_operational_error_json()
@@ -1045,11 +1251,9 @@ def _test_show_knowledge_empty_json(db_path):
     try:
         data = json.loads(output)
         test("show_knowledge empty rows --export json: valid JSON", True)
-        test("show_knowledge empty rows --export json: is empty list",
-             data == [], f"got: {data!r}")
+        test("show_knowledge empty rows --export json: is empty list", data == [], f"got: {data!r}")
     except json.JSONDecodeError as e:
-        test("show_knowledge empty rows --export json: valid JSON", False,
-             f"{e}; got: {output!r}")
+        test("show_knowledge empty rows --export json: valid JSON", False, f"{e}; got: {output!r}")
 
 
 _test_show_knowledge_empty_json()
@@ -1071,17 +1275,24 @@ def _test_task_briefing_empty_json(db_path):
         required_keys = {"task_id", "generated_at", "total_entries", "tagged_entries", "related_entries"}
         missing = required_keys - data.keys()
         test("generate_task_briefing empty --json: valid JSON", True)
-        test("generate_task_briefing empty --json: canonical shape present",
-             not missing, f"missing keys: {missing}")
-        test("generate_task_briefing empty --json: total_entries is 0",
-             data.get("total_entries") == 0, f"got: {data.get('total_entries')!r}")
-        test("generate_task_briefing empty --json: tagged_entries is []",
-             data.get("tagged_entries") == [], f"got: {data.get('tagged_entries')!r}")
-        test("generate_task_briefing empty --json: related_entries is []",
-             data.get("related_entries") == [], f"got: {data.get('related_entries')!r}")
+        test("generate_task_briefing empty --json: canonical shape present", not missing, f"missing keys: {missing}")
+        test(
+            "generate_task_briefing empty --json: total_entries is 0",
+            data.get("total_entries") == 0,
+            f"got: {data.get('total_entries')!r}",
+        )
+        test(
+            "generate_task_briefing empty --json: tagged_entries is []",
+            data.get("tagged_entries") == [],
+            f"got: {data.get('tagged_entries')!r}",
+        )
+        test(
+            "generate_task_briefing empty --json: related_entries is []",
+            data.get("related_entries") == [],
+            f"got: {data.get('related_entries')!r}",
+        )
     except json.JSONDecodeError as e:
-        test("generate_task_briefing empty --json: valid JSON", False,
-             f"{e}; got: {output!r}")
+        test("generate_task_briefing empty --json: valid JSON", False, f"{e}; got: {output!r}")
 
 
 _test_task_briefing_empty_json()
@@ -1103,16 +1314,23 @@ def _test_generate_briefing_empty_json(db_path):
         required_keys = {"query", "generated_at", "sections"}
         missing = required_keys - data.keys()
         test("generate_briefing empty --json: valid JSON", True)
-        test("generate_briefing empty --json: has 'query', 'generated_at', 'sections'",
-             not missing, f"missing keys: {missing}")
-        test("generate_briefing empty --json: 'sections' is a dict",
-             isinstance(data.get("sections"), dict),
-             f"got type: {type(data.get('sections')).__name__}")
-        test("generate_briefing empty --json: no 'briefing': null key (old shape gone)",
-             "briefing" not in data, f"unexpected key 'briefing' present")
+        test(
+            "generate_briefing empty --json: has 'query', 'generated_at', 'sections'",
+            not missing,
+            f"missing keys: {missing}",
+        )
+        test(
+            "generate_briefing empty --json: 'sections' is a dict",
+            isinstance(data.get("sections"), dict),
+            f"got type: {type(data.get('sections')).__name__}",
+        )
+        test(
+            "generate_briefing empty --json: no 'briefing': null key (old shape gone)",
+            "briefing" not in data,
+            "unexpected key 'briefing' present",
+        )
     except json.JSONDecodeError as e:
-        test("generate_briefing empty --json: valid JSON", False,
-             f"{e}; got: {output!r}")
+        test("generate_briefing empty --json: valid JSON", False, f"{e}; got: {output!r}")
 
 
 _test_generate_briefing_empty_json()
@@ -1127,25 +1345,46 @@ print("\n📋 briefing.py — generate_briefing --pack contract")
 def _test_generate_briefing_pack_contract(db_path):
     db = sqlite3.connect(db_path)
     import time as _time
+
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
-    doc_id = db.execute("""
+    doc_id = db.execute(
+        """
         INSERT INTO documents
             (session_id, doc_type, seq, title, file_path, indexed_at)
         VALUES (?, ?, ?, ?, ?, ?)
-    """, ("test-session-pack", "research", 0, "Pack source doc",
-          "notes/pack-source.md", now)).lastrowid
-    db.execute("""
+    """,
+        ("test-session-pack", "research", 0, "Pack source doc", "notes/pack-source.md", now),
+    ).lastrowid
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (category, title, content, confidence, session_id, task_id,
              affected_files, facts, tags, occurrence_count, first_seen, last_seen,
              document_id, source_section, source_file, start_line, end_line,
              code_language, code_snippet)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, ("pattern", "Pack output pattern",
-          "Pack output should be machine-readable and stable.",
-          0.88, "test-session-pack", "", '["briefing.py"]', '[]', "pack", now, now,
-          doc_id, "findings", "briefing.py", 390, 415, "python",
-          "def _serialize_pack_entry(entry: dict) -> dict:"))
+    """,
+        (
+            "pattern",
+            "Pack output pattern",
+            "Pack output should be machine-readable and stable.",
+            0.88,
+            "test-session-pack",
+            "",
+            '["briefing.py"]',
+            "[]",
+            "pack",
+            now,
+            now,
+            doc_id,
+            "findings",
+            "briefing.py",
+            390,
+            415,
+            "python",
+            "def _serialize_pack_entry(entry: dict) -> dict:",
+        ),
+    )
     db.execute("""
         INSERT INTO ke_fts (rowid, title, content, tags, category, wing, room, facts)
         VALUES (last_insert_rowid(),
@@ -1158,8 +1397,7 @@ def _test_generate_briefing_pack_contract(db_path):
 
     _briefing.DB_PATH = Path(db_path)
     output = _briefing.generate_briefing(
-        "review pack output", fmt="pack", mode="review",
-        min_confidence=0.0, limit=5, infer_auto_mode=True
+        "review pack output", fmt="pack", mode="review", min_confidence=0.0, limit=5, infer_auto_mode=True
     )
 
     try:
@@ -1169,17 +1407,28 @@ def _test_generate_briefing_pack_contract(db_path):
         test("generate_briefing --pack: valid JSON", False, f"{e}; got: {output[:200]!r}")
         return
 
-    required = {"query", "rewritten_query", "mode", "risk", "entries",
-                "task_matches", "file_matches", "past_work", "next_open"}
+    required = {
+        "query",
+        "rewritten_query",
+        "mode",
+        "risk",
+        "entries",
+        "task_matches",
+        "file_matches",
+        "past_work",
+        "next_open",
+    }
     missing = required - data.keys()
-    test("generate_briefing --pack: expected top-level keys present",
-         not missing, f"missing={sorted(missing)}")
-    test("generate_briefing --pack: explicit mode preserved",
-         data.get("mode") == "review", f"mode={data.get('mode')!r}")
-    test("generate_briefing --pack: entries is dict with canonical buckets",
-         isinstance(data.get("entries"), dict)
-         and all(k in data["entries"] for k in ("mistake", "pattern", "decision", "tool")),
-         f"entries={data.get('entries')!r}")
+    test("generate_briefing --pack: expected top-level keys present", not missing, f"missing={sorted(missing)}")
+    test(
+        "generate_briefing --pack: explicit mode preserved", data.get("mode") == "review", f"mode={data.get('mode')!r}"
+    )
+    test(
+        "generate_briefing --pack: entries is dict with canonical buckets",
+        isinstance(data.get("entries"), dict)
+        and all(k in data["entries"] for k in ("mistake", "pattern", "decision", "tool")),
+        f"entries={data.get('entries')!r}",
+    )
     first_entry = None
     for bucket in ("mistake", "pattern", "decision", "tool"):
         values = data.get("entries", {}).get(bucket, [])
@@ -1188,26 +1437,36 @@ def _test_generate_briefing_pack_contract(db_path):
             break
     if first_entry:
         src_doc = first_entry.get("source_document")
-        test("generate_briefing --pack: entry source_document includes section",
-             isinstance(src_doc, dict) and src_doc.get("section") == "findings",
-             f"source_document={src_doc!r}")
-        test("generate_briefing --pack: entry exposes code location handles",
-             first_entry.get("source_file") == "briefing.py"
-             and first_entry.get("start_line") == 390
-             and first_entry.get("end_line") == 415,
-             f"location=({first_entry.get('source_file')!r}, {first_entry.get('start_line')!r}, {first_entry.get('end_line')!r})")
-        test("generate_briefing --pack: entry exposes code snippet handles",
-             first_entry.get("code_language") == "python"
-             and "serialize_pack_entry" in (first_entry.get("code_snippet") or ""),
-             f"code=({first_entry.get('code_language')!r}, {first_entry.get('code_snippet')!r})")
+        test(
+            "generate_briefing --pack: entry source_document includes section",
+            isinstance(src_doc, dict) and src_doc.get("section") == "findings",
+            f"source_document={src_doc!r}",
+        )
+        test(
+            "generate_briefing --pack: entry exposes code location handles",
+            first_entry.get("source_file") == "briefing.py"
+            and first_entry.get("start_line") == 390
+            and first_entry.get("end_line") == 415,
+            f"location=({first_entry.get('source_file')!r}, {first_entry.get('start_line')!r}, {first_entry.get('end_line')!r})",
+        )
+        test(
+            "generate_briefing --pack: entry exposes code snippet handles",
+            first_entry.get("code_language") == "python"
+            and "serialize_pack_entry" in (first_entry.get("code_snippet") or ""),
+            f"code=({first_entry.get('code_language')!r}, {first_entry.get('code_snippet')!r})",
+        )
         valid_states = {"fresh", "drifted", "missing", "unknown"}
-        test("generate_briefing --pack: entry snippet_freshness enum",
-             first_entry.get("snippet_freshness") in valid_states,
-             f"snippet_freshness={first_entry.get('snippet_freshness')!r}")
+        test(
+            "generate_briefing --pack: entry snippet_freshness enum",
+            first_entry.get("snippet_freshness") in valid_states,
+            f"snippet_freshness={first_entry.get('snippet_freshness')!r}",
+        )
         rel_ids = first_entry.get("related_entry_ids", [])
-        test("generate_briefing --pack: entry related_entry_ids int list",
-             isinstance(rel_ids, list) and all(isinstance(x, int) for x in rel_ids) and len(rel_ids) <= 3,
-             f"related_entry_ids={rel_ids!r}")
+        test(
+            "generate_briefing --pack: entry related_entry_ids int list",
+            isinstance(rel_ids, list) and all(isinstance(x, int) for x in rel_ids) and len(rel_ids) <= 3,
+            f"related_entry_ids={rel_ids!r}",
+        )
     else:
         test("generate_briefing --pack: entry source_document includes section", True, "(skipped — no entries)")
         test("generate_briefing --pack: entry exposes code location handles", True, "(skipped — no entries)")
@@ -1227,6 +1486,7 @@ print("\n🔍 query-session.py — OperationalError → JSON (old-schema DB regr
 def _patch_get_db_raises(exc):
     """Return a mock db whose execute() raises the given exception."""
     import unittest.mock as _mock
+
     mock_db = _mock.MagicMock()
     mock_db.execute.side_effect = exc
     return mock_db
@@ -1246,13 +1506,10 @@ def _test_show_by_file_operational_error_json():
     try:
         data = json.loads(output)
         test("show_by_file OperationalError --export json: valid JSON", True)
-        test("show_by_file OperationalError --export json: is empty list",
-             data == [], f"got: {data!r}")
+        test("show_by_file OperationalError --export json: is empty list", data == [], f"got: {data!r}")
     except json.JSONDecodeError as e:
-        test("show_by_file OperationalError --export json: valid JSON", False,
-             f"{e}; got: {output!r}")
-        test("show_by_file OperationalError --export json: is empty list", False,
-             "parse failed")
+        test("show_by_file OperationalError --export json: valid JSON", False, f"{e}; got: {output!r}")
+        test("show_by_file OperationalError --export json: is empty list", False, "parse failed")
 
 
 _test_show_by_file_operational_error_json()
@@ -1272,13 +1529,10 @@ def _test_show_by_module_operational_error_json():
     try:
         data = json.loads(output)
         test("show_by_module OperationalError --export json: valid JSON", True)
-        test("show_by_module OperationalError --export json: is empty list",
-             data == [], f"got: {data!r}")
+        test("show_by_module OperationalError --export json: is empty list", data == [], f"got: {data!r}")
     except json.JSONDecodeError as e:
-        test("show_by_module OperationalError --export json: valid JSON", False,
-             f"{e}; got: {output!r}")
-        test("show_by_module OperationalError --export json: is empty list", False,
-             "parse failed")
+        test("show_by_module OperationalError --export json: valid JSON", False, f"{e}; got: {output!r}")
+        test("show_by_module OperationalError --export json: is empty list", False, "parse failed")
 
 
 _test_show_by_module_operational_error_json()
@@ -1298,15 +1552,18 @@ def _test_show_by_task_operational_error_json():
     try:
         data = json.loads(output)
         test("show_by_task OperationalError --export json: valid JSON", True)
-        test("show_by_task OperationalError --export json: has 'task_id'",
-             isinstance(data, dict) and "task_id" in data,
-             f"got: {data!r}")
-        test("show_by_task OperationalError --export json: 'entries' is empty list",
-             isinstance(data, dict) and data.get("entries") == [],
-             f"entries={data.get('entries')!r}")
+        test(
+            "show_by_task OperationalError --export json: has 'task_id'",
+            isinstance(data, dict) and "task_id" in data,
+            f"got: {data!r}",
+        )
+        test(
+            "show_by_task OperationalError --export json: 'entries' is empty list",
+            isinstance(data, dict) and data.get("entries") == [],
+            f"entries={data.get('entries')!r}",
+        )
     except json.JSONDecodeError as e:
-        test("show_by_task OperationalError --export json: valid JSON", False,
-             f"{e}; got: {output!r}")
+        test("show_by_task OperationalError --export json: valid JSON", False, f"{e}; got: {output!r}")
         test("show_by_task OperationalError --export json: has 'task_id'", False, "parse failed")
         test("show_by_task OperationalError --export json: 'entries' is empty list", False, "parse failed")
 
@@ -1337,15 +1594,18 @@ def _test_show_diff_context_operational_error_json():
     try:
         data = json.loads(output)
         test("show_diff_context OperationalError --export json: valid JSON", True)
-        test("show_diff_context OperationalError --export json: has 'changed_files'",
-             isinstance(data, dict) and "changed_files" in data,
-             f"got: {data!r}")
-        test("show_diff_context OperationalError --export json: 'entries' is empty list",
-             isinstance(data, dict) and data.get("entries") == [],
-             f"entries={data.get('entries')!r}")
+        test(
+            "show_diff_context OperationalError --export json: has 'changed_files'",
+            isinstance(data, dict) and "changed_files" in data,
+            f"got: {data!r}",
+        )
+        test(
+            "show_diff_context OperationalError --export json: 'entries' is empty list",
+            isinstance(data, dict) and data.get("entries") == [],
+            f"entries={data.get('entries')!r}",
+        )
     except json.JSONDecodeError as e:
-        test("show_diff_context OperationalError --export json: valid JSON", False,
-             f"{e}; got: {output!r}")
+        test("show_diff_context OperationalError --export json: valid JSON", False, f"{e}; got: {output!r}")
         test("show_diff_context OperationalError --export json: has 'changed_files'", False, "parse failed")
         test("show_diff_context OperationalError --export json: 'entries' is empty list", False, "parse failed")
 
@@ -1396,16 +1656,16 @@ def _test_load_codebase_map_files_unit():
         _briefing.SESSION_STATE = original_ss
         shutil.rmtree(str(fake_root), ignore_errors=True)
 
-    test("load_codebase_map_files: returns non-empty set for valid map",
-         len(result) > 0, f"got {result!r}")
-    test("load_codebase_map_files: parses exactly 3 file paths",
-         len(result) == 3, f"got {len(result)}: {result}")
+    test("load_codebase_map_files: returns non-empty set for valid map", len(result) > 0, f"got {result!r}")
+    test("load_codebase_map_files: parses exactly 3 file paths", len(result) == 3, f"got {len(result)}: {result}")
     test("load_codebase_map_files: includes README.md", "README.md" in result)
     test("load_codebase_map_files: includes src/main.py", "src/main.py" in result)
     test("load_codebase_map_files: includes setup.py", "setup.py" in result)
-    test("load_codebase_map_files: does not include table entries",
-         "`./`" not in result and "`src/`" not in result,
-         f"unexpected items in: {result}")
+    test(
+        "load_codebase_map_files: does not include table entries",
+        "`./`" not in result and "`src/`" not in result,
+        f"unexpected items in: {result}",
+    )
 
     # Non-existent SESSION_STATE → empty set (graceful degradation)
     _briefing.SESSION_STATE = Path("/nonexistent-path-ckmap-xyz-123")
@@ -1413,8 +1673,9 @@ def _test_load_codebase_map_files_unit():
         fallback = _briefing.load_codebase_map_files()
     finally:
         _briefing.SESSION_STATE = original_ss
-    test("load_codebase_map_files: returns empty set when session-state missing",
-         fallback == set(), f"got {fallback!r}")
+    test(
+        "load_codebase_map_files: returns empty set when session-state missing", fallback == set(), f"got {fallback!r}"
+    )
 
 
 _test_load_codebase_map_files_unit()
@@ -1433,6 +1694,7 @@ def _test_blast_radius_stale_annotation(db_path):
 
     db = sqlite3.connect(db_path)
     import time as _time
+
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
     # Seed entries mentioning both a tracked and an untracked file
     for title, content in [
@@ -1472,25 +1734,29 @@ def _test_blast_radius_stale_annotation(db_path):
         shutil.rmtree(str(fake_root), ignore_errors=True)
 
     files_found = [r["file"] for r in results]
-    test("blast_radius: briefing.py entry returned", "briefing.py" in files_found,
-         f"files={files_found}")
-    test("blast_radius: oldmodule.py entry returned", "oldmodule.py" in files_found,
-         f"files={files_found}")
+    test("blast_radius: briefing.py entry returned", "briefing.py" in files_found, f"files={files_found}")
+    test("blast_radius: oldmodule.py entry returned", "oldmodule.py" in files_found, f"files={files_found}")
 
     if "briefing.py" in files_found and "oldmodule.py" in files_found:
         br = {r["file"]: r for r in results}
-        test("blast_radius: briefing.py is NOT stale (tracked in codebase-map)",
-             not br["briefing.py"].get("stale", False),
-             f"stale={br['briefing.py'].get('stale')!r}")
-        test("blast_radius: oldmodule.py IS stale (not tracked in codebase-map)",
-             br["oldmodule.py"].get("stale") is True,
-             f"stale={br['oldmodule.py'].get('stale')!r}")
+        test(
+            "blast_radius: briefing.py is NOT stale (tracked in codebase-map)",
+            not br["briefing.py"].get("stale", False),
+            f"stale={br['briefing.py'].get('stale')!r}",
+        )
+        test(
+            "blast_radius: oldmodule.py IS stale (not tracked in codebase-map)",
+            br["oldmodule.py"].get("stale") is True,
+            f"stale={br['oldmodule.py'].get('stale')!r}",
+        )
         # Stale entries should sort after non-stale within same risk tier
         non_stale_idx = files_found.index("briefing.py")
         stale_idx = files_found.index("oldmodule.py")
-        test("blast_radius: non-stale entries sort before stale within same tier",
-             non_stale_idx <= stale_idx,
-             f"non_stale@{non_stale_idx} stale@{stale_idx}")
+        test(
+            "blast_radius: non-stale entries sort before stale within same tier",
+            non_stale_idx <= stale_idx,
+            f"non_stale@{non_stale_idx} stale@{stale_idx}",
+        )
 
     # stale key always present even without a codebase-map
     original_ss2 = _briefing.SESSION_STATE
@@ -1502,12 +1768,16 @@ def _test_blast_radius_stale_annotation(db_path):
         live_db2.close()
     finally:
         _briefing.SESSION_STATE = original_ss2
-    test("blast_radius: stale key always present (defaults False without codebase-map)",
-         all("stale" in r for r in results2),
-         f"results={[list(r.keys()) for r in results2]}")
-    test("blast_radius: stale is False when no codebase-map available",
-         all(r["stale"] is False for r in results2),
-         f"stale values={[r['stale'] for r in results2]}")
+    test(
+        "blast_radius: stale key always present (defaults False without codebase-map)",
+        all("stale" in r for r in results2),
+        f"results={[list(r.keys()) for r in results2]}",
+    )
+    test(
+        "blast_radius: stale is False when no codebase-map available",
+        all(r["stale"] is False for r in results2),
+        f"stale values={[r['stale'] for r in results2]}",
+    )
 
 
 _test_blast_radius_stale_annotation()
@@ -1527,49 +1797,71 @@ def _test_format_compact_ordering():
         "tool": {"emoji": "🔧", "title": "Tools", "desc": ""},
     }
     data = {
-        "mistake": [{"id": 1, "title": "Mistake A", "content": "A mistake content line here.",
-                     "tags": "", "confidence": 0.9}],
-        "pattern": [{"id": 2, "title": "Pattern B", "content": "A pattern content line here.",
-                     "tags": "", "confidence": 0.9}],
+        "mistake": [
+            {"id": 1, "title": "Mistake A", "content": "A mistake content line here.", "tags": "", "confidence": 0.9}
+        ],
+        "pattern": [
+            {"id": 2, "title": "Pattern B", "content": "A pattern content line here.", "tags": "", "confidence": 0.9}
+        ],
         "decision": [],
         "tool": [],
     }
-    past_work = [{"title": "Old session work", "doc_type": "checkpoint",
-                  "session_id": "abc12345", "excerpt": "..."}]
-    blast = [{"file": "auth.py", "mistakes": 2, "patterns": 1, "decisions": 0,
-              "risk_level": "MEDIUM", "risk_emoji": "🟡", "stale": False}]
+    past_work = [{"title": "Old session work", "doc_type": "checkpoint", "session_id": "abc12345", "excerpt": "..."}]
+    blast = [
+        {
+            "file": "auth.py",
+            "mistakes": 2,
+            "patterns": 1,
+            "decisions": 0,
+            "risk_level": "MEDIUM",
+            "risk_emoji": "🟡",
+            "stale": False,
+        }
+    ]
 
     output = _briefing._format_compact("test task", data, past_work, categories, blast)
 
-    test("_format_compact: contains <mistakes>", "<mistakes>" in output,
-         f"output[:300]={output[:300]!r}")
+    test("_format_compact: contains <mistakes>", "<mistakes>" in output, f"output[:300]={output[:300]!r}")
     test("_format_compact: contains <blast_radius>", "<blast_radius>" in output)
     test("_format_compact: contains <past_work>", "<past_work>" in output)
 
     # Ordering: blast_radius must appear BEFORE past_work
     idx_blast = output.find("<blast_radius>")
     idx_past = output.find("<past_work>")
-    test("_format_compact: blast_radius appears before past_work",
-         idx_blast != -1 and idx_past != -1 and idx_blast < idx_past,
-         f"blast@{idx_blast} past@{idx_past}")
+    test(
+        "_format_compact: blast_radius appears before past_work",
+        idx_blast != -1 and idx_past != -1 and idx_blast < idx_past,
+        f"blast@{idx_blast} past@{idx_past}",
+    )
 
     # Ordering: mistakes must appear BEFORE blast_radius
     idx_mistakes = output.find("<mistakes>")
-    test("_format_compact: mistakes appears before blast_radius",
-         idx_mistakes != -1 and idx_blast != -1 and idx_mistakes < idx_blast,
-         f"mistakes@{idx_mistakes} blast@{idx_blast}")
+    test(
+        "_format_compact: mistakes appears before blast_radius",
+        idx_mistakes != -1 and idx_blast != -1 and idx_mistakes < idx_blast,
+        f"mistakes@{idx_mistakes} blast@{idx_blast}",
+    )
 
     # Stale annotation in compact output
-    blast_stale = [{"file": "gone.py", "mistakes": 1, "patterns": 0, "decisions": 0,
-                    "risk_level": "MEDIUM", "risk_emoji": "🟡", "stale": True}]
+    blast_stale = [
+        {
+            "file": "gone.py",
+            "mistakes": 1,
+            "patterns": 0,
+            "decisions": 0,
+            "risk_level": "MEDIUM",
+            "risk_emoji": "🟡",
+            "stale": True,
+        }
+    ]
     output_stale = _briefing._format_compact("test", {}, [], categories, blast_stale)
-    test("_format_compact: stale entries annotated with '(stale)'",
-         "(stale)" in output_stale, f"output={output_stale!r}")
+    test(
+        "_format_compact: stale entries annotated with '(stale)'", "(stale)" in output_stale, f"output={output_stale!r}"
+    )
 
     # No blast → no blast_radius tag
     output_no_blast = _briefing._format_compact("test", data, [], categories, None)
-    test("_format_compact: no blast_radius tag when blast is empty",
-         "<blast_radius>" not in output_no_blast)
+    test("_format_compact: no blast_radius tag when blast is empty", "<blast_radius>" not in output_no_blast)
 
 
 _test_format_compact_ordering()
@@ -1590,27 +1882,49 @@ def _test_format_default_ordering():
     }
     data = {
         "mistake": [{"id": 1, "title": "M1", "content": "mistake content.", "confidence": 0.9}],
-        "pattern": [], "decision": [], "tool": [],
+        "pattern": [],
+        "decision": [],
+        "tool": [],
     }
-    past_work = [{"title": "Past work item", "doc_type": "checkpoint",
-                  "session_id": "zzz12345", "excerpt": ""}]
-    blast = [{"file": "api.py", "mistakes": 3, "patterns": 0, "decisions": 1,
-              "risk_level": "HIGH", "risk_emoji": "🔴", "stale": False}]
+    past_work = [{"title": "Past work item", "doc_type": "checkpoint", "session_id": "zzz12345", "excerpt": ""}]
+    blast = [
+        {
+            "file": "api.py",
+            "mistakes": 3,
+            "patterns": 0,
+            "decisions": 1,
+            "risk_level": "HIGH",
+            "risk_emoji": "🔴",
+            "stale": False,
+        }
+    ]
 
     output = _briefing._format_default("test task", data, past_work, categories, blast)
 
     idx_blast = output.find("💥 Blast Radius")
     idx_past = output.find("📚 Related Past Work")
-    test("_format_default: blast_radius appears before past_work",
-         idx_blast != -1 and idx_past != -1 and idx_blast < idx_past,
-         f"blast@{idx_blast} past@{idx_past}")
+    test(
+        "_format_default: blast_radius appears before past_work",
+        idx_blast != -1 and idx_past != -1 and idx_blast < idx_past,
+        f"blast@{idx_blast} past@{idx_past}",
+    )
 
     # Stale annotation in default output
-    blast_stale = [{"file": "old.py", "mistakes": 1, "patterns": 0, "decisions": 0,
-                    "risk_level": "MEDIUM", "risk_emoji": "🟡", "stale": True}]
+    blast_stale = [
+        {
+            "file": "old.py",
+            "mistakes": 1,
+            "patterns": 0,
+            "decisions": 0,
+            "risk_level": "MEDIUM",
+            "risk_emoji": "🟡",
+            "stale": True,
+        }
+    ]
     output_stale = _briefing._format_default("test", data, [], categories, blast_stale)
-    test("_format_default: stale entries annotated with '(stale)'",
-         "(stale)" in output_stale, f"output={output_stale!r}")
+    test(
+        "_format_default: stale entries annotated with '(stale)'", "(stale)" in output_stale, f"output={output_stale!r}"
+    )
 
 
 _test_format_default_ordering()
@@ -1623,18 +1937,26 @@ print("\n⚙️  Adaptive strictness — output contract stability")
 
 def _test_adaptive_strictness_modules():
     """Both modules expose _analyze_query_strictness and _build_adaptive_fts_query."""
-    test("qs has _analyze_query_strictness",
-         hasattr(_qs, "_analyze_query_strictness"),
-         "attribute missing from query-session.py")
-    test("br has _analyze_query_strictness",
-         hasattr(_briefing, "_analyze_query_strictness"),
-         "attribute missing from briefing.py")
-    test("qs has _build_adaptive_fts_query",
-         hasattr(_qs, "_build_adaptive_fts_query"),
-         "attribute missing from query-session.py")
-    test("br has _build_adaptive_fts_query",
-         hasattr(_briefing, "_build_adaptive_fts_query"),
-         "attribute missing from briefing.py")
+    test(
+        "qs has _analyze_query_strictness",
+        hasattr(_qs, "_analyze_query_strictness"),
+        "attribute missing from query-session.py",
+    )
+    test(
+        "br has _analyze_query_strictness",
+        hasattr(_briefing, "_analyze_query_strictness"),
+        "attribute missing from briefing.py",
+    )
+    test(
+        "qs has _build_adaptive_fts_query",
+        hasattr(_qs, "_build_adaptive_fts_query"),
+        "attribute missing from query-session.py",
+    )
+    test(
+        "br has _build_adaptive_fts_query",
+        hasattr(_briefing, "_build_adaptive_fts_query"),
+        "attribute missing from briefing.py",
+    )
 
 
 _test_adaptive_strictness_modules()
@@ -1645,15 +1967,29 @@ def _test_adaptive_briefing_json_strict(db_path):
     """generate_briefing with a strict (1-word) query still emits valid JSON."""
     db = sqlite3.connect(db_path)
     import time as _time
+
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (category, title, content, confidence, session_id, task_id,
              affected_files, facts, tags, occurrence_count, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
-    """, ("pattern", "Strict query test pattern",
-          "Strict query JSON contract verification.",
-          0.9, "test-session-strict", "", '[]', '[]', "", now, now))
+    """,
+        (
+            "pattern",
+            "Strict query test pattern",
+            "Strict query JSON contract verification.",
+            0.9,
+            "test-session-strict",
+            "",
+            "[]",
+            "[]",
+            "",
+            now,
+            now,
+        ),
+    )
     db.execute("""
         INSERT INTO ke_fts (rowid, title, content, tags, category, wing, room, facts)
         VALUES (last_insert_rowid(),
@@ -1670,16 +2006,15 @@ def _test_adaptive_briefing_json_strict(db_path):
     try:
         data = json.loads(result)
         test("generate_briefing strict query --json: valid JSON", True)
-        test("generate_briefing strict query --json: has 'query' key",
-             "query" in data, f"keys={list(data)}")
-        test("generate_briefing strict query --json: has 'sections' key",
-             "sections" in data, f"keys={list(data)}")
-        test("generate_briefing strict query --json: 'sections' is dict",
-             isinstance(data.get("sections"), dict),
-             f"type={type(data.get('sections')).__name__}")
+        test("generate_briefing strict query --json: has 'query' key", "query" in data, f"keys={list(data)}")
+        test("generate_briefing strict query --json: has 'sections' key", "sections" in data, f"keys={list(data)}")
+        test(
+            "generate_briefing strict query --json: 'sections' is dict",
+            isinstance(data.get("sections"), dict),
+            f"type={type(data.get('sections')).__name__}",
+        )
     except json.JSONDecodeError as e:
-        test("generate_briefing strict query --json: valid JSON",
-             False, f"{e}; result={result[:200]!r}")
+        test("generate_briefing strict query --json: valid JSON", False, f"{e}; result={result[:200]!r}")
 
 
 _test_adaptive_briefing_json_strict()
@@ -1690,15 +2025,29 @@ def _test_adaptive_briefing_json_broad(db_path):
     """generate_briefing with a broad (7+ word) query still emits valid JSON."""
     db = sqlite3.connect(db_path)
     import time as _time
+
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (category, title, content, confidence, session_id, task_id,
              affected_files, facts, tags, occurrence_count, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
-    """, ("mistake", "Broad query test mistake",
-          "Broad query JSON contract verification for auth implementation.",
-          0.4, "test-session-broad", "", '[]', '[]', "", now, now))
+    """,
+        (
+            "mistake",
+            "Broad query test mistake",
+            "Broad query JSON contract verification for auth implementation.",
+            0.4,
+            "test-session-broad",
+            "",
+            "[]",
+            "[]",
+            "",
+            now,
+            now,
+        ),
+    )
     db.execute("""
         INSERT INTO ke_fts (rowid, title, content, tags, category, wing, room, facts)
         VALUES (last_insert_rowid(),
@@ -1716,13 +2065,12 @@ def _test_adaptive_briefing_json_broad(db_path):
     try:
         data = json.loads(result)
         test("generate_briefing broad query --json: valid JSON", True)
-        test("generate_briefing broad query --json: has 'query' key",
-             "query" in data, f"keys={list(data)}")
-        test("generate_briefing broad query --json: 'generated_at' present",
-             "generated_at" in data, f"keys={list(data)}")
+        test("generate_briefing broad query --json: has 'query' key", "query" in data, f"keys={list(data)}")
+        test(
+            "generate_briefing broad query --json: 'generated_at' present", "generated_at" in data, f"keys={list(data)}"
+        )
     except json.JSONDecodeError as e:
-        test("generate_briefing broad query --json: valid JSON",
-             False, f"{e}; result={result[:200]!r}")
+        test("generate_briefing broad query --json: valid JSON", False, f"{e}; result={result[:200]!r}")
 
 
 _test_adaptive_briefing_json_broad()
@@ -1733,15 +2081,27 @@ def _test_adaptive_search_knowledge_json(db_path):
     """search_knowledge JSON export is a list regardless of adaptive strictness path."""
     db = sqlite3.connect(db_path)
     import time as _time
+
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (category, title, content, confidence, session_id,
              affected_files, facts, occurrence_count, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
-    """, ("pattern", "Frobnitz cache pattern",
-          "Use frobnitz for caching database results.",
-          0.8, "test-session-fqc", '[]', '[]', now, now))
+    """,
+        (
+            "pattern",
+            "Frobnitz cache pattern",
+            "Use frobnitz for caching database results.",
+            0.8,
+            "test-session-fqc",
+            "[]",
+            "[]",
+            now,
+            now,
+        ),
+    )
     db.execute("""
         INSERT INTO ke_fts (rowid, title, content, tags, category, wing, room, facts)
         VALUES (last_insert_rowid(),
@@ -1761,13 +2121,19 @@ def _test_adaptive_search_knowledge_json(db_path):
     if raw_strict:
         try:
             parsed = json.loads(raw_strict)
-            test("search_knowledge strict --json: output is a list",
-                 isinstance(parsed, list), f"type={type(parsed).__name__}")
+            test(
+                "search_knowledge strict --json: output is a list",
+                isinstance(parsed, list),
+                f"type={type(parsed).__name__}",
+            )
         except json.JSONDecodeError as e:
             test("search_knowledge strict --json: valid JSON", False, str(e))
     else:
-        test("search_knowledge strict --json: returned results", False,
-             "got empty output — strict+fallback found nothing")
+        test(
+            "search_knowledge strict --json: returned results",
+            False,
+            "got empty output — strict+fallback found nothing",
+        )
 
     # Medium query (3 terms)
     with _CapStdout() as cap:
@@ -1776,8 +2142,11 @@ def _test_adaptive_search_knowledge_json(db_path):
     if raw_med:
         try:
             parsed2 = json.loads(raw_med)
-            test("search_knowledge medium --json: output is a list",
-                 isinstance(parsed2, list), f"type={type(parsed2).__name__}")
+            test(
+                "search_knowledge medium --json: output is a list",
+                isinstance(parsed2, list),
+                f"type={type(parsed2).__name__}",
+            )
         except json.JSONDecodeError as e:
             test("search_knowledge medium --json: valid JSON", False, str(e))
     else:
@@ -1813,13 +2182,19 @@ def _test_qs_detail_missing_logs_no_hit_detail_open(db_path):
     """).fetchone()
     db.close()
 
-    test("--detail missing: command still reports missing entry",
-         "No knowledge entry with ID 424242" in output, f"output={output!r}")
+    test(
+        "--detail missing: command still reports missing entry",
+        "No knowledge entry with ID 424242" in output,
+        f"output={output!r}",
+    )
     test("--detail missing: telemetry row exists", row is not None)
     if row is not None:
         test("--detail missing: event_kind is detail_open", row[0] == "detail_open", f"event_kind={row[0]!r}")
-        test("--detail missing: tool/surface is query-session/detail",
-             row[1] == "query-session" and row[2] == "detail", f"tool/surface={(row[1], row[2])!r}")
+        test(
+            "--detail missing: tool/surface is query-session/detail",
+            row[1] == "query-session" and row[2] == "detail",
+            f"tool/surface={(row[1], row[2])!r}",
+        )
         test("--detail missing: opened_entry_id captured", row[3] == 424242, f"opened_entry_id={row[3]!r}")
         test("--detail missing: hit_count is 0", row[4] == 0, f"hit_count={row[4]!r}")
         try:
@@ -1856,9 +2231,11 @@ def _test_qs_default_search_telemetry_aggregates_full_surface(db_path):
 
     old_argv = sys.argv
     sys.argv = ["query-session.py", "phase5-contract"]
-    with _mock.patch.object(_qs, "search", side_effect=_fake_search), \
-         _mock.patch.object(_qs, "search_sessions_fts", side_effect=_fake_sessions), \
-         _mock.patch.object(_qs, "search_knowledge", side_effect=_fake_knowledge):
+    with (
+        _mock.patch.object(_qs, "search", side_effect=_fake_search),
+        _mock.patch.object(_qs, "search_sessions_fts", side_effect=_fake_sessions),
+        _mock.patch.object(_qs, "search_knowledge", side_effect=_fake_knowledge),
+    ):
         with _CapStdout() as cap:
             try:
                 _qs.main()
@@ -1876,21 +2253,31 @@ def _test_qs_default_search_telemetry_aggregates_full_surface(db_path):
     """).fetchone()
     db.close()
 
-    test("default search telemetry: emitted output includes session block",
-         "Session hits (3 results)" in output, f"output={output!r}")
-    test("default search telemetry: primary and knowledge blocks emitted",
-         "PRIMARY_SEARCH_BLOCK" in output and "KNOWLEDGE_BLOCK" in output, f"output={output!r}")
+    test(
+        "default search telemetry: emitted output includes session block",
+        "Session hits (3 results)" in output,
+        f"output={output!r}",
+    )
+    test(
+        "default search telemetry: primary and knowledge blocks emitted",
+        "PRIMARY_SEARCH_BLOCK" in output and "KNOWLEDGE_BLOCK" in output,
+        f"output={output!r}",
+    )
     test("default search telemetry: search recall row exists", row is not None)
     if row is not None:
         test("default search telemetry: event_kind is recall", row[0] == "recall", f"event_kind={row[0]!r}")
-        test("default search telemetry: hit_count aggregates full emitted surface",
-             row[2] == 6, f"hit_count={row[2]!r}")
+        test(
+            "default search telemetry: hit_count aggregates full emitted surface", row[2] == 6, f"hit_count={row[2]!r}"
+        )
         try:
             sel = json.loads(row[3] or "[]")
         except Exception:
             sel = None
-        test("default search telemetry: selected_entry_ids keeps knowledge/search IDs",
-             sel == [101, 102, 303], f"selected_entry_ids={row[3]!r}")
+        test(
+            "default search telemetry: selected_entry_ids keeps knowledge/search IDs",
+            sel == [101, 102, 303],
+            f"selected_entry_ids={row[3]!r}",
+        )
 
 
 _test_qs_default_search_telemetry_aggregates_full_surface()
@@ -1914,8 +2301,11 @@ def _test_recall_surfaces_fail_open_without_recall_table(db_path):
             pass
     sys.argv = old_argv
     output = cap.getvalue()
-    test("missing recall_events table: --detail still completes",
-         "No knowledge entry with ID 555555" in output, f"output={output!r}")
+    test(
+        "missing recall_events table: --detail still completes",
+        "No knowledge entry with ID 555555" in output,
+        f"output={output!r}",
+    )
 
 
 _test_recall_surfaces_fail_open_without_recall_table()
@@ -1929,44 +2319,107 @@ def _test_recall_stats_contracts(db_path):
     _health.DB_PATH = Path(db_path)
     db = sqlite3.connect(db_path)
     now = _time.strftime("%Y-%m-%dT%H:%M:%S")
-    db.executemany("""
+    db.executemany(
+        """
         INSERT INTO recall_events (
             created_at, event_kind, tool, surface, mode,
             raw_query, rewritten_query, task_id, files,
             selected_entry_ids, selected_snippet_ids, opened_entry_id,
             hit_count, output_chars, output_est_tokens
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, [
-        (now, "recall", "query-session", "search", "", "auth bug", "auth bug", "", "[]", "[11]", "[]", None, 2, 80, 20),
-        (now, "recall", "query-session", "search", "", "missing", "nohit query", "", "[]", "[]", "[]", None, 0, 40, 10),
-        (now, "recall", "query-session", "search", "", "missing", "nohit query", "", "[]", "[]", "[]", None, 0, 36, 9),
-        (now, "detail_open", "query-session", "detail", "", "", "", "", "[]", "[77]", "[]", 77, 1, 120, 30),
-        (now, "detail_open", "query-session", "detail", "", "", "", "", "[]", "[]", "[]", 88, 0, 18, 5),
-    ])
+    """,
+        [
+            (
+                now,
+                "recall",
+                "query-session",
+                "search",
+                "",
+                "auth bug",
+                "auth bug",
+                "",
+                "[]",
+                "[11]",
+                "[]",
+                None,
+                2,
+                80,
+                20,
+            ),
+            (
+                now,
+                "recall",
+                "query-session",
+                "search",
+                "",
+                "missing",
+                "nohit query",
+                "",
+                "[]",
+                "[]",
+                "[]",
+                None,
+                0,
+                40,
+                10,
+            ),
+            (
+                now,
+                "recall",
+                "query-session",
+                "search",
+                "",
+                "missing",
+                "nohit query",
+                "",
+                "[]",
+                "[]",
+                "[]",
+                None,
+                0,
+                36,
+                9,
+            ),
+            (now, "detail_open", "query-session", "detail", "", "", "", "", "[]", "[77]", "[]", 77, 1, 120, 30),
+            (now, "detail_open", "query-session", "detail", "", "", "", "", "[]", "[]", "[]", 88, 0, 18, 5),
+        ],
+    )
     db.commit()
     db.close()
 
     stats = _health.compute_recall_stats()
     test("compute_recall_stats: available is true", stats.get("available") is True, f"stats={stats!r}")
-    test("compute_recall_stats: total_events includes recall + detail_open rows",
-         stats.get("total_events") == 5, f"total_events={stats.get('total_events')!r}")
+    test(
+        "compute_recall_stats: total_events includes recall + detail_open rows",
+        stats.get("total_events") == 5,
+        f"total_events={stats.get('total_events')!r}",
+    )
 
     top_no_hit = stats.get("top_no_hit_queries", [])
-    test("compute_recall_stats: top no-hit query grouped by rewritten_query",
-         isinstance(top_no_hit, list) and top_no_hit and top_no_hit[0].get("rewritten_query") == "nohit query"
-         and top_no_hit[0].get("event_count") == 2,
-         f"top_no_hit={top_no_hit!r}")
+    test(
+        "compute_recall_stats: top no-hit query grouped by rewritten_query",
+        isinstance(top_no_hit, list)
+        and top_no_hit
+        and top_no_hit[0].get("rewritten_query") == "nohit query"
+        and top_no_hit[0].get("event_count") == 2,
+        f"top_no_hit={top_no_hit!r}",
+    )
 
     repeated = stats.get("top_repeated_detail_opens", [])
     seen_ids = {row.get("opened_entry_id") for row in repeated}
-    test("compute_recall_stats: repeated detail opens keyed by opened_entry_id",
-         77 in seen_ids and 88 in seen_ids, f"repeated={repeated!r}")
+    test(
+        "compute_recall_stats: repeated detail opens keyed by opened_entry_id",
+        77 in seen_ids and 88 in seen_ids,
+        f"repeated={repeated!r}",
+    )
 
     report = _health.format_recall_report(stats)
-    test("format_recall_report: recall-only heading present",
-         "Recall Telemetry" in report, f"report={report!r}")
-    test("format_recall_report: does not include default health heading",
-         "Knowledge Health Report" not in report, f"report={report!r}")
+    test("format_recall_report: recall-only heading present", "Recall Telemetry" in report, f"report={report!r}")
+    test(
+        "format_recall_report: does not include default health heading",
+        "Knowledge Health Report" not in report,
+        f"report={report!r}",
+    )
 
     old_argv = sys.argv
     _health.DB_PATH = Path(db_path)
@@ -1978,9 +2431,11 @@ def _test_recall_stats_contracts(db_path):
     try:
         parsed = json.loads(json_output)
         test("--recall --json: emits valid JSON", True)
-        test("--recall --json: remains recall-only payload keys",
-             "total_events" in parsed and "events_by_surface" in parsed and "score" not in parsed,
-             f"keys={list(parsed)}")
+        test(
+            "--recall --json: remains recall-only payload keys",
+            "total_events" in parsed and "events_by_surface" in parsed and "score" not in parsed,
+            f"keys={list(parsed)}",
+        )
     except json.JSONDecodeError as e:
         test("--recall --json: emits valid JSON", False, f"{e}; output={json_output!r}")
 
@@ -1998,8 +2453,11 @@ def _test_recall_stats_unavailable_contract(db_path):
 
     _health.DB_PATH = Path(db_path)
     stats = _health.compute_recall_stats()
-    test("missing recall_events: compute_recall_stats marks unavailable",
-         stats.get("available") is False, f"stats={stats!r}")
+    test(
+        "missing recall_events: compute_recall_stats marks unavailable",
+        stats.get("available") is False,
+        f"stats={stats!r}",
+    )
 
     old_argv = sys.argv
     sys.argv = ["knowledge-health.py", "--recall"]
@@ -2007,8 +2465,11 @@ def _test_recall_stats_unavailable_contract(db_path):
         _health.main()
     sys.argv = old_argv
     text_output = cap.getvalue().strip()
-    test("missing recall_events: --recall text says unavailable",
-         "Recall telemetry unavailable" in text_output, f"output={text_output!r}")
+    test(
+        "missing recall_events: --recall text says unavailable",
+        "Recall telemetry unavailable" in text_output,
+        f"output={text_output!r}",
+    )
 
 
 _test_recall_stats_unavailable_contract()
@@ -2034,45 +2495,69 @@ def _test_migrate_stable_ids_and_policy(db_path):
     db.row_factory = sqlite3.Row
     now = "2026-01-02T03:04:05"
     db.execute("INSERT INTO sessions (id, path, indexed_at) VALUES (?, ?, ?)", ("sess-a", "p", now))
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO documents (session_id, doc_type, seq, title, file_path, indexed_at)
         VALUES (?, ?, ?, ?, ?, ?)
-    """, ("sess-a", "checkpoint", 7, "  Hello   World  ", "cp/007.md", now))
+    """,
+        ("sess-a", "checkpoint", 7, "  Hello   World  ", "cp/007.md", now),
+    )
     doc_id = db.execute("SELECT last_insert_rowid()").fetchone()[0]
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO sections (document_id, section_name, content)
         VALUES (?, ?, ?)
-    """, (doc_id, "technical_details", "content"))
-    db.execute("""
+    """,
+        (doc_id, "technical_details", "content"),
+    )
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (session_id, category, title, content, topic_key, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?)
-    """, ("sess-a", "pattern", "Stable Entry", "content", "pattern/stable-entry", now, now))
+    """,
+        ("sess-a", "pattern", "Stable Entry", "content", "pattern/stable-entry", now, now),
+    )
     ke_id = db.execute("SELECT last_insert_rowid()").fetchone()[0]
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO knowledge_entries
             (session_id, category, title, content, topic_key, first_seen, last_seen)
         VALUES (?, ?, ?, ?, ?, ?, ?)
-    """, ("sess-a", "mistake", "Directional Source", "content", "mistake/directional-source", now, now))
+    """,
+        ("sess-a", "mistake", "Directional Source", "content", "mistake/directional-source", now, now),
+    )
     source_ke_id = db.execute("SELECT last_insert_rowid()").fetchone()[0]
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO knowledge_relations (source_id, target_id, relation_type, confidence)
         VALUES (?, ?, ?, ?)
-    """, (source_ke_id, ke_id, "RESOLVED_BY", 0.8))
-    db.execute("""
+    """,
+        (source_ke_id, ke_id, "RESOLVED_BY", 0.8),
+    )
+    db.execute(
+        """
         INSERT INTO entity_relations (subject, predicate, object, noted_at, session_id)
         VALUES (?, ?, ?, ?, ?)
-    """, ("svc", "calls", "db", now, "sess-a"))
-    db.execute("""
+    """,
+        ("svc", "calls", "db", now, "sess-a"),
+    )
+    db.execute(
+        """
         INSERT INTO search_feedback
             (query, result_id, result_kind, verdict, created_at, origin_replica_id)
         VALUES (?, ?, ?, ?, ?, ?)
-    """, ("auth bug", str(ke_id), "knowledge", 1, now, "replica-x"))
-    db.execute("""
+    """,
+        ("auth bug", str(ke_id), "knowledge", 1, now, "replica-x"),
+    )
+    db.execute(
+        """
         INSERT INTO search_feedback
             (query, result_id, result_kind, verdict, created_at, origin_replica_id)
         VALUES (?, ?, ?, ?, ?, ?)
-    """, ("local fallback bug", "local-result-1", "knowledge", -1, now, ""))
+    """,
+        ("local fallback bug", "local-result-1", "knowledge", -1, now, ""),
+    )
     db.commit()
     db.close()
 
@@ -2091,60 +2576,81 @@ def _test_migrate_stable_ids_and_policy(db_path):
     sec_row = db.execute("SELECT stable_id FROM sections WHERE document_id = ?", (doc_id,)).fetchone()
     ke_row = db.execute("SELECT stable_id FROM knowledge_entries WHERE id = ?", (ke_id,)).fetchone()
     source_ke_row = db.execute("SELECT stable_id FROM knowledge_entries WHERE id = ?", (source_ke_id,)).fetchone()
-    rel_row = db.execute("""
+    rel_row = db.execute(
+        """
         SELECT source_stable_id, target_stable_id, stable_id
         FROM knowledge_relations
         WHERE source_id = ? AND target_id = ? AND relation_type = 'RESOLVED_BY'
-    """, (source_ke_id, ke_id)).fetchone()
-    sf_row = db.execute("""
+    """,
+        (source_ke_id, ke_id),
+    ).fetchone()
+    sf_row = db.execute(
+        """
         SELECT stable_id, origin_replica_id
         FROM search_feedback
         WHERE result_id = ? AND result_kind = 'knowledge'
-    """, (str(ke_id),)).fetchone()
-    local_sf_row = db.execute("""
+    """,
+        (str(ke_id),),
+    ).fetchone()
+    local_sf_row = db.execute(
+        """
         SELECT id, stable_id, origin_replica_id, query, result_id, result_kind, verdict, created_at
         FROM search_feedback
         WHERE result_id = ? AND result_kind = 'knowledge'
-    """, ("local-result-1",)).fetchone()
+    """,
+        ("local-result-1",),
+    ).fetchone()
 
     expected_doc_sid = _stable_sha_for_test(
         "document", "sess-a", "checkpoint", 7, _normalize_title_for_test("  Hello   World  ")
     )
     expected_sec_sid = _stable_sha_for_test("section", expected_doc_sid, "technical_details")
-    expected_ke_sid = _stable_sha_for_test(
-        "knowledge", "sess-a", "pattern", "Stable Entry", "pattern/stable-entry"
-    )
+    expected_ke_sid = _stable_sha_for_test("knowledge", "sess-a", "pattern", "Stable Entry", "pattern/stable-entry")
     expected_source_ke_sid = _stable_sha_for_test(
         "knowledge", "sess-a", "mistake", "Directional Source", "mistake/directional-source"
     )
     expected_rel_sid = _stable_sha_for_test(
         "knowledge_relation", expected_source_ke_sid, expected_ke_sid, "RESOLVED_BY"
     )
-    expected_sf_sid = _stable_sha_for_test(
-        "search_feedback", now, "knowledge", str(ke_id), 1, "auth bug", "replica-x"
-    )
+    expected_sf_sid = _stable_sha_for_test("search_feedback", now, "knowledge", str(ke_id), 1, "auth bug", "replica-x")
 
-    test("migrate backfill: documents.stable_id deterministic",
-         doc_row and doc_row["stable_id"] == expected_doc_sid,
-         f"doc_stable_id={doc_row['stable_id'] if doc_row else None!r}")
-    test("migrate backfill: sections.stable_id deterministic",
-         sec_row and sec_row["stable_id"] == expected_sec_sid,
-         f"section_stable_id={sec_row['stable_id'] if sec_row else None!r}")
-    test("migrate backfill: knowledge_entries.stable_id deterministic",
-         ke_row and ke_row["stable_id"] == expected_ke_sid,
-         f"ke_stable_id={ke_row['stable_id'] if ke_row else None!r}")
-    test("migrate backfill: directional source stable_id deterministic",
-         source_ke_row and source_ke_row["stable_id"] == expected_source_ke_sid,
-         f"source_ke_stable_id={source_ke_row['stable_id'] if source_ke_row else None!r}")
-    test("migrate backfill: knowledge_relations preserves source->target stable IDs",
-         rel_row and rel_row["source_stable_id"] == expected_source_ke_sid and rel_row["target_stable_id"] == expected_ke_sid,
-         f"relation={dict(rel_row) if rel_row else None!r}")
-    test("migrate backfill: knowledge_relations.stable_id uses directional order",
-         rel_row and rel_row["stable_id"] == expected_rel_sid,
-         f"relation={dict(rel_row) if rel_row else None!r}")
-    test("migrate backfill: search_feedback stable+origin deterministic",
-         sf_row and sf_row["stable_id"] == expected_sf_sid and sf_row["origin_replica_id"] == "replica-x",
-         f"sf_row={dict(sf_row) if sf_row else None!r}")
+    test(
+        "migrate backfill: documents.stable_id deterministic",
+        doc_row and doc_row["stable_id"] == expected_doc_sid,
+        f"doc_stable_id={doc_row['stable_id'] if doc_row else None!r}",
+    )
+    test(
+        "migrate backfill: sections.stable_id deterministic",
+        sec_row and sec_row["stable_id"] == expected_sec_sid,
+        f"section_stable_id={sec_row['stable_id'] if sec_row else None!r}",
+    )
+    test(
+        "migrate backfill: knowledge_entries.stable_id deterministic",
+        ke_row and ke_row["stable_id"] == expected_ke_sid,
+        f"ke_stable_id={ke_row['stable_id'] if ke_row else None!r}",
+    )
+    test(
+        "migrate backfill: directional source stable_id deterministic",
+        source_ke_row and source_ke_row["stable_id"] == expected_source_ke_sid,
+        f"source_ke_stable_id={source_ke_row['stable_id'] if source_ke_row else None!r}",
+    )
+    test(
+        "migrate backfill: knowledge_relations preserves source->target stable IDs",
+        rel_row
+        and rel_row["source_stable_id"] == expected_source_ke_sid
+        and rel_row["target_stable_id"] == expected_ke_sid,
+        f"relation={dict(rel_row) if rel_row else None!r}",
+    )
+    test(
+        "migrate backfill: knowledge_relations.stable_id uses directional order",
+        rel_row and rel_row["stable_id"] == expected_rel_sid,
+        f"relation={dict(rel_row) if rel_row else None!r}",
+    )
+    test(
+        "migrate backfill: search_feedback stable+origin deterministic",
+        sf_row and sf_row["stable_id"] == expected_sf_sid and sf_row["origin_replica_id"] == "replica-x",
+        f"sf_row={dict(sf_row) if sf_row else None!r}",
+    )
     expected_local_sf_sid = _stable_sha_for_test(
         "search_feedback",
         now,
@@ -2154,11 +2660,11 @@ def _test_migrate_stable_ids_and_policy(db_path):
         "local fallback bug",
         local_sf_row["origin_replica_id"] if local_sf_row else "",
     )
-    test("migrate backfill: local-empty search_feedback origin normalized",
-         local_sf_row
-         and bool(local_sf_row["origin_replica_id"])
-         and local_sf_row["stable_id"] == expected_local_sf_sid,
-         f"local_sf_row={dict(local_sf_row) if local_sf_row else None!r}")
+    test(
+        "migrate backfill: local-empty search_feedback origin normalized",
+        local_sf_row and bool(local_sf_row["origin_replica_id"]) and local_sf_row["stable_id"] == expected_local_sf_sid,
+        f"local_sf_row={dict(local_sf_row) if local_sf_row else None!r}",
+    )
 
     if local_sf_row:
         db.execute(
@@ -2168,16 +2674,21 @@ def _test_migrate_stable_ids_and_policy(db_path):
         db.commit()
         embed_mod = _load_module("embed_mc_origin_norm", TOOLS_DIR / "embed.py")
         embed_mod.ensure_embedding_tables(db)
-        from_local = db.execute("""
+        from_local = db.execute(
+            """
             SELECT stable_id, origin_replica_id
             FROM search_feedback
             WHERE id = ?
-        """, (local_sf_row["id"],)).fetchone()
-        test("embed path keeps migrate local-origin stable_id for 'local' input",
-             from_local
-             and from_local["origin_replica_id"] == local_sf_row["origin_replica_id"]
-             and from_local["stable_id"] == expected_local_sf_sid,
-             f"from_local={dict(from_local) if from_local else None!r}")
+        """,
+            (local_sf_row["id"],),
+        ).fetchone()
+        test(
+            "embed path keeps migrate local-origin stable_id for 'local' input",
+            from_local
+            and from_local["origin_replica_id"] == local_sf_row["origin_replica_id"]
+            and from_local["stable_id"] == expected_local_sf_sid,
+            f"from_local={dict(from_local) if from_local else None!r}",
+        )
 
         db.execute(
             "UPDATE search_feedback SET origin_replica_id = '', stable_id = '' WHERE id = ?",
@@ -2185,16 +2696,21 @@ def _test_migrate_stable_ids_and_policy(db_path):
         )
         db.commit()
         embed_mod.ensure_embedding_tables(db)
-        from_empty = db.execute("""
+        from_empty = db.execute(
+            """
             SELECT stable_id, origin_replica_id
             FROM search_feedback
             WHERE id = ?
-        """, (local_sf_row["id"],)).fetchone()
-        test("embed path keeps migrate local-origin stable_id for empty input",
-             from_empty
-             and from_empty["origin_replica_id"] == local_sf_row["origin_replica_id"]
-             and from_empty["stable_id"] == expected_local_sf_sid,
-             f"from_empty={dict(from_empty) if from_empty else None!r}")
+        """,
+            (local_sf_row["id"],),
+        ).fetchone()
+        test(
+            "embed path keeps migrate local-origin stable_id for empty input",
+            from_empty
+            and from_empty["origin_replica_id"] == local_sf_row["origin_replica_id"]
+            and from_empty["stable_id"] == expected_local_sf_sid,
+            f"from_empty={dict(from_empty) if from_empty else None!r}",
+        )
 
     def _has_unique_stable_index(table_name: str) -> bool:
         for idx in db.execute(f"PRAGMA index_list({table_name})").fetchall():
@@ -2202,16 +2718,23 @@ def _test_migrate_stable_ids_and_policy(db_path):
             is_unique = int(idx["unique"] if "unique" in idx.keys() else idx[2]) == 1
             if not is_unique:
                 continue
-            cols = [row["name"] if "name" in row.keys() else row[2]
-                    for row in db.execute(f"PRAGMA index_info({idx_name})").fetchall()]
+            cols = [
+                row["name"] if "name" in row.keys() else row[2]
+                for row in db.execute(f"PRAGMA index_info({idx_name})").fetchall()
+            ]
             if cols == ["stable_id"]:
                 return True
         return False
 
     test("migrate schema: unique documents.stable_id index exists", _has_unique_stable_index("documents"))
     test("migrate schema: unique sections.stable_id index exists", _has_unique_stable_index("sections"))
-    test("migrate schema: unique knowledge_entries.stable_id index exists", _has_unique_stable_index("knowledge_entries"))
-    test("migrate schema: unique knowledge_relations.stable_id index exists", _has_unique_stable_index("knowledge_relations"))
+    test(
+        "migrate schema: unique knowledge_entries.stable_id index exists", _has_unique_stable_index("knowledge_entries")
+    )
+    test(
+        "migrate schema: unique knowledge_relations.stable_id index exists",
+        _has_unique_stable_index("knowledge_relations"),
+    )
     test("migrate schema: unique entity_relations.stable_id index exists", _has_unique_stable_index("entity_relations"))
     test("migrate schema: unique search_feedback.stable_id index exists", _has_unique_stable_index("search_feedback"))
 
@@ -2288,40 +2811,59 @@ def _test_migrate_stable_ids_and_policy(db_path):
     """).fetchone()
     policy_table_sql = (policy_table_sql_row["sql"] if policy_table_sql_row else "") or ""
     policy_sql_normalized = " ".join(policy_table_sql.lower().split())
-    test("sync policy: canonical knowledge_entries has stable_id",
-         ("knowledge_entries", "canonical", "stable_id") in policies,
-         f"policies={sorted(policies)!r}")
-    test("sync policy: recall_events is upload_only",
-         ("recall_events", "upload_only", "") in policies,
-         f"policies={sorted(policies)!r}")
-    test("sync policy: entry_recall_stats is upload_only",
-         ("entry_recall_stats", "upload_only", "") in policies,
-         f"policies={sorted(policies)!r}")
-    test("sync policy: entry_recall_day_log is upload_only",
-         ("entry_recall_day_log", "upload_only", "") in policies,
-         f"policies={sorted(policies)!r}")
-    test("sync policy: entry_recall_query_log is upload_only",
-         ("entry_recall_query_log", "upload_only", "") in policies,
-         f"policies={sorted(policies)!r}")
-    test("sync policy: local-only embeddings present",
-         ("embeddings", "local_only", "") in policies,
-         f"policies={sorted(policies)!r}")
-    test("sync policy: local-only knowledge_fts present",
-         ("knowledge_fts", "local_only", "") in policies,
-         f"policies={sorted(policies)!r}")
-    test("sync policy schema allows upload_only scope",
-         "check(sync_scope in ('canonical', 'local_only', 'upload_only'))" in policy_sql_normalized,
-         f"sync_table_policies.sql={policy_table_sql!r}")
+    test(
+        "sync policy: canonical knowledge_entries has stable_id",
+        ("knowledge_entries", "canonical", "stable_id") in policies,
+        f"policies={sorted(policies)!r}",
+    )
+    test(
+        "sync policy: recall_events is upload_only",
+        ("recall_events", "upload_only", "") in policies,
+        f"policies={sorted(policies)!r}",
+    )
+    test(
+        "sync policy: entry_recall_stats is upload_only",
+        ("entry_recall_stats", "upload_only", "") in policies,
+        f"policies={sorted(policies)!r}",
+    )
+    test(
+        "sync policy: entry_recall_day_log is upload_only",
+        ("entry_recall_day_log", "upload_only", "") in policies,
+        f"policies={sorted(policies)!r}",
+    )
+    test(
+        "sync policy: entry_recall_query_log is upload_only",
+        ("entry_recall_query_log", "upload_only", "") in policies,
+        f"policies={sorted(policies)!r}",
+    )
+    test(
+        "sync policy: local-only embeddings present",
+        ("embeddings", "local_only", "") in policies,
+        f"policies={sorted(policies)!r}",
+    )
+    test(
+        "sync policy: local-only knowledge_fts present",
+        ("knowledge_fts", "local_only", "") in policies,
+        f"policies={sorted(policies)!r}",
+    )
+    test(
+        "sync policy schema allows upload_only scope",
+        "check(sync_scope in ('canonical', 'local_only', 'upload_only'))" in policy_sql_normalized,
+        f"sync_table_policies.sql={policy_table_sql!r}",
+    )
     sync_tables = {
-        r["name"] for r in db.execute("""
+        r["name"]
+        for r in db.execute("""
             SELECT name FROM sqlite_master
             WHERE type = 'table'
               AND name IN ('sync_state', 'sync_txns', 'sync_ops', 'sync_cursors', 'sync_failures')
         """)
     }
-    test("sync foundation tables all exist",
-         sync_tables == {"sync_state", "sync_txns", "sync_ops", "sync_cursors", "sync_failures"},
-         f"sync_tables={sorted(sync_tables)!r}")
+    test(
+        "sync foundation tables all exist",
+        sync_tables == {"sync_state", "sync_txns", "sync_ops", "sync_cursors", "sync_failures"},
+        f"sync_tables={sorted(sync_tables)!r}",
+    )
     db.close()
 
 
@@ -2340,7 +2882,9 @@ def _test_recall_stats_counter_increment(db_path):
     db = sqlite3.connect(db_path)
     db.row_factory = sqlite3.Row
     # Seed a knowledge_entries row so FK-style int reference is valid.
-    db.execute("INSERT INTO knowledge_entries (id, session_id, category, title, content) VALUES (1, 's', 'pattern', 'T', 'C')")
+    db.execute(
+        "INSERT INTO knowledge_entries (id, session_id, category, title, content) VALUES (1, 's', 'pattern', 'T', 'C')"
+    )
     db.commit()
 
     _briefing._upsert_entry_recall_stats(db, [1], "query-a")
@@ -2348,9 +2892,11 @@ def _test_recall_stats_counter_increment(db_path):
     _briefing._upsert_entry_recall_stats(db, [1], "query-a")
 
     row = db.execute("SELECT recall_count FROM entry_recall_stats WHERE entry_id = 1").fetchone()
-    test("recall_count increments on every call",
-         row is not None and row["recall_count"] == 3,
-         f"row={dict(row) if row else None!r}")
+    test(
+        "recall_count increments on every call",
+        row is not None and row["recall_count"] == 3,
+        f"row={dict(row) if row else None!r}",
+    )
     db.close()
 
 
@@ -2363,7 +2909,9 @@ def _test_recall_stats_dedupes_duplicate_entry_ids(db_path):
     _briefing.DB_PATH = Path(db_path)
     db = sqlite3.connect(db_path)
     db.row_factory = sqlite3.Row
-    db.execute("INSERT INTO knowledge_entries (id, session_id, category, title, content) VALUES (1, 's', 'pattern', 'T', 'C')")
+    db.execute(
+        "INSERT INTO knowledge_entries (id, session_id, category, title, content) VALUES (1, 's', 'pattern', 'T', 'C')"
+    )
     db.commit()
 
     _briefing._upsert_entry_recall_stats(db, [1, 1, 1], "dup-query")
@@ -2371,15 +2919,21 @@ def _test_recall_stats_dedupes_duplicate_entry_ids(db_path):
     row = db.execute(
         "SELECT recall_count, recall_days, unique_queries FROM entry_recall_stats WHERE entry_id = 1"
     ).fetchone()
-    test("duplicate entry_ids count once per helper call",
-         row is not None and row["recall_count"] == 1 and row["recall_days"] == 1 and row["unique_queries"] == 1,
-         f"row={dict(row) if row else None!r}")
-    test("duplicate entry_ids create one day-log row",
-         db.execute("SELECT COUNT(*) FROM entry_recall_day_log WHERE entry_id = 1").fetchone()[0] == 1,
-         "")
-    test("duplicate entry_ids create one query-log row",
-         db.execute("SELECT COUNT(*) FROM entry_recall_query_log WHERE entry_id = 1").fetchone()[0] == 1,
-         "")
+    test(
+        "duplicate entry_ids count once per helper call",
+        row is not None and row["recall_count"] == 1 and row["recall_days"] == 1 and row["unique_queries"] == 1,
+        f"row={dict(row) if row else None!r}",
+    )
+    test(
+        "duplicate entry_ids create one day-log row",
+        db.execute("SELECT COUNT(*) FROM entry_recall_day_log WHERE entry_id = 1").fetchone()[0] == 1,
+        "",
+    )
+    test(
+        "duplicate entry_ids create one query-log row",
+        db.execute("SELECT COUNT(*) FROM entry_recall_query_log WHERE entry_id = 1").fetchone()[0] == 1,
+        "",
+    )
     db.close()
 
 
@@ -2392,7 +2946,9 @@ def _test_recall_stats_unique_day(db_path):
     _briefing.DB_PATH = Path(db_path)
     db = sqlite3.connect(db_path)
     db.row_factory = sqlite3.Row
-    db.execute("INSERT INTO knowledge_entries (id, session_id, category, title, content) VALUES (1, 's', 'pattern', 'T', 'C')")
+    db.execute(
+        "INSERT INTO knowledge_entries (id, session_id, category, title, content) VALUES (1, 's', 'pattern', 'T', 'C')"
+    )
     db.commit()
 
     # Two calls on the same day — recall_days should be 1, recall_count should be 2.
@@ -2400,13 +2956,16 @@ def _test_recall_stats_unique_day(db_path):
     _briefing._upsert_entry_recall_stats(db, [1], "query-b")
 
     row = db.execute("SELECT recall_count, recall_days FROM entry_recall_stats WHERE entry_id = 1").fetchone()
-    test("recall_days=1 after two same-day recalls",
-         row is not None and row["recall_days"] == 1,
-         f"recall_days={row['recall_days'] if row else None!r}")
+    test(
+        "recall_days=1 after two same-day recalls",
+        row is not None and row["recall_days"] == 1,
+        f"recall_days={row['recall_days'] if row else None!r}",
+    )
 
     # Simulate calendar rollover: rename today's dedupe row to "yesterday" so the
     # next helper call sees a genuinely new calendar day and increments recall_days.
     import time as _time
+
     yesterday = _time.strftime("%Y-%m-%d", _time.gmtime(_time.time() - 86400))
     db.execute(
         "UPDATE entry_recall_day_log SET day = ? WHERE entry_id = 1",
@@ -2418,12 +2977,16 @@ def _test_recall_stats_unique_day(db_path):
     _briefing._upsert_entry_recall_stats(db, [1], "query-b")
 
     row2 = db.execute("SELECT recall_count, recall_days FROM entry_recall_stats WHERE entry_id = 1").fetchone()
-    test("recall_days=2 after second-day recall",
-         row2 is not None and row2["recall_days"] == 2,
-         f"recall_days={row2['recall_days'] if row2 else None!r}")
-    test("recall_count=3 after three total recalls",
-         row2 is not None and row2["recall_count"] == 3,
-         f"recall_count={row2['recall_count'] if row2 else None!r}")
+    test(
+        "recall_days=2 after second-day recall",
+        row2 is not None and row2["recall_days"] == 2,
+        f"recall_days={row2['recall_days'] if row2 else None!r}",
+    )
+    test(
+        "recall_count=3 after three total recalls",
+        row2 is not None and row2["recall_count"] == 3,
+        f"recall_count={row2['recall_count'] if row2 else None!r}",
+    )
     db.close()
 
 
@@ -2436,20 +2999,26 @@ def _test_recall_stats_unique_query(db_path):
     _briefing.DB_PATH = Path(db_path)
     db = sqlite3.connect(db_path)
     db.row_factory = sqlite3.Row
-    db.execute("INSERT INTO knowledge_entries (id, session_id, category, title, content) VALUES (1, 's', 'pattern', 'T', 'C')")
+    db.execute(
+        "INSERT INTO knowledge_entries (id, session_id, category, title, content) VALUES (1, 's', 'pattern', 'T', 'C')"
+    )
     db.commit()
 
-    _briefing._upsert_entry_recall_stats(db, [1], "query-x")   # new query → unique_queries = 1
-    _briefing._upsert_entry_recall_stats(db, [1], "query-x")   # same → still 1
-    _briefing._upsert_entry_recall_stats(db, [1], "query-y")   # new query → unique_queries = 2
+    _briefing._upsert_entry_recall_stats(db, [1], "query-x")  # new query → unique_queries = 1
+    _briefing._upsert_entry_recall_stats(db, [1], "query-x")  # same → still 1
+    _briefing._upsert_entry_recall_stats(db, [1], "query-y")  # new query → unique_queries = 2
 
     row = db.execute("SELECT unique_queries FROM entry_recall_stats WHERE entry_id = 1").fetchone()
-    test("unique_queries=2 after two distinct queries",
-         row is not None and row["unique_queries"] == 2,
-         f"unique_queries={row['unique_queries'] if row else None!r}")
-    test("entry_recall_query_log holds two distinct hashes",
-         db.execute("SELECT COUNT(*) FROM entry_recall_query_log WHERE entry_id = 1").fetchone()[0] == 2,
-         "")
+    test(
+        "unique_queries=2 after two distinct queries",
+        row is not None and row["unique_queries"] == 2,
+        f"unique_queries={row['unique_queries'] if row else None!r}",
+    )
+    test(
+        "entry_recall_query_log holds two distinct hashes",
+        db.execute("SELECT COUNT(*) FROM entry_recall_query_log WHERE entry_id = 1").fetchone()[0] == 2,
+        "",
+    )
     db.close()
 
 
@@ -2472,8 +3041,7 @@ def _test_recall_stats_fail_open_no_tables(db_path):
         raised = False
     except Exception:
         raised = True
-    test("_upsert_entry_recall_stats: no exception when tables absent",
-         not raised, "helper should be fail-open")
+    test("_upsert_entry_recall_stats: no exception when tables absent", not raised, "helper should be fail-open")
     db.close()
 
 
@@ -2489,25 +3057,31 @@ def _test_recall_stats_multiple_entries(db_path):
     for eid in (1, 2, 3):
         db.execute(
             "INSERT INTO knowledge_entries (id, session_id, category, title, content) VALUES (?, 's', 'pattern', 'T', 'C')",
-            (eid,)
+            (eid,),
         )
     db.commit()
 
     _briefing._upsert_entry_recall_stats(db, [1, 2, 3], "q1")
-    _briefing._upsert_entry_recall_stats(db, [1, 3], "q2")     # entry 2 not recalled this time
+    _briefing._upsert_entry_recall_stats(db, [1, 3], "q2")  # entry 2 not recalled this time
 
     row1 = db.execute("SELECT recall_count, unique_queries FROM entry_recall_stats WHERE entry_id = 1").fetchone()
     row2 = db.execute("SELECT recall_count, unique_queries FROM entry_recall_stats WHERE entry_id = 2").fetchone()
     row3 = db.execute("SELECT recall_count, unique_queries FROM entry_recall_stats WHERE entry_id = 3").fetchone()
-    test("entry 1: recall_count=2 unique_queries=2",
-         row1 is not None and row1["recall_count"] == 2 and row1["unique_queries"] == 2,
-         f"row1={dict(row1) if row1 else None!r}")
-    test("entry 2: recall_count=1 unique_queries=1 (not in second call)",
-         row2 is not None and row2["recall_count"] == 1 and row2["unique_queries"] == 1,
-         f"row2={dict(row2) if row2 else None!r}")
-    test("entry 3: recall_count=2 unique_queries=2",
-         row3 is not None and row3["recall_count"] == 2 and row3["unique_queries"] == 2,
-         f"row3={dict(row3) if row3 else None!r}")
+    test(
+        "entry 1: recall_count=2 unique_queries=2",
+        row1 is not None and row1["recall_count"] == 2 and row1["unique_queries"] == 2,
+        f"row1={dict(row1) if row1 else None!r}",
+    )
+    test(
+        "entry 2: recall_count=1 unique_queries=1 (not in second call)",
+        row2 is not None and row2["recall_count"] == 1 and row2["unique_queries"] == 1,
+        f"row2={dict(row2) if row2 else None!r}",
+    )
+    test(
+        "entry 3: recall_count=2 unique_queries=2",
+        row3 is not None and row3["recall_count"] == 2 and row3["unique_queries"] == 2,
+        f"row3={dict(row3) if row3 else None!r}",
+    )
     db.close()
 
 
@@ -2520,12 +3094,17 @@ def _test_recall_stats_new_tables_exist(db_path):
     db = sqlite3.connect(db_path)
     db.row_factory = sqlite3.Row
     tables = {r["name"] for r in db.execute("SELECT name FROM sqlite_master WHERE type='table'")}
-    test("entry_recall_stats table exists in test schema",
-         "entry_recall_stats" in tables, f"tables={sorted(tables)!r}")
-    test("entry_recall_day_log table exists in test schema",
-         "entry_recall_day_log" in tables, f"tables={sorted(tables)!r}")
-    test("entry_recall_query_log table exists in test schema",
-         "entry_recall_query_log" in tables, f"tables={sorted(tables)!r}")
+    test("entry_recall_stats table exists in test schema", "entry_recall_stats" in tables, f"tables={sorted(tables)!r}")
+    test(
+        "entry_recall_day_log table exists in test schema",
+        "entry_recall_day_log" in tables,
+        f"tables={sorted(tables)!r}",
+    )
+    test(
+        "entry_recall_query_log table exists in test schema",
+        "entry_recall_query_log" in tables,
+        f"tables={sorted(tables)!r}",
+    )
     db.close()
 
 
@@ -2541,9 +3120,11 @@ _ENTRY_RECALL_TABLES = ("entry_recall_stats", "entry_recall_day_log", "entry_rec
 
 def _assert_entry_recall_policies(policies: set, source_label: str):
     for tbl in _ENTRY_RECALL_TABLES:
-        test(f"{source_label}: {tbl} is upload_only",
-             (tbl, "upload_only", "") in policies,
-             f"policies={sorted(policies)!r}")
+        test(
+            f"{source_label}: {tbl} is upload_only",
+            (tbl, "upload_only", "") in policies,
+            f"policies={sorted(policies)!r}",
+        )
 
 
 @with_test_db
@@ -2631,17 +3212,17 @@ def _test_format_compact_no_repeated_prefix():
         "  Fix: use context managers or explicit close() in finally blocks."
     )
     data_noisy = {
-        "mistake": [{"id": 1, "title": long_title, "content": long_content,
-                     "tags": "python", "confidence": 1.0}],
-        "pattern": [], "decision": [], "tool": [],
+        "mistake": [{"id": 1, "title": long_title, "content": long_content, "tags": "python", "confidence": 1.0}],
+        "pattern": [],
+        "decision": [],
+        "tool": [],
     }
 
     output = _briefing._format_compact("fix briefing noise", data_noisy, [], categories)
 
     # The rendered mistake line must NOT contain the repeated prefix
     mistake_line = [ln for ln in output.splitlines() if ln.startswith("- Forgot")]
-    test("_format_compact: at least one mistake line rendered",
-         len(mistake_line) >= 1, f"output={output!r}")
+    test("_format_compact: at least one mistake line rendered", len(mistake_line) >= 1, f"output={output!r}")
     if mistake_line:
         line = mistake_line[0]
         # The key symptom: title text should not appear twice in the same line
@@ -2649,23 +3230,30 @@ def _test_format_compact_no_repeated_prefix():
         lower_line = line.lower()
         first_occ = lower_line.find(title_prefix)
         second_occ = lower_line.find(title_prefix, first_occ + 1) if first_occ != -1 else -1
-        test("_format_compact: title text does not appear twice in same line",
-             second_occ == -1,
-             f"line={line!r}")
+        test("_format_compact: title text does not appear twice in same line", second_occ == -1, f"line={line!r}")
 
     # When title and first_line differ meaningfully, both should still be shown.
     data_distinct = {
-        "mistake": [{"id": 2,
-                     "title": "Auth token expiry bug",
-                     "content": "JWT tokens were not refreshed; the fix is to call refresh() before expiry.",
-                     "tags": "", "confidence": 0.9}],
-        "pattern": [], "decision": [], "tool": [],
+        "mistake": [
+            {
+                "id": 2,
+                "title": "Auth token expiry bug",
+                "content": "JWT tokens were not refreshed; the fix is to call refresh() before expiry.",
+                "tags": "",
+                "confidence": 0.9,
+            }
+        ],
+        "pattern": [],
+        "decision": [],
+        "tool": [],
     }
     output_distinct = _briefing._format_compact("auth", data_distinct, [], categories)
     mistake_distinct = [ln for ln in output_distinct.splitlines() if ln.startswith("- Auth")]
-    test("_format_compact: distinct title+content still shows both parts",
-         mistake_distinct and ": " in mistake_distinct[0],
-         f"line={mistake_distinct[0] if mistake_distinct else '(none)'!r}")
+    test(
+        "_format_compact: distinct title+content still shows both parts",
+        mistake_distinct and ": " in mistake_distinct[0],
+        f"line={mistake_distinct[0] if mistake_distinct else '(none)'!r}",
+    )
 
 
 _test_format_compact_no_repeated_prefix()
@@ -2679,9 +3267,7 @@ print("\n🚦 learn.py — status-note title guard (issue #163)")
 def _test_learn_status_note_title_detector():
     """_is_status_note_title rejects operational progress-report titles."""
     # Must have the function exposed
-    test("learn has _is_status_note_title",
-         hasattr(_learn, "_is_status_note_title"),
-         "function missing from learn.py")
+    test("learn has _is_status_note_title", hasattr(_learn, "_is_status_note_title"), "function missing from learn.py")
     if not hasattr(_learn, "_is_status_note_title"):
         return
 
@@ -2695,18 +3281,16 @@ def _test_learn_status_note_title_detector():
         "Auth token expiry bug — tokens were not refreshed",
         "FTS5 sanitization must strip OR/AND operators before MATCH queries",
         "Atomic lock pattern using O_CREAT | O_EXCL prevents TOCTOU races",
-        "wave-shaped LED pattern looks nice",   # "wave" in context, no digit
+        "wave-shaped LED pattern looks nice",  # "wave" in context, no digit
     ]
 
     for title in reject_cases:
         reason = _learn._is_status_note_title(title)
-        test(f"_is_status_note_title rejects: '{title[:50]}…'",
-             bool(reason), f"reason={reason!r}")
+        test(f"_is_status_note_title rejects: '{title[:50]}…'", bool(reason), f"reason={reason!r}")
 
     for title in accept_cases:
         reason = _learn._is_status_note_title(title)
-        test(f"_is_status_note_title accepts: '{title[:50]}'",
-             not reason, f"unexpected rejection={reason!r}")
+        test(f"_is_status_note_title accepts: '{title[:50]}'", not reason, f"unexpected rejection={reason!r}")
 
 
 _test_learn_status_note_title_detector()
@@ -2727,35 +3311,38 @@ def _test_learn_status_note_guard_blocks_add_entry(db_path):
     sys.stderr = old_stderr
     stderr_out = captured_stderr.getvalue()
 
-    test("add_entry: status-note mistake title returns -1",
-         result == -1, f"result={result!r}")
-    test("add_entry: rejection message printed to stderr",
-         "REJECTED" in stderr_out or "status-note" in stderr_out,
-         f"stderr={stderr_out!r}")
+    test("add_entry: status-note mistake title returns -1", result == -1, f"result={result!r}")
+    test(
+        "add_entry: rejection message printed to stderr",
+        "REJECTED" in stderr_out or "status-note" in stderr_out,
+        f"stderr={stderr_out!r}",
+    )
 
     # skip_gate=True should bypass the guard
-    result_bypassed = _learn.add_entry(
-        "mistake", bad_title, "Some detail.", session_id="test-sess", skip_gate=True
-    )
-    test("add_entry: skip_gate=True bypasses status-note guard",
-         result_bypassed > 0, f"result={result_bypassed!r}")
+    result_bypassed = _learn.add_entry("mistake", bad_title, "Some detail.", session_id="test-sess", skip_gate=True)
+    test("add_entry: skip_gate=True bypasses status-note guard", result_bypassed > 0, f"result={result_bypassed!r}")
 
     # Legitimate mistake title must not be blocked
     result_legit = _learn.add_entry(
-        "mistake", "FTS5 MATCH query crashed when input contained bare AND operator",
+        "mistake",
+        "FTS5 MATCH query crashed when input contained bare AND operator",
         "The fix is to strip AND/OR/NOT before passing to FTS5 MATCH.",
         session_id="test-sess",
     )
-    test("add_entry: legitimate mistake title is NOT blocked",
-         result_legit > 0, f"result={result_legit!r}")
+    test("add_entry: legitimate mistake title is NOT blocked", result_legit > 0, f"result={result_legit!r}")
 
     # status-note guard only applies to mistake/pattern/discovery — decision is exempt
     result_decision = _learn.add_entry(
-        "decision", bad_title, "Decision content.",
+        "decision",
+        bad_title,
+        "Decision content.",
         session_id="test-sess",
     )
-    test("add_entry: status-note guard does NOT apply to 'decision' category",
-         result_decision > 0, f"result={result_decision!r}")
+    test(
+        "add_entry: status-note guard does NOT apply to 'decision' category",
+        result_decision > 0,
+        f"result={result_decision!r}",
+    )
 
 
 _test_learn_status_note_guard_blocks_add_entry()
@@ -2772,35 +3359,30 @@ def _test_issue163_word_trim():
 
     # Normal title (< limit): returned unchanged
     short = "Fence closer allowed unlimited leading whitespace"
-    test("_word_trim: short title unchanged", wt(short, 80) == short,
-         f"got={wt(short, 80)!r}")
+    test("_word_trim: short title unchanged", wt(short, 80) == short, f"got={wt(short, 80)!r}")
 
     # Simulates stored-truncated title ending with a 3-char fragment ("tou" from "touched")
     stored = "Wave14 verification is complete on this workstation for the runtime surfaces tou"
     assert len(stored) == 80, f"test fixture length changed: {len(stored)}"
     trimmed = wt(stored, 80)
-    test("_word_trim: mid-word suffix 'tou' stripped",
-         not trimmed.endswith("tou") and "surfaces" in trimmed,
-         f"got={trimmed!r}")
-    test("_word_trim: trimmed result shorter than original",
-         len(trimmed) < len(stored),
-         f"len={len(trimmed)}")
+    test(
+        "_word_trim: mid-word suffix 'tou' stripped",
+        not trimmed.endswith("tou") and "surfaces" in trimmed,
+        f"got={trimmed!r}",
+    )
+    test("_word_trim: trimmed result shorter than original", len(trimmed) < len(stored), f"len={len(trimmed)}")
 
     # Title longer than limit: hard-cut then word-trim
     long_title = "A" * 70 + " fragment"
     result = wt(long_title, 80)
-    test("_word_trim: over-limit title clamped to <= 80",
-         len(result) <= 80,
-         f"len={len(result)}")
+    test("_word_trim: over-limit title clamped to <= 80", len(result) <= 80, f"len={len(result)}")
 
     # Title of exactly limit chars ending with a complete word (≥5 chars) → unchanged
     # "undetected" is 10 chars, so the heuristic should not trim
     normal_80 = "Avoid skipping tests after code changes because bugs may slip through undetected"
     assert len(normal_80) == 80, f"test fixture length changed: {len(normal_80)}"
     result_80 = wt(normal_80, 80)
-    test("_word_trim: 80-char title ending with long word left untouched",
-         result_80 == normal_80,
-         f"got={result_80!r}")
+    test("_word_trim: 80-char title ending with long word left untouched", result_80 == normal_80, f"got={result_80!r}")
 
     # Regression guard (issue #163 wave5): 80-char title ending with 4-char complete
     # word "null" must NOT be stripped — only ≤3-char alpha fragments are candidates.
@@ -2809,9 +3391,11 @@ def _test_issue163_word_trim():
     if len(null_title) != 80:
         return
     result_null = wt(null_title, 80)
-    test("_word_trim: 80-char title ending with 4-char word 'null' left untouched",
-         result_null == null_title,
-         f"got={result_null!r}")
+    test(
+        "_word_trim: 80-char title ending with 4-char word 'null' left untouched",
+        result_null == null_title,
+        f"got={result_null!r}",
+    )
 
 
 _test_issue163_word_trim()
@@ -2832,104 +3416,149 @@ def _test_issue163_status_note_suppression():
     # Entries: one real mistake, one Wave-style status note
     data_mixed = {
         "mistake": [
-            {"id": 1, "title": "Real bug: forgot to close DB connection",
-             "content": "Always close the DB connection after use.", "tags": "", "confidence": 0.9},
+            {
+                "id": 1,
+                "title": "Real bug: forgot to close DB connection",
+                "content": "Always close the DB connection after use.",
+                "tags": "",
+                "confidence": 0.9,
+            },
             # Wave-style stored-truncated status note (the polluted rows from issue #163)
-            {"id": 2,
-             "title": "Wave19 verification is complete on this workstation for the runtime surfaces tou",
-             "content": "Wave19 verification is complete on this workstation for the runtime surfaces "
-                        "touched in this iteration:\n- sk watch: ...",
-             "tags": "", "confidence": 0.9},
-            {"id": 3,
-             "title": "Wave20 verification is complete on this workstation for the runtime surfaces tou",
-             "content": "Wave20 verification is complete on this workstation for the runtime surfaces "
-                        "touched in this iteration:\n- sk sync: ...",
-             "tags": "", "confidence": 0.9},
+            {
+                "id": 2,
+                "title": "Wave19 verification is complete on this workstation for the runtime surfaces tou",
+                "content": "Wave19 verification is complete on this workstation for the runtime surfaces "
+                "touched in this iteration:\n- sk watch: ...",
+                "tags": "",
+                "confidence": 0.9,
+            },
+            {
+                "id": 3,
+                "title": "Wave20 verification is complete on this workstation for the runtime surfaces tou",
+                "content": "Wave20 verification is complete on this workstation for the runtime surfaces "
+                "touched in this iteration:\n- sk sync: ...",
+                "tags": "",
+                "confidence": 0.9,
+            },
         ],
         "pattern": [],
     }
 
     output = _briefing._format_compact("test task", data_mixed, [], categories, None)
 
-    test("_format_compact[163]: real mistake entry is present",
-         "Real bug" in output,
-         f"output={output!r}")
-    test("_format_compact[163]: Wave19 status-note suppressed",
-         "Wave19 verification is complete" not in output,
-         f"output={output!r}")
-    test("_format_compact[163]: Wave20 status-note suppressed",
-         "Wave20 verification is complete" not in output,
-         f"output={output!r}")
+    test("_format_compact[163]: real mistake entry is present", "Real bug" in output, f"output={output!r}")
+    test(
+        "_format_compact[163]: Wave19 status-note suppressed",
+        "Wave19 verification is complete" not in output,
+        f"output={output!r}",
+    )
+    test(
+        "_format_compact[163]: Wave20 status-note suppressed",
+        "Wave20 verification is complete" not in output,
+        f"output={output!r}",
+    )
 
     # All-suppressed block: if only status notes in a category, the tag must not appear
     data_only_noise = {
         "mistake": [
-            {"id": 4,
-             "title": "Wave18 verification is complete on this workstation for the runtime surfaces tou",
-             "content": "Wave18 complete.", "tags": "", "confidence": 0.9},
+            {
+                "id": 4,
+                "title": "Wave18 verification is complete on this workstation for the runtime surfaces tou",
+                "content": "Wave18 complete.",
+                "tags": "",
+                "confidence": 0.9,
+            },
         ],
         "pattern": [],
     }
     output_noise = _briefing._format_compact("test", data_only_noise, [], categories, None)
-    test("_format_compact[163]: <mistakes> tag absent when all entries suppressed",
-         "<mistakes>" not in output_noise,
-         f"output_noise={output_noise!r}")
+    test(
+        "_format_compact[163]: <mistakes> tag absent when all entries suppressed",
+        "<mistakes>" not in output_noise,
+        f"output_noise={output_noise!r}",
+    )
 
     # Wave planner-recommendation entries flagged "(not yet implemented)" must be suppressed.
     # These are aspirational planning notes, not actionable past lessons (issue #163).
     data_planner = {
         "mistake": [
-            {"id": 1, "title": "Real bug: forgot to close DB connection",
-             "content": "Always close the DB connection after use.", "tags": "", "confidence": 0.9},
+            {
+                "id": 1,
+                "title": "Real bug: forgot to close DB connection",
+                "content": "Always close the DB connection after use.",
+                "tags": "",
+                "confidence": 0.9,
+            },
         ],
         "pattern": [
-            {"id": 10,
-             "title": "Wave11 planner recommendation (not yet implemented):",
-             "content": "**Wave11 planner recommendation (not yet implemented):**\n"
-                        "Do not target a full managed preToolUse routing flip yet.",
-             "tags": "python", "confidence": 1.0},
+            {
+                "id": 10,
+                "title": "Wave11 planner recommendation (not yet implemented):",
+                "content": "**Wave11 planner recommendation (not yet implemented):**\n"
+                "Do not target a full managed preToolUse routing flip yet.",
+                "tags": "python",
+                "confidence": 1.0,
+            },
         ],
     }
     output_planner = _briefing._format_compact(
-        "Implement P0 audio foundation slices in isolated worktree",
-        data_planner, [], categories, None)
-    test("_format_compact[163]: Wave planner '(not yet implemented)' suppressed",
-         "Wave11 planner recommendation" not in output_planner,
-         f"output_planner={output_planner!r}")
-    test("_format_compact[163]: real mistake still present after planner suppression",
-         "Real bug" in output_planner,
-         f"output_planner={output_planner!r}")
-    test("_format_compact[163]: <patterns> absent when only planner noise remains",
-         "<patterns>" not in output_planner,
-         f"output_planner={output_planner!r}")
+        "Implement P0 audio foundation slices in isolated worktree", data_planner, [], categories, None
+    )
+    test(
+        "_format_compact[163]: Wave planner '(not yet implemented)' suppressed",
+        "Wave11 planner recommendation" not in output_planner,
+        f"output_planner={output_planner!r}",
+    )
+    test(
+        "_format_compact[163]: real mistake still present after planner suppression",
+        "Real bug" in output_planner,
+        f"output_planner={output_planner!r}",
+    )
+    test(
+        "_format_compact[163]: <patterns> absent when only planner noise remains",
+        "<patterns>" not in output_planner,
+        f"output_planner={output_planner!r}",
+    )
 
     # [rust-wave…] tentacle titles must also be suppressed
     data_rust = {
         "mistake": [
-            {"id": 5,
-             "title": "[rust-wave7-hook-parity] Wave7 hook parity complete: all four sub-tasks",
-             "content": "Tentacle summary.", "tags": "", "confidence": 0.9},
+            {
+                "id": 5,
+                "title": "[rust-wave7-hook-parity] Wave7 hook parity complete: all four sub-tasks",
+                "content": "Tentacle summary.",
+                "tags": "",
+                "confidence": 0.9,
+            },
         ],
         "pattern": [],
     }
     output_rust = _briefing._format_compact("test", data_rust, [], categories, None)
-    test("_format_compact[163]: [rust-wave…] tentacle titles suppressed",
-         "[rust-wave7-hook-parity]" not in output_rust,
-         f"output_rust={output_rust!r}")
+    test(
+        "_format_compact[163]: [rust-wave…] tentacle titles suppressed",
+        "[rust-wave7-hook-parity]" not in output_rust,
+        f"output_rust={output_rust!r}",
+    )
 
     # Non-Wave title truncated mid-word must be word-trimmed in output
     data_long = {
         "mistake": [
-            {"id": 6,
-             "title": "Avoid using shutil.rmtree on git repos on Window",  # naturally 49 chars, clean
-             "content": "shutil.rmtree may fail on Windows with git repos.", "tags": "", "confidence": 0.9},
+            {
+                "id": 6,
+                "title": "Avoid using shutil.rmtree on git repos on Window",  # naturally 49 chars, clean
+                "content": "shutil.rmtree may fail on Windows with git repos.",
+                "tags": "",
+                "confidence": 0.9,
+            },
         ],
         "pattern": [],
     }
     output_long = _briefing._format_compact("test", data_long, [], categories, None)
-    test("_format_compact[163]: clean 49-char title not truncated",
-         "Avoid using shutil.rmtree on git repos on Window" in output_long,
-         f"output_long={output_long!r}")
+    test(
+        "_format_compact[163]: clean 49-char title not truncated",
+        "Avoid using shutil.rmtree on git repos on Window" in output_long,
+        f"output_long={output_long!r}",
+    )
 
 
 _test_issue163_status_note_suppression()
@@ -2959,8 +3588,7 @@ def _test_issue163_compact_cap():
     }
 
     def _mk_entry(eid, title, conf=0.9):
-        return {"id": eid, "title": title,
-                "content": f"Content for {title}.", "tags": "", "confidence": conf}
+        return {"id": eid, "title": title, "content": f"Content for {title}.", "tags": "", "confidence": conf}
 
     # 5 real mistake entries — compact must show only the first 3.
     data_many = {
@@ -2977,68 +3605,99 @@ def _test_issue163_compact_cap():
             _mk_entry(12, "Pattern three", 0.8),
             _mk_entry(13, "Pattern four should NOT appear", 0.7),
         ],
-        "decision": [], "tool": [],
+        "decision": [],
+        "tool": [],
     }
 
     output = _briefing._format_compact("test cap", data_many, [], categories)
     mistake_lines = [ln for ln in output.splitlines() if ln.startswith("- Real mistake")]
     pattern_lines = [ln for ln in output.splitlines() if ln.startswith("- Pattern")]
 
-    test("_format_compact[163-cap]: mistakes capped at 3",
-         len(mistake_lines) <= 3,
-         f"rendered {len(mistake_lines)} mistake lines: {mistake_lines}")
-    test("_format_compact[163-cap]: patterns capped at 3",
-         len(pattern_lines) <= 3,
-         f"rendered {len(pattern_lines)} pattern lines: {pattern_lines}")
-    test("_format_compact[163-cap]: 4th mistake entry absent",
-         not any("delta" in ln for ln in mistake_lines),
-         f"mistake_lines={mistake_lines}")
-    test("_format_compact[163-cap]: 4th pattern entry absent",
-         not any("four" in ln for ln in pattern_lines),
-         f"pattern_lines={pattern_lines}")
+    test(
+        "_format_compact[163-cap]: mistakes capped at 3",
+        len(mistake_lines) <= 3,
+        f"rendered {len(mistake_lines)} mistake lines: {mistake_lines}",
+    )
+    test(
+        "_format_compact[163-cap]: patterns capped at 3",
+        len(pattern_lines) <= 3,
+        f"rendered {len(pattern_lines)} pattern lines: {pattern_lines}",
+    )
+    test(
+        "_format_compact[163-cap]: 4th mistake entry absent",
+        not any("delta" in ln for ln in mistake_lines),
+        f"mistake_lines={mistake_lines}",
+    )
+    test(
+        "_format_compact[163-cap]: 4th pattern entry absent",
+        not any("four" in ln for ln in pattern_lines),
+        f"pattern_lines={pattern_lines}",
+    )
 
     # Relevance order: first 3 entries (highest confidence) must appear,
     # in the order they were provided (alpha, beta, gamma).
-    test("_format_compact[163-cap]: top-3 mistakes present (alpha)",
-         any("alpha" in ln for ln in mistake_lines),
-         f"mistake_lines={mistake_lines}")
-    test("_format_compact[163-cap]: top-3 mistakes present (beta)",
-         any("beta" in ln for ln in mistake_lines),
-         f"mistake_lines={mistake_lines}")
-    test("_format_compact[163-cap]: top-3 mistakes present (gamma)",
-         any("gamma" in ln for ln in mistake_lines),
-         f"mistake_lines={mistake_lines}")
+    test(
+        "_format_compact[163-cap]: top-3 mistakes present (alpha)",
+        any("alpha" in ln for ln in mistake_lines),
+        f"mistake_lines={mistake_lines}",
+    )
+    test(
+        "_format_compact[163-cap]: top-3 mistakes present (beta)",
+        any("beta" in ln for ln in mistake_lines),
+        f"mistake_lines={mistake_lines}",
+    )
+    test(
+        "_format_compact[163-cap]: top-3 mistakes present (gamma)",
+        any("gamma" in ln for ln in mistake_lines),
+        f"mistake_lines={mistake_lines}",
+    )
 
     # Status notes do NOT consume cap slots: 2 Wave status-notes + 4 real entries
     # → should yield 3 real entries rendered (not 1).
     data_with_noise = {
         "mistake": [
-            {"id": 20, "title": "Wave19 verification is complete for runtime surfaces touched in this iteration",
-             "content": "Wave19 done.", "tags": "", "confidence": 1.0},
-            {"id": 21, "title": "Wave20 verification is complete for runtime surfaces touched in this iteration",
-             "content": "Wave20 done.", "tags": "", "confidence": 1.0},
+            {
+                "id": 20,
+                "title": "Wave19 verification is complete for runtime surfaces touched in this iteration",
+                "content": "Wave19 done.",
+                "tags": "",
+                "confidence": 1.0,
+            },
+            {
+                "id": 21,
+                "title": "Wave20 verification is complete for runtime surfaces touched in this iteration",
+                "content": "Wave20 done.",
+                "tags": "",
+                "confidence": 1.0,
+            },
             _mk_entry(22, "Real mistake after noise one", 0.9),
             _mk_entry(23, "Real mistake after noise two", 0.8),
             _mk_entry(24, "Real mistake after noise three", 0.7),
             _mk_entry(25, "Real mistake after noise four should NOT appear", 0.6),
         ],
-        "pattern": [], "decision": [], "tool": [],
+        "pattern": [],
+        "decision": [],
+        "tool": [],
     }
 
     output_noise = _briefing._format_compact("test noise cap", data_with_noise, [], categories)
     real_lines = [ln for ln in output_noise.splitlines() if ln.startswith("- Real mistake after noise")]
 
-    test("_format_compact[163-cap]: status-notes don't consume cap slots — 3 real entries shown",
-         len(real_lines) == 3,
-         f"rendered {len(real_lines)} lines: {real_lines}")
-    test("_format_compact[163-cap]: 4th real entry after noise absent",
-         not any("four" in ln for ln in real_lines),
-         f"real_lines={real_lines}")
+    test(
+        "_format_compact[163-cap]: status-notes don't consume cap slots — 3 real entries shown",
+        len(real_lines) == 3,
+        f"rendered {len(real_lines)} lines: {real_lines}",
+    )
+    test(
+        "_format_compact[163-cap]: 4th real entry after noise absent",
+        not any("four" in ln for ln in real_lines),
+        f"real_lines={real_lines}",
+    )
 
 
 _test_issue163_compact_cap()
 
-print(f"\n{'='*50}")
+print(f"\n{'=' * 50}")
 print(f"Results: {PASS} passed, {FAIL} failed out of {PASS + FAIL} tests")
 
 if FAIL:

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -145,6 +145,18 @@ class TestSkDirectCommands(unittest.TestCase):
     def test_buglog_with_output_flag(self):
         self._assert_routes("buglog", "buglog-export.py", ["--output", "BUGLOG.md"])
 
+    def test_dream(self):
+        self._assert_routes("dream", "dream.py")
+
+    def test_dream_dry_run(self):
+        self._assert_routes("dream", "dream.py", ["--dry-run"])
+
+    def test_dream_json(self):
+        self._assert_routes("dream", "dream.py", ["--json"])
+
+    def test_dream_top_n(self):
+        self._assert_routes("dream", "dream.py", ["--top", "10"])
+
 
 class TestSkHooksCompat(unittest.TestCase):
     def test_hooks_run_drops_run_subcommand(self):
@@ -410,8 +422,11 @@ class TestSkNativeRoutingPreconditions(unittest.TestCase):
         hooks_json = TOOLS_DIR / "hooks" / "hooks.json"
         self.assertTrue(hooks_json.exists(), f"hooks/hooks.json not found: {hooks_json}")
         content = hooks_json.read_text(encoding="utf-8")
-        self.assertIn("sk hooks run", content,
-                      "hooks.json bash/powershell fields should use 'sk hooks run <event>' for native routing")
+        self.assertIn(
+            "sk hooks run",
+            content,
+            "hooks.json bash/powershell fields should use 'sk hooks run <event>' for native routing",
+        )
 
     def test_hooks_json_retains_python3_fallback(self):
         """The managed hooks.json must retain python3 hook_runner.py as a fallback."""
@@ -505,7 +520,6 @@ class TestSkNativeFeaturePreconditions(unittest.TestCase):
         )
 
 
-
 class TestBuglogTagFilterSemantics(unittest.TestCase):
     """Regression tests for issue #90: --limit must apply after --tags filtering.
 
@@ -522,9 +536,7 @@ class TestBuglogTagFilterSemantics(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not cls.BUGLOG_PATH.exists():
-            raise unittest.SkipTest(
-                "buglog-export.py not present — skipping filter-semantics tests"
-            )
+            raise unittest.SkipTest("buglog-export.py not present — skipping filter-semantics tests")
         spec = importlib.util.spec_from_file_location("buglog_export", cls.BUGLOG_PATH)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
@@ -555,8 +567,7 @@ class TestBuglogTagFilterSemantics(unittest.TestCase):
                 "INSERT INTO knowledge_entries "
                 "(id, title, content, tags, confidence, session_id, category) "
                 "VALUES (?, ?, ?, ?, ?, ?, 'mistake')",
-                (i + 1, f"High entry {i+1}", f"Content {i+1}", "python,database",
-                 1.0 - i * 0.01, f"sess-{i+1}"),
+                (i + 1, f"High entry {i + 1}", f"Content {i + 1}", "python,database", 1.0 - i * 0.01, f"sess-{i + 1}"),
             )
         # One entry WITH the target tag at lower confidence (ranked 4th — below limit=3).
         db.execute(
@@ -594,7 +605,8 @@ class TestBuglogTagFilterSemantics(unittest.TestCase):
             filtered = [e for e in entries if "docker" in (e.get("tags") or "").lower()]
             # False-negative: the docker entry was excluded by LIMIT before filtering.
             self.assertEqual(
-                filtered, [],
+                filtered,
+                [],
                 "Reproducer: old LIMIT-first logic produces an empty result (false-negative)",
             )
         finally:
@@ -609,9 +621,7 @@ class TestBuglogTagFilterSemantics(unittest.TestCase):
         """
         db = self._make_db()
         try:
-            results = self.buglog._fetch_mistakes(
-                db, limit=3, tags_filter=["docker"], min_confidence=0.0
-            )
+            results = self.buglog._fetch_mistakes(db, limit=3, tags_filter=["docker"], min_confidence=0.0)
         finally:
             db.close()
         titles = [r["title"] for r in results]
@@ -647,7 +657,7 @@ class TestBuglogTagFilterSemantics(unittest.TestCase):
                 "INSERT INTO knowledge_entries "
                 "(id, title, content, tags, confidence, session_id, category) "
                 "VALUES (?, ?, ?, ?, ?, ?, 'mistake')",
-                (i + 1, f"Top {i+1}", "body", "python", 1.0 - i * 0.01, f"s{i}"),
+                (i + 1, f"Top {i + 1}", "body", "python", 1.0 - i * 0.01, f"s{i}"),
             )
         # 3 low-confidence tagged entries.
         for j in range(3):
@@ -660,9 +670,7 @@ class TestBuglogTagFilterSemantics(unittest.TestCase):
         db.commit()
         try:
             # limit=2 with tags=['docker'] — should return the 2 highest-confidence docker entries.
-            results = self.buglog._fetch_mistakes(
-                db, limit=2, tags_filter=["docker"], min_confidence=0.0
-            )
+            results = self.buglog._fetch_mistakes(db, limit=2, tags_filter=["docker"], min_confidence=0.0)
         finally:
             db.close()
         self.assertEqual(len(results), 2, "limit=2 should cap filtered results at 2")
@@ -675,9 +683,7 @@ class TestBuglogTagFilterSemantics(unittest.TestCase):
         """Without --tags, LIMIT is pushed into SQL (efficiency path); result count is correct."""
         db = self._make_db()
         try:
-            results = self.buglog._fetch_mistakes(
-                db, limit=2, tags_filter=[], min_confidence=0.0
-            )
+            results = self.buglog._fetch_mistakes(db, limit=2, tags_filter=[], min_confidence=0.0)
         finally:
             db.close()
         self.assertEqual(len(results), 2, "Without tags, limit=2 should return exactly 2 entries")
@@ -690,9 +696,7 @@ class TestBuglogTagFilterSemantics(unittest.TestCase):
         """
         db = self._make_db()
         try:
-            results = self.buglog._fetch_mistakes(
-                db, limit=200, tags_filter=["doc"], min_confidence=0.0
-            )
+            results = self.buglog._fetch_mistakes(db, limit=200, tags_filter=["doc"], min_confidence=0.0)
         finally:
             db.close()
         titles = [r["title"] for r in results]
@@ -717,9 +721,7 @@ class TestBuglogTagFilterSemantics(unittest.TestCase):
 
         db = self._make_db()
         try:
-            results = self.buglog._fetch_mistakes(
-                db, limit=200, tags_filter=tags_filter, min_confidence=0.0
-            )
+            results = self.buglog._fetch_mistakes(db, limit=200, tags_filter=tags_filter, min_confidence=0.0)
         finally:
             db.close()
         # Only the docker-tagged entry should be returned, not all 4 entries.
@@ -737,12 +739,23 @@ class TestBuglogTagFilterSemantics(unittest.TestCase):
         A timestamp that changes every run defeats this contract.
         """
         entries = [
-            {"id": 1, "title": "T", "content": "C", "tags": "x", "confidence": 0.9,
-             "session_id": "abc12345", "occurrence_count": 1, "wing": "", "room": "", "source": "copilot"}
+            {
+                "id": 1,
+                "title": "T",
+                "content": "C",
+                "tags": "x",
+                "confidence": 0.9,
+                "session_id": "abc12345",
+                "occurrence_count": 1,
+                "wing": "",
+                "room": "",
+                "source": "copilot",
+            }
         ]
         md = self.buglog._render_markdown(entries)
         # Must not contain any timestamp pattern like 2024-01-01T00:00:00Z
         import re
+
         self.assertIsNone(
             re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", md),
             "Markdown output must not contain a timestamp (breaks git-diff determinism)",
@@ -759,9 +772,7 @@ class TestBuglogArgValidation(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not cls.BUGLOG_PATH.exists():
-            raise unittest.SkipTest(
-                "buglog-export.py not present — skipping arg-validation tests"
-            )
+            raise unittest.SkipTest("buglog-export.py not present — skipping arg-validation tests")
         spec = importlib.util.spec_from_file_location("buglog_export_val", cls.BUGLOG_PATH)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
@@ -770,13 +781,13 @@ class TestBuglogArgValidation(unittest.TestCase):
     def _call_main(self, argv):
         """Call main() and return (exit_code, stderr_output).  Patches _get_db to avoid needing a real DB."""
         import io
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import patch
+
         fake_db = MagicMock()
         fake_db.execute.return_value.fetchall.return_value = []
         stderr_capture = io.StringIO()
         try:
-            with patch.object(self.buglog, "_get_db", return_value=fake_db), \
-                 patch("sys.stderr", stderr_capture):
+            with patch.object(self.buglog, "_get_db", return_value=fake_db), patch("sys.stderr", stderr_capture):
                 rc = self.buglog.main(argv)
             return rc, stderr_capture.getvalue()
         except SystemExit as exc:
@@ -810,4 +821,3 @@ class TestBuglogArgValidation(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary
- add `dream.py` with weighted dream-score calculation, persistence, and `sk dream --dry-run`
- mark `entry_dream_scores` as local-only on both Python and Rust sync surfaces
- add docs and regression coverage for naive timestamps and weight normalization

## Verification
- `python test_security.py`
- `python test_fixes.py`
- `python tests/test_dream_score.py`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

Closes #159