### PR TITLE
feat: inject MEMORY.md into sessionStart briefing

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -223,7 +223,7 @@ sk scout status                     # scout-status.py
 
 | Event | Native behavior |
 |-------|----------------|
-| `sessionStart` | `AutoBriefingRule` (spawns `briefing.py`, 10s timeout, signs HMAC markers) + `IntegrityRule` (SHA256 manifest) |
+| `sessionStart` | `AutoBriefingRule` (spawns `briefing.py`, 10s timeout, signs HMAC markers, injects MEMORY.md) + `IntegrityRule` (SHA256 manifest) |
 | `sessionEnd` | `SessionEndRule` (marker cleanup + `session.log`) + `RecurrenceDetectorRule` |
 | `preToolUse` | All deny-capable rules active: `subagent-git-guard`, `block-edit-dist`, `block-unsafe-html`, `pnpm-lockfile-guard`, `read-before-edit`, `VerificationGatePreRule`, `EnforceBriefingRule`, `EnforceLearnRule`, `TentacleEnforceRule`, `SyntaxGateRule` |
 | `postToolUse` | All 7 rules: `TrackEditsRule`, `LearnReminderRule`, `TestReminderRule`, `NextjsTypecheckReminderRule`, `VerificationGatePostRule`, `ReadBeforeEditRule`, `TentacleSuggestRule` |
@@ -235,13 +235,65 @@ sk scout status                     # scout-status.py
 > Full rule inventory, HMAC details, and platform event notes: **[docs/HOOKS.md](HOOKS.md)**
 
 ```bash
-sk hooks run sessionStart           # AutoBriefingRule + IntegrityRule
+sk hooks run sessionStart           # AutoBriefingRule + IntegrityRule (+ MEMORY.md injection)
 sk hooks run preToolUse             # all deny rules (Rust binary); hook_runner.py (Python shim)
 sk hooks run postToolUse            # all 7 postToolUse rules
 sk hooks run sessionEnd             # SessionEndRule + RecurrenceDetectorRule
 sk hooks run agentStop              # marker-cleanup
 sk hooks run subagentStop           # marker-cleanup
 sk hooks run errorOccurred          # native FTS5; query-session.py fallback if DB unavailable
+```
+
+#### MEMORY.md injection at `sessionStart`
+
+When `MEMORY.md` exists in the project root (written by `sk dream`), its promoted-knowledge
+content is automatically **prepended** to every `sessionStart` auto-briefing so the AI sees the
+highest-value knowledge entries before other briefing output.
+
+**Guards — injection is skipped (graceful no-op) when:**
+
+| Guard | Default |
+|-------|---------|
+| `memory_inject_enabled: false` in `~/.copilot/hooks-config.json` | Disabled entirely |
+| File is older than max-age | Default: 1 day |
+| File does not exist | Always silently skipped |
+| Effective content is empty | Silently skipped |
+
+**Token budget:** content is truncated to an approximate token budget (default 500 tokens,
+estimated at 4 chars/token).  Truncated content ends with `… (truncated to token budget)`.
+
+**Config keys (`~/.copilot/hooks-config.json`):**
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `memory_inject_enabled` | bool | `true` | Set to `false` to disable injection entirely |
+| `memory_inject_max_age_days` | number | `1` | Max MEMORY.md age in days (e.g. `0.5` = 12 h) |
+| `memory_inject_max_tokens` | int | `500` | Approximate token cap for injected content |
+
+**Example `~/.copilot/hooks-config.json`:**
+
+```json
+{
+  "memory_inject_enabled": true,
+  "memory_inject_max_age_days": 1,
+  "memory_inject_max_tokens": 500
+}
+```
+
+**Example — disable injection:**
+
+```bash
+# Add to ~/.copilot/hooks-config.json:
+# { "memory_inject_enabled": false }
+```
+
+**Example — keep injection fresh (12-hour max age):**
+
+```json
+{
+  "memory_inject_enabled": true,
+  "memory_inject_max_age_days": 0.5
+}
 ```
 
 The managed `hooks.json` prefers `sk hooks run <event>` when `sk` is in PATH. Bash falls back to `python3 hook_runner.py`; PowerShell falls back to `python hook_runner.py`. Install the launcher first: `python install.py --install-sk`.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -250,12 +250,18 @@ When `MEMORY.md` exists in the project root (written by `sk dream`), its promote
 content is automatically **prepended** to every `sessionStart` auto-briefing so the AI sees the
 highest-value knowledge entries before other briefing output.
 
+**Both runtime paths inject MEMORY.md:**
+- **Rust-binary installs** (`sk hooks run sessionStart`): native `AutoBriefingRule` in
+  `sk-rust/src/hooks/rules.rs` handles injection directly.
+- **Python `sk.py` shim / non-binary installs**: `hook_runner.py` delegates to
+  `hooks/rules/briefing.py::AutoBriefingRule`.
+
 **Guards — injection is skipped (graceful no-op) when:**
 
-| Guard | Default |
-|-------|---------|
-| `memory_inject_enabled: false` in `~/.copilot/hooks-config.json` | Disabled entirely |
-| File is older than max-age | Default: 1 day |
+| Guard | Behaviour |
+|-------|-----------|
+| `memory_inject_enabled` explicitly set to `false` in `~/.copilot/hooks-config.json` | Explicit opt-out; injection is **on by default** |
+| File is older than max-age | Default max age: 1 day |
 | File does not exist | Always silently skipped |
 | Effective content is empty | Silently skipped |
 

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -275,18 +275,22 @@ Fields written by the scheduler:
 ## sessionStart Auto-Injection
 
 `MEMORY.md` is automatically **prepended** into every `sessionStart` auto-briefing by
-`AutoBriefingRule` (in `hooks/rules/briefing.py`) and by the standalone
+`AutoBriefingRule` — natively in `sk-rust/src/hooks/rules.rs` for Rust-binary installs,
+and via `hooks/rules/briefing.py` for the Python fallback — and by the standalone
 `hooks/auto-briefing.py` script.  This surfaces the most valuable promoted entries
 before other briefing output at the beginning of every AI session without requiring
 the operator to run an extra command.
+
+Both runtime paths implement the same semantics: config-guard, max-age check, token
+budget cap, and graceful no-op behavior.
 
 ### Guards
 
 Injection is a **graceful no-op** when any of the following apply:
 
-| Guard | Default |
-|-------|---------|
-| `memory_inject_enabled: false` in `~/.copilot/hooks-config.json` | Explicitly disabled |
+| Guard | Behaviour |
+|-------|-----------|
+| `memory_inject_enabled` explicitly set to `false` in `~/.copilot/hooks-config.json` | Explicit opt-out; injection is **on by default** |
 | `MEMORY.md` does not exist in the project root | File missing |
 | `MEMORY.md` is older than *max-age* | Default: 1 day |
 | Effective content is empty | Silently skipped |

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -271,3 +271,65 @@ Fields written by the scheduler:
   daemon re-reads `sync-config.json` at the start of every loop iteration, so
   changes made with `python sync-config.py` are picked up automatically on the
   next cycle.
+
+## sessionStart Auto-Injection
+
+`MEMORY.md` is automatically **prepended** into every `sessionStart` auto-briefing by
+`AutoBriefingRule` (in `hooks/rules/briefing.py`) and by the standalone
+`hooks/auto-briefing.py` script.  This surfaces the most valuable promoted entries
+before other briefing output at the beginning of every AI session without requiring
+the operator to run an extra command.
+
+### Guards
+
+Injection is a **graceful no-op** when any of the following apply:
+
+| Guard | Default |
+|-------|---------|
+| `memory_inject_enabled: false` in `~/.copilot/hooks-config.json` | Explicitly disabled |
+| `MEMORY.md` does not exist in the project root | File missing |
+| `MEMORY.md` is older than *max-age* | Default: 1 day |
+| Effective content is empty | Silently skipped |
+
+### Token budget
+
+Injected content is truncated to an approximate token budget (1 token ≈ 4 chars).
+The default budget is **500 tokens**.  Truncated content ends with
+`… (truncated to token budget)`.
+
+### Configuration
+
+Config is stored in `~/.copilot/hooks-config.json` using the exact key names from
+issue #161:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `memory_inject_enabled` | bool | `true` | Set to `false` to skip injection |
+| `memory_inject_max_age_days` | number | `1` | Max file age in days (e.g. `0.5` = 12 h) |
+| `memory_inject_max_tokens` | int | `500` | Approximate token cap |
+
+Example `~/.copilot/hooks-config.json`:
+
+```json
+{
+  "memory_inject_enabled": true,
+  "memory_inject_max_age_days": 1,
+  "memory_inject_max_tokens": 500
+}
+```
+
+### Typical workflow
+
+```bash
+# 1. Run dream to promote entries into MEMORY.md
+sk dream
+
+# 2. Start a new session — MEMORY.md prepended automatically at sessionStart
+#    (hook_runner dispatches AutoBriefingRule → _load_memory_md())
+
+# 3. To force a refresh of injected content mid-day:
+sk dream               # re-scores and overwrites MEMORY.md
+
+# 4. To opt out permanently, set in ~/.copilot/hooks-config.json:
+#    { "memory_inject_enabled": false }
+```

--- a/hooks/auto-briefing.py
+++ b/hooks/auto-briefing.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 if os.name == "nt":
@@ -30,6 +31,79 @@ BRIEFING = TOOLS_DIR / "briefing.py"
 CODEBASE_MAP = TOOLS_DIR / "codebase-map.py"
 MARKERS_DIR = Path.home() / ".copilot" / "markers"
 MARKER = MARKERS_DIR / "briefing-done"
+
+# MEMORY.md injection config (mirrors hooks/rules/briefing.py)
+# Primary config: ~/.copilot/hooks-config.json using issue #161 key names:
+#   memory_inject_enabled      — bool, default true
+#   memory_inject_max_tokens   — int, default 500
+#   memory_inject_max_age_days — int/float, default 1
+_HOOKS_CONFIG_PATH = Path.home() / ".copilot" / "hooks-config.json"
+_DEFAULT_MAX_AGE_DAYS = 1    # 1 day
+_DEFAULT_TOKEN_BUDGET = 500  # approximate tokens
+
+
+def _load_hooks_config() -> dict:
+    """Load ~/.copilot/hooks-config.json; return empty dict on any error."""
+    try:
+        if _HOOKS_CONFIG_PATH.is_file():
+            return json.loads(_HOOKS_CONFIG_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    return {}
+
+
+def _load_memory_md(cwd=None, max_age_secs=None, token_budget=None):
+    """Load MEMORY.md for injection. Returns content string or None (no-op).
+
+    Primary config keys (``~/.copilot/hooks-config.json``):
+      memory_inject_enabled      — bool, default true
+      memory_inject_max_tokens   — int, default 500
+      memory_inject_max_age_days — int/float, default 1
+    """
+    cfg = _load_hooks_config()
+
+    if not cfg.get("memory_inject_enabled", True):
+        return None
+
+    if max_age_secs is None:
+        if "memory_inject_max_age_days" in cfg:
+            try:
+                max_age_secs = float(cfg["memory_inject_max_age_days"]) * 86400
+            except (ValueError, TypeError):
+                max_age_secs = _DEFAULT_MAX_AGE_DAYS * 86400
+        else:
+            max_age_secs = _DEFAULT_MAX_AGE_DAYS * 86400
+
+    if token_budget is None:
+        if "memory_inject_max_tokens" in cfg:
+            try:
+                token_budget = int(cfg["memory_inject_max_tokens"])
+            except (ValueError, TypeError):
+                token_budget = _DEFAULT_TOKEN_BUDGET
+        else:
+            token_budget = _DEFAULT_TOKEN_BUDGET
+
+    memory_path = Path(cwd or Path.cwd()) / "MEMORY.md"
+    if not memory_path.is_file():
+        return None
+
+    try:
+        age_secs = time.time() - memory_path.stat().st_mtime
+        if age_secs > max_age_secs:
+            return None
+
+        content = memory_path.read_text(encoding="utf-8", errors="replace").strip()
+        if not content:
+            return None
+
+        char_limit = max(token_budget * 4, 1)
+        if len(content) > char_limit:
+            content = content[:char_limit].rstrip()
+            content += "\n\u2026 (truncated to token budget)"
+
+        return content
+    except Exception:
+        return None
 
 
 def _try_refresh_codebase_map():
@@ -85,6 +159,19 @@ def main():
 
     print(f"\n  📋 Session briefing for: {project}")
     print("  ─────────────────────────────────")
+
+    # PREPEND: inject MEMORY.md content before briefing subprocess output
+    memory_content = _load_memory_md()
+    if memory_content:
+        print("\n  📌 MEMORY.md (promoted knowledge):")
+        for mem_line in memory_content.splitlines():
+            print(f"  {mem_line}")
+        print("  ─────────────────────────────────")
+
+    # Flush buffered output before subprocess inherits stdout.
+    # Without this, piped capture can observe subprocess bytes before
+    # the MEMORY.md print() buffer is drained, violating the prepend contract.
+    sys.stdout.flush()
 
     try:
         subprocess.run(

--- a/hooks/auto-briefing.py
+++ b/hooks/auto-briefing.py
@@ -38,7 +38,7 @@ MARKER = MARKERS_DIR / "briefing-done"
 #   memory_inject_max_tokens   — int, default 500
 #   memory_inject_max_age_days — int/float, default 1
 _HOOKS_CONFIG_PATH = Path.home() / ".copilot" / "hooks-config.json"
-_DEFAULT_MAX_AGE_DAYS = 1    # 1 day
+_DEFAULT_MAX_AGE_DAYS = 1  # 1 day
 _DEFAULT_TOKEN_BUDGET = 500  # approximate tokens
 
 

--- a/hooks/rules/briefing.py
+++ b/hooks/rules/briefing.py
@@ -16,7 +16,7 @@ from .common import MARKERS_DIR, TOOLS_DIR, bash_writes_source_files, deny, info
 #   memory_inject_max_tokens   — int, default 500
 #   memory_inject_max_age_days — int/float, default 1
 _HOOKS_CONFIG_PATH = Path.home() / ".copilot" / "hooks-config.json"
-_DEFAULT_MAX_AGE_DAYS = 1    # 1 day
+_DEFAULT_MAX_AGE_DAYS = 1  # 1 day
 _DEFAULT_TOKEN_BUDGET = 500  # approximate tokens (1 token ≈ 4 chars)
 
 
@@ -95,6 +95,7 @@ def _load_memory_md(cwd=None, max_age_secs=None, token_budget=None):
         return content
     except Exception:
         return None
+
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 try:
@@ -179,7 +180,9 @@ class AutoBriefingRule(Rule):
             lines.append("\n  \U0001f4cc MEMORY.md (promoted knowledge):")
             for mem_line in memory_content.splitlines():
                 lines.append(f"  {mem_line}")
-            lines.append("  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500")
+            lines.append(
+                "  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500"
+            )
 
         # Run briefing subprocess, capturing output so it follows MEMORY.md in the message
         try:

--- a/hooks/rules/briefing.py
+++ b/hooks/rules/briefing.py
@@ -1,5 +1,6 @@
 """Briefing enforcement rules."""
 
+import json
 import os
 import subprocess
 import sys
@@ -8,6 +9,92 @@ from pathlib import Path
 
 from . import Rule
 from .common import MARKERS_DIR, TOOLS_DIR, bash_writes_source_files, deny, info
+
+# ── MEMORY.md injection config ──────────────────────────────────────────────
+# Primary config: ~/.copilot/hooks-config.json using keys defined in issue #161:
+#   memory_inject_enabled      — bool, default true
+#   memory_inject_max_tokens   — int, default 500
+#   memory_inject_max_age_days — int/float, default 1
+_HOOKS_CONFIG_PATH = Path.home() / ".copilot" / "hooks-config.json"
+_DEFAULT_MAX_AGE_DAYS = 1    # 1 day
+_DEFAULT_TOKEN_BUDGET = 500  # approximate tokens (1 token ≈ 4 chars)
+
+
+def _load_hooks_config() -> dict:
+    """Load ~/.copilot/hooks-config.json; return empty dict on any error."""
+    try:
+        if _HOOKS_CONFIG_PATH.is_file():
+            return json.loads(_HOOKS_CONFIG_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    return {}
+
+
+def _load_memory_md(cwd=None, max_age_secs=None, token_budget=None):
+    """Load MEMORY.md content for injection into sessionStart auto-briefing.
+
+    Returns a (possibly truncated) string when the file is fresh enough and
+    injection is enabled, or ``None`` for a graceful no-op when:
+
+    * ``memory_inject_enabled`` is ``false`` in ``~/.copilot/hooks-config.json``, or
+    * ``MEMORY.md`` does not exist in the project root (``cwd``), or
+    * ``MEMORY.md`` is older than the configured max age (default 1 day).
+
+    Primary config keys (``~/.copilot/hooks-config.json``):
+      memory_inject_enabled      — bool, default true
+      memory_inject_max_tokens   — int, default 500
+      memory_inject_max_age_days — int/float, default 1
+
+    The ``max_age_secs`` and ``token_budget`` keyword arguments override the
+    config file values when provided; they exist for direct test use only.
+    """
+    cfg = _load_hooks_config()
+
+    # memory_inject_enabled is the primary on/off switch
+    if not cfg.get("memory_inject_enabled", True):
+        return None
+
+    if max_age_secs is None:
+        if "memory_inject_max_age_days" in cfg:
+            try:
+                max_age_secs = float(cfg["memory_inject_max_age_days"]) * 86400
+            except (ValueError, TypeError):
+                max_age_secs = _DEFAULT_MAX_AGE_DAYS * 86400
+        else:
+            max_age_secs = _DEFAULT_MAX_AGE_DAYS * 86400
+
+    if token_budget is None:
+        if "memory_inject_max_tokens" in cfg:
+            try:
+                token_budget = int(cfg["memory_inject_max_tokens"])
+            except (ValueError, TypeError):
+                token_budget = _DEFAULT_TOKEN_BUDGET
+        else:
+            token_budget = _DEFAULT_TOKEN_BUDGET
+
+    memory_path = Path(cwd or Path.cwd()) / "MEMORY.md"
+
+    if not memory_path.is_file():
+        return None
+
+    try:
+        age_secs = time.time() - memory_path.stat().st_mtime
+        if age_secs > max_age_secs:
+            return None
+
+        content = memory_path.read_text(encoding="utf-8", errors="replace").strip()
+        if not content:
+            return None
+
+        # Approximate token budget: 1 token ≈ 4 characters
+        char_limit = max(token_budget * 4, 1)
+        if len(content) > char_limit:
+            content = content[:char_limit].rstrip()
+            content += "\n\u2026 (truncated to token budget)"
+
+        return content
+    except Exception:
+        return None
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 try:
@@ -86,12 +173,27 @@ class AutoBriefingRule(Rule):
             "  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
         ]
 
+        # PREPEND: inject MEMORY.md content before briefing subprocess output
+        memory_content = _load_memory_md()
+        if memory_content:
+            lines.append("\n  \U0001f4cc MEMORY.md (promoted knowledge):")
+            for mem_line in memory_content.splitlines():
+                lines.append(f"  {mem_line}")
+            lines.append("  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500")
+
+        # Run briefing subprocess, capturing output so it follows MEMORY.md in the message
         try:
-            subprocess.run(
+            briefing_proc = subprocess.run(
                 [sys.executable, str(BRIEFING_SCRIPT), project, "--budget", "2000"],
                 timeout=10,
+                stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
             )
+            if briefing_proc.stdout.strip():
+                lines.append(briefing_proc.stdout.rstrip())
         except subprocess.TimeoutExpired:
             lines.append("  \u23f1 Briefing timed out (10s)")
         except Exception:

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -294,12 +294,20 @@ fn load_memory_md(cwd: Option<&Path>) -> Option<String> {
     }
 
     // Age guard: skip if the file is older than max_age_secs.
+    // `duration_since` returns Err when mtime is in the future (clock skew);
+    // treat that as age = 0 (fresh), matching the Python hook behaviour where
+    //   age_secs = time.time() - mtime  →  negative  →  not > max_age_secs.
     let age_ok = memory_path
         .metadata()
         .ok()
         .and_then(|m| m.modified().ok())
-        .and_then(|mtime| SystemTime::now().duration_since(mtime).ok())
-        .map(|age| age.as_secs() <= max_age_secs)
+        .map(|mtime| {
+            SystemTime::now()
+                .duration_since(mtime)
+                .unwrap_or(Duration::ZERO)
+                .as_secs()
+                <= max_age_secs
+        })
         .unwrap_or(false);
     if !age_ok {
         return None;
@@ -4929,6 +4937,55 @@ mod tests {
         assert!(
             std::str::from_utf8(text.as_bytes()).is_ok(),
             "truncated output must be valid UTF-8"
+        );
+
+        match old_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match old_up {
+            Some(v) => std::env::set_var("USERPROFILE", v),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Regression: a future mtime (clock skew) must be treated as fresh, not stale.
+    ///
+    /// Python behaviour:
+    ///   `age_secs = time.time() - mtime`  →  negative when mtime is future
+    ///   `if age_secs > max_age_secs`      →  False  →  file is fresh
+    ///
+    /// Previous Rust behaviour:
+    ///   `duration_since(future_mtime).ok()` → `None` → `unwrap_or(false)` → stale
+    ///   The file was silently skipped even though it was not old.
+    #[test]
+    fn memory_inject_future_mtime_treated_as_fresh() {
+        use std::fs::{File, FileTimes};
+        let _guard = env_lock();
+        let tmp = std::env::temp_dir().join("sk_mem_inject_future_mtime");
+        let copilot_dir = tmp.join(".copilot");
+        let _ = fs::create_dir_all(&copilot_dir);
+        let memory_path = tmp.join("MEMORY.md");
+        fs::write(&memory_path, "## Future mtime\n- content\n").unwrap();
+
+        // Set the file's mtime 30 seconds into the future to simulate clock skew.
+        let future_mtime = SystemTime::now() + Duration::from_secs(30);
+        let file = File::options().write(true).open(&memory_path).unwrap();
+        let times = FileTimes::new().set_modified(future_mtime);
+        file.set_times(times).unwrap();
+        drop(file);
+
+        let old_home = std::env::var("HOME").ok();
+        let old_up = std::env::var("USERPROFILE").ok();
+        std::env::set_var("HOME", &tmp);
+        std::env::set_var("USERPROFILE", &tmp);
+
+        // Must return Some — future mtime is treated as fresh (age = 0).
+        let result = load_memory_md(Some(&tmp));
+        assert!(
+            result.is_some(),
+            "load_memory_md must treat a future mtime as fresh (not stale); got None"
         );
 
         match old_home {

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -319,18 +319,20 @@ fn load_memory_md(cwd: Option<&Path>) -> Option<String> {
         return None;
     }
 
-    // Approximate token budget: 1 token ≈ 4 characters.
+    // Approximate token budget: 1 token ≈ 4 Unicode characters (matching
+    // Python's len() semantics which counts Unicode code points, not bytes).
     let char_limit = ((token_budget * 4) as usize).max(1);
-    if trimmed.len() > char_limit {
-        // Walk back to the nearest UTF-8 char boundary at or before
-        // char_limit.  String::truncate panics when the index falls inside
-        // a multi-byte codepoint, so this prevents a runtime panic on
-        // non-ASCII MEMORY.md content (issue #161 regression fix).
-        let mut safe_limit = char_limit;
-        while safe_limit > 0 && !trimmed.is_char_boundary(safe_limit) {
-            safe_limit -= 1;
-        }
-        trimmed.truncate(safe_limit);
+    if trimmed.chars().count() > char_limit {
+        // Find the byte offset of the char_limit-th Unicode scalar so that
+        // String::truncate lands on a valid char boundary.  This preserves
+        // UTF-8 safety while counting characters rather than bytes, matching
+        // Python's character-count semantics for non-ASCII content (issue #161).
+        let byte_offset = trimmed
+            .char_indices()
+            .nth(char_limit)
+            .map(|(i, _)| i)
+            .unwrap_or(trimmed.len());
+        trimmed.truncate(byte_offset);
         trimmed = trimmed.trim_end().to_string();
         trimmed.push_str("\n\u{2026} (truncated to token budget)");
     }
@@ -4698,6 +4700,7 @@ mod tests {
     fn auto_briefing_is_fail_open_when_briefing_py_absent() {
         // Point SK_TOOLS_DIR at an empty directory so briefing.py is absent.
         use std::fs;
+        let _guard = env_lock();
         let tmp = std::env::temp_dir().join("sk_auto_briefing_test");
         let _ = fs::create_dir_all(&tmp);
 
@@ -4725,6 +4728,7 @@ mod tests {
     fn auto_briefing_never_denies() {
         // Even when briefing.py is absent, the rule must not return a deny.
         use std::fs;
+        let _guard = env_lock();
         let tmp = std::env::temp_dir().join("sk_auto_briefing_no_deny_test");
         let _ = fs::create_dir_all(&tmp);
 
@@ -4937,6 +4941,94 @@ mod tests {
         assert!(
             std::str::from_utf8(text.as_bytes()).is_ok(),
             "truncated output must be valid UTF-8"
+        );
+
+        match old_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match old_up {
+            Some(v) => std::env::set_var("USERPROFILE", v),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Non-ASCII character-count parity with Python's `len()` semantics.
+    ///
+    /// Python's `len()` counts Unicode code points, not UTF-8 bytes.
+    /// CJK characters (e.g. '中') are 3 UTF-8 bytes but 1 Unicode char.
+    ///
+    /// With budget=5 tokens: char_limit = 20.
+    /// 20 CJK chars = 20 bytes under old (byte-count) code → would truncate.
+    /// 20 CJK chars = 20 chars under new (char-count) code → must NOT truncate.
+    /// 21 CJK chars = 21 chars → must truncate at exactly 20 chars.
+    #[test]
+    fn memory_inject_non_ascii_char_count_parity() {
+        use std::fs;
+        let _guard = env_lock();
+        let tmp = std::env::temp_dir().join("sk_mem_inject_nonascii_parity");
+        let copilot_dir = tmp.join(".copilot");
+        let _ = fs::create_dir_all(&copilot_dir);
+        // Budget: 5 tokens × 4 chars = 20-char limit.
+        fs::write(
+            copilot_dir.join("hooks-config.json"),
+            r#"{"memory_inject_max_tokens": 5}"#,
+        )
+        .unwrap();
+
+        let old_home = std::env::var("HOME").ok();
+        let old_up = std::env::var("USERPROFILE").ok();
+        std::env::set_var("HOME", &tmp);
+        std::env::set_var("USERPROFILE", &tmp);
+
+        // --- Case 1: exactly at budget (20 CJK chars = 60 UTF-8 bytes) ---
+        // Old byte-count code: 60 bytes > 20 → would truncate (bug).
+        // New char-count code: 20 chars == 20 → must NOT truncate.
+        let exactly_budget = "中".repeat(20);
+        fs::write(tmp.join("MEMORY.md"), &exactly_budget).unwrap();
+        let result = load_memory_md(Some(&tmp));
+        assert!(
+            result.is_some(),
+            "load_memory_md must return Some for content at char budget"
+        );
+        let text = result.unwrap();
+        assert!(
+            !text.contains("truncated to token budget"),
+            "20 CJK chars at 20-char budget must NOT be truncated; got: {text:?}"
+        );
+        assert_eq!(
+            text.chars().count(),
+            20,
+            "returned text must have exactly 20 Unicode chars; got {}",
+            text.chars().count()
+        );
+
+        // --- Case 2: one over budget (21 CJK chars) ---
+        let over_budget = "中".repeat(21);
+        fs::write(tmp.join("MEMORY.md"), &over_budget).unwrap();
+        let result2 = load_memory_md(Some(&tmp));
+        assert!(
+            result2.is_some(),
+            "21-char CJK content must return Some (truncated)"
+        );
+        let text2 = result2.unwrap();
+        assert!(
+            text2.contains("truncated to token budget"),
+            "21-char CJK content must include truncation notice; got: {text2:?}"
+        );
+        // The body before the truncation notice must be exactly 20 Unicode chars.
+        let body = text2.split('\n').next().unwrap_or("");
+        assert_eq!(
+            body.chars().count(),
+            20,
+            "truncated body must be exactly 20 Unicode chars; got {} chars: {body:?}",
+            body.chars().count()
+        );
+        // Truncated output must be valid UTF-8.
+        assert!(
+            std::str::from_utf8(text2.as_bytes()).is_ok(),
+            "truncated non-ASCII output must be valid UTF-8"
         );
 
         match old_home {
@@ -5402,9 +5494,12 @@ mod tests {
         // the rule must return None (fail-open).
         // We use SK_DB pointing to a non-existent file (native fails-open) and
         // SK_TOOLS_DIR pointing to a temp dir without query-session.py (Python fails-open).
+        let _guard = env_lock();
         let tmp = std::env::temp_dir().join("sk_error_kb_test");
         let _ = std::fs::create_dir_all(&tmp);
         let nonexistent_db = tmp.join("nonexistent.db");
+        let old_tools_dir = std::env::var("SK_TOOLS_DIR").ok();
+        let old_db = std::env::var("SK_DB").ok();
         std::env::set_var("SK_TOOLS_DIR", &tmp);
         std::env::set_var("SK_DB", &nonexistent_db);
         let rule = ErrorOccurredRule;
@@ -5415,8 +5510,14 @@ mod tests {
             result.is_none(),
             "must return None when native DB and Python fallback are both unavailable"
         );
-        std::env::remove_var("SK_TOOLS_DIR");
-        std::env::remove_var("SK_DB");
+        match old_tools_dir {
+            Some(v) => std::env::set_var("SK_TOOLS_DIR", v),
+            None => std::env::remove_var("SK_TOOLS_DIR"),
+        }
+        match old_db {
+            Some(v) => std::env::set_var("SK_DB", v),
+            None => std::env::remove_var("SK_DB"),
+        }
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -222,10 +222,120 @@ impl HookRule for SessionStartRule {
 }
 
 // ---------------------------------------------------------------------------
+// MEMORY.md injection helpers (issue #161)
+// ---------------------------------------------------------------------------
+
+/// Load `~/.copilot/hooks-config.json`; returns a null `Value` on any error.
+///
+/// Mirrors `hooks/rules/briefing.py::_load_hooks_config()`.
+fn load_hooks_config() -> Value {
+    let home = resolve_home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let path = home.join(".copilot").join("hooks-config.json");
+    if path.is_file() {
+        if let Ok(text) = fs::read_to_string(&path) {
+            if let Ok(val) = serde_json::from_str::<Value>(&text) {
+                return val;
+            }
+        }
+    }
+    Value::Null
+}
+
+/// Load `MEMORY.md` from `cwd` (defaults to the process working directory)
+/// for injection into the `sessionStart` auto-briefing.
+///
+/// Returns the (possibly truncated) file content when:
+///   - `memory_inject_enabled` is not explicitly `false` in hooks-config,
+///   - `MEMORY.md` exists in `cwd`,
+///   - the file is not older than `memory_inject_max_age_days` (default 1 day),
+///   - the effective content is non-empty.
+///
+/// Returns `None` for a graceful no-op in all other cases.
+///
+/// Config keys (`~/.copilot/hooks-config.json`):
+///   `memory_inject_enabled`      — bool, default `true`
+///   `memory_inject_max_tokens`   — int, default `500` (1 token ≈ 4 chars)
+///   `memory_inject_max_age_days` — number, default `1`
+///
+/// Mirrors `hooks/rules/briefing.py::_load_memory_md()`.
+fn load_memory_md(cwd: Option<&Path>) -> Option<String> {
+    let cfg = load_hooks_config();
+
+    // memory_inject_enabled: default true; skip only when explicitly false.
+    if cfg
+        .get("memory_inject_enabled")
+        .and_then(|v| v.as_bool())
+        .map(|b| !b)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    // Max age in seconds; default 1 day (86 400 s).
+    let max_age_secs: u64 = cfg
+        .get("memory_inject_max_age_days")
+        .and_then(|v| v.as_f64())
+        .map(|days| (days * 86_400.0) as u64)
+        .unwrap_or(86_400);
+
+    // Token budget (1 token ≈ 4 chars); default 500 tokens.
+    let token_budget: u64 = cfg
+        .get("memory_inject_max_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(500);
+
+    let base = cwd
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let memory_path = base.join("MEMORY.md");
+
+    if !memory_path.is_file() {
+        return None;
+    }
+
+    // Age guard: skip if the file is older than max_age_secs.
+    let age_ok = memory_path
+        .metadata()
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|mtime| SystemTime::now().duration_since(mtime).ok())
+        .map(|age| age.as_secs() <= max_age_secs)
+        .unwrap_or(false);
+    if !age_ok {
+        return None;
+    }
+
+    let content = fs::read_to_string(&memory_path).ok()?;
+    let mut trimmed = content.trim().to_string();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Approximate token budget: 1 token ≈ 4 characters.
+    let char_limit = ((token_budget * 4) as usize).max(1);
+    if trimmed.len() > char_limit {
+        // Walk back to the nearest UTF-8 char boundary at or before
+        // char_limit.  String::truncate panics when the index falls inside
+        // a multi-byte codepoint, so this prevents a runtime panic on
+        // non-ASCII MEMORY.md content (issue #161 regression fix).
+        let mut safe_limit = char_limit;
+        while safe_limit > 0 && !trimmed.is_char_boundary(safe_limit) {
+            safe_limit -= 1;
+        }
+        trimmed.truncate(safe_limit);
+        trimmed = trimmed.trim_end().to_string();
+        trimmed.push_str("\n\u{2026} (truncated to token budget)");
+    }
+
+    Some(trimmed)
+}
+
+// ---------------------------------------------------------------------------
 // AutoBriefingRule
 // ---------------------------------------------------------------------------
 
-/// Run `briefing.py` at session start and sign HMAC markers (wave9).
+/// Run `briefing.py` at session start, prepend `MEMORY.md`, and sign HMAC
+/// markers (wave9, extended in wave10 with issue #161 MEMORY.md injection).
 ///
 /// Ports `hooks/rules/briefing.py::AutoBriefingRule`.
 ///
@@ -234,10 +344,13 @@ impl HookRule for SessionStartRule {
 ///   2. Cleans up stale session-specific markers (own session: deleted and
 ///      re-signed below; orphaned `briefing-done*` markers older than 2h:
 ///      deleted).
-///   3. Spawns `briefing.py <project> --budget 2000` as a subprocess.
-///   4. Signs `briefing-done` and `briefing-done-{session_id}` HMAC markers
+///   3. Prepends `MEMORY.md` content when present, fresh, and injection is
+///      not explicitly disabled via `hooks-config.json` (issue #161).
+///   4. Spawns `briefing.py <project> --budget 2000` as a subprocess and
+///      captures its stdout to follow the MEMORY.md section.
+///   5. Signs `briefing-done` and `briefing-done-{session_id}` HMAC markers
 ///      via [`marker_auth::sign_marker`].
-///   5. Returns an informational message.
+///   6. Returns an informational message.
 ///
 /// Fail-open at every step:
 ///   - `briefing.py` absent → `None` (no briefing, no markers).
@@ -245,6 +358,7 @@ impl HookRule for SessionStartRule {
 ///   - Hung subprocess → killed after 10s with a timeout notice (mirrors Python).
 ///   - Marker signing error → silently skipped.
 ///   - Filesystem errors during cleanup → silently swallowed.
+///   - MEMORY.md absent, stale, or disabled → silently skipped (no-op).
 ///
 /// Informational only; never produces `permissionDecision`.
 pub struct AutoBriefingRule;
@@ -352,17 +466,44 @@ impl HookRule for AutoBriefingRule {
             "  \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}".to_string(),
         ];
 
-        // --- Spawn briefing.py (fail-open; enforce the same 10s timeout as Python) ---
+        // --- MEMORY.md injection (issue #161): prepend promoted knowledge ---
+        if let Some(mem) = load_memory_md(None) {
+            lines.push("\n  \u{1f4cc} MEMORY.md (promoted knowledge):".to_string());
+            for mem_line in mem.lines() {
+                lines.push(format!("  {mem_line}"));
+            }
+            lines.push("  \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}".to_string());
+        }
+
+        // --- Spawn briefing.py (capture stdout so it follows MEMORY.md in the message) ---
+        // Drain stdout in a dedicated thread to prevent pipe-buffer deadlock.
+        // If briefing.py writes more bytes than the OS pipe buffer (~64 KB on
+        // Linux, 4–64 KB on Windows) the child blocks mid-write and never
+        // exits; the parent's try_wait() loop sees None forever and eventually
+        // kills what appeared to be a 10-second hang — even though the child
+        // had real output ready.  Moving the read into a separate thread lets
+        // the OS buffer stay empty while we poll for exit.
         let python = python_exe();
         match Command::new(python)
             .arg(&briefing_script)
             .arg(&project)
             .args(["--budget", "2000"])
+            .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()
         {
             Ok(mut child) => {
+                // Take the stdout handle *before* any wait/poll call so the
+                // reader thread can drain the pipe concurrently.
+                let reader_thread = child.stdout.take().map(|mut stdout| {
+                    std::thread::spawn(move || -> Vec<u8> {
+                        let mut buf = Vec::new();
+                        let _ = stdout.read_to_end(&mut buf);
+                        buf
+                    })
+                });
                 let deadline = Instant::now() + Duration::from_secs(10);
+                let mut timed_out = false;
                 loop {
                     match child.try_wait() {
                         Ok(Some(_status)) => break,
@@ -370,12 +511,27 @@ impl HookRule for AutoBriefingRule {
                             if Instant::now() >= deadline {
                                 let _ = child.kill();
                                 let _ = child.wait();
-                                lines.push("  \u{23f1} Briefing timed out (10s)".to_string());
+                                timed_out = true;
                                 break;
                             }
                             std::thread::sleep(Duration::from_millis(50));
                         }
                         Err(_) => break,
+                    }
+                }
+                if timed_out {
+                    // Reap the reader thread (pipe is closed after kill+wait).
+                    if let Some(handle) = reader_thread {
+                        let _ = handle.join();
+                    }
+                    lines.push("  \u{23f1} Briefing timed out (10s)".to_string());
+                } else if let Some(handle) = reader_thread {
+                    if let Ok(bytes) = handle.join() {
+                        let output = String::from_utf8_lossy(&bytes);
+                        let briefing_out = output.trim_end().to_string();
+                        if !briefing_out.is_empty() {
+                            lines.push(briefing_out);
+                        }
                     }
                 }
             }
@@ -4579,6 +4735,209 @@ mod tests {
         match old {
             Some(v) => std::env::set_var("SK_TOOLS_DIR", v),
             None => std::env::remove_var("SK_TOOLS_DIR"),
+        }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    // --- load_memory_md helper tests (issue #161 native parity) ---
+
+    /// Graceful no-op: MEMORY.md absent → returns None.
+    #[test]
+    fn memory_inject_returns_none_when_memory_md_absent() {
+        let tmp = std::env::temp_dir().join("sk_mem_inject_absent");
+        let _ = std::fs::create_dir_all(&tmp);
+        // Ensure no MEMORY.md in tmp.
+        let _ = std::fs::remove_file(tmp.join("MEMORY.md"));
+        let result = load_memory_md(Some(&tmp));
+        assert!(
+            result.is_none(),
+            "load_memory_md must return None when MEMORY.md is absent"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Fresh MEMORY.md with default config → returns content.
+    #[test]
+    fn memory_inject_returns_content_when_memory_md_present() {
+        use std::fs;
+        let _guard = env_lock();
+        let tmp = std::env::temp_dir().join("sk_mem_inject_present");
+        let copilot_dir = tmp.join(".copilot");
+        let _ = fs::create_dir_all(&copilot_dir);
+        fs::write(tmp.join("MEMORY.md"), "## Key Facts\n- Important thing\n").unwrap();
+        // No hooks-config.json → defaults apply (enabled=true, max_age=1 day).
+        let old_home = std::env::var("HOME").ok();
+        let old_up = std::env::var("USERPROFILE").ok();
+        std::env::set_var("HOME", &tmp);
+        std::env::set_var("USERPROFILE", &tmp);
+
+        let result = load_memory_md(Some(&tmp));
+        assert!(
+            result.is_some(),
+            "load_memory_md must return content when MEMORY.md is fresh"
+        );
+        let content = result.unwrap();
+        assert!(
+            content.contains("Important thing"),
+            "returned content must include MEMORY.md text; got: {content:?}"
+        );
+
+        match old_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match old_up {
+            Some(v) => std::env::set_var("USERPROFILE", v),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Explicit opt-out: `memory_inject_enabled: false` → returns None even with fresh file.
+    #[test]
+    fn memory_inject_skipped_when_disabled_in_config() {
+        use std::fs;
+        let _guard = env_lock();
+        let tmp = std::env::temp_dir().join("sk_mem_inject_disabled");
+        let copilot_dir = tmp.join(".copilot");
+        let _ = fs::create_dir_all(&copilot_dir);
+        // Explicit opt-out in hooks-config.json.
+        fs::write(
+            copilot_dir.join("hooks-config.json"),
+            r#"{"memory_inject_enabled": false}"#,
+        )
+        .unwrap();
+        // Write a fresh MEMORY.md so file-absence is not the reason for skip.
+        fs::write(
+            tmp.join("MEMORY.md"),
+            "## Should not appear\n- Hidden content\n",
+        )
+        .unwrap();
+
+        let old_home = std::env::var("HOME").ok();
+        let old_up = std::env::var("USERPROFILE").ok();
+        std::env::set_var("HOME", &tmp);
+        std::env::set_var("USERPROFILE", &tmp);
+
+        let result = load_memory_md(Some(&tmp));
+        assert!(
+            result.is_none(),
+            "load_memory_md must return None when memory_inject_enabled is false"
+        );
+
+        match old_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match old_up {
+            Some(v) => std::env::set_var("USERPROFILE", v),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Token budget truncation: content longer than budget ends with truncation notice.
+    #[test]
+    fn memory_inject_truncates_to_token_budget() {
+        use std::fs;
+        let _guard = env_lock();
+        let tmp = std::env::temp_dir().join("sk_mem_inject_truncate");
+        let copilot_dir = tmp.join(".copilot");
+        let _ = fs::create_dir_all(&copilot_dir);
+        // Very small budget: 5 tokens × 4 chars = 20-char limit.
+        fs::write(
+            copilot_dir.join("hooks-config.json"),
+            r#"{"memory_inject_max_tokens": 5}"#,
+        )
+        .unwrap();
+        // Write MEMORY.md much longer than 20 chars.
+        let long_content = "A".repeat(200);
+        fs::write(tmp.join("MEMORY.md"), &long_content).unwrap();
+
+        let old_home = std::env::var("HOME").ok();
+        let old_up = std::env::var("USERPROFILE").ok();
+        std::env::set_var("HOME", &tmp);
+        std::env::set_var("USERPROFILE", &tmp);
+
+        let result = load_memory_md(Some(&tmp));
+        assert!(
+            result.is_some(),
+            "load_memory_md must return truncated content (not None)"
+        );
+        let content = result.unwrap();
+        assert!(
+            content.contains("truncated to token budget"),
+            "truncated output must include notice; got: {content:?}"
+        );
+        assert!(
+            content.len() < long_content.len(),
+            "truncated output must be shorter than original"
+        );
+
+        match old_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match old_up {
+            Some(v) => std::env::set_var("USERPROFILE", v),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Non-ASCII (multi-byte UTF-8) content must truncate without panic.
+    ///
+    /// token_budget = 0 → char_limit = max(1, 0) = 1.  The content starts
+    /// with '中' (3 UTF-8 bytes), so byte 1 is a continuation byte — not a
+    /// char boundary.  The old `String::truncate(1)` would panic; the fixed
+    /// `is_char_boundary` walk-back must produce valid UTF-8 + truncation notice.
+    #[test]
+    fn memory_inject_truncates_non_ascii_utf8_safe() {
+        use std::fs;
+        let _guard = env_lock();
+        let tmp = std::env::temp_dir().join("sk_mem_inject_utf8_safe");
+        let copilot_dir = tmp.join(".copilot");
+        let _ = fs::create_dir_all(&copilot_dir);
+        // token_budget 0 → char_limit = max(1, 0*4) = 1; the first byte of
+        // '中' (U+4E2D, encoded as [0xE4,0xB8,0xAD]) is a char boundary but
+        // byte 1 is not — the old truncate(1) would panic here.
+        fs::write(
+            copilot_dir.join("hooks-config.json"),
+            r#"{"memory_inject_max_tokens": 0}"#,
+        )
+        .unwrap();
+        let content = "中文重要笔记".repeat(20);
+        fs::write(tmp.join("MEMORY.md"), &content).unwrap();
+
+        let old_home = std::env::var("HOME").ok();
+        let old_up = std::env::var("USERPROFILE").ok();
+        std::env::set_var("HOME", &tmp);
+        std::env::set_var("USERPROFILE", &tmp);
+
+        // Must not panic; must return Some with a truncation notice.
+        let result = load_memory_md(Some(&tmp));
+        assert!(
+            result.is_some(),
+            "non-ASCII MEMORY.md with tiny budget must return Some (not panic)"
+        );
+        let text = result.unwrap();
+        assert!(
+            text.contains("truncated to token budget"),
+            "output must contain truncation notice; got: {text:?}"
+        );
+        // The String type guarantees valid UTF-8, but verify explicitly.
+        assert!(
+            std::str::from_utf8(text.as_bytes()).is_ok(),
+            "truncated output must be valid UTF-8"
+        );
+
+        match old_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match old_up {
+            Some(v) => std::env::set_var("USERPROFILE", v),
+            None => std::env::remove_var("USERPROFILE"),
         }
         let _ = fs::remove_dir_all(&tmp);
     }

--- a/tests/test_hook_runner_entrypoints.py
+++ b/tests/test_hook_runner_entrypoints.py
@@ -398,6 +398,142 @@ test("Edit src/utils.py → no deny from any rule", '"deny"' not in r.stdout,
 
 
 # ══════════════════════════════════════════════════════════════════════
+#  Section 10: sessionStart with MEMORY.md injection
+# ══════════════════════════════════════════════════════════════════════
+
+print("\n\U0001f4cc Section 10: sessionStart MEMORY.md injection via hook_runner")
+
+# 10a. sessionStart with fresh MEMORY.md in project cwd → output includes memory content
+#      Config: no hooks-config.json → default (injection enabled)
+_mi_isolated = Path(tempfile.mkdtemp(prefix="test-mi-ep-home-"))
+_mi_copilot = _mi_isolated / ".copilot"
+_mi_copilot.mkdir(parents=True, exist_ok=True)
+(_mi_isolated / ".copilot" / "markers").mkdir(parents=True, exist_ok=True)
+# Create a dummy briefing.py so AutoBriefingRule doesn't short-circuit
+_mi_tools = _mi_isolated / ".copilot" / "tools"
+_mi_tools.mkdir(parents=True, exist_ok=True)
+(_mi_tools / "briefing.py").write_text("# dummy briefing\nimport sys\n", encoding="utf-8")
+# Put a fresh MEMORY.md in the working dir we'll run from
+_mi_cwd = Path(tempfile.mkdtemp(prefix="test-mi-cwd-"))
+_mi_memory = _mi_cwd / "MEMORY.md"
+_mi_memory.write_text("# Promoted Memory\n\n## Pattern\nUse parameterised SQL always.", encoding="utf-8")
+# No hooks-config.json → default enabled
+_mi_env = {**os.environ, "HOME": str(_mi_isolated), "USERPROFILE": str(_mi_isolated)}
+
+try:
+    r = subprocess.run(
+        [sys.executable, str(RUNNER), "sessionStart"],
+        input=json.dumps({}),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=_mi_env,
+        cwd=str(_mi_cwd),
+        timeout=15,
+    )
+    test("10a: sessionStart with fresh MEMORY.md → exit 0", r.returncode == 0,
+         f"rc={r.returncode} stderr={r.stderr[:200]}")
+    _combined_output10a = r.stdout + r.stderr
+    test("10a: sessionStart output contains 'MEMORY'",
+         "MEMORY" in _combined_output10a or "parameterised SQL" in _combined_output10a,
+         f"stdout={r.stdout[:400]}")
+finally:
+    shutil.rmtree(str(_mi_isolated), ignore_errors=True)
+    shutil.rmtree(str(_mi_cwd), ignore_errors=True)
+
+# 10b. sessionStart with memory_inject_enabled=false in hooks-config.json → no memory content
+_mi2_isolated = Path(tempfile.mkdtemp(prefix="test-mi2-ep-home-"))
+(_mi2_isolated / ".copilot" / "markers").mkdir(parents=True, exist_ok=True)
+# Write hooks-config.json with injection disabled
+import json as _json10b
+(_mi2_isolated / ".copilot" / "hooks-config.json").write_text(
+    _json10b.dumps({"memory_inject_enabled": False}), encoding="utf-8"
+)
+_mi2_cwd = Path(tempfile.mkdtemp(prefix="test-mi2-cwd-"))
+(_mi2_cwd / "MEMORY.md").write_text("# Promoted Memory\n\n## Pattern\nThis must NOT appear.", encoding="utf-8")
+_mi2_env = {**os.environ, "HOME": str(_mi2_isolated), "USERPROFILE": str(_mi2_isolated)}
+
+try:
+    r = subprocess.run(
+        [sys.executable, str(RUNNER), "sessionStart"],
+        input=json.dumps({}),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=_mi2_env,
+        cwd=str(_mi2_cwd),
+        timeout=15,
+    )
+    test("10b: sessionStart memory_inject_enabled=false → exit 0", r.returncode == 0,
+         f"rc={r.returncode}")
+    test("10b: disabled injection → memory text not in output",
+         "This must NOT appear." not in r.stdout,
+         f"stdout={r.stdout[:400]}")
+finally:
+    shutil.rmtree(str(_mi2_isolated), ignore_errors=True)
+    shutil.rmtree(str(_mi2_cwd), ignore_errors=True)
+
+# 10c. sessionStart with no MEMORY.md → no crash, exit 0
+_mi3_isolated = Path(tempfile.mkdtemp(prefix="test-mi3-ep-home-"))
+(_mi3_isolated / ".copilot" / "markers").mkdir(parents=True, exist_ok=True)
+_mi3_cwd = Path(tempfile.mkdtemp(prefix="test-mi3-cwd-"))  # no MEMORY.md
+_mi3_env = {**os.environ, "HOME": str(_mi3_isolated), "USERPROFILE": str(_mi3_isolated)}
+
+try:
+    r = subprocess.run(
+        [sys.executable, str(RUNNER), "sessionStart"],
+        input=json.dumps({}),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=_mi3_env,
+        cwd=str(_mi3_cwd),
+        timeout=15,
+    )
+    test("10c: sessionStart without MEMORY.md → no crash (exit 0)", r.returncode == 0,
+         f"rc={r.returncode} stderr={r.stderr[:200]}")
+finally:
+    shutil.rmtree(str(_mi3_isolated), ignore_errors=True)
+    shutil.rmtree(str(_mi3_cwd), ignore_errors=True)
+
+# 10d. sessionStart with memory_inject_max_tokens=5 in config → content truncated
+_mi4_isolated = Path(tempfile.mkdtemp(prefix="test-mi4-ep-home-"))
+(_mi4_isolated / ".copilot" / "markers").mkdir(parents=True, exist_ok=True)
+(_mi4_isolated / ".copilot" / "hooks-config.json").write_text(
+    _json10b.dumps({"memory_inject_enabled": True, "memory_inject_max_tokens": 5}),
+    encoding="utf-8"
+)
+_mi4_cwd = Path(tempfile.mkdtemp(prefix="test-mi4-cwd-"))
+(_mi4_cwd / "MEMORY.md").write_text("A" * 200, encoding="utf-8")
+_mi4_env = {**os.environ, "HOME": str(_mi4_isolated), "USERPROFILE": str(_mi4_isolated)}
+
+try:
+    r = subprocess.run(
+        [sys.executable, str(RUNNER), "sessionStart"],
+        input=json.dumps({}),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=_mi4_env,
+        cwd=str(_mi4_cwd),
+        timeout=15,
+    )
+    test("10d: sessionStart memory_inject_max_tokens=5 → exit 0", r.returncode == 0,
+         f"rc={r.returncode}")
+    _out10d = r.stdout + r.stderr
+    test("10d: output does not contain 200 'A's (content was truncated)",
+         "A" * 200 not in _out10d,
+         f"stdout={r.stdout[:400]}")
+finally:
+    shutil.rmtree(str(_mi4_isolated), ignore_errors=True)
+    shutil.rmtree(str(_mi4_cwd), ignore_errors=True)
+
+
+# ══════════════════════════════════════════════════════════════════════
 #  Cleanup
 # ══════════════════════════════════════════════════════════════════════
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -4399,6 +4399,8 @@ try:
     # ── 25d. Fresh MEMORY.md → returns content ───────────────────────
     _td25d = Path(tempfile.mkdtemp(prefix="test-25d-"))
     try:
+        _orig_cfg25d = _rb25._load_hooks_config
+        _rb25._load_hooks_config = lambda: {"memory_inject_enabled": True}
         _mem25d = _td25d / "MEMORY.md"
         _content25d = "# Promoted Memory\n\n## Pattern\nUse parameterised SQL."
         _mem25d.write_text(_content25d, encoding="utf-8")
@@ -4408,11 +4410,14 @@ try:
         test("25d: returned content contains entry text", _r25d is not None and "parameterised SQL" in _r25d,
              f"got: {_r25d!r}")
     finally:
+        _rb25._load_hooks_config = _orig_cfg25d
         shutil.rmtree(str(_td25d), ignore_errors=True)
 
     # ── 25e. Token budget cap → content truncated ─────────────────────
     _td25e = Path(tempfile.mkdtemp(prefix="test-25e-"))
     try:
+        _orig_cfg25e = _rb25._load_hooks_config
+        _rb25._load_hooks_config = lambda: {"memory_inject_enabled": True}
         _mem25e = _td25e / "MEMORY.md"
         # Create content well over 5-token budget (5 * 4 = 20 chars)
         _big_content25e = "A" * 200
@@ -4423,6 +4428,7 @@ try:
         test("25e: truncated content includes ellipsis marker", _r25e is not None and "truncated" in _r25e.lower(),
              f"got: {_r25e!r}")
     finally:
+        _rb25._load_hooks_config = _orig_cfg25e
         shutil.rmtree(str(_td25e), ignore_errors=True)
 
     # ── 25f. AutoBriefingRule.evaluate() PREPENDS memory before briefing ─

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -4346,6 +4346,219 @@ except Exception as _e24:
 
 
 # ═══════════════════════════════════════════════════════════════════
+#  Section 25: MEMORY.md injection into sessionStart auto-briefing
+#  Tests _load_memory_md() and AutoBriefingRule prepend behaviour.
+# ═══════════════════════════════════════════════════════════════════
+
+print("\n\U0001f4cc Section 25: MEMORY.md injection into sessionStart")
+
+try:
+    import importlib as _il25
+    import sys as _sys25
+    import os as _os25
+    import time as _time25
+
+    # Import the briefing rule module
+    sys.path.insert(0, str(REPO / "hooks"))
+    import rules.briefing as _rb25
+    from rules.briefing import _load_memory_md as _lmm25, _DEFAULT_MAX_AGE_DAYS as _DMA25, _DEFAULT_TOKEN_BUDGET as _DTB25
+
+    _td25 = Path(tempfile.mkdtemp(prefix="test-25-"))
+
+    # ── 25a. Disabled via memory_inject_enabled=False config key → None ──
+    try:
+        _orig_cfg25a = _rb25._load_hooks_config
+        _rb25._load_hooks_config = lambda: {"memory_inject_enabled": False}
+        (_td25 / "MEMORY.md").write_text("# Promoted Memory\n\nEntry A", encoding="utf-8")
+        _r25a = _lmm25(cwd=_td25)
+        test("25a: memory_inject_enabled=False → None (no-op)", _r25a is None, f"got: {_r25a!r}")
+    finally:
+        _rb25._load_hooks_config = _orig_cfg25a
+
+    # ── 25b. Missing MEMORY.md → None ────────────────────────────────
+    _td25b = Path(tempfile.mkdtemp(prefix="test-25b-"))
+    try:
+        _r25b = _lmm25(cwd=_td25b)
+        test("25b: missing MEMORY.md → None (no-op)", _r25b is None, f"got: {_r25b!r}")
+    finally:
+        shutil.rmtree(str(_td25b), ignore_errors=True)
+
+    # ── 25c. Stale MEMORY.md (older than max_age_secs) → None ────────
+    _td25c = Path(tempfile.mkdtemp(prefix="test-25c-"))
+    try:
+        _mem25c = _td25c / "MEMORY.md"
+        _mem25c.write_text("# Promoted Memory\n\nEntry B", encoding="utf-8")
+        # Set mtime to 2 days ago (172800 s), max_age = 1 day (86400 s)
+        _old_time = _time25.time() - 172800
+        os.utime(str(_mem25c), (_old_time, _old_time))
+        _r25c = _lmm25(cwd=_td25c, max_age_secs=86400)
+        test("25c: stale MEMORY.md (2d old, max_age=1d) → None (no-op)", _r25c is None, f"got: {_r25c!r}")
+    finally:
+        shutil.rmtree(str(_td25c), ignore_errors=True)
+
+    # ── 25d. Fresh MEMORY.md → returns content ───────────────────────
+    _td25d = Path(tempfile.mkdtemp(prefix="test-25d-"))
+    try:
+        _mem25d = _td25d / "MEMORY.md"
+        _content25d = "# Promoted Memory\n\n## Pattern\nUse parameterised SQL."
+        _mem25d.write_text(_content25d, encoding="utf-8")
+        _r25d = _lmm25(cwd=_td25d)
+        test("25d: fresh MEMORY.md → returns content", _r25d is not None and "Promoted Memory" in _r25d,
+             f"got: {_r25d!r}")
+        test("25d: returned content contains entry text", _r25d is not None and "parameterised SQL" in _r25d,
+             f"got: {_r25d!r}")
+    finally:
+        shutil.rmtree(str(_td25d), ignore_errors=True)
+
+    # ── 25e. Token budget cap → content truncated ─────────────────────
+    _td25e = Path(tempfile.mkdtemp(prefix="test-25e-"))
+    try:
+        _mem25e = _td25e / "MEMORY.md"
+        # Create content well over 5-token budget (5 * 4 = 20 chars)
+        _big_content25e = "A" * 200
+        _mem25e.write_text(_big_content25e, encoding="utf-8")
+        _r25e = _lmm25(cwd=_td25e, token_budget=5)
+        test("25e: token_budget=5 → content truncated", _r25e is not None and len(_r25e) < len(_big_content25e),
+             f"length: {len(_r25e) if _r25e else 0}")
+        test("25e: truncated content includes ellipsis marker", _r25e is not None and "truncated" in _r25e.lower(),
+             f"got: {_r25e!r}")
+    finally:
+        shutil.rmtree(str(_td25e), ignore_errors=True)
+
+    # ── 25f. AutoBriefingRule.evaluate() PREPENDS memory before briefing ─
+    _td25f = Path(tempfile.mkdtemp(prefix="test-25f-"))
+    _markers25f = _td25f / ".copilot" / "markers"
+    _markers25f.mkdir(parents=True, exist_ok=True)
+    # Dummy briefing script that emits a distinguishable marker so we can verify order
+    _dummy_briefing25f = _td25f / "briefing.py"
+    _dummy_briefing25f.write_text(
+        'import sys\nprint("BRIEFING_OUTPUT_SENTINEL")\n', encoding="utf-8"
+    )
+    try:
+        _mem25f = _td25f / "MEMORY.md"
+        _mem25f.write_text("# Promoted Memory\n\n## Pattern\nAlways use atomic locks.", encoding="utf-8")
+
+        from rules.briefing import AutoBriefingRule as _ABR25
+        _rule25f = _ABR25()
+
+        # Patch _load_memory_md to load from our temp dir
+        _orig_lmm25f = _rb25._load_memory_md
+        _rb25._load_memory_md = lambda **kw: _lmm25(cwd=_td25f)
+
+        # Patch MARKERS_DIR and sign_marker to isolate filesystem side-effects
+        _orig_mdir25f = _rb25.MARKERS_DIR
+        _rb25.MARKERS_DIR = _markers25f
+        _orig_sm25f = _rb25.sign_marker
+        _rb25.sign_marker = lambda p, n: None
+        # Point BRIEFING_SCRIPT to the dummy script (exists, emits sentinel)
+        _orig_bs25f = _rb25.BRIEFING_SCRIPT
+        _rb25.BRIEFING_SCRIPT = _dummy_briefing25f
+
+        _result25f = _rule25f.evaluate("sessionStart", {})
+        _msg25f = _result25f.get("message", "") if isinstance(_result25f, dict) else ""
+
+        test("25f: AutoBriefingRule returns info() dict", isinstance(_result25f, dict) and "message" in _result25f,
+             f"got: {_result25f!r}")
+        test("25f: returned message contains MEMORY.md content", "atomic locks" in _msg25f,
+             f"message: {_msg25f[:300]!r}")
+        test("25f: returned message contains MEMORY.md header marker", "MEMORY" in _msg25f,
+             f"message: {_msg25f[:200]!r}")
+        # Ordering: MEMORY.md content must come BEFORE briefing output (true prepend)
+        _idx_memory = _msg25f.find("atomic locks")
+        _idx_briefing = _msg25f.find("BRIEFING_OUTPUT_SENTINEL")
+        test("25f: MEMORY.md content precedes briefing output (true prepend)",
+             _idx_memory != -1 and _idx_briefing != -1 and _idx_memory < _idx_briefing,
+             f"memory@{_idx_memory} briefing@{_idx_briefing} msg={_msg25f[:400]!r}")
+
+    finally:
+        _rb25._load_memory_md = _orig_lmm25f
+        _rb25.MARKERS_DIR = _orig_mdir25f
+        _rb25.sign_marker = _orig_sm25f
+        _rb25.BRIEFING_SCRIPT = _orig_bs25f
+        shutil.rmtree(str(_td25f), ignore_errors=True)
+
+    # ── 25g. AutoBriefingRule.evaluate() — no MEMORY.md → no injection ─
+    _td25g = Path(tempfile.mkdtemp(prefix="test-25g-"))
+    _markers25g = _td25g / ".copilot" / "markers"
+    _markers25g.mkdir(parents=True, exist_ok=True)
+    try:
+        from rules.briefing import AutoBriefingRule as _ABR25g
+        _rule25g = _ABR25g()
+
+        _orig_lmm25g = _rb25._load_memory_md
+        _rb25._load_memory_md = lambda **kw: None  # simulate missing MEMORY.md
+        _orig_mdir25g = _rb25.MARKERS_DIR
+        _rb25.MARKERS_DIR = _markers25g
+        _orig_sm25g = _rb25.sign_marker
+        _rb25.sign_marker = lambda p, n: None
+        _orig_bs25g = _rb25.BRIEFING_SCRIPT
+        _rb25.BRIEFING_SCRIPT = _td25g / "nonexistent_briefing.py"
+
+        _result25g = _rule25g.evaluate("sessionStart", {})
+        _msg25g = _result25g.get("message", "") if isinstance(_result25g, dict) else ""
+
+        test("25g: no MEMORY.md → message has no MEMORY injection", "MEMORY.md" not in _msg25g,
+             f"message: {_msg25g[:200]!r}")
+
+    finally:
+        _rb25._load_memory_md = _orig_lmm25g
+        _rb25.MARKERS_DIR = _orig_mdir25g
+        _rb25.sign_marker = _orig_sm25g
+        _rb25.BRIEFING_SCRIPT = _orig_bs25g
+        shutil.rmtree(str(_td25g), ignore_errors=True)
+
+    # ── 25h. Default constants have expected values ────────────────────
+    test("25h: default max_age_days == 1", _DMA25 == 1,
+         f"got: {_DMA25}")
+    test("25h: default token_budget == 500", _DTB25 == 500,
+         f"got: {_DTB25}")
+
+    # ── 25i. memory_inject_max_tokens config key controls budget ──────
+    _td25i = Path(tempfile.mkdtemp(prefix="test-25i-"))
+    try:
+        _orig_cfg25i = _rb25._load_hooks_config
+        # Set max_tokens=5 → char_limit = 20 → content truncated
+        _rb25._load_hooks_config = lambda: {"memory_inject_enabled": True, "memory_inject_max_tokens": 5}
+        (_td25i / "MEMORY.md").write_text("A" * 200, encoding="utf-8")
+        _r25i = _lmm25(cwd=_td25i)
+        test("25i: memory_inject_max_tokens=5 via config → content truncated",
+             _r25i is not None and len(_r25i) < 200,
+             f"got length: {len(_r25i) if _r25i else 0}")
+        test("25i: truncated content includes ellipsis marker",
+             _r25i is not None and "truncated" in _r25i.lower(),
+             f"got: {_r25i!r}")
+    finally:
+        _rb25._load_hooks_config = _orig_cfg25i
+        shutil.rmtree(str(_td25i), ignore_errors=True)
+
+    # ── 25j. memory_inject_max_age_days config key controls max age ───
+    _td25j = Path(tempfile.mkdtemp(prefix="test-25j-"))
+    try:
+        _orig_cfg25j = _rb25._load_hooks_config
+        # Set max_age_days=0.0001 (~8 seconds) → any file older than 8s is stale
+        _rb25._load_hooks_config = lambda: {"memory_inject_enabled": True, "memory_inject_max_age_days": 0.0001}
+        _mem25j = _td25j / "MEMORY.md"
+        _mem25j.write_text("# Promoted Memory\n\nEntry J", encoding="utf-8")
+        # Age the file to 1 minute old (well past 0.0001 days = ~8.6 seconds)
+        _old_j = _time25.time() - 60
+        os.utime(str(_mem25j), (_old_j, _old_j))
+        _r25j = _lmm25(cwd=_td25j)
+        test("25j: memory_inject_max_age_days=0.0001 → stale file → None",
+             _r25j is None,
+             f"got: {_r25j!r}")
+    finally:
+        _rb25._load_hooks_config = _orig_cfg25j
+        shutil.rmtree(str(_td25j), ignore_errors=True)
+
+    # ── Cleanup ──────────────────────────────────────────────────────
+    shutil.rmtree(str(_td25), ignore_errors=True)
+
+    test("Section 25 MEMORY.md injection tests ran without exception", True)
+except Exception as _e25:
+    test("Section 25 MEMORY.md injection tests ran without exception", False, str(_e25))
+
+
+# ═══════════════════════════════════════════════════════════════════
 #  Results
 # ═══════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary
- inject fresh MEMORY.md into sessionStart auto-briefing when enabled and fresh
- use exact `memory_inject_enabled`, `memory_inject_max_tokens`, and `memory_inject_max_age_days` config keys
- add ordering/config regression tests and docs for the prepend contract

Closes #161
