### PR TITLE
feat: automate dreaming sweeps in sync-daemon

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -131,6 +131,55 @@ sk sync gateway --host 127.0.0.1 --port 8765         # sync-gateway.py (referenc
 sk sync merge --source /path/to/other.db             # sync-knowledge.py
 ```
 
+#### Dream scheduler config
+
+The sync daemon runs periodic **dream sweeps** (calling `dream.py`) on a configurable interval
+via the `DreamingScheduler` class (issue #162).  Sweeps score knowledge entries and promote
+high-signal entries to `MEMORY.md`.
+
+```bash
+python sync-config.py --dream-status                    # show current dream scheduler config
+python sync-config.py --dream-interval-hours 12         # set sweep interval to 12 h (default: 24)
+python sync-config.py --dream-disable                   # pause scheduled sweeps
+python sync-config.py --dream-enable                    # resume scheduled sweeps
+python sync-config.py --dream-min-score 0.8             # gate: min dream score (default: 0.75)
+python sync-config.py --dream-min-recall-count 5        # gate: min recall count (default: 3)
+python sync-config.py --dream-min-unique-queries 3      # gate: min unique queries (default: 2)
+python sync-config.py --dream-memory-path /path/MEMORY.md  # promoted-memory output path (default: MEMORY.md)
+python sync-config.py --status                          # includes dream config in the output
+```
+
+**Manual trigger:** drop a `dream-trigger.json` marker in `~/.copilot/markers/` and the
+daemon will run a sweep immediately — the sleep loop wakes early on this marker,
+so there is no full-interval wait.  **Note:** the manual trigger is suppressed when
+`dream_enabled=false`; the marker is consumed but no sweep fires.
+
+```bash
+echo '{}' > ~/.copilot/markers/dream-trigger.json  # trigger one sweep immediately
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `dream_enabled` | bool | `true` | Enable/disable scheduled sweeps |
+| `dream_interval_hours` | float | `24` | Hours between sweeps (**must be > 0**) |
+| `dream_min_score` | float | `0.75` | Gate: minimum dream score |
+| `dream_min_recall_count` | int | `3` | Gate: minimum recall count |
+| `dream_min_unique_queries` | int | `2` | Gate: minimum unique queries |
+| `dream_memory_path` | str | `MEMORY.md` | Output path for promoted-memory surface |
+
+**Operator notes:**
+- `last_dream_run` is persisted in `.sync-daemon-state.json` (never synced remotely).
+- A sweep that fails is logged (including promoted-entry count on success) but does **not** update `last_dream_run`, so it retries on the next cycle.
+- Disabling sweeps (`--dream-disable`) does not clear `last_dream_run`; re-enabling resumes from where the scheduler left off.
+- **Manual trigger markers are suppressed when sweeps are disabled**: the marker is consumed (removed) but no sweep fires.
+- `dream_interval_hours` must be **greater than 0**; the CLI exits 1 on zero or negative values.  A pre-existing config with `0` is normalized to `24` on load.
+- **Config changes take effect without restarting the daemon** — the running daemon re-reads `sync-config.json` at the start of every loop cycle.
+- Each successful sweep logs: `[sync] dream sweep OK | promoted=N min_score=0.75 interval_hours=24`
+- **`--once` mode**: scheduled-due sweeps do **not** fire in one-shot runs.  Only an
+  explicit `dream-trigger.json` manual marker causes a sweep in `--once` mode.  This
+  preserves fast one-shot exit semantics (`run_sweep` has a 300 s subprocess timeout
+  that would otherwise block a fresh-install `--once` run for up to 5 minutes).
+
 ### `sk checkpoint` — session checkpoints
 
 ```bash

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -172,5 +172,102 @@ When `--json` is used, the response includes a `memory_output` key:
 
 ## Out of Scope (future issues)
 
-- **#161** Scheduling: periodic automatic dream runs.
-- **#162** Cross-replica score merging / collaborative dreaming.
+- **#163** Cross-replica score merging / collaborative dreaming.
+
+## Dream Scheduler (issue #162)
+
+Dream sweeps can be automated via the sync daemon using the `DreamingScheduler` class.
+The scheduler runs `dream.py` on a configurable hour-based interval, passes all gate
+thresholds as CLI arguments, and persists state between restarts.
+
+### Configuration
+
+Scheduler settings live in `sync-config.json` alongside the gateway URL:
+
+```bash
+python sync-config.py --dream-status                    # show current settings
+python sync-config.py --dream-interval-hours 12         # sweep every 12 hours
+python sync-config.py --dream-disable                   # pause automatic sweeps
+python sync-config.py --dream-enable                    # resume automatic sweeps
+python sync-config.py --dream-min-score 0.8             # gate: min dream score (default: 0.75)
+python sync-config.py --dream-min-recall-count 5        # gate: min recall count (default: 3)
+python sync-config.py --dream-min-unique-queries 3      # gate: min unique queries (default: 2)
+python sync-config.py --dream-memory-path /path/MEMORY.md  # promoted-memory output path (default: MEMORY.md)
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `dream_enabled` | `true` | Whether the daemon runs scheduled sweeps |
+| `dream_interval_hours` | `24` | Hours between sweeps (**must be > 0**; zero/negative values are rejected by the CLI and normalized to 24h on config load) |
+| `dream_min_score` | `0.75` | Gate: minimum dream score to pass |
+| `dream_min_recall_count` | `3` | Gate: minimum recall count to pass |
+| `dream_min_unique_queries` | `2` | Gate: minimum unique queries to pass |
+| `dream_memory_path` | `MEMORY.md` | Output path for promoted-memory surface |
+
+### Manual trigger
+
+Drop a `dream-trigger.json` marker to run one sweep immediately.  The daemon's
+sleep loop wakes as soon as the marker appears — no full-interval wait required:
+
+```bash
+echo '{}' > ~/.copilot/markers/dream-trigger.json
+```
+
+The marker is consumed (deleted) after the sweep fires.
+
+> **Important:** when `dream_enabled=false`, a manual trigger marker is **not**
+> honoured — the marker is consumed and removed (to prevent stale accumulation)
+> but the sweep is suppressed.  Re-enable sweeps first with
+> `python sync-config.py --dream-enable` if you want the trigger to fire.
+
+### Operator-visible logging
+
+Each successful sweep emits a structured log line:
+
+```
+[sync] dream sweep OK | promoted=3 min_score=0.75 interval_hours=24
+```
+
+Sweep failures are logged as:
+
+```
+[sync] dream sweep failed: <error>
+```
+
+When `dream.py` is absent the daemon logs a skip and continues running (fail-open):
+
+```
+[sync] dream sweep skipped: dream.py not found (fail-open)
+```
+
+### State persistence
+
+`last_dream_run` is stored in `.sync-daemon-state.json`.  It records the ISO
+timestamp of the last **successful** sweep.  If a sweep fails, `last_dream_run`
+is not updated, so the scheduler retries on the next daemon cycle.
+
+Fields written by the scheduler:
+
+| Key | Description |
+|---|---|
+| `last_dream_run` | ISO-8601 UTC timestamp of the last successful sweep |
+
+### Operator notes
+
+- Disabling sweeps via `--dream-disable` does **not** clear `last_dream_run`.
+  Re-enabling picks up from the previous timestamp.
+- **Manual trigger markers are suppressed when `dream_enabled=false`**: the marker
+  is consumed (removed) but no sweep fires.  This prevents stale markers from
+  accidentally running a sweep the operator intended to pause.
+- In `--once` mode the daemon runs a dream sweep **only on explicit manual trigger** —
+  scheduled-due sweeps do not fire in one-shot runs to preserve fast exit semantics
+  (`run_sweep` has a 300 s subprocess timeout, which would block a fresh-install
+  `--once` run for up to 5 minutes).
+- `entry_dream_scores` remains **`local_only`** — scores are never synced.
+- **`dream_interval_hours` must be greater than 0.**  The CLI rejects 0 or negative
+  values (exit 1).  If a pre-existing config file contains 0, the value is
+  silently normalized to the 24h default on load.
+- **Dream config changes take effect without restarting the daemon.**  The running
+  daemon re-reads `sync-config.json` at the start of every loop iteration, so
+  changes made with `python sync-config.py` are picked up automatically on the
+  next cycle.

--- a/sync-config.py
+++ b/sync-config.py
@@ -3,6 +3,7 @@
 sync-config.py — Manage local sync connection string configuration.
 
 Stores a single gateway connection string in ~/.copilot/tools/sync-config.json.
+Also manages the dream scheduler settings (issue #162 contract).
 
 Usage:
     python sync-config.py --setup <url>
@@ -11,6 +12,16 @@ Usage:
     python sync-config.py --status --json
     python sync-config.py --clear
     python sync-config.py --get
+
+    # Dream scheduler config
+    python sync-config.py --dream-interval-hours 12  # hours between sweeps (default: 24, must be > 0)
+    python sync-config.py --dream-disable             # pause scheduled sweeps
+    python sync-config.py --dream-enable              # resume scheduled sweeps
+    python sync-config.py --dream-status              # show dream scheduler config
+    python sync-config.py --dream-min-score 0.8       # gate: min dream score (default: 0.75)
+    python sync-config.py --dream-min-recall-count 5  # gate: min recall count (default: 3)
+    python sync-config.py --dream-min-unique-queries 3  # gate: min unique queries (default: 2)
+    python sync-config.py --dream-memory-path /path/to/MEMORY.md  # output path (default: MEMORY.md)
 """
 
 import json
@@ -28,6 +39,11 @@ if os.name == "nt":
 
 TOOLS_DIR = Path(__file__).resolve().parent
 CONFIG_PATH = TOOLS_DIR / "sync-config.json"
+DEFAULT_DREAM_INTERVAL_HOURS = 24  # issue #162 contract
+DEFAULT_DREAM_MIN_SCORE = 0.75
+DEFAULT_DREAM_MIN_RECALL_COUNT = 3
+DEFAULT_DREAM_MIN_UNIQUE_QUERIES = 2
+DEFAULT_DREAM_MEMORY_PATH = "MEMORY.md"
 
 
 def _check_permissions() -> None:
@@ -69,12 +85,47 @@ def _classify_gateway_target(value: str) -> str:
 
 
 def load_config() -> dict:
-    config = {"connection_string": ""}
+    config: dict = {
+        "connection_string": "",
+        "dream_enabled": True,
+        "dream_interval_hours": DEFAULT_DREAM_INTERVAL_HOURS,
+        "dream_min_score": DEFAULT_DREAM_MIN_SCORE,
+        "dream_min_recall_count": DEFAULT_DREAM_MIN_RECALL_COUNT,
+        "dream_min_unique_queries": DEFAULT_DREAM_MIN_UNIQUE_QUERIES,
+        "dream_memory_path": DEFAULT_DREAM_MEMORY_PATH,
+    }
     if CONFIG_PATH.exists():
         try:
             obj = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
             if isinstance(obj, dict):
                 config["connection_string"] = str(obj.get("connection_string", "") or "")
+                if "dream_enabled" in obj:
+                    config["dream_enabled"] = bool(obj["dream_enabled"])
+                if "dream_interval_hours" in obj:
+                    try:
+                        v = float(obj["dream_interval_hours"])
+                        config["dream_interval_hours"] = v if v > 0 else DEFAULT_DREAM_INTERVAL_HOURS
+                    except (TypeError, ValueError):
+                        pass
+                if "dream_min_score" in obj:
+                    try:
+                        config["dream_min_score"] = float(obj["dream_min_score"])
+                    except (TypeError, ValueError):
+                        pass
+                if "dream_min_recall_count" in obj:
+                    try:
+                        config["dream_min_recall_count"] = int(obj["dream_min_recall_count"])
+                    except (TypeError, ValueError):
+                        pass
+                if "dream_min_unique_queries" in obj:
+                    try:
+                        config["dream_min_unique_queries"] = int(obj["dream_min_unique_queries"])
+                    except (TypeError, ValueError):
+                        pass
+                if "dream_memory_path" in obj:
+                    val = str(obj["dream_memory_path"] or "").strip()
+                    if val:
+                        config["dream_memory_path"] = val
         except (json.JSONDecodeError, OSError):
             pass
     _check_permissions()
@@ -83,7 +134,35 @@ def load_config() -> dict:
 
 def save_config(config: dict) -> None:
     TOOLS_DIR.mkdir(parents=True, exist_ok=True)
-    payload = {"connection_string": str(config.get("connection_string", "") or "")}
+    payload: dict = {"connection_string": str(config.get("connection_string", "") or "")}
+    # Persist dream scheduler fields when explicitly provided.
+    if "dream_enabled" in config:
+        payload["dream_enabled"] = bool(config["dream_enabled"])
+    if "dream_interval_hours" in config:
+        try:
+            v = float(config["dream_interval_hours"])
+            payload["dream_interval_hours"] = v if v > 0 else DEFAULT_DREAM_INTERVAL_HOURS
+        except (TypeError, ValueError):
+            pass
+    if "dream_min_score" in config:
+        try:
+            payload["dream_min_score"] = float(config["dream_min_score"])
+        except (TypeError, ValueError):
+            pass
+    if "dream_min_recall_count" in config:
+        try:
+            payload["dream_min_recall_count"] = int(config["dream_min_recall_count"])
+        except (TypeError, ValueError):
+            pass
+    if "dream_min_unique_queries" in config:
+        try:
+            payload["dream_min_unique_queries"] = int(config["dream_min_unique_queries"])
+        except (TypeError, ValueError):
+            pass
+    if "dream_memory_path" in config:
+        val = str(config["dream_memory_path"] or "").strip()
+        if val:
+            payload["dream_memory_path"] = val
     CONFIG_PATH.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
     if os.name != "nt":
         os.chmod(CONFIG_PATH, 0o600)
@@ -91,12 +170,87 @@ def save_config(config: dict) -> None:
 
 def set_connection_string(value: str) -> str:
     normalized = _normalize_connection_string(value)
-    save_config({"connection_string": normalized})
+    cfg = load_config()
+    cfg["connection_string"] = normalized
+    save_config(cfg)
     return normalized
 
 
 def clear_connection_string() -> None:
-    save_config({"connection_string": ""})
+    cfg = load_config()
+    cfg["connection_string"] = ""
+    save_config(cfg)
+
+
+def set_dream_interval_hours(hours: float) -> float:
+    """Set the dream sweep interval in hours (must be > 0); returns the stored value."""
+    interval = float(hours)
+    if interval <= 0:
+        raise ValueError(f"dream_interval_hours must be greater than 0, got {interval!r}")
+    cfg = load_config()
+    cfg["dream_interval_hours"] = interval
+    save_config(cfg)
+    return interval
+
+
+def set_dream_min_score(value: float) -> float:
+    """Set the gate min-score threshold; returns the stored value."""
+    cfg = load_config()
+    cfg["dream_min_score"] = float(value)
+    save_config(cfg)
+    return float(value)
+
+
+def set_dream_min_recall_count(value: int) -> int:
+    """Set the gate min-recall-count threshold; returns the stored value."""
+    cfg = load_config()
+    cfg["dream_min_recall_count"] = int(value)
+    save_config(cfg)
+    return int(value)
+
+
+def set_dream_min_unique_queries(value: int) -> int:
+    """Set the gate min-unique-queries threshold; returns the stored value."""
+    cfg = load_config()
+    cfg["dream_min_unique_queries"] = int(value)
+    save_config(cfg)
+    return int(value)
+
+
+def set_dream_memory_path(path: str) -> str:
+    """Set the MEMORY.md output path; returns the stored value.
+
+    Raises ValueError if *path* is empty or whitespace-only, consistent with
+    the CLI guard that prevents ``save_config()`` from silently dropping the
+    value and falling back to the default ``MEMORY.md``.
+    """
+    normalized = str(path).strip()
+    if not normalized:
+        raise ValueError("dream_memory_path must not be empty or whitespace-only")
+    cfg = load_config()
+    cfg["dream_memory_path"] = normalized
+    save_config(cfg)
+    return normalized
+
+
+def set_dream_enabled(enabled: bool) -> None:
+    """Enable or disable scheduled dream sweeps."""
+    cfg = load_config()
+    cfg["dream_enabled"] = bool(enabled)
+    save_config(cfg)
+
+
+def get_dream_config() -> dict:
+    """Return the current dream scheduler config."""
+    cfg = load_config()
+    return {
+        "dream_enabled": cfg.get("dream_enabled", True),
+        "dream_interval_hours": cfg.get("dream_interval_hours", DEFAULT_DREAM_INTERVAL_HOURS),
+        "dream_min_score": cfg.get("dream_min_score", DEFAULT_DREAM_MIN_SCORE),
+        "dream_min_recall_count": cfg.get("dream_min_recall_count", DEFAULT_DREAM_MIN_RECALL_COUNT),
+        "dream_min_unique_queries": cfg.get("dream_min_unique_queries", DEFAULT_DREAM_MIN_UNIQUE_QUERIES),
+        "dream_memory_path": cfg.get("dream_memory_path", DEFAULT_DREAM_MEMORY_PATH),
+    }
 
 
 def get_status() -> dict:
@@ -124,7 +278,9 @@ def main() -> None:
     if not args or "--status" in args:
         status = get_status()
         if "--json" in args:
-            print(json.dumps(status, indent=2, ensure_ascii=False))
+            full = dict(status)
+            full.update(get_dream_config())
+            print(json.dumps(full, indent=2, ensure_ascii=False))
             return
         print("Sync configuration")
         print(f"  Config file: {status['config_path']}")
@@ -136,6 +292,9 @@ def main() -> None:
             print(f"  Target:      {status['gateway_target']}")
         else:
             print("  Target:      unconfigured")
+        dcfg = get_dream_config()
+        print(f"  Dream sweeps: {'enabled' if dcfg['dream_enabled'] else 'disabled'}")
+        print(f"  Dream interval: {dcfg['dream_interval_hours']}h")
         return
 
     if "--help" in args or "-h" in args:
@@ -149,6 +308,94 @@ def main() -> None:
     if "--clear" in args:
         clear_connection_string()
         print(f"✓ Cleared connection string in {CONFIG_PATH}")
+        return
+
+    if "--dream-status" in args:
+        dcfg = get_dream_config()
+        if "--json" in args:
+            print(json.dumps(dcfg, indent=2, ensure_ascii=False))
+        else:
+            print(f"Dream sweeps: {'enabled' if dcfg['dream_enabled'] else 'disabled'}")
+            print(f"Dream interval: {dcfg['dream_interval_hours']}h")
+            print(f"Dream min score: {dcfg['dream_min_score']}")
+            print(f"Dream min recall count: {dcfg['dream_min_recall_count']}")
+            print(f"Dream min unique queries: {dcfg['dream_min_unique_queries']}")
+            print(f"Dream memory path: {dcfg['dream_memory_path']}")
+        return
+
+    if "--dream-disable" in args:
+        set_dream_enabled(False)
+        print(f"✓ Dream sweeps disabled in {CONFIG_PATH}")
+        return
+
+    if "--dream-enable" in args:
+        set_dream_enabled(True)
+        print(f"✓ Dream sweeps enabled in {CONFIG_PATH}")
+        return
+
+    if "--dream-interval-hours" in args:
+        idx = args.index("--dream-interval-hours")
+        if idx + 1 >= len(args):
+            print("Error: --dream-interval-hours requires a value in hours", file=sys.stderr)
+            sys.exit(1)
+        try:
+            stored = set_dream_interval_hours(float(args[idx + 1]))
+        except (ValueError, TypeError) as exc:
+            print(f"Error: --dream-interval-hours {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(f"✓ Dream interval set to {stored}h in {CONFIG_PATH}")
+        return
+
+    if "--dream-min-score" in args:
+        idx = args.index("--dream-min-score")
+        if idx + 1 >= len(args):
+            print("Error: --dream-min-score requires a value", file=sys.stderr)
+            sys.exit(1)
+        try:
+            stored = set_dream_min_score(float(args[idx + 1]))
+        except (ValueError, TypeError) as exc:
+            print(f"Error: --dream-min-score requires a number: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(f"✓ Dream min score set to {stored} in {CONFIG_PATH}")
+        return
+
+    if "--dream-min-recall-count" in args:
+        idx = args.index("--dream-min-recall-count")
+        if idx + 1 >= len(args):
+            print("Error: --dream-min-recall-count requires a value", file=sys.stderr)
+            sys.exit(1)
+        try:
+            stored = set_dream_min_recall_count(int(args[idx + 1]))
+        except (ValueError, TypeError) as exc:
+            print(f"Error: --dream-min-recall-count requires an integer: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(f"✓ Dream min recall count set to {stored} in {CONFIG_PATH}")
+        return
+
+    if "--dream-min-unique-queries" in args:
+        idx = args.index("--dream-min-unique-queries")
+        if idx + 1 >= len(args):
+            print("Error: --dream-min-unique-queries requires a value", file=sys.stderr)
+            sys.exit(1)
+        try:
+            stored = set_dream_min_unique_queries(int(args[idx + 1]))
+        except (ValueError, TypeError) as exc:
+            print(f"Error: --dream-min-unique-queries requires an integer: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(f"✓ Dream min unique queries set to {stored} in {CONFIG_PATH}")
+        return
+
+    if "--dream-memory-path" in args:
+        idx = args.index("--dream-memory-path")
+        if idx + 1 >= len(args):
+            print("Error: --dream-memory-path requires a path", file=sys.stderr)
+            sys.exit(1)
+        path_val = (args[idx + 1] or "").strip()
+        if not path_val:
+            print("Error: --dream-memory-path requires a non-empty path", file=sys.stderr)
+            sys.exit(1)
+        stored = set_dream_memory_path(path_val)
+        print(f"✓ Dream memory path set to {stored!r} in {CONFIG_PATH}")
         return
 
     if "--setup" in args:

--- a/sync-daemon.py
+++ b/sync-daemon.py
@@ -821,7 +821,8 @@ class DreamingScheduler:
         self.min_score = float(min_score)
         self.min_recall_count = int(min_recall_count)
         self.min_unique_queries = int(min_unique_queries)
-        self.memory_path = str(memory_path).strip() if memory_path else DEFAULT_DREAM_MEMORY_PATH
+        _stripped_path = str(memory_path).strip()
+        self.memory_path = _stripped_path if _stripped_path else DEFAULT_DREAM_MEMORY_PATH
 
     @classmethod
     def from_config(cls, config_path: Path) -> "DreamingScheduler":

--- a/sync-daemon.py
+++ b/sync-daemon.py
@@ -44,7 +44,13 @@ SYNC_CONFIG_PATH = TOOLS_DIR / "sync-config.json"
 MARKERS_DIR = Path.home() / ".copilot" / "markers"
 SYNC_NUDGE_MARKER = MARKERS_DIR / "sync-nudge.json"
 SYNC_FLUSH_MARKER = MARKERS_DIR / "sync-flush.json"
+DREAM_TRIGGER_MARKER = MARKERS_DIR / "dream-trigger.json"
 DEFAULT_INTERVAL = 60
+DEFAULT_DREAM_INTERVAL_HOURS = 24  # hours between dream sweeps (issue #162 contract)
+DEFAULT_DREAM_MIN_SCORE = 0.75
+DEFAULT_DREAM_MIN_RECALL_COUNT = 3
+DEFAULT_DREAM_MIN_UNIQUE_QUERIES = 2
+DEFAULT_DREAM_MEMORY_PATH = "MEMORY.md"
 MAX_SYNC_LIMIT = 1000
 MAX_PULL_PAGES_PER_CYCLE = 10
 PUSH_TIMEOUT_SECONDS = 120
@@ -216,11 +222,11 @@ def release_lock() -> None:
 
 def load_state() -> dict:
     if not STATE_FILE.exists():
-        return {"last_activity": "", "last_error": ""}
+        return {"last_activity": "", "last_error": "", "last_dream_run": ""}
     try:
         return json.loads(STATE_FILE.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
-        return {"last_activity": "", "last_error": ""}
+        return {"last_activity": "", "last_error": "", "last_dream_run": ""}
 
 
 def save_state(state: dict) -> None:
@@ -776,6 +782,189 @@ def _consume_sync_markers() -> dict:
     return consumed
 
 
+class DreamingScheduler:
+    """Manages automated dream sweep scheduling for the sync daemon (issue #162).
+
+    Reads configuration from sync-config.json and drives dream.py on the
+    configured interval.  Supports manual one-shot triggers via a marker file
+    and provides operator-visible logging including the promoted-entry count.
+
+    Config keys read from sync-config.json:
+        dream_enabled            (bool)  – whether scheduled sweeps are active
+        dream_interval_hours     (float) – hours between sweeps (default 24)
+        dream_min_score          (float) – gate threshold score (default 0.75)
+        dream_min_recall_count   (int)   – gate threshold recall count (default 3)
+        dream_min_unique_queries (int)   – gate threshold unique queries (default 2)
+        dream_memory_path        (str)   – output path for MEMORY.md (default "MEMORY.md")
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        interval_hours: float = DEFAULT_DREAM_INTERVAL_HOURS,
+        min_score: float = DEFAULT_DREAM_MIN_SCORE,
+        min_recall_count: int = DEFAULT_DREAM_MIN_RECALL_COUNT,
+        min_unique_queries: int = DEFAULT_DREAM_MIN_UNIQUE_QUERIES,
+        memory_path: str = DEFAULT_DREAM_MEMORY_PATH,
+    ) -> None:
+        self.enabled = bool(enabled)
+        raw_interval = float(interval_hours)
+        if raw_interval <= 0:
+            print(
+                f"[sync] dream_interval_hours={raw_interval!r} is not positive; "
+                f"normalizing to default ({DEFAULT_DREAM_INTERVAL_HOURS}h)",
+                file=sys.stderr,
+            )
+            raw_interval = float(DEFAULT_DREAM_INTERVAL_HOURS)
+        self.interval_hours = raw_interval
+        self.min_score = float(min_score)
+        self.min_recall_count = int(min_recall_count)
+        self.min_unique_queries = int(min_unique_queries)
+        self.memory_path = str(memory_path).strip() if memory_path else DEFAULT_DREAM_MEMORY_PATH
+
+    @classmethod
+    def from_config(cls, config_path: Path) -> "DreamingScheduler":
+        """Load scheduler settings from sync-config.json; fall back to defaults."""
+        kwargs: dict = {
+            "enabled": True,
+            "interval_hours": DEFAULT_DREAM_INTERVAL_HOURS,
+            "min_score": DEFAULT_DREAM_MIN_SCORE,
+            "min_recall_count": DEFAULT_DREAM_MIN_RECALL_COUNT,
+            "min_unique_queries": DEFAULT_DREAM_MIN_UNIQUE_QUERIES,
+            "memory_path": DEFAULT_DREAM_MEMORY_PATH,
+        }
+        if not config_path.exists():
+            return cls(**kwargs)
+        try:
+            obj = json.loads(config_path.read_text(encoding="utf-8"))
+            if isinstance(obj, dict):
+                if "dream_enabled" in obj:
+                    kwargs["enabled"] = bool(obj["dream_enabled"])
+                if "dream_interval_hours" in obj:
+                    try:
+                        v = float(obj["dream_interval_hours"])
+                        kwargs["interval_hours"] = v  # __init__ normalizes zero/negative
+                    except (TypeError, ValueError):
+                        pass
+                if "dream_min_score" in obj:
+                    try:
+                        kwargs["min_score"] = float(obj["dream_min_score"])
+                    except (TypeError, ValueError):
+                        pass
+                if "dream_min_recall_count" in obj:
+                    try:
+                        kwargs["min_recall_count"] = int(obj["dream_min_recall_count"])
+                    except (TypeError, ValueError):
+                        pass
+                if "dream_min_unique_queries" in obj:
+                    try:
+                        kwargs["min_unique_queries"] = int(obj["dream_min_unique_queries"])
+                    except (TypeError, ValueError):
+                        pass
+                if "dream_memory_path" in obj:
+                    val = str(obj["dream_memory_path"] or "").strip()
+                    if val:
+                        kwargs["memory_path"] = val
+        except (json.JSONDecodeError, OSError):
+            pass
+        return cls(**kwargs)
+
+    def is_due(self, state: dict) -> bool:
+        """Return True if a dream sweep should run now based on config and elapsed time."""
+        if not self.enabled:
+            return False
+        interval_secs = self.interval_hours * 3600.0
+        last_run = str(state.get("last_dream_run", "") or "")
+        if not last_run:
+            return True
+        try:
+            ts = datetime.fromisoformat(last_run.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return True
+        return (time.time() - ts) >= interval_secs
+
+    def consume_trigger(self) -> bool:
+        """Consume the dream-trigger marker; return True if it was present AND enabled.
+
+        When ``dream_enabled=False`` the marker is removed (to avoid stale marker
+        accumulation) but ``False`` is returned so the caller skips the sweep.
+        """
+        try:
+            if not DREAM_TRIGGER_MARKER.exists():
+                return False
+            DREAM_TRIGGER_MARKER.unlink(missing_ok=True)
+            if not self.enabled:
+                print(
+                    "[sync] dream-trigger.json marker found but dream_enabled=False; marker consumed, sweep suppressed"
+                )
+                return False
+            return True
+        except OSError:
+            return False
+
+    def run_sweep(self, db_path: Path = DB_PATH) -> dict:
+        """Run a dream sweep by invoking dream.py as a subprocess.
+
+        Passes all gate thresholds and memory path as CLI arguments.
+        Returns a dict with keys:
+            ok             (bool) – True if sweep succeeded or was skipped.
+            error          (str)  – non-empty on failure.
+            skipped        (bool) – True if dream.py was absent (non-fatal).
+            promoted_count (int)  – entries that passed the gate (0 if unknown).
+        """
+        import subprocess as _subprocess
+
+        dream_script = TOOLS_DIR / "dream.py"
+        if not dream_script.exists():
+            print("[sync] dream sweep skipped: dream.py not found (fail-open)")
+            return {"ok": True, "error": "", "skipped": True, "promoted_count": 0}
+        memory_path = self.memory_path if Path(self.memory_path).is_absolute() else str(TOOLS_DIR / self.memory_path)
+        cmd = [
+            sys.executable,
+            str(dream_script),
+            "--db",
+            str(db_path),
+            "--json",
+            "--min-score",
+            str(self.min_score),
+            "--min-recall",
+            str(self.min_recall_count),
+            "--min-queries",
+            str(self.min_unique_queries),
+            "--memory-output",
+            memory_path,
+        ]
+        try:
+            result = _subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=300,
+                encoding="utf-8",
+                errors="replace",
+            )
+            if result.returncode == 0:
+                promoted_count = 0
+                try:
+                    out_data = json.loads(result.stdout.strip() or "{}")
+                    promoted_count = int(out_data.get("gate_count", 0))
+                except (json.JSONDecodeError, ValueError, TypeError):
+                    pass
+                print(
+                    f"[sync] dream sweep OK | promoted={promoted_count} "
+                    f"min_score={self.min_score} interval_hours={self.interval_hours}"
+                )
+                return {"ok": True, "error": "", "skipped": False, "promoted_count": promoted_count}
+            else:
+                err = result.stderr.strip()
+                print(f"[sync] dream sweep failed: {err}")
+                return {"ok": False, "error": err, "skipped": False, "promoted_count": 0}
+        except Exception as exc:
+            print(f"[sync] dream sweep error: {exc}")
+            return {"ok": False, "error": str(exc), "skipped": False, "promoted_count": 0}
+
+
 def _refresh_knowledge_fts_for_documents(db: sqlite3.Connection, document_ids: set[int]) -> None:
     if not document_ids:
         return
@@ -1080,6 +1269,7 @@ def run_loop(
     if not base_url:
         print("[sync] No connection_string configured; daemon will remain idle (local-first fail-open).")
 
+    dream_scheduler = DreamingScheduler.from_config(SYNC_CONFIG_PATH)
     state = load_state()
 
     try:
@@ -1100,12 +1290,29 @@ def run_loop(
             else:
                 state["last_error"] = cycle["error"]
                 print(f"[sync] once degraded: {cycle['error']}")
+            # Dream sweep in --once mode: only on explicit manual trigger.
+            # Scheduled-due sweeps are NOT run in --once mode to preserve fast
+            # one-shot semantics.  DreamingScheduler.run_sweep uses a 300 s
+            # subprocess timeout, so allowing is_due() to fire on a fresh
+            # install (no last_dream_run) or on any overdue interval would block
+            # one-shot runs for up to 5 minutes.  Scheduled sweeps run only in
+            # the continuous daemon loop below.
+            manual_dream = dream_scheduler.consume_trigger()
+            if manual_dream:
+                dream_result = dream_scheduler.run_sweep(db_path=DB_PATH)
+                # Only stamp last_dream_run on a real successful sweep.
+                # A skipped sweep (dream.py absent) must NOT stamp last_dream_run so
+                # the scheduler does not suppress retries for the full interval.
+                if dream_result.get("ok") and not dream_result.get("skipped"):
+                    state["last_dream_run"] = utc_now()
             save_state(state)
             return 0
 
         print(f"[sync] Running sync loop | interval={interval}s")
         pending_flush = False
         while running:
+            # Hot-reload dream scheduler config so operator changes take effect without restart.
+            dream_scheduler = DreamingScheduler.from_config(SYNC_CONFIG_PATH)
             signals = _consume_sync_markers()
             pending_flush = pending_flush or signals["flush"]
             cycle = run_sync_cycle(
@@ -1125,6 +1332,17 @@ def run_loop(
                 print(f"[sync] degraded: {cycle['error']}")
             save_state(state)
 
+            # Dream sweep: run if manually triggered or scheduled interval has elapsed.
+            manual_dream = dream_scheduler.consume_trigger()
+            if manual_dream or dream_scheduler.is_due(state):
+                dream_result = dream_scheduler.run_sweep(db_path=DB_PATH)
+                # Only stamp last_dream_run on a real successful sweep.
+                # A skipped sweep (dream.py absent) must NOT stamp last_dream_run so
+                # the scheduler does not suppress retries for the full interval.
+                if dream_result.get("ok") and not dream_result.get("skipped"):
+                    state["last_dream_run"] = utc_now()
+                    save_state(state)
+
             sleep_secs = interval if "--interval" in sys.argv else _adaptive_poll_interval(state)
             for _ in range(max(1, int(sleep_secs))):
                 if not running:
@@ -1132,6 +1350,9 @@ def run_loop(
                 signals = _consume_sync_markers()
                 if signals["nudge"] or signals["flush"]:
                     pending_flush = pending_flush or signals["flush"]
+                    break
+                # Wake early if a manual dream trigger is dropped during sleep.
+                if DREAM_TRIGGER_MARKER.exists():
                     break
                 time.sleep(1)
 

--- a/tests/test_sync_runtime.py
+++ b/tests/test_sync_runtime.py
@@ -147,12 +147,12 @@ class _GatewayState:
                             "total_files": 0,
                             "has_plan": 0,
                             "source": "sync",
-                            "indexed_at": "2026-01-01T00:00:00Z"
+                            "indexed_at": "2026-01-01T00:00:00Z",
                         },
                         "op_index": 0,
-                        "created_at": "2026-01-01T00:00:00Z"
+                        "created_at": "2026-01-01T00:00:00Z",
                     }
-                ]
+                ],
             }
         ]
 
@@ -194,11 +194,10 @@ def make_gateway_handler(state: _GatewayState):
             body = json.loads(raw or "{}")
             state.pushed_payloads.append(body)
             txn_ids = [str(t.get("txn_id", "")) for t in body.get("txns", [])]
-            self._write(200, {
-                "accepted_txn_ids": txn_ids,
-                "duplicate_txn_ids": [],
-                "latest_txn_id": txn_ids[-1] if txn_ids else ""
-            })
+            self._write(
+                200,
+                {"accepted_txn_ids": txn_ids, "duplicate_txn_ids": [], "latest_txn_id": txn_ids[-1] if txn_ids else ""},
+            )
 
     return Handler
 
@@ -259,9 +258,7 @@ db.close()
 
 # Seed one pending local transaction.
 db = sqlite3.connect(str(db_path))
-db.execute(
-    "INSERT OR REPLACE INTO sync_state (key, value) VALUES ('local_replica_id', 'local-test')"
-)
+db.execute("INSERT OR REPLACE INTO sync_state (key, value) VALUES ('local_replica_id', 'local-test')")
 db.execute(
     "INSERT INTO sync_txns (txn_id, replica_id, status, created_at, committed_at) VALUES (?, ?, 'pending', ?, '')",
     ("local-txn-1", "local-test", datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")),
@@ -273,17 +270,19 @@ db.execute(
     """,
     (
         "local-txn-1",
-        json.dumps({
-            "id": "session-local-1",
-            "path": "/repo/local",
-            "summary": "local row",
-            "total_checkpoints": 1,
-            "total_research": 0,
-            "total_files": 0,
-            "has_plan": 1,
-            "source": "copilot",
-            "indexed_at": "2026-01-01T00:00:00Z",
-        }),
+        json.dumps(
+            {
+                "id": "session-local-1",
+                "path": "/repo/local",
+                "summary": "local row",
+                "total_checkpoints": 1,
+                "total_research": 0,
+                "total_files": 0,
+                "has_plan": 1,
+                "source": "copilot",
+                "indexed_at": "2026-01-01T00:00:00Z",
+            }
+        ),
         datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
     ),
 )
@@ -295,12 +294,22 @@ db = sqlite3.connect(str(db_path))
 db.row_factory = sqlite3.Row
 db.execute("DELETE FROM sync_state WHERE key='local_replica_id'")
 seeded_id = sync_daemon.get_local_replica_id(db)
-test("sync-daemon seeds machine-specific replica id", seeded_id.startswith("local-") and seeded_id != "local", seeded_id)
+test(
+    "sync-daemon seeds machine-specific replica id", seeded_id.startswith("local-") and seeded_id != "local", seeded_id
+)
 stored_seeded = db.execute("SELECT value FROM sync_state WHERE key='local_replica_id'").fetchone()
-test("sync-daemon persists seeded replica id", stored_seeded is not None and stored_seeded[0] == seeded_id, str(stored_seeded))
+test(
+    "sync-daemon persists seeded replica id",
+    stored_seeded is not None and stored_seeded[0] == seeded_id,
+    str(stored_seeded),
+)
 db.execute("UPDATE sync_state SET value='local' WHERE key='local_replica_id'")
 migrated_id = sync_daemon.get_local_replica_id(db)
-test("sync-daemon migrates legacy local replica id", migrated_id.startswith("local-") and migrated_id != "local", migrated_id)
+test(
+    "sync-daemon migrates legacy local replica id",
+    migrated_id.startswith("local-") and migrated_id != "local",
+    migrated_id,
+)
 db.commit()
 db.close()
 
@@ -340,13 +349,8 @@ for txn_id, txn_replica, committed_at in [
         (txn_id, txn_id),
     )
 repaired = sync_daemon.repair_nonlocal_committed_txns(db, "local-test")
-remote_status = db.execute(
-    "SELECT status FROM sync_txns WHERE txn_id='remote-pending-filter'"
-).fetchone()
-pending_ids = [
-    t["txn_id"]
-    for t in sync_daemon.collect_pending_txns(db, limit=20, replica_id="local-test")
-]
+remote_status = db.execute("SELECT status FROM sync_txns WHERE txn_id='remote-pending-filter'").fetchone()
+pending_ids = [t["txn_id"] for t in sync_daemon.collect_pending_txns(db, limit=20, replica_id="local-test")]
 test(
     "sync-daemon repairs committed nonlocal pending txns",
     repaired >= 1 and remote_status is not None and remote_status[0] == "committed",
@@ -365,6 +369,7 @@ db.close()
 # DB-open failures should degrade a cycle instead of crashing the background loop.
 original_get_db = sync_daemon.get_db
 try:
+
     def _raise_locked(_db_path=sync_daemon.DB_PATH):
         raise sqlite3.OperationalError("database is locked")
 
@@ -384,6 +389,7 @@ finally:
 
 original_gateway_health = sync_daemon.gateway_health
 try:
+
     def _raise_timeout(_base_url):
         raise TimeoutError("The read operation timed out")
 
@@ -448,12 +454,14 @@ try:
             (
                 txn_id,
                 f"session-{txn_id}",
-                json.dumps({
-                    "id": f"session-{txn_id}",
-                    "path": f"/repo/{txn_id}",
-                    "summary": txn_id,
-                    "indexed_at": now,
-                }),
+                json.dumps(
+                    {
+                        "id": f"session-{txn_id}",
+                        "path": f"/repo/{txn_id}",
+                        "summary": txn_id,
+                        "indexed_at": now,
+                    }
+                ),
                 now,
             ),
         )
@@ -461,6 +469,7 @@ try:
 
     original_request_json = sync_daemon._request_json
     try:
+
         def _phantom_push_response(*_args, **_kwargs):
             return {
                 "accepted_txn_ids": ["local-txn-response-check", "local-txn-unsent"],
@@ -485,21 +494,25 @@ try:
             """
         ).fetchall()
         test("sync-daemon rejects gateway txn_ids not in pushed batch", phantom_rejected, phantom_error)
-        test("unsent txn_ids remain pending after rejected gateway response", all(r[1] == "pending" for r in rows), str(rows))
+        test(
+            "unsent txn_ids remain pending after rejected gateway response",
+            all(r[1] == "pending" for r in rows),
+            str(rows),
+        )
     finally:
         sync_daemon._request_json = original_request_json
-        db.execute(
-            "DELETE FROM sync_ops WHERE txn_id IN ('local-txn-response-check', 'local-txn-unsent')"
-        )
-        db.execute(
-            "DELETE FROM sync_txns WHERE txn_id IN ('local-txn-response-check', 'local-txn-unsent')"
-        )
+        db.execute("DELETE FROM sync_ops WHERE txn_id IN ('local-txn-response-check', 'local-txn-unsent')")
+        db.execute("DELETE FROM sync_txns WHERE txn_id IN ('local-txn-response-check', 'local-txn-unsent')")
         db.commit()
         db.close()
 
     status_obj = sync_status.collect_status(db_path=db_path, check_health=True)
     test("sync-status finds local replica id", status_obj["local_replica_id"] == "local-test")
-    test("sync-status gateway reachable", status_obj["gateway_health"]["status"] == "ok", str(status_obj["gateway_health"]))
+    test(
+        "sync-status gateway reachable",
+        status_obj["gateway_health"]["status"] == "ok",
+        str(status_obj["gateway_health"]),
+    )
     test("sync-status keeps http-gateway client contract", status_obj["client_contract"] == "http-gateway")
     test("sync-status direct DB sync remains disabled", status_obj["direct_db_sync"] is False)
     test(
@@ -577,16 +590,16 @@ try:
     pull_result = sync_daemon.pull_once(db2, base_url2, "local-runtime-2", limit=10)
     db2.commit()
     remote2 = db2.execute("SELECT summary FROM sessions WHERE id='session-remote-2'").fetchone()
-    cursor2 = db2.execute(
-        "SELECT last_txn_id FROM sync_cursors WHERE replica_id='local-runtime-2'"
-    ).fetchone()
+    cursor2 = db2.execute("SELECT last_txn_id FROM sync_cursors WHERE replica_id='local-runtime-2'").fetchone()
     test("pull fail-open ignores unknown future table", pull_result["applied"] == 2, str(pull_result))
     test("pull still applies known canonical op", remote2 is not None and remote2[0] == "remote row 2", str(remote2))
-    test("pull cursor advances after unknown table op", cursor2 is not None and cursor2[0] == "remote-unknown-2", str(cursor2))
-
-    db2.execute(
-        "UPDATE sync_table_policies SET stable_id_column='bad-col' WHERE table_name='sessions'"
+    test(
+        "pull cursor advances after unknown table op",
+        cursor2 is not None and cursor2[0] == "remote-unknown-2",
+        str(cursor2),
     )
+
+    db2.execute("UPDATE sync_table_policies SET stable_id_column='bad-col' WHERE table_name='sessions'")
     sync_daemon._apply_op(
         db2,
         {
@@ -600,10 +613,12 @@ try:
             },
         },
     )
-    fallback_row = db2.execute(
-        "SELECT summary FROM sessions WHERE id='session-invalid-stable-col'"
-    ).fetchone()
-    test("invalid stable_id_column is validated and does not break apply", fallback_row is not None and fallback_row[0] == "stable col fallback", str(fallback_row))
+    fallback_row = db2.execute("SELECT summary FROM sessions WHERE id='session-invalid-stable-col'").fetchone()
+    test(
+        "invalid stable_id_column is validated and does not break apply",
+        fallback_row is not None and fallback_row[0] == "stable col fallback",
+        str(fallback_row),
+    )
     db2.commit()
     db2.close()
 finally:
@@ -832,30 +847,14 @@ try:
     pull_result4 = sync_daemon.pull_once(db4, base_url4, "local-runtime-contract", limit=20)
     db4.commit()
 
-    session_contract = db4.execute(
-        "SELECT id, summary FROM sessions WHERE id='session-contract-1'"
-    ).fetchone()
-    session_after_fail = db4.execute(
-        "SELECT id, summary FROM sessions WHERE id='session-after-fail-open'"
-    ).fetchone()
-    ignored_session = db4.execute(
-        "SELECT id FROM sessions WHERE id='remote-session-id-ignored'"
-    ).fetchone()
-    doc_row = db4.execute(
-        "SELECT id, stable_id FROM documents WHERE stable_id='doc-contract-1'"
-    ).fetchone()
-    doc_payload_mismatch = db4.execute(
-        "SELECT id FROM documents WHERE stable_id='doc-payload-mismatch'"
-    ).fetchone()
-    section_row = db4.execute(
-        "SELECT document_id FROM sections WHERE stable_id='section-contract-1'"
-    ).fetchone()
-    ke_one = db4.execute(
-        "SELECT id, document_id FROM knowledge_entries WHERE stable_id='ke-contract-1'"
-    ).fetchone()
-    ke_two = db4.execute(
-        "SELECT id FROM knowledge_entries WHERE stable_id='ke-contract-2'"
-    ).fetchone()
+    session_contract = db4.execute("SELECT id, summary FROM sessions WHERE id='session-contract-1'").fetchone()
+    session_after_fail = db4.execute("SELECT id, summary FROM sessions WHERE id='session-after-fail-open'").fetchone()
+    ignored_session = db4.execute("SELECT id FROM sessions WHERE id='remote-session-id-ignored'").fetchone()
+    doc_row = db4.execute("SELECT id, stable_id FROM documents WHERE stable_id='doc-contract-1'").fetchone()
+    doc_payload_mismatch = db4.execute("SELECT id FROM documents WHERE stable_id='doc-payload-mismatch'").fetchone()
+    section_row = db4.execute("SELECT document_id FROM sections WHERE stable_id='section-contract-1'").fetchone()
+    ke_one = db4.execute("SELECT id, document_id FROM knowledge_entries WHERE stable_id='ke-contract-1'").fetchone()
+    ke_two = db4.execute("SELECT id FROM knowledge_entries WHERE stable_id='ke-contract-2'").fetchone()
     kr_row = db4.execute(
         "SELECT source_id, target_id FROM knowledge_relations WHERE stable_id='kr-contract-1'"
     ).fetchone()
@@ -865,20 +864,24 @@ try:
     sf_row = db4.execute(
         "SELECT id, stable_id, origin_replica_id FROM search_feedback WHERE stable_id='sf-contract-1'"
     ).fetchone()
-    sf_empty_row = db4.execute(
-        "SELECT id FROM search_feedback WHERE stable_id=''"
-    ).fetchone()
-    ke_fts_row = db4.execute(
-        "SELECT rowid, title FROM ke_fts WHERE rowid = ?",
-        (ke_one[0],),
-    ).fetchone() if ke_one is not None else None
-    knowledge_fts_row = db4.execute(
-        "SELECT document_id, content FROM knowledge_fts WHERE document_id = ?",
-        (doc_row[0],),
-    ).fetchone() if doc_row is not None else None
-    cursor4 = db4.execute(
-        "SELECT last_txn_id FROM sync_cursors WHERE replica_id='local-runtime-contract'"
-    ).fetchone()
+    sf_empty_row = db4.execute("SELECT id FROM search_feedback WHERE stable_id=''").fetchone()
+    ke_fts_row = (
+        db4.execute(
+            "SELECT rowid, title FROM ke_fts WHERE rowid = ?",
+            (ke_one[0],),
+        ).fetchone()
+        if ke_one is not None
+        else None
+    )
+    knowledge_fts_row = (
+        db4.execute(
+            "SELECT document_id, content FROM knowledge_fts WHERE document_id = ?",
+            (doc_row[0],),
+        ).fetchone()
+        if doc_row is not None
+        else None
+    )
+    cursor4 = db4.execute("SELECT last_txn_id FROM sync_cursors WHERE replica_id='local-runtime-contract'").fetchone()
     failure4 = db4.execute(
         """
         SELECT table_name, row_stable_id
@@ -890,20 +893,68 @@ try:
     ).fetchone()
 
     test("real-schema pull applies both txns", pull_result4["applied"] == 2, str(pull_result4))
-    test("sessions use row_stable_id instead of remote id", session_contract is not None and ignored_session is None, str(session_contract))
+    test(
+        "sessions use row_stable_id instead of remote id",
+        session_contract is not None and ignored_session is None,
+        str(session_contract),
+    )
     test("documents ignore remote surrogate id", doc_row is not None and doc_row[0] != 9001, str(doc_row))
-    test("documents keep envelope row_stable_id authoritative over payload stable_id", doc_row is not None and doc_row[1] == "doc-contract-1" and doc_payload_mismatch is None, str(doc_row))
-    test("sections resolve document_stable_id to local document_id", section_row is not None and doc_row is not None and section_row[0] == doc_row[0], str(section_row))
-    test("knowledge_entries resolve optional document_stable_id", ke_one is not None and doc_row is not None and ke_one[1] == doc_row[0], str(ke_one))
-    test("knowledge_relations resolve source/target local ids", kr_row is not None and ke_one is not None and ke_two is not None and kr_row[0] == ke_one[0] and kr_row[1] == ke_two[0], str(kr_row))
+    test(
+        "documents keep envelope row_stable_id authoritative over payload stable_id",
+        doc_row is not None and doc_row[1] == "doc-contract-1" and doc_payload_mismatch is None,
+        str(doc_row),
+    )
+    test(
+        "sections resolve document_stable_id to local document_id",
+        section_row is not None and doc_row is not None and section_row[0] == doc_row[0],
+        str(section_row),
+    )
+    test(
+        "knowledge_entries resolve optional document_stable_id",
+        ke_one is not None and doc_row is not None and ke_one[1] == doc_row[0],
+        str(ke_one),
+    )
+    test(
+        "knowledge_relations resolve source/target local ids",
+        kr_row is not None
+        and ke_one is not None
+        and ke_two is not None
+        and kr_row[0] == ke_one[0]
+        and kr_row[1] == ke_two[0],
+        str(kr_row),
+    )
     test("entity_relations apply by stable_id contract", er_row is not None and er_row[0] == "sync", str(er_row))
-    test("search_feedback applies without trusting remote id", sf_row is not None and sf_row[0] != 4001 and sf_row[1] == "sf-contract-1", str(sf_row))
+    test(
+        "search_feedback applies without trusting remote id",
+        sf_row is not None and sf_row[0] != 4001 and sf_row[1] == "sf-contract-1",
+        str(sf_row),
+    )
     test("empty row_stable_id delete is ignored", sf_empty_row is not None, str(sf_empty_row))
-    test("pull refreshes ke_fts for synced knowledge entries", ke_fts_row is not None and ke_fts_row[0] == ke_one[0], str(ke_fts_row))
-    test("pull refreshes knowledge_fts for synced sections", knowledge_fts_row is not None and "section content" in knowledge_fts_row[1], str(knowledge_fts_row))
-    test("per-op failure is fail-open for remaining ops", session_after_fail is not None and session_after_fail[1] == "still applied", str(session_after_fail))
-    test("pull cursor advances after partial-op failures", cursor4 is not None and cursor4[0] == "remote-contract-2", str(cursor4))
-    test("failed unresolved helper reference is recorded", failure4 is not None and failure4[0] == "sections", str(failure4))
+    test(
+        "pull refreshes ke_fts for synced knowledge entries",
+        ke_fts_row is not None and ke_fts_row[0] == ke_one[0],
+        str(ke_fts_row),
+    )
+    test(
+        "pull refreshes knowledge_fts for synced sections",
+        knowledge_fts_row is not None and "section content" in knowledge_fts_row[1],
+        str(knowledge_fts_row),
+    )
+    test(
+        "per-op failure is fail-open for remaining ops",
+        session_after_fail is not None and session_after_fail[1] == "still applied",
+        str(session_after_fail),
+    )
+    test(
+        "pull cursor advances after partial-op failures",
+        cursor4 is not None and cursor4[0] == "remote-contract-2",
+        str(cursor4),
+    )
+    test(
+        "failed unresolved helper reference is recorded",
+        failure4 is not None and failure4[0] == "sections",
+        str(failure4),
+    )
 
     db4.close()
 finally:
@@ -994,22 +1045,28 @@ try:
     seeded_pull = sync_daemon.pull_once(db_delete, base_url_delete, "local-delete-fts", limit=20)
     db_delete.commit()
 
-    seeded_doc = db_delete.execute(
-        "SELECT id FROM documents WHERE stable_id='doc-delete-1'"
-    ).fetchone()
-    seeded_entry = db_delete.execute(
-        "SELECT id FROM knowledge_entries WHERE stable_id='ke-delete-1'"
-    ).fetchone()
-    seeded_knowledge_fts = db_delete.execute(
-        "SELECT document_id FROM knowledge_fts WHERE document_id=?",
-        (seeded_doc[0],),
-    ).fetchone() if seeded_doc is not None else None
-    seeded_ke_fts = db_delete.execute(
-        "SELECT rowid FROM ke_fts WHERE rowid=?",
-        (seeded_entry[0],),
-    ).fetchone() if seeded_entry is not None else None
+    seeded_doc = db_delete.execute("SELECT id FROM documents WHERE stable_id='doc-delete-1'").fetchone()
+    seeded_entry = db_delete.execute("SELECT id FROM knowledge_entries WHERE stable_id='ke-delete-1'").fetchone()
+    seeded_knowledge_fts = (
+        db_delete.execute(
+            "SELECT document_id FROM knowledge_fts WHERE document_id=?",
+            (seeded_doc[0],),
+        ).fetchone()
+        if seeded_doc is not None
+        else None
+    )
+    seeded_ke_fts = (
+        db_delete.execute(
+            "SELECT rowid FROM ke_fts WHERE rowid=?",
+            (seeded_entry[0],),
+        ).fetchone()
+        if seeded_entry is not None
+        else None
+    )
     test("delete regression seed pull applied", seeded_pull["applied"] == 1, str(seeded_pull))
-    test("delete regression seed creates knowledge_fts row", seeded_knowledge_fts is not None, str(seeded_knowledge_fts))
+    test(
+        "delete regression seed creates knowledge_fts row", seeded_knowledge_fts is not None, str(seeded_knowledge_fts)
+    )
     test("delete regression seed creates ke_fts row", seeded_ke_fts is not None, str(seeded_ke_fts))
 
     gateway_state_delete.pull_txns = [
@@ -1042,26 +1099,32 @@ try:
     delete_pull = sync_daemon.pull_once(db_delete, base_url_delete, "local-delete-fts", limit=20)
     db_delete.commit()
 
-    deleted_doc = db_delete.execute(
-        "SELECT id FROM documents WHERE stable_id='doc-delete-1'"
-    ).fetchone()
-    deleted_entry = db_delete.execute(
-        "SELECT id FROM knowledge_entries WHERE stable_id='ke-delete-1'"
-    ).fetchone()
-    stale_knowledge_fts = db_delete.execute(
-        "SELECT document_id FROM knowledge_fts WHERE document_id=?",
-        (seeded_doc[0],),
-    ).fetchone() if seeded_doc is not None else None
-    stale_ke_fts = db_delete.execute(
-        "SELECT rowid FROM ke_fts WHERE rowid=?",
-        (seeded_entry[0],),
-    ).fetchone() if seeded_entry is not None else None
+    deleted_doc = db_delete.execute("SELECT id FROM documents WHERE stable_id='doc-delete-1'").fetchone()
+    deleted_entry = db_delete.execute("SELECT id FROM knowledge_entries WHERE stable_id='ke-delete-1'").fetchone()
+    stale_knowledge_fts = (
+        db_delete.execute(
+            "SELECT document_id FROM knowledge_fts WHERE document_id=?",
+            (seeded_doc[0],),
+        ).fetchone()
+        if seeded_doc is not None
+        else None
+    )
+    stale_ke_fts = (
+        db_delete.execute(
+            "SELECT rowid FROM ke_fts WHERE rowid=?",
+            (seeded_entry[0],),
+        ).fetchone()
+        if seeded_entry is not None
+        else None
+    )
     db_delete.close()
 
     test("delete regression pull applied", delete_pull["applied"] == 1, str(delete_pull))
     test("remote document delete removes canonical document row", deleted_doc is None, str(deleted_doc))
     test("remote knowledge entry delete removes canonical entry row", deleted_entry is None, str(deleted_entry))
-    test("remote document delete removes stale knowledge_fts row", stale_knowledge_fts is None, str(stale_knowledge_fts))
+    test(
+        "remote document delete removes stale knowledge_fts row", stale_knowledge_fts is None, str(stale_knowledge_fts)
+    )
     test("remote knowledge entry delete removes stale ke_fts row", stale_ke_fts is None, str(stale_ke_fts))
 finally:
     server_delete.shutdown()
@@ -1077,7 +1140,11 @@ sync_daemon.ensure_sync_foundation(db3)
 db3.execute("INSERT OR REPLACE INTO sync_state (key, value) VALUES ('local_replica_id', 'local-test-flush')")
 db3.execute(
     "INSERT INTO sync_txns (txn_id, replica_id, status, created_at, committed_at) VALUES (?, ?, 'pending', ?, '')",
-    ("local-txn-flush", "local-test-flush", datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")),
+    (
+        "local-txn-flush",
+        "local-test-flush",
+        datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    ),
 )
 db3.execute(
     """
@@ -1157,8 +1224,16 @@ try:
     remote_flush_row = db3.execute("SELECT summary FROM sessions WHERE id='session-remote-flush-1'").fetchone()
     local_txn_state = db3.execute("SELECT status FROM sync_txns WHERE txn_id='local-txn-flush'").fetchone()
     db3.close()
-    test("flush marker still performs pull", remote_flush_row is not None and remote_flush_row[0] == "remote flush row", str(remote_flush_row))
-    test("flush marker push commits pending txn", local_txn_state is not None and local_txn_state[0] == "committed", str(local_txn_state))
+    test(
+        "flush marker still performs pull",
+        remote_flush_row is not None and remote_flush_row[0] == "remote flush row",
+        str(remote_flush_row),
+    )
+    test(
+        "flush marker push commits pending txn",
+        local_txn_state is not None and local_txn_state[0] == "committed",
+        str(local_txn_state),
+    )
 finally:
     server3.shutdown()
     server3.server_close()
@@ -1224,6 +1299,7 @@ pages = [
 request_calls = []
 original_request_json = sync_daemon._request_json
 try:
+
     def _paged_request(url: str, method: str = "GET", payload: dict | None = None, timeout: int = 10):
         request_calls.append(url)
         if not pages:
@@ -1234,12 +1310,18 @@ try:
     db5 = sync_daemon.get_db(db5_path)
     paged_pull = sync_daemon.pull_once(db5, "http://sync.test", "local-pagination", limit=1)
     db5.commit()
-    page_rows = db5.execute("SELECT COUNT(*) FROM sessions WHERE id IN ('session-page-1','session-page-2')").fetchone()[0]
+    page_rows = db5.execute("SELECT COUNT(*) FROM sessions WHERE id IN ('session-page-1','session-page-2')").fetchone()[
+        0
+    ]
     page_cursor = db5.execute("SELECT last_txn_id FROM sync_cursors WHERE replica_id='local-pagination'").fetchone()
     db5.close()
     test("pull pagination fetches multiple pages in one cycle", len(request_calls) >= 2, str(request_calls))
     test("pull pagination applies all paged txns", paged_pull["applied"] == 2 and page_rows == 2, str(paged_pull))
-    test("pull pagination advances cursor to last page", page_cursor is not None and page_cursor[0] == "remote-page-2", str(page_cursor))
+    test(
+        "pull pagination advances cursor to last page",
+        page_cursor is not None and page_cursor[0] == "remote-page-2",
+        str(page_cursor),
+    )
 finally:
     sync_daemon._request_json = original_request_json
 
@@ -1475,7 +1557,10 @@ def test_sk_binary_path_falls_back_to_shim():
         else:
             shim_name = "sk"
         shim = bin_dir / shim_name
-        shim.write_text("@echo off\npython sk.py %*" if _platform.system() == "Windows" else "#!/bin/sh\npython3 sk.py \"$@\"", encoding="utf-8")
+        shim.write_text(
+            "@echo off\npython sk.py %*" if _platform.system() == "Windows" else '#!/bin/sh\npython3 sk.py "$@"',
+            encoding="utf-8",
+        )
 
         original_home = auto_update.HOME
         auto_update.HOME = tmp_home
@@ -1523,6 +1608,7 @@ def test_sk_binary_path_prefers_native_over_shim():
 def test_restart_manual_source_references_sk_binary_path():
     """_restart_manual() source must call _sk_binary_path() for native watch routing."""
     import inspect as _inspect
+
     source = _inspect.getsource(auto_update._restart_manual)
     test(
         "_restart_manual calls _sk_binary_path() for native watch routing",
@@ -1641,18 +1727,22 @@ def test_fts_refresh_works_for_documents():
     db.commit()
 
     # knowledge_fts should be empty before refresh.
-    pre_fts = db.execute(
-        "SELECT document_id FROM knowledge_fts WHERE document_id=?", (doc_id,)
-    ).fetchone() if doc_id else None
+    pre_fts = (
+        db.execute("SELECT document_id FROM knowledge_fts WHERE document_id=?", (doc_id,)).fetchone()
+        if doc_id
+        else None
+    )
 
     # Call the Python FTS refresh function directly (mirrors what pull_once does).
     if doc_id is not None:
         sync_daemon._refresh_knowledge_fts_for_documents(db, {doc_id})
     db.commit()
 
-    post_fts = db.execute(
-        "SELECT document_id FROM knowledge_fts WHERE document_id=?", (doc_id,)
-    ).fetchone() if doc_id else None
+    post_fts = (
+        db.execute("SELECT document_id FROM knowledge_fts WHERE document_id=?", (doc_id,)).fetchone()
+        if doc_id
+        else None
+    )
     db.close()
 
     test(
@@ -1689,22 +1779,16 @@ def test_fts_refresh_works_for_entries():
         """
     )
     db.commit()
-    entry_row = db.execute(
-        "SELECT id FROM knowledge_entries WHERE stable_id='ke-fts-refresh'"
-    ).fetchone()
+    entry_row = db.execute("SELECT id FROM knowledge_entries WHERE stable_id='ke-fts-refresh'").fetchone()
     entry_id = entry_row[0] if entry_row else None
 
-    pre_ke_fts = db.execute(
-        "SELECT rowid FROM ke_fts WHERE rowid=?", (entry_id,)
-    ).fetchone() if entry_id else None
+    pre_ke_fts = db.execute("SELECT rowid FROM ke_fts WHERE rowid=?", (entry_id,)).fetchone() if entry_id else None
 
     if entry_id is not None:
         sync_daemon._refresh_ke_fts_for_entries(db, {entry_id})
     db.commit()
 
-    post_ke_fts = db.execute(
-        "SELECT rowid FROM ke_fts WHERE rowid=?", (entry_id,)
-    ).fetchone() if entry_id else None
+    post_ke_fts = db.execute("SELECT rowid FROM ke_fts WHERE rowid=?", (entry_id,)).fetchone() if entry_id else None
     db.close()
 
     test(
@@ -1796,13 +1880,1139 @@ def test_usage_md_documents_watch_state():
     # Must still acknowledge that some Python fallback remains.
     test(
         "docs/USAGE.md still documents remaining Python watch fallback (no overclaim)",
-        "extract-knowledge.py" in content or "first-run db creation" in content.lower() or "first-run db" in content.lower(),
+        "extract-knowledge.py" in content
+        or "first-run db creation" in content.lower()
+        or "first-run db" in content.lower(),
         "docs/USAGE.md must still document the remaining Python watch fallback",
     )
 
 
 test_watch_sync_enqueue_module_exists()
 test_usage_md_documents_watch_state()
+
+
+# ---------------------------------------------------------------------------
+# Dream scheduler — timing, disabled state, manual trigger, state persistence
+# Issue #162 contract: DreamingScheduler class, dream_interval_hours, etc.
+# ---------------------------------------------------------------------------
+print("\n── Dream scheduler (issue #162) ────────────────────────────────────────")
+
+
+def test_dreaming_scheduler_defaults():
+    """DreamingScheduler defaults match the issue #162 contract."""
+    sched = sync_daemon.DreamingScheduler()
+    test("DreamingScheduler.enabled defaults True", sched.enabled is True)
+    test(
+        "DreamingScheduler.interval_hours defaults 24",
+        sched.interval_hours == 24,
+        f"got {sched.interval_hours}",
+    )
+    test(
+        "DreamingScheduler.min_score defaults 0.75",
+        sched.min_score == 0.75,
+        f"got {sched.min_score}",
+    )
+    test(
+        "DreamingScheduler.min_recall_count defaults 3",
+        sched.min_recall_count == 3,
+        f"got {sched.min_recall_count}",
+    )
+    test(
+        "DreamingScheduler.min_unique_queries defaults 2",
+        sched.min_unique_queries == 2,
+        f"got {sched.min_unique_queries}",
+    )
+    test(
+        "DreamingScheduler.memory_path defaults MEMORY.md",
+        sched.memory_path == "MEMORY.md",
+        f"got {sched.memory_path!r}",
+    )
+
+
+def test_dreaming_scheduler_from_config_no_file():
+    """DreamingScheduler.from_config falls back to defaults when no config file exists."""
+    nonexistent = ARTIFACT_DIR / "sync-config-nonexistent.json"
+    sched = sync_daemon.DreamingScheduler.from_config(nonexistent)
+    test(
+        "from_config: enabled=True when no config",
+        sched.enabled is True,
+    )
+    test(
+        "from_config: interval_hours=24 when no config",
+        sched.interval_hours == 24,
+        f"got {sched.interval_hours}",
+    )
+
+
+def test_dreaming_scheduler_from_config_reads_keys():
+    """DreamingScheduler.from_config reads all issue #162 config keys."""
+    cfg_path = ARTIFACT_DIR / "sync-config-sched-read.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "connection_string": "",
+                "dream_enabled": False,
+                "dream_interval_hours": 12,
+                "dream_min_score": 0.5,
+                "dream_min_recall_count": 5,
+                "dream_min_unique_queries": 3,
+                "dream_memory_path": "/custom/MEMORY.md",
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        sched = sync_daemon.DreamingScheduler.from_config(cfg_path)
+        test("from_config: dream_enabled=False", sched.enabled is False)
+        test("from_config: dream_interval_hours=12", sched.interval_hours == 12, f"got {sched.interval_hours}")
+        test("from_config: dream_min_score=0.5", sched.min_score == 0.5, f"got {sched.min_score}")
+        test("from_config: dream_min_recall_count=5", sched.min_recall_count == 5, f"got {sched.min_recall_count}")
+        test(
+            "from_config: dream_min_unique_queries=3", sched.min_unique_queries == 3, f"got {sched.min_unique_queries}"
+        )
+        test(
+            "from_config: dream_memory_path custom",
+            sched.memory_path == "/custom/MEMORY.md",
+            f"got {sched.memory_path!r}",
+        )
+    finally:
+        cfg_path.unlink(missing_ok=True)
+
+
+def test_dream_is_due_no_last_run():
+    """DreamingScheduler.is_due returns True when no last_dream_run has been recorded."""
+    sched = sync_daemon.DreamingScheduler(interval_hours=24)
+    test(
+        "is_due: True when no last_dream_run in state",
+        sched.is_due({}),
+    )
+
+
+def test_dream_is_due_just_ran():
+    """DreamingScheduler.is_due returns False when the sweep ran just now."""
+    sched = sync_daemon.DreamingScheduler(interval_hours=24)
+    state = {"last_dream_run": sync_daemon.utc_now()}
+    test(
+        "is_due: False when sweep just completed",
+        not sched.is_due(state),
+    )
+
+
+def test_dream_is_due_interval_elapsed():
+    """DreamingScheduler.is_due returns True when the configured interval has fully elapsed."""
+    import time as _time
+
+    old_ts = (
+        datetime.fromtimestamp(_time.time() - 7200, timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    sched = sync_daemon.DreamingScheduler(interval_hours=1)  # 1h = 3600s; 7200s ago
+    state = {"last_dream_run": old_ts}
+    test(
+        "is_due: True when 1h interval has elapsed (last_run 2h ago)",
+        sched.is_due(state),
+    )
+
+
+def test_dream_is_due_disabled():
+    """DreamingScheduler.is_due returns False when enabled=False, even if overdue."""
+    sched = sync_daemon.DreamingScheduler(enabled=False, interval_hours=24)
+    test(
+        "is_due: False when enabled=False",
+        not sched.is_due({}),
+    )
+
+
+def test_dream_is_due_invalid_last_run():
+    """DreamingScheduler.is_due treats a corrupt last_dream_run timestamp as overdue."""
+    sched = sync_daemon.DreamingScheduler(interval_hours=24)
+    state = {"last_dream_run": "not-a-timestamp"}
+    test(
+        "is_due: True when last_dream_run is malformed",
+        sched.is_due(state),
+    )
+
+
+def test_consume_dream_trigger_present():
+    """consume_trigger returns True and removes the marker file."""
+    marker_dir = ARTIFACT_DIR / "dream-markers"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    original_marker = sync_daemon.DREAM_TRIGGER_MARKER
+    sync_daemon.DREAM_TRIGGER_MARKER = marker_dir / "dream-trigger.json"
+    try:
+        sync_daemon.DREAM_TRIGGER_MARKER.write_text(json.dumps({"ts": "2026-01-01T00:00:00Z"}), encoding="utf-8")
+        sched = sync_daemon.DreamingScheduler()
+        consumed = sched.consume_trigger()
+        test(
+            "consume_trigger: returns True when marker present",
+            consumed is True,
+        )
+        test(
+            "consume_trigger: marker file removed after consumption",
+            not sync_daemon.DREAM_TRIGGER_MARKER.exists(),
+        )
+    finally:
+        sync_daemon.DREAM_TRIGGER_MARKER = original_marker
+
+
+def test_consume_dream_trigger_absent():
+    """consume_trigger returns False when no marker file exists."""
+    marker_dir = ARTIFACT_DIR / "dream-markers-absent"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    original_marker = sync_daemon.DREAM_TRIGGER_MARKER
+    sync_daemon.DREAM_TRIGGER_MARKER = marker_dir / "dream-trigger-absent.json"
+    try:
+        sched = sync_daemon.DreamingScheduler()
+        result = sched.consume_trigger()
+        test(
+            "consume_trigger: returns False when marker absent",
+            result is False,
+        )
+    finally:
+        sync_daemon.DREAM_TRIGGER_MARKER = original_marker
+
+
+def test_last_dream_run_persisted():
+    """last_dream_run is written to the state file and survives a reload."""
+    state_path = ARTIFACT_DIR / ".dream-state-test.json"
+    state_path.unlink(missing_ok=True)
+
+    original_state_file = sync_daemon.STATE_FILE
+    sync_daemon.STATE_FILE = state_path
+    try:
+        state = sync_daemon.load_state()
+        test(
+            "load_state: last_dream_run defaults to empty string",
+            state.get("last_dream_run") == "",
+            str(state),
+        )
+        state["last_dream_run"] = sync_daemon.utc_now()
+        sync_daemon.save_state(state)
+        reloaded = sync_daemon.load_state()
+        test(
+            "last_dream_run persists through save_state/load_state round-trip",
+            reloaded.get("last_dream_run") == state["last_dream_run"],
+            f"saved={state['last_dream_run']!r}  reloaded={reloaded.get('last_dream_run')!r}",
+        )
+    finally:
+        sync_daemon.STATE_FILE = original_state_file
+        state_path.unlink(missing_ok=True)
+
+
+def test_dream_sweep_skipped_when_no_dream_py():
+    """run_sweep returns ok=True/skipped=True/promoted_count=0 when dream.py is absent."""
+    sched = sync_daemon.DreamingScheduler()
+    original_tools_dir = sync_daemon.TOOLS_DIR
+    sync_daemon.TOOLS_DIR = ARTIFACT_DIR  # no dream.py here
+    try:
+        result = sched.run_sweep(db_path=ARTIFACT_DIR / "knowledge.db")
+        test(
+            "run_sweep: ok=True when dream.py absent (fail-open)",
+            result.get("ok") is True,
+            str(result),
+        )
+        test(
+            "run_sweep: skipped=True when dream.py absent",
+            result.get("skipped") is True,
+            str(result),
+        )
+        test(
+            "run_sweep: promoted_count=0 when dream.py absent",
+            result.get("promoted_count") == 0,
+            str(result),
+        )
+    finally:
+        sync_daemon.TOOLS_DIR = original_tools_dir
+
+
+def test_dream_sweep_updates_last_run():
+    """last_dream_run is NOT updated when sweep is skipped (dream.py absent)."""
+    sched = sync_daemon.DreamingScheduler()
+    original_tools_dir = sync_daemon.TOOLS_DIR
+    sync_daemon.TOOLS_DIR = ARTIFACT_DIR  # triggers skipped path
+    try:
+        state: dict = {"last_dream_run": ""}
+        result = sched.run_sweep(db_path=ARTIFACT_DIR / "knowledge.db")
+        if result.get("ok") and not result.get("skipped"):
+            state["last_dream_run"] = sync_daemon.utc_now()
+        test(
+            "run_sweep (skipped): last_dream_run NOT stamped on skipped sweep",
+            state["last_dream_run"] == "",
+            str(state),
+        )
+    finally:
+        sync_daemon.TOOLS_DIR = original_tools_dir
+
+
+def test_dream_sweep_no_update_on_failure():
+    """last_dream_run is NOT updated when run_sweep returns ok=False."""
+    # Patch TOOLS_DIR to a directory that has a fake dream.py that fails.
+    import sys as _sys
+
+    fake_dream_dir = ARTIFACT_DIR / "fake-dream-fail"
+    fake_dream_dir.mkdir(parents=True, exist_ok=True)
+    fake_dream = fake_dream_dir / "dream.py"
+    fake_dream.write_text("import sys\nsys.exit(1)\n", encoding="utf-8")
+    sched = sync_daemon.DreamingScheduler()
+    original_tools_dir = sync_daemon.TOOLS_DIR
+    sync_daemon.TOOLS_DIR = fake_dream_dir
+    try:
+        state: dict = {"last_dream_run": ""}
+        result = sched.run_sweep(db_path=ARTIFACT_DIR / "knowledge.db")
+        if result.get("ok") or result.get("skipped"):
+            state["last_dream_run"] = sync_daemon.utc_now()
+        test(
+            "run_sweep (failure): last_dream_run NOT updated on failure",
+            state["last_dream_run"] == "",
+            str(state),
+        )
+    finally:
+        sync_daemon.TOOLS_DIR = original_tools_dir
+        fake_dream.unlink(missing_ok=True)
+
+
+def test_manual_trigger_wakes_sleep_early():
+    """DREAM_TRIGGER_MARKER.exists() check in sleep loop enables early wake."""
+    # This tests that the sleep loop will see the marker and break early.
+    # We verify the condition logic by checking the marker existence works correctly.
+    marker_dir = ARTIFACT_DIR / "dream-sleep-markers"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    original_marker = sync_daemon.DREAM_TRIGGER_MARKER
+    sync_daemon.DREAM_TRIGGER_MARKER = marker_dir / "dream-trigger.json"
+    try:
+        # No marker → loop would not break early.
+        test(
+            "manual trigger: DREAM_TRIGGER_MARKER.exists() False when absent",
+            not sync_daemon.DREAM_TRIGGER_MARKER.exists(),
+        )
+        # Drop marker → loop would break early.
+        sync_daemon.DREAM_TRIGGER_MARKER.write_text("{}", encoding="utf-8")
+        test(
+            "manual trigger: DREAM_TRIGGER_MARKER.exists() True when present",
+            sync_daemon.DREAM_TRIGGER_MARKER.exists(),
+        )
+        # Consuming the marker makes it disappear for the sleep-break check.
+        sched = sync_daemon.DreamingScheduler()
+        sched.consume_trigger()
+        test(
+            "manual trigger: consume_trigger removes marker for next sleep iteration",
+            not sync_daemon.DREAM_TRIGGER_MARKER.exists(),
+        )
+    finally:
+        sync_daemon.DREAM_TRIGGER_MARKER = original_marker
+
+
+def test_sync_config_dream_round_trip():
+    """sync-config dream_enabled/dream_interval_hours survive a save/load round-trip."""
+    cfg_path = ARTIFACT_DIR / "sync-config-dream-rt.json"
+    cfg_path.unlink(missing_ok=True)
+    original_cfg_path = sync_config.CONFIG_PATH
+    original_tools_dir = sync_config.TOOLS_DIR
+    sync_config.CONFIG_PATH = cfg_path
+    sync_config.TOOLS_DIR = ARTIFACT_DIR
+    try:
+        sync_config.set_dream_interval_hours(12)
+        loaded = sync_config.load_config()
+        test(
+            "sync-config: dream_interval_hours=12 survives round-trip",
+            loaded["dream_interval_hours"] == 12,
+            str(loaded),
+        )
+        sync_config.set_dream_enabled(False)
+        loaded = sync_config.load_config()
+        test(
+            "sync-config: dream_enabled=False survives round-trip",
+            loaded["dream_enabled"] is False,
+            str(loaded),
+        )
+        sync_config.set_dream_enabled(True)
+        loaded = sync_config.load_config()
+        test(
+            "sync-config: dream_enabled=True survives round-trip",
+            loaded["dream_enabled"] is True,
+            str(loaded),
+        )
+        # Connection string must be preserved when only dream fields are written.
+        sync_config.set_connection_string("https://gateway.example.com/")
+        sync_config.set_dream_interval_hours(0.5)
+        loaded = sync_config.load_config()
+        test(
+            "sync-config: connection_string preserved when dream_interval_hours written",
+            loaded["connection_string"] == "https://gateway.example.com",
+            str(loaded),
+        )
+    finally:
+        sync_config.CONFIG_PATH = original_cfg_path
+        sync_config.TOOLS_DIR = original_tools_dir
+        cfg_path.unlink(missing_ok=True)
+
+
+def test_sync_config_dream_new_keys_round_trip():
+    """sync-config dream_min_score/recall/queries/memory_path survive round-trip."""
+    cfg_path = ARTIFACT_DIR / "sync-config-dream-newkeys.json"
+    cfg_path.unlink(missing_ok=True)
+    original_cfg_path = sync_config.CONFIG_PATH
+    original_tools_dir = sync_config.TOOLS_DIR
+    sync_config.CONFIG_PATH = cfg_path
+    sync_config.TOOLS_DIR = ARTIFACT_DIR
+    try:
+        sync_config.set_dream_min_score(0.5)
+        loaded = sync_config.load_config()
+        test("sync-config: dream_min_score=0.5 survives round-trip", loaded["dream_min_score"] == 0.5, str(loaded))
+
+        sync_config.set_dream_min_recall_count(5)
+        loaded = sync_config.load_config()
+        test(
+            "sync-config: dream_min_recall_count=5 survives round-trip",
+            loaded["dream_min_recall_count"] == 5,
+            str(loaded),
+        )
+
+        sync_config.set_dream_min_unique_queries(4)
+        loaded = sync_config.load_config()
+        test(
+            "sync-config: dream_min_unique_queries=4 survives round-trip",
+            loaded["dream_min_unique_queries"] == 4,
+            str(loaded),
+        )
+
+        sync_config.set_dream_memory_path("/custom/path/MEMORY.md")
+        loaded = sync_config.load_config()
+        test(
+            "sync-config: dream_memory_path survives round-trip",
+            loaded["dream_memory_path"] == "/custom/path/MEMORY.md",
+            str(loaded),
+        )
+    finally:
+        sync_config.CONFIG_PATH = original_cfg_path
+        sync_config.TOOLS_DIR = original_tools_dir
+        cfg_path.unlink(missing_ok=True)
+
+
+def test_sync_config_cli_dream_setters():
+    """New CLI flags --dream-min-score/recall-count/unique-queries/memory-path round-trip."""
+    import importlib
+    import sys as _sys
+
+    cfg_path = ARTIFACT_DIR / "sync-config-cli-setters.json"
+    cfg_path.unlink(missing_ok=True)
+    original_cfg_path = sync_config.CONFIG_PATH
+    original_tools_dir = sync_config.TOOLS_DIR
+    sync_config.CONFIG_PATH = cfg_path
+    sync_config.TOOLS_DIR = ARTIFACT_DIR
+
+    def run_main(*argv):
+        saved = _sys.argv[:]
+        saved_exit = None
+        try:
+            _sys.argv = ["sync-config.py"] + list(argv)
+            sync_config.main()
+        except SystemExit as exc:
+            saved_exit = exc.code
+        finally:
+            _sys.argv = saved
+        return saved_exit
+
+    try:
+        # --dream-min-score
+        exit_code = run_main("--dream-min-score", "0.6")
+        test("CLI --dream-min-score: exits 0 (None)", exit_code is None)
+        loaded = sync_config.load_config()
+        test("CLI --dream-min-score: value persisted", loaded["dream_min_score"] == 0.6, str(loaded))
+
+        # --dream-min-recall-count
+        exit_code = run_main("--dream-min-recall-count", "7")
+        test("CLI --dream-min-recall-count: exits 0 (None)", exit_code is None)
+        loaded = sync_config.load_config()
+        test("CLI --dream-min-recall-count: value persisted", loaded["dream_min_recall_count"] == 7, str(loaded))
+
+        # --dream-min-unique-queries
+        exit_code = run_main("--dream-min-unique-queries", "4")
+        test("CLI --dream-min-unique-queries: exits 0 (None)", exit_code is None)
+        loaded = sync_config.load_config()
+        test("CLI --dream-min-unique-queries: value persisted", loaded["dream_min_unique_queries"] == 4, str(loaded))
+
+        # --dream-memory-path
+        exit_code = run_main("--dream-memory-path", "/custom/MEMORY.md")
+        test("CLI --dream-memory-path: exits 0 (None)", exit_code is None)
+        loaded = sync_config.load_config()
+        test(
+            "CLI --dream-memory-path: value persisted", loaded["dream_memory_path"] == "/custom/MEMORY.md", str(loaded)
+        )
+
+        # Bad value for --dream-min-score
+        exit_code = run_main("--dream-min-score", "not-a-number")
+        test("CLI --dream-min-score: exits 1 on bad value", exit_code == 1)
+
+        # Missing value for --dream-min-recall-count
+        exit_code = run_main("--dream-min-recall-count")
+        test("CLI --dream-min-recall-count: exits 1 when value missing", exit_code == 1)
+
+        # Empty path for --dream-memory-path
+        exit_code = run_main("--dream-memory-path", "   ")
+        test("CLI --dream-memory-path: exits 1 on empty path", exit_code == 1)
+    finally:
+        sync_config.CONFIG_PATH = original_cfg_path
+        sync_config.TOOLS_DIR = original_tools_dir
+        cfg_path.unlink(missing_ok=True)
+
+
+def test_dreaming_scheduler_from_config_defaults():
+    """DreamingScheduler.from_config returns issue #162 defaults when no config file exists."""
+    nonexistent = ARTIFACT_DIR / "sync-config-missing.json"
+    sched = sync_daemon.DreamingScheduler.from_config(nonexistent)
+    test(
+        "from_config: enabled=True when no config",
+        sched.enabled is True,
+    )
+    test(
+        "from_config: interval_hours=24 when no config",
+        sched.interval_hours == 24,
+        f"got {sched.interval_hours}",
+    )
+    test(
+        "from_config: min_score=0.75 when no config",
+        sched.min_score == 0.75,
+        f"got {sched.min_score}",
+    )
+    test(
+        "from_config: min_recall_count=3 when no config",
+        sched.min_recall_count == 3,
+        f"got {sched.min_recall_count}",
+    )
+    test(
+        "from_config: min_unique_queries=2 when no config",
+        sched.min_unique_queries == 2,
+        f"got {sched.min_unique_queries}",
+    )
+    test(
+        "from_config: memory_path=MEMORY.md when no config",
+        sched.memory_path == "MEMORY.md",
+        f"got {sched.memory_path!r}",
+    )
+
+
+test_dreaming_scheduler_defaults()
+test_dreaming_scheduler_from_config_no_file()
+test_dreaming_scheduler_from_config_reads_keys()
+test_dream_is_due_no_last_run()
+test_dream_is_due_just_ran()
+test_dream_is_due_interval_elapsed()
+test_dream_is_due_disabled()
+test_dream_is_due_invalid_last_run()
+test_consume_dream_trigger_present()
+test_consume_dream_trigger_absent()
+test_last_dream_run_persisted()
+test_dream_sweep_skipped_when_no_dream_py()
+test_dream_sweep_updates_last_run()
+test_dream_sweep_no_update_on_failure()
+test_manual_trigger_wakes_sleep_early()
+test_sync_config_dream_round_trip()
+test_sync_config_dream_new_keys_round_trip()
+test_sync_config_cli_dream_setters()
+test_dreaming_scheduler_from_config_defaults()
+
+
+# ---------------------------------------------------------------------------
+# Follow-up code-review fixes (issue #162 narrow follow-up)
+# Finding 1: consume_trigger must respect dream_enabled=False
+# Finding 2: dream_interval_hours=0 must be rejected / normalized
+# Finding 3: hot-reload config (covered by from_config round-trip; daemon test here)
+# ---------------------------------------------------------------------------
+print("\n── Dream scheduler follow-up fixes ──────────────────────────────────────")
+
+
+def test_consume_trigger_suppressed_when_disabled():
+    """consume_trigger returns False and deletes the marker when dream_enabled=False."""
+    marker_dir = ARTIFACT_DIR / "dream-disabled-markers"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    original_marker = sync_daemon.DREAM_TRIGGER_MARKER
+    sync_daemon.DREAM_TRIGGER_MARKER = marker_dir / "dream-trigger-disabled.json"
+    try:
+        sync_daemon.DREAM_TRIGGER_MARKER.write_text(json.dumps({"ts": "2026-01-01T00:00:00Z"}), encoding="utf-8")
+        sched = sync_daemon.DreamingScheduler(enabled=False)
+        consumed = sched.consume_trigger()
+        test(
+            "consume_trigger: returns False when dream_enabled=False",
+            consumed is False,
+            f"got {consumed!r}",
+        )
+        test(
+            "consume_trigger: marker still removed when dream_enabled=False (no stale accumulation)",
+            not sync_daemon.DREAM_TRIGGER_MARKER.exists(),
+        )
+    finally:
+        sync_daemon.DREAM_TRIGGER_MARKER = original_marker
+
+
+def test_consume_trigger_enabled_still_works():
+    """consume_trigger returns True when dream_enabled=True (regression guard)."""
+    marker_dir = ARTIFACT_DIR / "dream-enabled-markers"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    original_marker = sync_daemon.DREAM_TRIGGER_MARKER
+    sync_daemon.DREAM_TRIGGER_MARKER = marker_dir / "dream-trigger-enabled.json"
+    try:
+        sync_daemon.DREAM_TRIGGER_MARKER.write_text("{}", encoding="utf-8")
+        sched = sync_daemon.DreamingScheduler(enabled=True)
+        consumed = sched.consume_trigger()
+        test(
+            "consume_trigger: returns True when dream_enabled=True",
+            consumed is True,
+        )
+    finally:
+        sync_daemon.DREAM_TRIGGER_MARKER = original_marker
+
+
+def test_zero_interval_normalized_in_scheduler():
+    """DreamingScheduler normalizes interval_hours=0 to the default (24h)."""
+    sched = sync_daemon.DreamingScheduler(interval_hours=0)
+    test(
+        "DreamingScheduler: interval_hours=0 normalizes to DEFAULT (24)",
+        sched.interval_hours == sync_daemon.DEFAULT_DREAM_INTERVAL_HOURS,
+        f"got {sched.interval_hours}",
+    )
+
+
+def test_negative_interval_normalized_in_scheduler():
+    """DreamingScheduler normalizes negative interval_hours to the default (24h)."""
+    sched = sync_daemon.DreamingScheduler(interval_hours=-5)
+    test(
+        "DreamingScheduler: interval_hours=-5 normalizes to DEFAULT (24)",
+        sched.interval_hours == sync_daemon.DEFAULT_DREAM_INTERVAL_HOURS,
+        f"got {sched.interval_hours}",
+    )
+
+
+def test_zero_interval_not_stored_by_sync_config():
+    """sync-config.set_dream_interval_hours raises ValueError for 0."""
+    cfg_path = ARTIFACT_DIR / "sync-config-zero-interval.json"
+    cfg_path.unlink(missing_ok=True)
+    original_cfg_path = sync_config.CONFIG_PATH
+    original_tools_dir = sync_config.TOOLS_DIR
+    sync_config.CONFIG_PATH = cfg_path
+    sync_config.TOOLS_DIR = ARTIFACT_DIR
+    try:
+        raised = False
+        try:
+            sync_config.set_dream_interval_hours(0)
+        except ValueError:
+            raised = True
+        test("sync-config: set_dream_interval_hours(0) raises ValueError", raised)
+
+        raised_neg = False
+        try:
+            sync_config.set_dream_interval_hours(-1)
+        except ValueError:
+            raised_neg = True
+        test("sync-config: set_dream_interval_hours(-1) raises ValueError", raised_neg)
+    finally:
+        sync_config.CONFIG_PATH = original_cfg_path
+        sync_config.TOOLS_DIR = original_tools_dir
+        cfg_path.unlink(missing_ok=True)
+
+
+def test_zero_interval_cli_exits_1():
+    """CLI --dream-interval-hours 0 exits with code 1."""
+    import sys as _sys
+
+    cfg_path = ARTIFACT_DIR / "sync-config-cli-zero.json"
+    cfg_path.unlink(missing_ok=True)
+    original_cfg_path = sync_config.CONFIG_PATH
+    original_tools_dir = sync_config.TOOLS_DIR
+    sync_config.CONFIG_PATH = cfg_path
+    sync_config.TOOLS_DIR = ARTIFACT_DIR
+
+    def run_main(*argv):
+        saved = _sys.argv[:]
+        exit_code = None
+        try:
+            _sys.argv = ["sync-config.py"] + list(argv)
+            sync_config.main()
+        except SystemExit as exc:
+            exit_code = exc.code
+        finally:
+            _sys.argv = saved
+        return exit_code
+
+    try:
+        exit_code = run_main("--dream-interval-hours", "0")
+        test("CLI --dream-interval-hours 0: exits 1", exit_code == 1)
+
+        exit_code = run_main("--dream-interval-hours", "-3")
+        test("CLI --dream-interval-hours -3: exits 1", exit_code == 1)
+    finally:
+        sync_config.CONFIG_PATH = original_cfg_path
+        sync_config.TOOLS_DIR = original_tools_dir
+        cfg_path.unlink(missing_ok=True)
+
+
+def test_zero_interval_in_config_file_normalized_on_load():
+    """load_config normalizes dream_interval_hours=0 stored in JSON to the default."""
+    cfg_path = ARTIFACT_DIR / "sync-config-legacy-zero.json"
+    cfg_path.write_text(
+        json.dumps({"connection_string": "", "dream_interval_hours": 0}),
+        encoding="utf-8",
+    )
+    original_cfg_path = sync_config.CONFIG_PATH
+    original_tools_dir = sync_config.TOOLS_DIR
+    sync_config.CONFIG_PATH = cfg_path
+    sync_config.TOOLS_DIR = ARTIFACT_DIR
+    try:
+        loaded = sync_config.load_config()
+        test(
+            "load_config: dream_interval_hours=0 in JSON normalized to default",
+            loaded["dream_interval_hours"] == sync_config.DEFAULT_DREAM_INTERVAL_HOURS,
+            f"got {loaded['dream_interval_hours']}",
+        )
+    finally:
+        sync_config.CONFIG_PATH = original_cfg_path
+        sync_config.TOOLS_DIR = original_tools_dir
+        cfg_path.unlink(missing_ok=True)
+
+
+def test_from_config_zero_interval_normalized():
+    """DreamingScheduler.from_config normalizes dream_interval_hours=0 to default."""
+    cfg_path = ARTIFACT_DIR / "sync-config-sched-zero.json"
+    cfg_path.write_text(
+        json.dumps({"connection_string": "", "dream_interval_hours": 0}),
+        encoding="utf-8",
+    )
+    try:
+        sched = sync_daemon.DreamingScheduler.from_config(cfg_path)
+        test(
+            "from_config: dream_interval_hours=0 in JSON normalized to DEFAULT",
+            sched.interval_hours == sync_daemon.DEFAULT_DREAM_INTERVAL_HOURS,
+            f"got {sched.interval_hours}",
+        )
+    finally:
+        cfg_path.unlink(missing_ok=True)
+
+
+def test_hot_reload_config_reflected_in_scheduler():
+    """DreamingScheduler.from_config picks up changes written to the config file."""
+    cfg_path = ARTIFACT_DIR / "sync-config-hot-reload.json"
+    cfg_path.write_text(
+        json.dumps({"connection_string": "", "dream_interval_hours": 6, "dream_enabled": True}),
+        encoding="utf-8",
+    )
+    try:
+        sched1 = sync_daemon.DreamingScheduler.from_config(cfg_path)
+        test(
+            "hot-reload: initial interval_hours=6 read from config",
+            sched1.interval_hours == 6,
+            f"got {sched1.interval_hours}",
+        )
+        # Simulate operator changing config while daemon is running
+        cfg_path.write_text(
+            json.dumps({"connection_string": "", "dream_interval_hours": 48, "dream_enabled": False}),
+            encoding="utf-8",
+        )
+        sched2 = sync_daemon.DreamingScheduler.from_config(cfg_path)
+        test(
+            "hot-reload: updated interval_hours=48 reflected after re-read",
+            sched2.interval_hours == 48,
+            f"got {sched2.interval_hours}",
+        )
+        test(
+            "hot-reload: dream_enabled=False reflected after re-read",
+            sched2.enabled is False,
+        )
+    finally:
+        cfg_path.unlink(missing_ok=True)
+
+
+test_consume_trigger_suppressed_when_disabled()
+test_consume_trigger_enabled_still_works()
+test_zero_interval_normalized_in_scheduler()
+test_negative_interval_normalized_in_scheduler()
+test_zero_interval_not_stored_by_sync_config()
+test_zero_interval_cli_exits_1()
+test_zero_interval_in_config_file_normalized_on_load()
+test_from_config_zero_interval_normalized()
+test_hot_reload_config_reflected_in_scheduler()
+
+
+# ---------------------------------------------------------------------------
+# Follow-up: --once mode must not block on scheduled-due dream sweeps (#162)
+# ---------------------------------------------------------------------------
+print("\n── --once mode dream sweep semantics ────────────────────────────────────")
+
+
+def test_once_mode_skips_scheduled_dream_sweep():
+    """--once mode does NOT run a dream sweep that is only due by schedule (no trigger)."""
+    artifact_dir = ARTIFACT_DIR / "once-skip-dream"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    db_path = artifact_dir / "knowledge.db"
+    state_path = artifact_dir / ".once-skip-state.json"
+    lock_path = artifact_dir / ".once-skip.lock"
+    cfg_path = artifact_dir / "sync-config-once-skip.json"
+    cfg_path.write_text(json.dumps({"connection_string": ""}), encoding="utf-8")
+    marker_dir = artifact_dir / "markers-skip"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    # Ensure no trigger marker exists.
+    trigger_marker = marker_dir / "dream-trigger.json"
+    trigger_marker.unlink(missing_ok=True)
+
+    sweep_called = []
+    original_run_sweep = sync_daemon.DreamingScheduler.run_sweep
+
+    def fake_run_sweep(self, *, db_path=None):
+        sweep_called.append(True)
+        return {"ok": True, "skipped": True, "promoted_count": 0}
+
+    saved = {
+        k: getattr(sync_daemon, k)
+        for k in [
+            "SESSION_STATE",
+            "LOCK_FILE",
+            "STATE_FILE",
+            "DB_PATH",
+            "SYNC_CONFIG_PATH",
+            "DREAM_TRIGGER_MARKER",
+            "MARKERS_DIR",
+            "SYNC_NUDGE_MARKER",
+            "SYNC_FLUSH_MARKER",
+        ]
+    }
+    try:
+        sync_daemon.SESSION_STATE = artifact_dir
+        sync_daemon.LOCK_FILE = lock_path
+        sync_daemon.STATE_FILE = state_path
+        sync_daemon.DB_PATH = db_path
+        sync_daemon.SYNC_CONFIG_PATH = cfg_path
+        sync_daemon.MARKERS_DIR = marker_dir
+        sync_daemon.DREAM_TRIGGER_MARKER = trigger_marker
+        sync_daemon.SYNC_NUDGE_MARKER = marker_dir / "sync-nudge.json"
+        sync_daemon.SYNC_FLUSH_MARKER = marker_dir / "sync-flush.json"
+        sync_daemon.DreamingScheduler.run_sweep = fake_run_sweep
+
+        # State has no last_dream_run → is_due() returns True, but --once must NOT call run_sweep.
+        code = sync_daemon.run_loop(once=True)
+        test(
+            "--once (no trigger): exits 0",
+            code == 0,
+            f"exit code {code}",
+        )
+        test(
+            "--once (no trigger): scheduled sweep NOT called even when due",
+            len(sweep_called) == 0,
+            f"run_sweep called {len(sweep_called)} time(s)",
+        )
+    finally:
+        sync_daemon.DreamingScheduler.run_sweep = original_run_sweep
+        for k, v in saved.items():
+            setattr(sync_daemon, k, v)
+        lock_path.unlink(missing_ok=True)
+
+
+def test_once_mode_runs_dream_on_manual_trigger():
+    """--once mode DOES run a dream sweep when an explicit manual trigger marker is present."""
+    artifact_dir = ARTIFACT_DIR / "once-trigger-dream"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    db_path = artifact_dir / "knowledge.db"
+    state_path = artifact_dir / ".once-trigger-state.json"
+    lock_path = artifact_dir / ".once-trigger.lock"
+    cfg_path = artifact_dir / "sync-config-once-trigger.json"
+    cfg_path.write_text(json.dumps({"connection_string": ""}), encoding="utf-8")
+    marker_dir = artifact_dir / "markers-trigger"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    trigger_marker = marker_dir / "dream-trigger.json"
+
+    sweep_called = []
+    original_run_sweep = sync_daemon.DreamingScheduler.run_sweep
+
+    def fake_run_sweep(self, *, db_path=None):
+        sweep_called.append(True)
+        return {"ok": True, "skipped": True, "promoted_count": 0}
+
+    saved = {
+        k: getattr(sync_daemon, k)
+        for k in [
+            "SESSION_STATE",
+            "LOCK_FILE",
+            "STATE_FILE",
+            "DB_PATH",
+            "SYNC_CONFIG_PATH",
+            "DREAM_TRIGGER_MARKER",
+            "MARKERS_DIR",
+            "SYNC_NUDGE_MARKER",
+            "SYNC_FLUSH_MARKER",
+        ]
+    }
+    try:
+        sync_daemon.SESSION_STATE = artifact_dir
+        sync_daemon.LOCK_FILE = lock_path
+        sync_daemon.STATE_FILE = state_path
+        sync_daemon.DB_PATH = db_path
+        sync_daemon.SYNC_CONFIG_PATH = cfg_path
+        sync_daemon.MARKERS_DIR = marker_dir
+        sync_daemon.DREAM_TRIGGER_MARKER = trigger_marker
+        sync_daemon.SYNC_NUDGE_MARKER = marker_dir / "sync-nudge.json"
+        sync_daemon.SYNC_FLUSH_MARKER = marker_dir / "sync-flush.json"
+        sync_daemon.DreamingScheduler.run_sweep = fake_run_sweep
+
+        # Drop a manual trigger marker — run_loop should call run_sweep exactly once.
+        trigger_marker.write_text("{}", encoding="utf-8")
+        code = sync_daemon.run_loop(once=True)
+        test(
+            "--once (manual trigger): exits 0",
+            code == 0,
+            f"exit code {code}",
+        )
+        test(
+            "--once (manual trigger): dream sweep called exactly once",
+            len(sweep_called) == 1,
+            f"run_sweep called {len(sweep_called)} time(s)",
+        )
+        test(
+            "--once (manual trigger): trigger marker consumed",
+            not trigger_marker.exists(),
+        )
+    finally:
+        sync_daemon.DreamingScheduler.run_sweep = original_run_sweep
+        for k, v in saved.items():
+            setattr(sync_daemon, k, v)
+        lock_path.unlink(missing_ok=True)
+
+
+test_once_mode_skips_scheduled_dream_sweep()
+test_once_mode_runs_dream_on_manual_trigger()
+
+
+# ---------------------------------------------------------------------------
+# Final review blockers (wave10-issue-162-final-review-fix)
+# Blocker 1: skipped sweep (dream.py absent) must NOT stamp last_dream_run
+# Blocker 2: set_dream_memory_path must reject empty / whitespace-only values
+# ---------------------------------------------------------------------------
+print("\n── Final review blockers (issue #162) ───────────────────────────────────")
+
+
+def test_last_dream_run_not_stamped_when_dream_py_missing_once_mode():
+    """--once mode must NOT stamp last_dream_run when run_sweep returns skipped=True.
+
+    Regression guard for the bug where `if ok or skipped:` unconditionally
+    stamped last_dream_run even when dream.py was absent, silencing retries
+    for the full interval.
+    """
+    artifact_dir = ARTIFACT_DIR / "once-skip-stamp"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    db_path = artifact_dir / "knowledge.db"
+    state_path = artifact_dir / ".once-skip-stamp-state.json"
+    lock_path = artifact_dir / ".once-skip-stamp.lock"
+    cfg_path = artifact_dir / "sync-config-once-skip-stamp.json"
+    cfg_path.write_text(json.dumps({"connection_string": ""}), encoding="utf-8")
+    marker_dir = artifact_dir / "markers-skip-stamp"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    trigger_marker = marker_dir / "dream-trigger.json"
+
+    original_run_sweep = sync_daemon.DreamingScheduler.run_sweep
+
+    def fake_skipped_sweep(self, *, db_path=None):
+        # Simulates dream.py absent: fail-open skip.
+        return {"ok": True, "skipped": True, "error": "", "promoted_count": 0}
+
+    saved = {
+        k: getattr(sync_daemon, k)
+        for k in [
+            "SESSION_STATE",
+            "LOCK_FILE",
+            "STATE_FILE",
+            "DB_PATH",
+            "SYNC_CONFIG_PATH",
+            "DREAM_TRIGGER_MARKER",
+            "MARKERS_DIR",
+            "SYNC_NUDGE_MARKER",
+            "SYNC_FLUSH_MARKER",
+        ]
+    }
+    try:
+        sync_daemon.SESSION_STATE = artifact_dir
+        sync_daemon.LOCK_FILE = lock_path
+        sync_daemon.STATE_FILE = state_path
+        sync_daemon.DB_PATH = db_path
+        sync_daemon.SYNC_CONFIG_PATH = cfg_path
+        sync_daemon.MARKERS_DIR = marker_dir
+        sync_daemon.DREAM_TRIGGER_MARKER = trigger_marker
+        sync_daemon.SYNC_NUDGE_MARKER = marker_dir / "sync-nudge.json"
+        sync_daemon.SYNC_FLUSH_MARKER = marker_dir / "sync-flush.json"
+        sync_daemon.DreamingScheduler.run_sweep = fake_skipped_sweep
+
+        # Drop a manual trigger marker so the dream path is exercised.
+        trigger_marker.write_text("{}", encoding="utf-8")
+        code = sync_daemon.run_loop(once=True)
+        test(
+            "--once (skipped sweep): exits 0",
+            code == 0,
+            f"exit code {code}",
+        )
+        # Reload persisted state to check last_dream_run.
+        reloaded = sync_daemon.load_state()
+        test(
+            "--once (skipped sweep): last_dream_run NOT stamped when dream.py absent",
+            not reloaded.get("last_dream_run"),
+            f"last_dream_run={reloaded.get('last_dream_run')!r}",
+        )
+    finally:
+        sync_daemon.DreamingScheduler.run_sweep = original_run_sweep
+        for k, v in saved.items():
+            setattr(sync_daemon, k, v)
+        lock_path.unlink(missing_ok=True)
+
+
+def test_last_dream_run_stamped_on_real_success_once_mode():
+    """--once mode MUST stamp last_dream_run when run_sweep returns ok=True/skipped=False.
+
+    Regression guard to ensure the fix does not suppress the stamp for genuine sweeps.
+    """
+    artifact_dir = ARTIFACT_DIR / "once-real-stamp"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    db_path = artifact_dir / "knowledge.db"
+    state_path = artifact_dir / ".once-real-stamp-state.json"
+    lock_path = artifact_dir / ".once-real-stamp.lock"
+    cfg_path = artifact_dir / "sync-config-once-real-stamp.json"
+    cfg_path.write_text(json.dumps({"connection_string": ""}), encoding="utf-8")
+    marker_dir = artifact_dir / "markers-real-stamp"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    trigger_marker = marker_dir / "dream-trigger.json"
+
+    original_run_sweep = sync_daemon.DreamingScheduler.run_sweep
+
+    def fake_real_sweep(self, *, db_path=None):
+        # Simulates a genuine dream sweep that ran successfully.
+        return {"ok": True, "skipped": False, "error": "", "promoted_count": 3}
+
+    saved = {
+        k: getattr(sync_daemon, k)
+        for k in [
+            "SESSION_STATE",
+            "LOCK_FILE",
+            "STATE_FILE",
+            "DB_PATH",
+            "SYNC_CONFIG_PATH",
+            "DREAM_TRIGGER_MARKER",
+            "MARKERS_DIR",
+            "SYNC_NUDGE_MARKER",
+            "SYNC_FLUSH_MARKER",
+        ]
+    }
+    try:
+        sync_daemon.SESSION_STATE = artifact_dir
+        sync_daemon.LOCK_FILE = lock_path
+        sync_daemon.STATE_FILE = state_path
+        sync_daemon.DB_PATH = db_path
+        sync_daemon.SYNC_CONFIG_PATH = cfg_path
+        sync_daemon.MARKERS_DIR = marker_dir
+        sync_daemon.DREAM_TRIGGER_MARKER = trigger_marker
+        sync_daemon.SYNC_NUDGE_MARKER = marker_dir / "sync-nudge.json"
+        sync_daemon.SYNC_FLUSH_MARKER = marker_dir / "sync-flush.json"
+        sync_daemon.DreamingScheduler.run_sweep = fake_real_sweep
+
+        # Drop a manual trigger marker so the dream path is exercised.
+        trigger_marker.write_text("{}", encoding="utf-8")
+        code = sync_daemon.run_loop(once=True)
+        test(
+            "--once (real sweep): exits 0",
+            code == 0,
+            f"exit code {code}",
+        )
+        reloaded = sync_daemon.load_state()
+        test(
+            "--once (real sweep): last_dream_run IS stamped on genuine ok sweep",
+            bool(reloaded.get("last_dream_run")),
+            f"last_dream_run={reloaded.get('last_dream_run')!r}",
+        )
+    finally:
+        sync_daemon.DreamingScheduler.run_sweep = original_run_sweep
+        for k, v in saved.items():
+            setattr(sync_daemon, k, v)
+        lock_path.unlink(missing_ok=True)
+
+
+def test_set_dream_memory_path_rejects_empty():
+    """set_dream_memory_path('') must raise ValueError (consistent with CLI guard)."""
+    cfg_path = ARTIFACT_DIR / "sync-config-empty-path.json"
+    cfg_path.unlink(missing_ok=True)
+    original_cfg_path = sync_config.CONFIG_PATH
+    original_tools_dir = sync_config.TOOLS_DIR
+    sync_config.CONFIG_PATH = cfg_path
+    sync_config.TOOLS_DIR = ARTIFACT_DIR
+    try:
+        raised = False
+        try:
+            sync_config.set_dream_memory_path("")
+        except ValueError:
+            raised = True
+        test(
+            "set_dream_memory_path(''): raises ValueError",
+            raised,
+            "expected ValueError for empty dream_memory_path",
+        )
+    finally:
+        sync_config.CONFIG_PATH = original_cfg_path
+        sync_config.TOOLS_DIR = original_tools_dir
+        cfg_path.unlink(missing_ok=True)
+
+
+def test_set_dream_memory_path_rejects_whitespace():
+    """set_dream_memory_path('   ') must raise ValueError (consistent with CLI guard)."""
+    cfg_path = ARTIFACT_DIR / "sync-config-whitespace-path.json"
+    cfg_path.unlink(missing_ok=True)
+    original_cfg_path = sync_config.CONFIG_PATH
+    original_tools_dir = sync_config.TOOLS_DIR
+    sync_config.CONFIG_PATH = cfg_path
+    sync_config.TOOLS_DIR = ARTIFACT_DIR
+    try:
+        raised = False
+        try:
+            sync_config.set_dream_memory_path("   ")
+        except ValueError:
+            raised = True
+        test(
+            "set_dream_memory_path('   '): raises ValueError",
+            raised,
+            "expected ValueError for whitespace-only dream_memory_path",
+        )
+    finally:
+        sync_config.CONFIG_PATH = original_cfg_path
+        sync_config.TOOLS_DIR = original_tools_dir
+        cfg_path.unlink(missing_ok=True)
+
+
+def test_set_dream_memory_path_valid_path_persisted():
+    """set_dream_memory_path with a valid path must persist correctly (regression guard)."""
+    cfg_path = ARTIFACT_DIR / "sync-config-valid-path.json"
+    cfg_path.unlink(missing_ok=True)
+    original_cfg_path = sync_config.CONFIG_PATH
+    original_tools_dir = sync_config.TOOLS_DIR
+    sync_config.CONFIG_PATH = cfg_path
+    sync_config.TOOLS_DIR = ARTIFACT_DIR
+    try:
+        returned = sync_config.set_dream_memory_path("/my/MEMORY.md")
+        test(
+            "set_dream_memory_path('/my/MEMORY.md'): returns normalized path",
+            returned == "/my/MEMORY.md",
+            f"returned={returned!r}",
+        )
+        loaded = sync_config.load_config()
+        test(
+            "set_dream_memory_path('/my/MEMORY.md'): persisted in config",
+            loaded.get("dream_memory_path") == "/my/MEMORY.md",
+            str(loaded),
+        )
+    finally:
+        sync_config.CONFIG_PATH = original_cfg_path
+        sync_config.TOOLS_DIR = original_tools_dir
+        cfg_path.unlink(missing_ok=True)
+
+
+test_last_dream_run_not_stamped_when_dream_py_missing_once_mode()
+test_last_dream_run_stamped_on_real_success_once_mode()
+test_set_dream_memory_path_rejects_empty()
+test_set_dream_memory_path_rejects_whitespace()
+test_set_dream_memory_path_valid_path_persisted()
+
 
 print(f"\nFinal total: {PASS} passed, {FAIL} failed")
 if FAIL:

--- a/tests/test_sync_runtime.py
+++ b/tests/test_sync_runtime.py
@@ -1929,6 +1929,23 @@ def test_dreaming_scheduler_defaults():
     )
 
 
+def test_dreaming_scheduler_whitespace_memory_path():
+    """DreamingScheduler normalizes whitespace-only memory_path to the default."""
+    sched = sync_daemon.DreamingScheduler(memory_path="   ")
+    test(
+        "DreamingScheduler: whitespace-only memory_path normalizes to MEMORY.md",
+        sched.memory_path == "MEMORY.md",
+        f"got {sched.memory_path!r}",
+    )
+    # Empty string should also normalize.
+    sched2 = sync_daemon.DreamingScheduler(memory_path="")
+    test(
+        "DreamingScheduler: empty memory_path normalizes to MEMORY.md",
+        sched2.memory_path == "MEMORY.md",
+        f"got {sched2.memory_path!r}",
+    )
+
+
 def test_dreaming_scheduler_from_config_no_file():
     """DreamingScheduler.from_config falls back to defaults when no config file exists."""
     nonexistent = ARTIFACT_DIR / "sync-config-nonexistent.json"
@@ -2161,7 +2178,7 @@ def test_dream_sweep_no_update_on_failure():
     try:
         state: dict = {"last_dream_run": ""}
         result = sched.run_sweep(db_path=ARTIFACT_DIR / "knowledge.db")
-        if result.get("ok") or result.get("skipped"):
+        if result.get("ok") and not result.get("skipped"):
             state["last_dream_run"] = sync_daemon.utc_now()
         test(
             "run_sweep (failure): last_dream_run NOT updated on failure",
@@ -2395,6 +2412,7 @@ def test_dreaming_scheduler_from_config_defaults():
 
 
 test_dreaming_scheduler_defaults()
+test_dreaming_scheduler_whitespace_memory_path()
 test_dreaming_scheduler_from_config_no_file()
 test_dreaming_scheduler_from_config_reads_keys()
 test_dream_is_due_no_last_run()


### PR DESCRIPTION
## Summary
- automate DreamingScheduler sweeps in sync-daemon
- add dream scheduler config and CLI controls
- cover skip-state, once-mode, and review-fix regressions

Closes #162