### PR TITLE
feat(#129): auto-continue goal loops

### DIFF
--- a/tentacle.py
+++ b/tentacle.py
@@ -2417,7 +2417,8 @@ def _goal_loop_dispatch_and_wait(
             return False, {}
         entries = _goal_iteration_tentacle_entries(current, tentacles)
         blocking = [
-            e for e in entries
+            e
+            for e in entries
             if e["name"] in dispatched_names
             and e["dispatch_state"] not in {"resolved", "resolved_error", "failed_dependencies"}
         ]
@@ -4562,10 +4563,7 @@ def _cmd_goal_loop(
                 _monotonic_fn=_monotonic_fn,
             )
             if not all_resolved:
-                reason = (
-                    f"poll_timeout={poll_timeout:.0f}s waiting for tentacle handoffs "
-                    f"in iteration {current_iter}"
-                )
+                reason = f"poll_timeout={poll_timeout:.0f}s waiting for tentacle handoffs in iteration {current_iter}"
                 _goal_loop_mark_budget_limited(tentacles, current_iter, reason)
                 break
 

--- a/tentacle.py
+++ b/tentacle.py
@@ -2355,6 +2355,85 @@ def _goal_dispatch_plan(state: dict, tentacles: Path, *, concurrency: int) -> di
     }
 
 
+def _goal_loop_dispatch_and_wait(
+    args,
+    state: dict,
+    tentacles: Path,
+    *,
+    poll_interval: float = 10.0,
+    poll_timeout: float = 300.0,
+    _dispatch_fn=None,
+    _sleep_fn=None,
+    _monotonic_fn=None,
+) -> tuple[bool, dict]:
+    """
+    Auto-dispatch step for ``goal loop`` (runs by default; disabled with ``--no-auto-dispatch``).
+
+    1. Fire dispatch commands for all *ready* tentacles in the current iteration.
+    2. Poll ``_goal_iteration_tentacle_entries`` until every tentacle is resolved
+       (``resolved`` / ``resolved_error`` / ``failed_dependencies``) or
+       ``poll_timeout`` seconds expire.
+
+    Returns ``(all_resolved: bool, latest_state: dict)``.
+    - ``all_resolved`` is True when no tentacle remains in a non-terminal
+      ``dispatch_state``.
+    - ``latest_state`` is the freshest ``goal.json`` read after polling.
+
+    Keyword-only injection points (for testing):
+    - ``_dispatch_fn(cmd_str, tentacle_name)`` replaces ``subprocess.run``.
+    - ``_sleep_fn(seconds)`` replaces ``time.sleep``.
+    - ``_monotonic_fn()`` replaces ``time.monotonic``.
+    """
+    _sleep = _sleep_fn if _sleep_fn is not None else time.sleep
+    _monotonic = _monotonic_fn if _monotonic_fn is not None else time.monotonic
+
+    # Fire dispatch commands for ready tentacles (up to concurrency cap).
+    plan = _goal_dispatch_plan(state, tentacles, concurrency=4)
+    dispatched_names: set[str] = set()
+    for entry in plan["selected"]:
+        cmd = _goal_dispatch_command(args, entry["name"])
+        print(f"   \U0001f680 Auto-dispatching: {entry['name']}")
+        dispatched_names.add(entry["name"])
+        if _dispatch_fn is not None:
+            _dispatch_fn(cmd, entry["name"])
+        else:
+            try:
+                subprocess.run(cmd, shell=True, check=False, capture_output=True)
+            except Exception as exc:
+                print(f"   \u26a0\ufe0f  Dispatch subprocess failed for '{entry['name']}': {exc}")
+
+    skipped = len(plan["selected"]) - len(dispatched_names)  # always 0, but harmless
+    if plan["ready_total"] > len(plan["selected"]):
+        deferred_count = plan["ready_total"] - len(plan["selected"])
+        print(f"   \u23f1  {deferred_count} ready tentacle(s) deferred to next iteration (concurrency cap)")
+
+    # Poll until the *dispatched* tentacles resolve (or timeout).
+    # Tentacles skipped due to the concurrency cap remain "ready" and are intentionally
+    # excluded from the wait set — they will be dispatched in a subsequent iteration.
+    deadline = _monotonic() + poll_timeout
+    while True:
+        current = _goal_load(tentacles)
+        if not current:
+            return False, {}
+        entries = _goal_iteration_tentacle_entries(current, tentacles)
+        blocking = [
+            e for e in entries
+            if e["name"] in dispatched_names
+            and e["dispatch_state"] not in {"resolved", "resolved_error", "failed_dependencies"}
+        ]
+        if not blocking:
+            return True, current
+        remaining_s = deadline - _monotonic()
+        if remaining_s <= 0:
+            names = ", ".join(e["name"] for e in blocking)
+            print(f"   \u23f0 Poll timeout after {poll_timeout:.0f}s — still unresolved: {names}")
+            return False, current
+        wait_s = min(poll_interval, remaining_s)
+        names = ", ".join(e["name"] for e in blocking)
+        print(f"   \u23f3 Waiting for handoffs: {names} ({int(remaining_s)}s left)")
+        _sleep(wait_s)
+
+
 def _goal_budget_status(state: dict) -> dict:
     """Return a dict summarising current budget consumption vs limits."""
     budget = state.get("budget") or {}
@@ -4335,7 +4414,14 @@ def _goal_loop_mark_budget_limited(tentacles: Path, current_iter: int, reason: s
     print("   Run `goal resume` then `goal loop` to continue.")
 
 
-def _cmd_goal_loop(args, tentacles: Path) -> None:
+def _cmd_goal_loop(
+    args,
+    tentacles: Path,
+    *,
+    _dispatch_fn=None,
+    _sleep_fn=None,
+    _monotonic_fn=None,
+) -> None:
     """
     Auto-continuation goal loop: verify criteria → eval continue/complete/budget_limited.
 
@@ -4343,13 +4429,22 @@ def _cmd_goal_loop(args, tentacles: Path) -> None:
     1. Check goal status — stop if already terminal or needs-human.
     2. Check budget (iteration/tentacle/timeout) — stop and mark budget_limited if exceeded.
     3. Check blocking gates — stop and set awaiting-gate status if any gate blocks.
+    3b. Dispatch ready tentacles and wait for their handoffs (skip with --no-auto-dispatch).
     4. Run success criteria verification commands.
     5. All criteria pass → eval complete.
     6. Criteria fail, goal iteration budget reached → mark budget_limited.
     7. Criteria fail, budget OK → eval continue (advance iteration) and repeat.
+
+    Keyword-only injection points (for testing):
+    - ``_dispatch_fn(cmd_str, tentacle_name)`` replaces ``subprocess.run`` in dispatch.
+    - ``_sleep_fn(seconds)`` replaces ``time.sleep`` in the poll loop.
+    - ``_monotonic_fn()`` replaces ``time.monotonic`` in the poll loop.
     """
     max_steps: int | None = getattr(args, "max_iterations", None)
     criterion_timeout: int = getattr(args, "timeout", 60) or 60
+    auto_dispatch: bool = bool(getattr(args, "auto_dispatch", True))
+    poll_interval: float = float(getattr(args, "poll_interval", 10) or 10)
+    poll_timeout: float = float(getattr(args, "poll_timeout", 300) or 300)
 
     state = _goal_load(tentacles)
     if not state:
@@ -4453,6 +4548,26 @@ def _cmd_goal_loop(args, tentacles: Path) -> None:
                 f"   Goal status set to '{GOAL_STATUS_AWAITING_GATE}'. Approve gate(s) with `goal gate approve <id>` then re-run `goal loop`."
             )
             break
+
+        # 3b. Dispatch ready tentacles and wait for handoffs (--no-auto-dispatch to skip).
+        if auto_dispatch:
+            all_resolved, state = _goal_loop_dispatch_and_wait(
+                args,
+                state,
+                tentacles,
+                poll_interval=poll_interval,
+                poll_timeout=poll_timeout,
+                _dispatch_fn=_dispatch_fn,
+                _sleep_fn=_sleep_fn,
+                _monotonic_fn=_monotonic_fn,
+            )
+            if not all_resolved:
+                reason = (
+                    f"poll_timeout={poll_timeout:.0f}s waiting for tentacle handoffs "
+                    f"in iteration {current_iter}"
+                )
+                _goal_loop_mark_budget_limited(tentacles, current_iter, reason)
+                break
 
         # 4. Run success criteria.
         runnable = [c for c in (state.get("success_criteria") or []) if c.get("verification_command", "")]
@@ -6547,6 +6662,36 @@ def main():
         type=_positive_int_arg,
         default=60,
         help="Per-criterion verification timeout in seconds (default: 60)",
+    )
+    p_goal_loop.add_argument(
+        "--no-auto-dispatch",
+        dest="auto_dispatch",
+        action="store_false",
+        default=True,
+        help=(
+            "Skip the automatic dispatch-and-wait step so that ready tentacles are NOT "
+            "dispatched by the loop. By default, `goal loop` dispatches ready tentacles "
+            "and waits for their handoffs before each criteria check, implementing the "
+            "dispatch \u2192 wait \u2192 eval \u2192 continue/complete cycle described in "
+            "issue #129. Pass this flag to disable that behavior."
+        ),
+    )
+    p_goal_loop.add_argument(
+        "--poll-interval",
+        dest="poll_interval",
+        type=_positive_int_arg,
+        default=10,
+        help="Seconds between handoff-poll checks during auto-dispatch (default: 10).",
+    )
+    p_goal_loop.add_argument(
+        "--poll-timeout",
+        dest="poll_timeout",
+        type=_positive_int_arg,
+        default=300,
+        help=(
+            "Maximum seconds to wait for tentacle handoffs per iteration during auto-dispatch. "
+            "Marks goal budget_limited if this expires (default: 300)."
+        ),
     )
 
     args = parser.parse_args()

--- a/tentacle.py
+++ b/tentacle.py
@@ -2315,6 +2315,36 @@ def _goal_dispatch_command(args, name: str) -> str:
     return _render_shell_command(parts)
 
 
+def _goal_dispatch_argv(args, name: str) -> list[str]:
+    """Return the argv list for dispatching one ready tentacle.
+
+    Produces the same logical command as :func:`_goal_dispatch_command` but as
+    a list suitable for ``subprocess.run(..., shell=False)`` — no shell injection
+    risk, and a bounded timeout can be applied.
+    """
+    argv = [sys.executable, str(Path(__file__).resolve())]
+    session_dir = getattr(args, "session_dir", None)
+    if session_dir:
+        argv.extend(["--session-dir", session_dir])
+    argv.extend(
+        [
+            "dispatch",
+            name,
+            "--agent-type",
+            getattr(args, "agent_type", "general-purpose") or "general-purpose",
+            "--model",
+            getattr(args, "model", "claude-sonnet-4.6") or "claude-sonnet-4.6",
+        ]
+    )
+    if getattr(args, "briefing", False):
+        argv.append("--briefing")
+    if getattr(args, "worktree", False):
+        argv.append("--worktree")
+    if not _bundle_enabled(args):
+        argv.append("--no-bundle")
+    return argv
+
+
 def _goal_dispatch_plan(state: dict, tentacles: Path, *, concurrency: int) -> dict:
     """Build a concurrency-limited dispatch plan for the current goal iteration."""
     entries = _goal_iteration_tentacle_entries(state, tentacles)
@@ -2360,6 +2390,7 @@ def _goal_loop_dispatch_and_wait(
     state: dict,
     tentacles: Path,
     *,
+    concurrency: int = 4,
     poll_interval: float = 10.0,
     poll_timeout: float = 300.0,
     _dispatch_fn=None,
@@ -2369,70 +2400,96 @@ def _goal_loop_dispatch_and_wait(
     """
     Auto-dispatch step for ``goal loop`` (runs by default; disabled with ``--no-auto-dispatch``).
 
-    1. Fire dispatch commands for all *ready* tentacles in the current iteration.
-    2. Poll ``_goal_iteration_tentacle_entries`` until every tentacle is resolved
-       (``resolved`` / ``resolved_error`` / ``failed_dependencies``) or
-       ``poll_timeout`` seconds expire.
+    Dispatches ready tentacles in concurrency-bounded batches and polls until
+    every *dispatched* tentacle reaches a terminal state
+    (``resolved`` / ``resolved_error`` / ``failed_dependencies``) or
+    ``poll_timeout`` seconds expire.  When the concurrency cap defers some ready
+    tentacles, this function keeps dispatching subsequent batches within the same
+    call so that no ready tentacle in the current iteration is stranded — the
+    outer goal loop only advances to criteria evaluation once all current-iteration
+    tentacles have been dispatched and resolved.
 
     Returns ``(all_resolved: bool, latest_state: dict)``.
-    - ``all_resolved`` is True when no tentacle remains in a non-terminal
-      ``dispatch_state``.
+    - ``all_resolved`` is True when all dispatched tentacles reached a terminal state.
     - ``latest_state`` is the freshest ``goal.json`` read after polling.
 
     Keyword-only injection points (for testing):
-    - ``_dispatch_fn(cmd_str, tentacle_name)`` replaces ``subprocess.run``.
+    - ``_dispatch_fn(cmd_str, tentacle_name)`` replaces the real subprocess call.
     - ``_sleep_fn(seconds)`` replaces ``time.sleep``.
     - ``_monotonic_fn()`` replaces ``time.monotonic``.
     """
     _sleep = _sleep_fn if _sleep_fn is not None else time.sleep
     _monotonic = _monotonic_fn if _monotonic_fn is not None else time.monotonic
 
-    # Fire dispatch commands for ready tentacles (up to concurrency cap).
-    plan = _goal_dispatch_plan(state, tentacles, concurrency=4)
-    dispatched_names: set[str] = set()
-    for entry in plan["selected"]:
-        cmd = _goal_dispatch_command(args, entry["name"])
-        print(f"   \U0001f680 Auto-dispatching: {entry['name']}")
-        dispatched_names.add(entry["name"])
-        if _dispatch_fn is not None:
-            _dispatch_fn(cmd, entry["name"])
-        else:
-            try:
-                subprocess.run(cmd, shell=True, check=False, capture_output=True)
-            except Exception as exc:
-                print(f"   \u26a0\ufe0f  Dispatch subprocess failed for '{entry['name']}': {exc}")
+    terminal_states = {"resolved", "resolved_error", "failed_dependencies"}
 
-    skipped = len(plan["selected"]) - len(dispatched_names)  # always 0, but harmless
-    if plan["ready_total"] > len(plan["selected"]):
-        deferred_count = plan["ready_total"] - len(plan["selected"])
-        print(f"   \u23f1  {deferred_count} ready tentacle(s) deferred to next iteration (concurrency cap)")
-
-    # Poll until the *dispatched* tentacles resolve (or timeout).
-    # Tentacles skipped due to the concurrency cap remain "ready" and are intentionally
-    # excluded from the wait set — they will be dispatched in a subsequent iteration.
+    # Single shared deadline for all batches in this iteration.
     deadline = _monotonic() + poll_timeout
+    dispatched_names: set[str] = set()
+
+    # Multi-batch loop: dispatch → wait → check for more ready → repeat.
     while True:
-        current = _goal_load(tentacles)
-        if not current:
+        current_state = _goal_load(tentacles)
+        if not current_state:
             return False, {}
-        entries = _goal_iteration_tentacle_entries(current, tentacles)
-        blocking = [
-            e
-            for e in entries
-            if e["name"] in dispatched_names
-            and e["dispatch_state"] not in {"resolved", "resolved_error", "failed_dependencies"}
-        ]
-        if not blocking:
-            return True, current
-        remaining_s = deadline - _monotonic()
-        if remaining_s <= 0:
+
+        plan = _goal_dispatch_plan(current_state, tentacles, concurrency=concurrency)
+        if not plan["selected"]:
+            # No more ready tentacles to dispatch in this iteration.
+            break
+
+        # Dispatch this batch.
+        batch_dispatched: set[str] = set()
+        for entry in plan["selected"]:
+            cmd_str = _goal_dispatch_command(args, entry["name"])
+            argv = _goal_dispatch_argv(args, entry["name"])
+            print(f"   \U0001f680 Auto-dispatching: {entry['name']}")
+            dispatched_names.add(entry["name"])
+            batch_dispatched.add(entry["name"])
+            if _dispatch_fn is not None:
+                _dispatch_fn(cmd_str, entry["name"])
+            else:
+                try:
+                    subprocess.run(
+                        argv,
+                        check=False,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        timeout=30,
+                    )
+                except subprocess.TimeoutExpired:
+                    print(f"   \u26a0\ufe0f  Dispatch timed out for '{entry['name']}'")
+                except Exception as exc:
+                    print(f"   \u26a0\ufe0f  Dispatch subprocess failed for '{entry['name']}': {exc}")
+
+        remaining_ready = plan["ready_total"] - len(plan["selected"])
+        if remaining_ready > 0:
+            print(f"   \u23f1  {remaining_ready} ready tentacle(s) queued for dispatch after this batch resolves")
+
+        # Poll until this batch resolves (or the shared deadline expires).
+        while True:
+            current = _goal_load(tentacles)
+            if not current:
+                return False, {}
+            entries = _goal_iteration_tentacle_entries(current, tentacles)
+            blocking = [
+                e for e in entries if e["name"] in batch_dispatched and e["dispatch_state"] not in terminal_states
+            ]
+            if not blocking:
+                break  # Batch resolved — check for more ready tentacles.
+            remaining_s = deadline - _monotonic()
+            if remaining_s <= 0:
+                names = ", ".join(e["name"] for e in blocking)
+                print(f"   \u23f0 Poll timeout after {poll_timeout:.0f}s — still unresolved: {names}")
+                return False, current
+            wait_s = min(poll_interval, remaining_s)
             names = ", ".join(e["name"] for e in blocking)
-            print(f"   \u23f0 Poll timeout after {poll_timeout:.0f}s — still unresolved: {names}")
-            return False, current
-        wait_s = min(poll_interval, remaining_s)
-        names = ", ".join(e["name"] for e in blocking)
-        print(f"   \u23f3 Waiting for handoffs: {names} ({int(remaining_s)}s left)")
-        _sleep(wait_s)
+            print(f"   \u23f3 Waiting for handoffs: {names} ({int(remaining_s)}s left)")
+            _sleep(wait_s)
+
+    # All batches dispatched and resolved.
+    final_state = _goal_load(tentacles)
+    return True, (final_state or {})
 
 
 def _goal_budget_status(state: dict) -> dict:
@@ -4444,6 +4501,7 @@ def _cmd_goal_loop(
     max_steps: int | None = getattr(args, "max_iterations", None)
     criterion_timeout: int = getattr(args, "timeout", 60) or 60
     auto_dispatch: bool = bool(getattr(args, "auto_dispatch", True))
+    concurrency: int = int(getattr(args, "concurrency", 4) or 4)
     poll_interval: float = float(getattr(args, "poll_interval", 10) or 10)
     poll_timeout: float = float(getattr(args, "poll_timeout", 300) or 300)
 
@@ -4556,6 +4614,7 @@ def _cmd_goal_loop(
                 args,
                 state,
                 tentacles,
+                concurrency=concurrency,
                 poll_interval=poll_interval,
                 poll_timeout=poll_timeout,
                 _dispatch_fn=_dispatch_fn,
@@ -6672,6 +6731,15 @@ def main():
             "and waits for their handoffs before each criteria check, implementing the "
             "dispatch \u2192 wait \u2192 eval \u2192 continue/complete cycle described in "
             "issue #129. Pass this flag to disable that behavior."
+        ),
+    )
+    p_goal_loop.add_argument(
+        "--concurrency",
+        type=_positive_int_arg,
+        default=4,
+        help=(
+            "Maximum ready tentacles to dispatch per batch during auto-dispatch (default: 4). "
+            "Matches the concurrency contract of `goal dispatch`."
         ),
     )
     p_goal_loop.add_argument(

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -4961,10 +4961,7 @@ class TestParseHandoffBridgeLinks(unittest.TestCase):
         self.assertEqual(T._parse_handoff_bridge_links(content), ["sc-1"])
 
     def test_multiple_bridge_lines_in_order(self):
-        content = (
-            "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\nDone.\n"
-            "Bridge: sc-1\nBridge: sc-2\n"
-        )
+        content = "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\nDone.\nBridge: sc-1\nBridge: sc-2\n"
         self.assertEqual(T._parse_handoff_bridge_links(content), ["sc-1", "sc-2"])
 
     def test_deduplicates_repeated_id_keeps_first_seen_order(self):
@@ -5116,9 +5113,7 @@ class TestGoalCoverageUnit(unittest.TestCase):
         with patch("builtins.print"):
             T._cmd_goal_criteria(args, self.tentacles)
 
-    def _tentacle_with_bridges(
-        self, name: str, bridge_links: list, *, status: str = "completed"
-    ) -> Path:
+    def _tentacle_with_bridges(self, name: str, bridge_links: list, *, status: str = "completed") -> Path:
         """Create a tentacle with the given bridge_links.
 
         Defaults to ``status="completed"`` because ``goal coverage`` only counts
@@ -5511,14 +5506,11 @@ class TestGoalLoop(unittest.TestCase):
         self.assertEqual(state["status"], T.GOAL_STATUS_BUDGET_LIMITED)
         iterations = state.get("iterations", {})
         has_budget_decision = any(
-            v.get("eval_decision") == "budget_limited"
-            for v in iterations.values()
-            if isinstance(v, dict)
+            v.get("eval_decision") == "budget_limited" for v in iterations.values() if isinstance(v, dict)
         )
         self.assertTrue(has_budget_decision, "expected an iteration entry with eval_decision='budget_limited'")
         budget_entry = next(
-            v for v in iterations.values()
-            if isinstance(v, dict) and v.get("eval_decision") == "budget_limited"
+            v for v in iterations.values() if isinstance(v, dict) and v.get("eval_decision") == "budget_limited"
         )
         self.assertIn("completed_at", budget_entry)
 
@@ -5540,7 +5532,7 @@ class TestGoalLoop(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Tests for --auto-dispatch dispatch/wait cycle (issue #129)
+# Tests for auto-dispatch / --no-auto-dispatch dispatch/wait cycle (issue #129)
 # ---------------------------------------------------------------------------
 
 
@@ -5608,6 +5600,7 @@ class TestGoalLoopAutoDispatch(unittest.TestCase):
         timeout=60,
         poll_interval=0,
         poll_timeout=60,
+        concurrency=4,
         dispatch_fn=None,
         sleep_fn=None,
         monotonic_fn=None,
@@ -5618,9 +5611,10 @@ class TestGoalLoopAutoDispatch(unittest.TestCase):
             max_iterations=max_iterations,
             timeout=timeout,
             auto_dispatch=auto_dispatch,
+            concurrency=concurrency,
             poll_interval=poll_interval,
             poll_timeout=poll_timeout,
-            # attrs required by _goal_dispatch_command
+            # attrs required by _goal_dispatch_command / _goal_dispatch_argv
             agent_type="general-purpose",
             model="claude-sonnet-4.6",
             briefing=False,
@@ -5791,12 +5785,14 @@ class TestGoalLoopAutoDispatch(unittest.TestCase):
 
     def test_concurrency_cap_does_not_deadlock_with_extra_ready_tentacles(self):
         """
-        When more ready tentacles exist than the concurrency cap allows, the poll
-        loop must NOT wait on the un-dispatched ones.
+        When more ready tentacles exist than the concurrency cap allows,
+        _goal_loop_dispatch_and_wait must dispatch ALL of them in sequential
+        batches within the same call — no tentacle is stranded.
 
-        Scenario: 5 ready tentacles, concurrency=4 (hard-coded in _goal_loop_dispatch_and_wait).
-        The dispatch_fn resolves the 4 dispatched ones immediately; the 5th remains "ready"
-        (not dispatched).  The call must return True (not time out).
+        Scenario: 5 ready tentacles, concurrency=4.
+        The dispatch_fn resolves each tentacle immediately.  The multi-batch loop
+        must dispatch batch-1 (4 tentacles), wait, then pick up the 5th and
+        dispatch it too before returning True.  Goal must complete.
         """
         names = [f"task-cap-{i}" for i in range(5)]
         for name in names:
@@ -5809,27 +5805,26 @@ class TestGoalLoopAutoDispatch(unittest.TestCase):
             _mark_terminal_handoff(self.tentacles, name, "DONE")
 
         self._add_passing_criterion()
-        # Tight poll_timeout — would fire if the poll waits on the un-dispatched entry.
         self._run_auto(
             max_iterations=3,
             dispatch_fn=mock_dispatch,
-            poll_timeout=5,
+            poll_timeout=30,
+            concurrency=4,
         )
-        # Exactly 4 dispatched (concurrency cap).
-        self.assertEqual(len(dispatched), 4, f"Expected 4 dispatched, got {len(dispatched)}")
+        # All 5 must have been dispatched across two batches (4 + 1).
+        self.assertEqual(len(dispatched), 5, f"Expected all 5 dispatched, got {len(dispatched)}")
         # Goal must complete (not be budget_limited).
         state = T._goal_load(self.tentacles)
         self.assertNotEqual(
             state.get("status"),
             T.GOAL_STATUS_BUDGET_LIMITED,
-            "Goal must NOT be budget_limited when the concurrency cap deferred a ready tentacle",
+            "Goal must NOT be budget_limited when concurrency cap deferred some ready tentacles",
         )
 
     def test_concurrency_cap_poll_only_includes_dispatched_names(self):
         """
-        _goal_loop_dispatch_and_wait must return all_resolved=True as soon as the
-        dispatched batch resolves, even when extra ready tentacles were deferred.
-        Uses a fast-advancing monotonic so any spurious wait would exceed poll_timeout.
+        After all batches are dispatched and resolved, goal must complete without
+        being budget_limited even when multiple batches were required.
         """
         names = [f"task-poll-{i}" for i in range(6)]
         for name in names:
@@ -5842,26 +5837,27 @@ class TestGoalLoopAutoDispatch(unittest.TestCase):
             _mark_terminal_handoff(self.tentacles, name, "DONE")
 
         self._add_passing_criterion()
-        # If the poll erroneously waits on un-dispatched entries the monotonic mock
-        # would advance past poll_timeout and budget_limit the goal.
         self._run_auto(
             max_iterations=5,
             dispatch_fn=mock_dispatch,
             poll_timeout=60,
+            concurrency=4,
         )
+        # All 6 tentacles dispatched across two batches (4 + 2).
+        self.assertEqual(len(dispatched), 6, f"Expected all 6 dispatched, got {len(dispatched)}")
         state = T._goal_load(self.tentacles)
         self.assertNotEqual(
             state.get("status"),
             T.GOAL_STATUS_BUDGET_LIMITED,
-            "Poll must not time out waiting on un-dispatched (concurrency-deferred) entries",
+            "Goal must not be budget_limited after all batches complete successfully",
         )
 
     def test_timeout_still_fires_when_dispatched_entry_stalls(self):
         """
-        Even with concurrency-cap deferred entries present, a genuinely stalled
-        dispatched tentacle must still trigger budget_limited (timeout still works).
+        A genuinely stalled dispatched tentacle must still trigger budget_limited
+        even when other ready tentacles are waiting for a concurrency slot.
         """
-        # 5 tentacles: 4 will be dispatched; the 5th deferred.
+        # 5 tentacles: batch-1 dispatches 4; the 5th waits for a slot.
         names = [f"task-stall-{i}" for i in range(5)]
         for name in names:
             self._link_tentacle(name)
@@ -5876,6 +5872,7 @@ class TestGoalLoopAutoDispatch(unittest.TestCase):
             dispatch_fn=mock_dispatch_stall,
             monotonic_fn=self._make_instant_monotonic(advance=1000.0),
             poll_timeout=10,
+            concurrency=4,
         )
         state = T._goal_load(self.tentacles)
         self.assertEqual(
@@ -5885,6 +5882,129 @@ class TestGoalLoopAutoDispatch(unittest.TestCase):
         )
         reason = state.get("budget_limited_reason", "")
         self.assertIn("poll_timeout", reason)
+
+    def test_multi_batch_dispatch_with_concurrency_1(self):
+        """
+        With concurrency=1, three ready tentacles are dispatched one at a time in
+        three sequential batches within a single _goal_loop_dispatch_and_wait call.
+        All three must be dispatched; no stranded tentacles.
+        """
+        names = ["batch-t0", "batch-t1", "batch-t2"]
+        for name in names:
+            self._link_tentacle(name)
+
+        dispatched: list[str] = []
+
+        def mock_dispatch(cmd, name):
+            dispatched.append(name)
+            _mark_terminal_handoff(self.tentacles, name, "DONE")
+
+        self._add_passing_criterion()
+        self._run_auto(
+            max_iterations=3,
+            dispatch_fn=mock_dispatch,
+            poll_timeout=30,
+            concurrency=1,
+        )
+        self.assertEqual(
+            set(dispatched),
+            set(names),
+            f"All 3 tentacles must be dispatched across batches; got {dispatched}",
+        )
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(
+            state.get("status"),
+            T.GOAL_STATUS_COMPLETED,
+            "Goal must complete after all batches are dispatched and resolved",
+        )
+
+    def test_goal_loop_help_includes_concurrency_flag(self):
+        """--concurrency flag must appear in `goal loop --help` output."""
+        import subprocess as _sp
+
+        result = _sp.run(
+            [sys.executable, "tentacle.py", "goal", "loop", "--help"],
+            capture_output=True,
+            text=True,
+            cwd=str(TOOLS_DIR),
+        )
+        self.assertIn("--concurrency", result.stdout)
+
+    def test_goal_dispatch_argv_returns_list_without_shell(self):
+        """_goal_dispatch_argv must return a list (not a string) with no shell meta-characters."""
+        args = _fake_args(
+            agent_type="general-purpose",
+            model="claude-sonnet-4.6",
+            briefing=False,
+            bundle=True,
+            worktree=False,
+        )
+        argv = T._goal_dispatch_argv(args, "my-tentacle")
+        self.assertIsInstance(argv, list, "_goal_dispatch_argv must return a list")
+        self.assertGreater(len(argv), 2)
+        # First element must be a Python executable path (no shell interpolation risk).
+        self.assertIn("python", argv[0].lower(), "argv[0] must be the Python interpreter")
+        # tentacle name appears verbatim in the argv list.
+        self.assertIn("my-tentacle", argv)
+        # dispatch subcommand present.
+        self.assertIn("dispatch", argv)
+
+    def test_real_dispatch_subprocess_does_not_capture_output(self):
+        """
+        The real dispatch subprocess path must NOT use capture_output=True.
+
+        Capturing large agent stdout/stderr into memory defeats the purpose of
+        fire-and-discard dispatch for large prompts.  The subprocess must redirect
+        stdout/stderr to DEVNULL (or inherit), never to PIPE.
+        """
+        import subprocess as _sp
+
+        self._link_tentacle("cap-check")
+        captured_kwargs: list[dict] = []
+
+        def recording_run(*args, **kwargs):
+            captured_kwargs.append(kwargs)
+            # Return a minimal CompletedProcess so the caller does not crash.
+            return _sp.CompletedProcess(args=args[0] if args else [], returncode=0)
+
+        with patch("subprocess.run", side_effect=recording_run):
+            with patch("builtins.print"):
+                T._goal_loop_dispatch_and_wait(
+                    _fake_args(
+                        agent_type="general-purpose",
+                        model="claude-sonnet-4.6",
+                        briefing=False,
+                        bundle=True,
+                        worktree=False,
+                    ),
+                    T._goal_load(self.tentacles),
+                    self.tentacles,
+                    poll_timeout=0,  # expire immediately after one dispatch
+                    _sleep_fn=lambda s: None,
+                    _monotonic_fn=iter([0.0, 9999.0]).__next__,
+                )
+
+        self.assertTrue(captured_kwargs, "subprocess.run must have been called at least once")
+        for kwargs in captured_kwargs:
+            self.assertNotIn(
+                "capture_output",
+                kwargs,
+                "capture_output must NOT be passed to dispatch subprocess.run — "
+                "it buffers large agent output into memory",
+            )
+            # stdout/stderr must be DEVNULL (not PIPE) to avoid memory buffering.
+            if "stdout" in kwargs:
+                self.assertEqual(
+                    kwargs["stdout"],
+                    _sp.DEVNULL,
+                    "stdout must be subprocess.DEVNULL, not PIPE",
+                )
+            if "stderr" in kwargs:
+                self.assertEqual(
+                    kwargs["stderr"],
+                    _sp.DEVNULL,
+                    "stderr must be subprocess.DEVNULL, not PIPE",
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -5539,5 +5539,353 @@ class TestGoalLoop(unittest.TestCase):
         self.assertIn("G2", blocked[0]["blocked_by_gates"])
 
 
+# ---------------------------------------------------------------------------
+# Tests for --auto-dispatch dispatch/wait cycle (issue #129)
+# ---------------------------------------------------------------------------
+
+
+class TestGoalLoopAutoDispatch(unittest.TestCase):
+    """
+    Test the dispatch → wait → eval → continue/complete cycle.
+
+    By default ``goal loop`` dispatches ready tentacles and waits for handoffs.
+    Pass ``--no-auto-dispatch`` to skip that step.
+
+    Uses injected _dispatch_fn / _sleep_fn / _monotonic_fn instead of real subprocess
+    and clock calls so tests are deterministic and fast.
+    """
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "loop_autodispatch"
+        _, self.tentacles = _make_octogent(self.base)
+        _init_goal(self.tentacles, title="AutoDispatch Goal", max_iterations=10)
+
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    # -- helpers --
+
+    def _link_tentacle(self, name: str, **meta_extra) -> Path:
+        """Create a tentacle and link it to the current goal iteration."""
+        d = _make_tentacle(name, self.tentacles, **meta_extra)
+        state = T._goal_load(self.tentacles)
+        state.setdefault("tentacles", [])
+        if name not in state["tentacles"]:
+            state["tentacles"].append(name)
+        iter_key = str(T._goal_current_iteration(state))
+        state.setdefault("iterations", {}).setdefault(iter_key, {"tentacles": []})
+        if name not in state["iterations"][iter_key]["tentacles"]:
+            state["iterations"][iter_key]["tentacles"].append(name)
+        T._goal_write(self.tentacles, state)
+        return d
+
+    def _add_passing_criterion(self) -> None:
+        state = T._goal_load(self.tentacles)
+        state.setdefault("success_criteria", []).append(
+            {
+                "id": "sc-pass",
+                "description": "always passes",
+                "status": "pending",
+                "verification_command": _py_inline("raise SystemExit(0)"),
+            }
+        )
+        T._goal_write(self.tentacles, state)
+
+    def _make_instant_monotonic(self, advance: float = 1000.0):
+        """Return a monotonic mock that jumps `advance` seconds on every call."""
+        calls = [0.0]
+
+        def _mono():
+            calls[0] += advance
+            return calls[0]
+
+        return _mono
+
+    def _run_auto(
+        self,
+        *,
+        max_iterations=None,
+        timeout=60,
+        poll_interval=0,
+        poll_timeout=60,
+        dispatch_fn=None,
+        sleep_fn=None,
+        monotonic_fn=None,
+        auto_dispatch=True,
+    ) -> None:
+        args = _fake_args(
+            goal_action="loop",
+            max_iterations=max_iterations,
+            timeout=timeout,
+            auto_dispatch=auto_dispatch,
+            poll_interval=poll_interval,
+            poll_timeout=poll_timeout,
+            # attrs required by _goal_dispatch_command
+            agent_type="general-purpose",
+            model="claude-sonnet-4.6",
+            briefing=False,
+            bundle=True,
+            worktree=False,
+        )
+        with patch("builtins.print"):
+            T._cmd_goal_loop(
+                args,
+                self.tentacles,
+                _dispatch_fn=dispatch_fn if dispatch_fn is not None else (lambda cmd, name: None),
+                _sleep_fn=sleep_fn if sleep_fn is not None else (lambda s: None),
+                _monotonic_fn=monotonic_fn,
+            )
+
+    # -- tests --
+
+    def test_dispatch_fn_called_for_ready_tentacle(self):
+        """_dispatch_fn must be called for each ready tentacle when --auto-dispatch is active."""
+        self._link_tentacle("task-a")
+        dispatched: list[str] = []
+
+        def mock_dispatch(cmd, name):
+            dispatched.append(name)
+            _mark_terminal_handoff(self.tentacles, name, "DONE")
+
+        self._add_passing_criterion()
+        self._run_auto(max_iterations=2, dispatch_fn=mock_dispatch)
+        self.assertIn("task-a", dispatched)
+
+    def test_loop_completes_after_dispatch_resolves_tentacle(self):
+        """When dispatch_fn resolves the tentacle, loop reaches 'completed' on criteria pass."""
+        self._link_tentacle("task-b")
+
+        def mock_dispatch(cmd, name):
+            _mark_terminal_handoff(self.tentacles, name, "DONE")
+
+        self._add_passing_criterion()
+        self._run_auto(max_iterations=3, dispatch_fn=mock_dispatch)
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_COMPLETED)
+
+    def test_poll_timeout_marks_budget_limited(self):
+        """If tentacle never resolves before poll_timeout, goal is marked budget_limited."""
+        self._link_tentacle("slow-task")
+        self._add_passing_criterion()
+        # Advance monotonic by 1000s per call so the deadline is always exceeded.
+        self._run_auto(
+            max_iterations=2,
+            dispatch_fn=lambda cmd, name: None,  # never resolves tentacle
+            monotonic_fn=self._make_instant_monotonic(advance=1000.0),
+            poll_timeout=60,
+        )
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_BUDGET_LIMITED)
+
+    def test_budget_limited_reason_mentions_poll_timeout(self):
+        """budget_limited_reason must reference poll_timeout on handoff timeout."""
+        self._link_tentacle("stuck-task")
+        self._add_passing_criterion()
+        self._run_auto(
+            max_iterations=2,
+            dispatch_fn=lambda cmd, name: None,
+            monotonic_fn=self._make_instant_monotonic(advance=1000.0),
+            poll_timeout=42,
+        )
+        state = T._goal_load(self.tentacles)
+        reason = state.get("budget_limited_reason", "")
+        self.assertIn("poll_timeout", reason)
+
+    def test_dispatch_fn_called_by_default_no_flags_needed(self):
+        """Default goal loop (no auto_dispatch attr) MUST invoke _dispatch_fn for ready tentacles."""
+        self._link_tentacle("task-default")
+        dispatched: list[str] = []
+
+        def mock_dispatch(cmd, name):
+            dispatched.append(name)
+            _mark_terminal_handoff(self.tentacles, name, "DONE")
+
+        # Build args with NO auto_dispatch attribute — mirrors argparse default (True).
+        args = _fake_args(
+            goal_action="loop",
+            max_iterations=2,
+            timeout=60,
+            # auto_dispatch intentionally absent — _cmd_goal_loop falls back to getattr default True
+            poll_interval=0,
+            poll_timeout=60,
+            agent_type="general-purpose",
+            model="claude-sonnet-4.6",
+            briefing=False,
+            bundle=True,
+            worktree=False,
+        )
+        self._add_passing_criterion()
+        with patch("builtins.print"):
+            T._cmd_goal_loop(
+                args,
+                self.tentacles,
+                _dispatch_fn=mock_dispatch,
+                _sleep_fn=lambda s: None,
+            )
+        self.assertIn("task-default", dispatched, "Default path must dispatch ready tentacles")
+
+    def test_dispatch_fn_not_called_with_no_auto_dispatch_flag(self):
+        """With auto_dispatch=False (--no-auto-dispatch), _dispatch_fn must NOT be invoked."""
+        self._link_tentacle("task-c")
+        dispatched: list[str] = []
+        self._add_passing_criterion()
+        self._run_auto(
+            max_iterations=1,
+            auto_dispatch=False,
+            dispatch_fn=lambda cmd, name: dispatched.append(name),
+        )
+        self.assertEqual(dispatched, [], "_dispatch_fn must NOT be called when --no-auto-dispatch")
+
+    def test_poll_wait_resumes_after_tentacle_resolves_during_sleep(self):
+        """Tentacle resolving during a sleep cycle causes loop to proceed to criteria."""
+        self._link_tentacle("async-task")
+        resolved = [False]
+
+        def mock_dispatch(cmd, name):
+            pass  # agent is "in flight"; resolution happens during poll sleep
+
+        call_count = [0]
+
+        def mock_sleep(seconds):
+            # On first sleep, simulate agent completing handoff.
+            if not resolved[0]:
+                _mark_terminal_handoff(self.tentacles, "async-task", "DONE")
+                resolved[0] = True
+            call_count[0] += 1
+
+        self._add_passing_criterion()
+        self._run_auto(
+            max_iterations=3,
+            dispatch_fn=mock_dispatch,
+            sleep_fn=mock_sleep,
+            poll_timeout=60,
+        )
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state["status"], T.GOAL_STATUS_COMPLETED)
+        self.assertTrue(resolved[0], "mock_sleep should have been called at least once")
+
+    def test_auto_dispatch_skips_dispatch_when_no_ready_tentacles(self):
+        """With no ready tentacles, dispatch_fn is never called."""
+        # Link a tentacle that is already resolved.
+        self._link_tentacle("done-task", status="completed", terminal_status="DONE")
+        dispatched: list[str] = []
+        self._add_passing_criterion()
+        self._run_auto(dispatch_fn=lambda cmd, name: dispatched.append(name))
+        self.assertEqual(dispatched, [])
+
+    def test_goal_loop_help_includes_no_auto_dispatch_flag(self):
+        """--no-auto-dispatch flag must appear in `goal loop --help` output."""
+        import subprocess as _sp
+
+        result = _sp.run(
+            [sys.executable, "tentacle.py", "goal", "loop", "--help"],
+            capture_output=True,
+            text=True,
+            cwd=str(TOOLS_DIR),
+        )
+        self.assertIn("--no-auto-dispatch", result.stdout)
+        self.assertIn("--poll-interval", result.stdout)
+        self.assertIn("--poll-timeout", result.stdout)
+
+    # -- concurrency-cap tests --
+
+    def test_concurrency_cap_does_not_deadlock_with_extra_ready_tentacles(self):
+        """
+        When more ready tentacles exist than the concurrency cap allows, the poll
+        loop must NOT wait on the un-dispatched ones.
+
+        Scenario: 5 ready tentacles, concurrency=4 (hard-coded in _goal_loop_dispatch_and_wait).
+        The dispatch_fn resolves the 4 dispatched ones immediately; the 5th remains "ready"
+        (not dispatched).  The call must return True (not time out).
+        """
+        names = [f"task-cap-{i}" for i in range(5)]
+        for name in names:
+            self._link_tentacle(name)
+
+        dispatched: list[str] = []
+
+        def mock_dispatch(cmd, name):
+            dispatched.append(name)
+            _mark_terminal_handoff(self.tentacles, name, "DONE")
+
+        self._add_passing_criterion()
+        # Tight poll_timeout — would fire if the poll waits on the un-dispatched entry.
+        self._run_auto(
+            max_iterations=3,
+            dispatch_fn=mock_dispatch,
+            poll_timeout=5,
+        )
+        # Exactly 4 dispatched (concurrency cap).
+        self.assertEqual(len(dispatched), 4, f"Expected 4 dispatched, got {len(dispatched)}")
+        # Goal must complete (not be budget_limited).
+        state = T._goal_load(self.tentacles)
+        self.assertNotEqual(
+            state.get("status"),
+            T.GOAL_STATUS_BUDGET_LIMITED,
+            "Goal must NOT be budget_limited when the concurrency cap deferred a ready tentacle",
+        )
+
+    def test_concurrency_cap_poll_only_includes_dispatched_names(self):
+        """
+        _goal_loop_dispatch_and_wait must return all_resolved=True as soon as the
+        dispatched batch resolves, even when extra ready tentacles were deferred.
+        Uses a fast-advancing monotonic so any spurious wait would exceed poll_timeout.
+        """
+        names = [f"task-poll-{i}" for i in range(6)]
+        for name in names:
+            self._link_tentacle(name)
+
+        dispatched: list[str] = []
+
+        def mock_dispatch(cmd, name):
+            dispatched.append(name)
+            _mark_terminal_handoff(self.tentacles, name, "DONE")
+
+        self._add_passing_criterion()
+        # If the poll erroneously waits on un-dispatched entries the monotonic mock
+        # would advance past poll_timeout and budget_limit the goal.
+        self._run_auto(
+            max_iterations=5,
+            dispatch_fn=mock_dispatch,
+            poll_timeout=60,
+        )
+        state = T._goal_load(self.tentacles)
+        self.assertNotEqual(
+            state.get("status"),
+            T.GOAL_STATUS_BUDGET_LIMITED,
+            "Poll must not time out waiting on un-dispatched (concurrency-deferred) entries",
+        )
+
+    def test_timeout_still_fires_when_dispatched_entry_stalls(self):
+        """
+        Even with concurrency-cap deferred entries present, a genuinely stalled
+        dispatched tentacle must still trigger budget_limited (timeout still works).
+        """
+        # 5 tentacles: 4 will be dispatched; the 5th deferred.
+        names = [f"task-stall-{i}" for i in range(5)]
+        for name in names:
+            self._link_tentacle(name)
+
+        def mock_dispatch_stall(cmd, name):
+            # Never resolves any tentacle — simulates stalled agents.
+            pass
+
+        self._add_passing_criterion()
+        self._run_auto(
+            max_iterations=2,
+            dispatch_fn=mock_dispatch_stall,
+            monotonic_fn=self._make_instant_monotonic(advance=1000.0),
+            poll_timeout=10,
+        )
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(
+            state.get("status"),
+            T.GOAL_STATUS_BUDGET_LIMITED,
+            "Stalled dispatched tentacles must still cause budget_limited",
+        )
+        reason = state.get("budget_limited_reason", "")
+        self.assertIn("poll_timeout", reason)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- make plain goal loop dispatch and wait by default with --no-auto-dispatch as opt-out
- avoid concurrency-cap polling deadlocks by only waiting on tentacles actually dispatched in the current batch
- cover the default-path and concurrency-cap regressions with focused goal-loop tests

Closes #129