### PR TITLE
feat: add cerebrum export auto-update

### DIFF
--- a/export-cerebrum.py
+++ b/export-cerebrum.py
@@ -16,7 +16,7 @@ Usage:
     python export-cerebrum.py --output CEREBRUM.md        # Write to file
     python export-cerebrum.py --format json               # JSON → stdout
     python export-cerebrum.py --output cerebrum.json --format json
-    python export-cerebrum.py --limit 50                  # Max entries per section
+    python export-cerebrum.py --limit 50                  # Max total entries across all sections
     python export-cerebrum.py --sections mistakes,decisions  # Select sections
     python export-cerebrum.py --tags docker,ci            # Filter all sections by tag
     python export-cerebrum.py --min-confidence 0.7        # Minimum confidence
@@ -32,6 +32,7 @@ Output contracts:
 import argparse
 import json
 import os
+import re
 import sqlite3
 import sys
 from datetime import datetime, timezone
@@ -84,6 +85,21 @@ _SECTION_META: dict[str, dict] = {
 ALL_SECTIONS = list(_SECTION_META.keys())
 
 
+def _is_preference_entry(entry: dict) -> bool:
+    """Classify a pattern entry as preference-like using tags_hint + title heuristic.
+
+    An entry is considered a "preference" if any hint keyword from the preferences
+    section's tags_hint appears in the entry's tags or title.  This is deterministic
+    and reuses existing metadata so no new user-facing flags are needed.
+    """
+    hints = set(_SECTION_META["preferences"]["tags_hint"])  # {"style","naming","preference","convention"}
+    entry_tags = {t.strip().lower() for t in (entry.get("tags") or "").split(",") if t.strip()}
+    if entry_tags & hints:
+        return True
+    title_lower = (entry.get("title") or "").lower()
+    return any(re.search(r"\b" + re.escape(hint) + r"\b", title_lower) for hint in hints)
+
+
 def _get_db(db_path: Path) -> sqlite3.Connection:
     if not db_path.exists():
         print(
@@ -100,11 +116,14 @@ def _get_db(db_path: Path) -> sqlite3.Connection:
 def _fetch_entries(
     db: sqlite3.Connection,
     category: str,
-    limit: int,
+    limit: int | None,
     tags_filter: list[str],
     min_confidence: float,
 ) -> list[dict]:
-    """Fetch knowledge entries for a given category, deterministically ordered."""
+    """Fetch knowledge entries for a given category, deterministically ordered.
+
+    Pass ``limit=None`` to fetch the entire matching pool without any cap.
+    """
     sql = """
         SELECT id, title, content, tags, confidence, session_id, occurrence_count,
                COALESCE(wing, '') AS wing, COALESCE(room, '') AS room,
@@ -115,7 +134,7 @@ def _fetch_entries(
           AND confidence >= ?
         ORDER BY confidence DESC, id ASC
     """
-    if not tags_filter:
+    if not tags_filter and limit is not None:
         sql += "\nLIMIT ?"
         params: tuple = (category, min_confidence, limit)
     else:
@@ -135,7 +154,8 @@ def _fetch_entries(
             e for e in entries
             if {tok.strip().lower() for tok in (e.get("tags") or "").split(",") if tok.strip()} & lower_tags
         ]
-        entries = entries[:limit]
+        if limit is not None:
+            entries = entries[:limit]
 
     return entries
 
@@ -244,14 +264,54 @@ def export_cerebrum(
 ) -> str:
     """Core export logic — returns the rendered string.  Separated for testability."""
     sections_data: dict[str, list[dict]] = {}
+    # Renormalize limit fractions across the active sections so that a
+    # single-section export (e.g. --sections mistakes --limit 200) can use the
+    # full limit rather than only its global fraction.  For all-sections exports
+    # the fractions sum to 1.0 so behaviour is identical to before.
+    total_fraction = sum(_SECTION_META[s]["limit_fraction"] for s in sections)
+
+    # --- Largest Remainder Method allocation -----------------------------------
+    # Guarantees total exported == limit (the documented contract).  Each section
+    # receives floor(limit * norm_fraction); remaining slots go to sections with
+    # the largest fractional remainder, tie-broken by section key descending for
+    # determinism.
+    _base = total_fraction if total_fraction > 0 else 1.0
+    _exact: dict[str, float] = {
+        s: limit * (_SECTION_META[s]["limit_fraction"] / _base) for s in sections
+    }
+    _floor: dict[str, int] = {s: int(v) for s, v in _exact.items()}
+    _remaining = limit - sum(_floor.values())
+    _sorted_rem = sorted(sections, key=lambda s: (_exact[s] - _floor[s], s), reverse=True)
+    section_limits: dict[str, int] = dict(_floor)
+    for _i, _s in enumerate(_sorted_rem):
+        if _i < _remaining:
+            section_limits[_s] += 1
+
+    # --- Pre-compute full pattern pool for preferences + learnings. ----------
+    # Fetching the entire pool (no top-N cap) before any slicing ensures that
+    # _is_preference_entry classifies ALL entries, so preference-like entries
+    # can never bleed into learnings regardless of how many there are.
+    pref_all: list[dict] = []
+    learn_all: list[dict] = []
+    if "preferences" in sections or "learnings" in sections:
+        pattern_pool = _fetch_entries(db, "pattern", None, tags_filter, min_confidence)
+        pref_all = [e for e in pattern_pool if _is_preference_entry(e)]
+        learn_all = [e for e in pattern_pool if not _is_preference_entry(e)]
+
+    if "preferences" in sections:
+        sections_data["preferences"] = pref_all[:section_limits["preferences"]]
+
     for section_key in sections:
-        meta = _SECTION_META[section_key]
-        category = meta["category"]
-        # Allocate limit proportionally per section; minimum 1.
-        section_limit = max(1, int(limit * meta["limit_fraction"]))
-        sections_data[section_key] = _fetch_entries(
-            db, category, section_limit, tags_filter, min_confidence
-        )
+        if section_key == "preferences":
+            continue  # already handled above
+
+        if section_key == "learnings":
+            sections_data["learnings"] = learn_all[:section_limits["learnings"]]
+        else:
+            sections_data[section_key] = _fetch_entries(
+                db, _SECTION_META[section_key]["category"],
+                section_limits[section_key], tags_filter, min_confidence,
+            )
 
     if fmt == "json":
         return _render_json(sections_data, sections, generated_at)

--- a/export-cerebrum.py
+++ b/export-cerebrum.py
@@ -379,6 +379,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # Validate and normalise sections
     raw_sections = [s.strip().lower() for s in args.sections.split(",") if s.strip()]
+    raw_sections = list(dict.fromkeys(raw_sections))
     invalid = [s for s in raw_sections if s not in _SECTION_META]
     if invalid:
         parser.error(

--- a/export-cerebrum.py
+++ b/export-cerebrum.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""
+export-cerebrum.py — Render learned knowledge into a flat CEREBRUM.md file.
+
+Inspired by OpenWolf's cerebrum.md pattern: a flat file always present in the
+repo that any agent can read without running a query.  Exports four curated
+sections from the session knowledge DB:
+
+  1. User Preferences  — coding style, naming conventions (top patterns)
+  2. Key Learnings     — proven patterns and best practices
+  3. Do-Not-Repeat     — dated mistakes with prevention guidance
+  4. Decision Log      — architectural decisions with rationale
+
+Usage:
+    python export-cerebrum.py                              # Markdown → stdout
+    python export-cerebrum.py --output CEREBRUM.md        # Write to file
+    python export-cerebrum.py --format json               # JSON → stdout
+    python export-cerebrum.py --output cerebrum.json --format json
+    python export-cerebrum.py --limit 50                  # Max entries per section
+    python export-cerebrum.py --sections mistakes,decisions  # Select sections
+    python export-cerebrum.py --tags docker,ci            # Filter all sections by tag
+    python export-cerebrum.py --min-confidence 0.7        # Minimum confidence
+
+Output contracts:
+  Markdown — human-readable, git-diff friendly, no ANSI escapes, deterministic
+             ordering (confidence DESC, id ASC).  Suitable for committing as
+             CEREBRUM.md for team sharing.
+  JSON     — machine-readable envelope:
+             {"generated_at": ISO8601, "sections": {name: [entries]}}
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+SESSION_STATE = Path.home() / ".copilot" / "session-state"
+DB_PATH = SESSION_STATE / "knowledge.db"
+
+# Section identifiers and their display metadata
+_SECTION_META: dict[str, dict] = {
+    "preferences": {
+        "label": "User Preferences",
+        "emoji": "⚙️",
+        "description": "Coding style, naming conventions, and personal workflow preferences.",
+        "category": "pattern",
+        "tags_hint": ["style", "naming", "preference", "convention"],
+        "limit_fraction": 0.25,  # proportion of --limit allocated to this section
+    },
+    "learnings": {
+        "label": "Key Learnings",
+        "emoji": "✅",
+        "description": "Proven patterns and best practices distilled from past sessions.",
+        "category": "pattern",
+        "tags_hint": [],
+        "limit_fraction": 0.30,
+    },
+    "mistakes": {
+        "label": "Do-Not-Repeat",
+        "emoji": "🚫",
+        "description": "Past mistakes with prevention guidance — do not repeat these.",
+        "category": "mistake",
+        "tags_hint": [],
+        "limit_fraction": 0.30,
+    },
+    "decisions": {
+        "label": "Decision Log",
+        "emoji": "🎯",
+        "description": "Architectural and design decisions with rationale.",
+        "category": "decision",
+        "tags_hint": [],
+        "limit_fraction": 0.15,
+    },
+}
+
+ALL_SECTIONS = list(_SECTION_META.keys())
+
+
+def _get_db(db_path: Path) -> sqlite3.Connection:
+    if not db_path.exists():
+        print(
+            f"Error: knowledge database not found at {db_path}\n"
+            "Run 'python build-session-index.py' then 'python extract-knowledge.py' first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    db = sqlite3.connect(str(db_path))
+    db.row_factory = sqlite3.Row
+    return db
+
+
+def _fetch_entries(
+    db: sqlite3.Connection,
+    category: str,
+    limit: int,
+    tags_filter: list[str],
+    min_confidence: float,
+) -> list[dict]:
+    """Fetch knowledge entries for a given category, deterministically ordered."""
+    sql = """
+        SELECT id, title, content, tags, confidence, session_id, occurrence_count,
+               COALESCE(wing, '') AS wing, COALESCE(room, '') AS room,
+               COALESCE(last_seen, '') AS last_seen,
+               COALESCE(source, 'copilot') AS source
+        FROM knowledge_entries
+        WHERE category = ?
+          AND confidence >= ?
+        ORDER BY confidence DESC, id ASC
+    """
+    if not tags_filter:
+        sql += "\nLIMIT ?"
+        params: tuple = (category, min_confidence, limit)
+    else:
+        params = (category, min_confidence)
+
+    try:
+        rows = db.execute(sql, params).fetchall()
+    except sqlite3.OperationalError as exc:
+        print(f"Error querying database: {exc}", file=sys.stderr)
+        return []
+
+    entries = [dict(r) for r in rows]
+
+    if tags_filter:
+        lower_tags = {t.lower() for t in tags_filter}
+        entries = [
+            e for e in entries
+            if {tok.strip().lower() for tok in (e.get("tags") or "").split(",") if tok.strip()} & lower_tags
+        ]
+        entries = entries[:limit]
+
+    return entries
+
+
+def _render_entry_markdown(entry: dict, index: int) -> list[str]:
+    lines: list[str] = []
+    title = (entry.get("title") or "Untitled").strip()
+    lines.append(f"### {index}. {title}\n")
+
+    meta: list[str] = []
+    if entry.get("tags"):
+        meta.append(f"- **Tags**: `{entry['tags']}`")
+    meta.append(f"- **Confidence**: {entry['confidence']:.2f}")
+    if entry.get("occurrence_count", 1) > 1:
+        meta.append(f"- **Occurrences**: {entry['occurrence_count']}")
+    if entry.get("wing"):
+        room_part = f" / {entry['room']}" if entry.get("room") else ""
+        meta.append(f"- **Domain**: {entry['wing']}{room_part}")
+    if entry.get("last_seen"):
+        meta.append(f"- **Last seen**: {entry['last_seen'][:10]}")
+    lines.extend(meta)
+    lines.append("")
+
+    content = (entry.get("content") or "").strip()
+    if content:
+        lines.append(content)
+    lines.append("")
+    lines.append("---\n")
+    return lines
+
+
+def _render_markdown(
+    sections_data: dict[str, list[dict]],
+    active_sections: list[str],
+    generated_at: str,
+) -> str:
+    lines: list[str] = []
+    lines.append("# CEREBRUM — Agent Knowledge Snapshot\n")
+    lines.append(
+        "> Auto-generated from the session knowledge DB.  "
+        "Read this file before starting any task — no query needed.\n"
+    )
+    lines.append(f"<!-- generated_at: {generated_at} -->\n")
+    lines.append("---\n")
+
+    for section_key in active_sections:
+        meta = _SECTION_META[section_key]
+        entries = sections_data.get(section_key, [])
+        emoji = meta["emoji"]
+        label = meta["label"]
+        desc = meta["description"]
+
+        lines.append(f"\n## {emoji} {label}\n")
+        lines.append(f"*{desc}*\n")
+
+        if not entries:
+            lines.append("*No entries found for this section.*\n")
+            continue
+
+        for i, entry in enumerate(entries, 1):
+            lines.extend(_render_entry_markdown(entry, i))
+
+    lines.append("\n---\n")
+    lines.append(
+        f"*Refresh: `python export-cerebrum.py --output CEREBRUM.md`  "
+        f"— {generated_at}*\n"
+    )
+    return "\n".join(lines)
+
+
+def _render_json(
+    sections_data: dict[str, list[dict]],
+    active_sections: list[str],
+    generated_at: str,
+) -> str:
+    payload = {
+        "generated_at": generated_at,
+        "sections": {k: sections_data.get(k, []) for k in active_sections},
+    }
+    return json.dumps(payload, indent=2, ensure_ascii=False, default=str)
+
+
+def _write_output(text: str, output_path: Path | None) -> None:
+    if output_path is None:
+        try:
+            print(text)
+        except UnicodeEncodeError:
+            sys.stdout.buffer.write(text.encode("utf-8"))
+            sys.stdout.buffer.write(b"\n")
+        return
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(text, encoding="utf-8")
+    print(f"Written {len(text)} chars to {output_path}", file=sys.stderr)
+
+
+def export_cerebrum(
+    db: sqlite3.Connection,
+    *,
+    sections: list[str],
+    limit: int,
+    tags_filter: list[str],
+    min_confidence: float,
+    fmt: str,
+    generated_at: str,
+) -> str:
+    """Core export logic — returns the rendered string.  Separated for testability."""
+    sections_data: dict[str, list[dict]] = {}
+    for section_key in sections:
+        meta = _SECTION_META[section_key]
+        category = meta["category"]
+        # Allocate limit proportionally per section; minimum 1.
+        section_limit = max(1, int(limit * meta["limit_fraction"]))
+        sections_data[section_key] = _fetch_entries(
+            db, category, section_limit, tags_filter, min_confidence
+        )
+
+    if fmt == "json":
+        return _render_json(sections_data, sections, generated_at)
+    return _render_markdown(sections_data, sections, generated_at)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="export-cerebrum",
+        description="Export knowledge DB into a flat CEREBRUM.md agent-readable file.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="FILE",
+        default=None,
+        help="Write output to FILE instead of stdout",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        metavar="N",
+        help="Maximum total entries to export across all sections (default: 200)",
+    )
+    parser.add_argument(
+        "--sections",
+        default=",".join(ALL_SECTIONS),
+        metavar="SECTION[,SECTION...]",
+        help=(
+            f"Comma-separated list of sections to include "
+            f"(default: {','.join(ALL_SECTIONS)})"
+        ),
+    )
+    parser.add_argument(
+        "--tags",
+        default=None,
+        metavar="TAG[,TAG...]",
+        help="Filter all sections by tag (comma-separated, any-match)",
+    )
+    parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=0.0,
+        metavar="FLOAT",
+        help="Minimum confidence threshold (0.0–1.0, default: 0.0)",
+    )
+    parser.add_argument(
+        "--db",
+        default=None,
+        metavar="PATH",
+        help="Path to knowledge.db (default: ~/.copilot/session-state/knowledge.db)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.limit <= 0:
+        parser.error(f"--limit must be a positive integer, got {args.limit}")
+    if not (0.0 <= args.min_confidence <= 1.0):
+        parser.error(f"--min-confidence must be between 0.0 and 1.0, got {args.min_confidence}")
+
+    # Validate and normalise sections
+    raw_sections = [s.strip().lower() for s in args.sections.split(",") if s.strip()]
+    invalid = [s for s in raw_sections if s not in _SECTION_META]
+    if invalid:
+        parser.error(
+            f"Unknown section(s): {', '.join(invalid)}. "
+            f"Valid: {', '.join(ALL_SECTIONS)}"
+        )
+    if not raw_sections:
+        parser.error("--sections must include at least one valid section name.")
+
+    tags_filter = [t.strip() for t in args.tags.split(",") if t.strip()] if args.tags else []
+    output_path = Path(args.output) if args.output else None
+    db_path = Path(args.db) if args.db else DB_PATH
+
+    db = _get_db(db_path)
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    try:
+        text = export_cerebrum(
+            db,
+            sections=raw_sections,
+            limit=args.limit,
+            tags_filter=tags_filter,
+            min_confidence=args.min_confidence,
+            fmt=args.format,
+            generated_at=generated_at,
+        )
+    finally:
+        db.close()
+
+    _write_output(text, output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/learn.py
+++ b/learn.py
@@ -28,12 +28,18 @@ Usage:
     python learn.py --from-file notes.md          # Bulk import from markdown
     python learn.py --list                        # List recent entries
     python learn.py --stats                       # Show knowledge stats
+
+Auto-update cerebrum snapshot (opt-in):
+    python learn.py --pattern "Title" "Desc" --update-cerebrum
+    python learn.py --mistake "Title" "Desc" --update-cerebrum --cerebrum-output CEREBRUM.md
+    python learn.py --decision "Title" "Desc" --update-cerebrum --cerebrum-sections mistakes,decisions
 """
 
 import hashlib
 import json
 import os
 import sqlite3
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -521,6 +527,46 @@ def _extract_code_snippet(source_file: str, start_line: int, end_line: int, quie
     if len(snippet) > 2000:
         snippet = snippet[:1999] + "…"
     return snippet, code_language
+
+
+def _auto_update_cerebrum(output_path: str, sections: str | None, *, json_mode: bool = False) -> int:
+    """Invoke export-cerebrum.py to regenerate the cerebrum snapshot after a learn write.
+
+    This is an opt-in path triggered only when --update-cerebrum is passed.  It spawns
+    export-cerebrum.py as a subprocess so the two standalone scripts remain decoupled.
+
+    Args:
+        output_path: Destination file path for the cerebrum snapshot (e.g. CEREBRUM.md).
+        sections: Comma-separated section names to include, or None for all sections.
+        json_mode: When True, redirect subprocess stdout to DEVNULL so the
+            caller-visible JSON stream is not contaminated by exporter output.
+
+    Returns:
+        The subprocess exit code.  Non-zero indicates export failure.
+    """
+    exporter = TOOLS_DIR / "export-cerebrum.py"
+    cmd = [sys.executable, str(exporter), "--output", output_path]
+    if sections:
+        cmd += ["--sections", sections]
+    print(f"  Updating cerebrum snapshot → {output_path}", file=sys.stderr)
+    # In JSON mode the caller-visible stdout stream must stay clean; redirect
+    # subprocess stdout away from it.  In non-JSON mode stdout is inherited so
+    # the user can see exporter progress.
+    stdout_arg = subprocess.DEVNULL if json_mode else None
+    try:
+        result = subprocess.run(cmd, stdout=stdout_arg, timeout=120)
+        if result.returncode != 0:
+            print(
+                f"  ⚠ export-cerebrum failed (exit {result.returncode})",
+                file=sys.stderr,
+            )
+        return result.returncode
+    except subprocess.TimeoutExpired:
+        print("  ⚠ export-cerebrum timed out (120 s)", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"  ⚠ export-cerebrum error: {exc}", file=sys.stderr)
+        return 1
 
 
 def get_db() -> sqlite3.Connection:
@@ -1107,7 +1153,7 @@ def _embed_entry(db: sqlite3.Connection, entry_id: int, title: str, content: str
         print(f"  [info] Embedding skipped: {e}", file=sys.stderr)
 
 
-def import_from_file(filepath: str):
+def import_from_file(filepath: str) -> int:
     """Bulk import knowledge entries from a markdown file.
 
     Expected format:
@@ -1116,11 +1162,13 @@ def import_from_file(filepath: str):
 
     ## pattern: Title Here
     Content describing the pattern...
+
+    Returns the number of entries actually imported (0 on failure or no entries).
     """
     path = Path(filepath)
     if not path.exists():
         print(f"Error: File not found: {filepath}")
-        return
+        return 0
 
     content = path.read_text(encoding="utf-8", errors="replace")
     entries = []
@@ -1149,15 +1197,23 @@ def import_from_file(filepath: str):
 
     if not entries:
         print("No entries found. Use format: ## category: Title")
-        return
+        return 0
 
     print(f"Importing {len(entries)} entries from {filepath}...")
+    imported = 0
     for entry in entries:
         content = "\n".join(entry["lines"]).strip()
         if content:
             with_retry(add_entry, entry["category"], entry["title"], content)
+            imported += 1
 
-    print(f"Done. Imported {len(entries)} entries.")
+    print(f"Done. Imported {imported} entries.")
+    if imported == 0:
+        # Headers parsed successfully but all entries had empty body content.
+        # This is not the same error as "file not found" or "no headers found";
+        # return -1 so the caller can exit 0 rather than treating it as a hard failure.
+        return -1
+    return imported
 
 
 def list_recent(limit: int = 10):
@@ -1320,9 +1376,34 @@ def main():
     if "--from-file" in args:
         idx = args.index("--from-file")
         if idx + 1 < len(args):
-            import_from_file(args[idx + 1])
+            imported = import_from_file(args[idx + 1])
+            # -1 means "headers parsed but no body content" — valid but empty; exit 0.
+            if imported == -1:
+                return
+            # 0 means "file not found" or "no headers found" — hard failure.
+            if not imported:
+                sys.exit(1)
+            # Support --update-cerebrum after bulk import (same opt-in contract as
+            # single-entry writes; cerebrum refresh runs once after all entries land).
+            # Only run if the import actually succeeded (imported > 0).
+            if "--update-cerebrum" in args:
+                _co = "CEREBRUM.md"
+                if "--cerebrum-output" in args:
+                    _ci = args.index("--cerebrum-output")
+                    _cnext = args[_ci + 1] if _ci + 1 < len(args) else None
+                    _co = _cnext if _cnext and not _cnext.startswith("--") else "CEREBRUM.md"
+                _cs: str | None = None
+                if "--cerebrum-sections" in args:
+                    _ci = args.index("--cerebrum-sections")
+                    _cnext = args[_ci + 1] if _ci + 1 < len(args) else None
+                    _cs = _cnext if _cnext and not _cnext.startswith("--") else None
+                _json_mode = "--json" in args
+                rc = _auto_update_cerebrum(_co, _cs, json_mode=_json_mode)
+                if rc != 0:
+                    sys.exit(rc)
         else:
             print("Error: --from-file requires a filepath")
+            sys.exit(1)
         return
 
     # Handle --relate command
@@ -1494,8 +1575,11 @@ def main():
             "--fix-step",
             "--valence",
             "--intensity",
+            "--cerebrum-output",
+            "--cerebrum-sections",
         ):
-            skip_next = True
+            _next = args[i + 1] if i + 1 < len(args) else None
+            skip_next = bool(_next and not _next.startswith("--"))
             continue
         if a.startswith("--"):
             continue
@@ -1513,6 +1597,19 @@ def main():
     skip_gate = "--skip-gate" in args
     skip_scan = "--skip-scan" in args
     json_mode = "--json" in args
+    update_cerebrum = "--update-cerebrum" in args
+
+    cerebrum_output = "CEREBRUM.md"
+    if "--cerebrum-output" in args:
+        idx = args.index("--cerebrum-output")
+        _cnext = args[idx + 1] if idx + 1 < len(args) else None
+        cerebrum_output = _cnext if _cnext and not _cnext.startswith("--") else "CEREBRUM.md"
+
+    cerebrum_sections: str | None = None
+    if "--cerebrum-sections" in args:
+        idx = args.index("--cerebrum-sections")
+        _cnext = args[idx + 1] if idx + 1 < len(args) else None
+        cerebrum_sections = _cnext if _cnext and not _cnext.startswith("--") else None
     gate_categories = {"mistake", "pattern", "discovery"}
     if not json_mode:
         if category in gate_categories and not skip_gate:
@@ -1611,6 +1708,10 @@ def main():
             print(json.dumps(out_dict, indent=2, ensure_ascii=False))
         else:
             print(json.dumps({"status": "error", "id": entry_id, "reason": "entry_not_found_after_write"}, indent=2))
+        if update_cerebrum and entry_id >= 0:
+            rc = _auto_update_cerebrum(cerebrum_output, cerebrum_sections, json_mode=True)
+            if rc != 0:
+                sys.exit(rc)
         return
 
     if facts:
@@ -1618,6 +1719,10 @@ def main():
     if affected_files:
         print(f"  Affecting {len(affected_files)} file(s): {', '.join(affected_files[:3])}")
     print("Done.")
+    if update_cerebrum and entry_id >= 0:
+        rc = _auto_update_cerebrum(cerebrum_output, cerebrum_sections)
+        if rc != 0:
+            sys.exit(rc)
 
 
 if __name__ == "__main__":

--- a/learn.py
+++ b/learn.py
@@ -1167,7 +1167,7 @@ def import_from_file(filepath: str) -> int:
     """
     path = Path(filepath)
     if not path.exists():
-        print(f"Error: File not found: {filepath}")
+        print(f"Error: File not found: {filepath}", file=sys.stderr)
         return 0
 
     content = path.read_text(encoding="utf-8", errors="replace")
@@ -1196,7 +1196,7 @@ def import_from_file(filepath: str) -> int:
         entries.append(current)
 
     if not entries:
-        print("No entries found. Use format: ## category: Title")
+        print("No entries found. Use format: ## category: Title", file=sys.stderr)
         return 0
 
     print(f"Importing {len(entries)} entries from {filepath}...")

--- a/sk.py
+++ b/sk.py
@@ -20,6 +20,8 @@ Usage:
     sk watch    [<args>...]       Run watch-sessions.py
     sk export-buglog [<args>...]  Run buglog-export.py
     sk buglog   [<args>...]       Run buglog-export.py (alias for export-buglog)
+    sk export-cerebrum [<args>...] Run export-cerebrum.py
+    sk cerebrum [<args>...]       Run export-cerebrum.py (alias for export-cerebrum)
     sk dream    [<args>...]       Run dream.py
     sk hooks    run|list|<event>  Run hooks/hook_runner.py
 
@@ -69,6 +71,8 @@ _DIRECT: dict[str, str] = {
     "watch": "watch-sessions.py",
     "export-buglog": "buglog-export.py",
     "buglog": "buglog-export.py",  # alias for export-buglog (backward compat)
+    "export-cerebrum": "export-cerebrum.py",
+    "cerebrum": "export-cerebrum.py",  # alias for export-cerebrum (short form)
     "dream": "dream.py",
 }
 

--- a/tests/test_export_cerebrum.py
+++ b/tests/test_export_cerebrum.py
@@ -375,6 +375,19 @@ def test_main_sections_filter(tmp_db_path):
     test("main sections: other section absent", "Key Learnings" not in output)
 
 
+def test_main_sections_dedupes_duplicates(tmp_db_path):
+    import io
+    import contextlib
+
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
+        rc = ec.main(["--sections", "mistakes,mistakes,decisions", "--db", str(tmp_db_path)])
+    test("main sections dedupe: returns 0", rc == 0)
+    output = captured.getvalue()
+    test("main sections dedupe: Do-Not-Repeat rendered once", output.count("Do-Not-Repeat") == 1)
+    test("main sections dedupe: Decision Log rendered once", output.count("Decision Log") == 1)
+
+
 def test_main_invalid_section(tmp_db_path):
     try:
         rc = ec.main(["--sections", "nonexistent", "--db", str(tmp_db_path)])
@@ -770,6 +783,7 @@ if __name__ == "__main__":
         test_main_json_stdout(_tmp_db)
         test_main_output_file(_tmp_db, _out_dir)
         test_main_sections_filter(_tmp_db)
+        test_main_sections_dedupes_duplicates(_tmp_db)
         test_main_invalid_section(_tmp_db)
         test_main_bad_limit(_tmp_db)
         test_main_bad_confidence(_tmp_db)

--- a/tests/test_export_cerebrum.py
+++ b/tests/test_export_cerebrum.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""
+tests/test_export_cerebrum.py — Unit tests for export-cerebrum.py.
+
+Uses synthetic in-memory SQLite DBs; never touches the real knowledge.db.
+Tests cover: markdown/JSON rendering, section filtering, tag filtering,
+confidence threshold, limit allocation, and CLI dispatch via sk.py.
+"""
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+_HERE = Path(__file__).parent.parent
+
+# ---------------------------------------------------------------------------
+# Load modules under test
+# ---------------------------------------------------------------------------
+def _load(name: str, rel_path: str):
+    spec = importlib.util.spec_from_file_location(name, str(_HERE / rel_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ec = _load("export_cerebrum", "export-cerebrum.py")
+
+# ---------------------------------------------------------------------------
+# Simple test harness
+# ---------------------------------------------------------------------------
+_PASS = 0
+_FAIL = 0
+
+
+def test(name: str, expr: bool) -> None:
+    global _PASS, _FAIL
+    if expr:
+        _PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        _FAIL += 1
+        print(f"  FAIL  {name}")
+
+
+# ---------------------------------------------------------------------------
+# Shared DB helpers
+# ---------------------------------------------------------------------------
+_KE_SCHEMA = """
+CREATE TABLE knowledge_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT,
+    category TEXT,
+    title TEXT,
+    content TEXT,
+    tags TEXT,
+    confidence REAL DEFAULT 0.5,
+    occurrence_count INTEGER DEFAULT 1,
+    first_seen TEXT,
+    last_seen TEXT,
+    wing TEXT,
+    room TEXT,
+    source TEXT
+)
+"""
+
+
+def _make_db() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute(_KE_SCHEMA)
+    db.commit()
+    return db
+
+
+def _insert(db, entries):
+    for e in entries:
+        db.execute(
+            """INSERT INTO knowledge_entries
+               (category, title, content, tags, confidence, occurrence_count,
+                first_seen, last_seen, session_id, wing, room)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                e.get("category", "mistake"),
+                e.get("title", "untitled"),
+                e.get("content", ""),
+                e.get("tags", ""),
+                e.get("confidence", 0.5),
+                e.get("occurrence_count", 1),
+                e.get("first_seen", "2025-01-01"),
+                e.get("last_seen", "2025-01-01"),
+                e.get("session_id", "sess1"),
+                e.get("wing", ""),
+                e.get("room", ""),
+            ),
+        )
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests: _fetch_entries
+# ---------------------------------------------------------------------------
+
+def test_fetch_entries_basic():
+    db = _make_db()
+    _insert(db, [
+        {"category": "mistake", "title": "M1", "confidence": 0.9},
+        {"category": "mistake", "title": "M2", "confidence": 0.8},
+        {"category": "pattern", "title": "P1", "confidence": 0.7},
+    ])
+    mistakes = ec._fetch_entries(db, "mistake", 10, [], 0.0)
+    test("fetch_entries: returns only requested category", len(mistakes) == 2)
+    test("fetch_entries: ordered confidence DESC", mistakes[0]["title"] == "M1")
+
+
+def test_fetch_entries_limit():
+    db = _make_db()
+    _insert(db, [{"category": "mistake", "title": f"M{i}", "confidence": 0.5} for i in range(10)])
+    results = ec._fetch_entries(db, "mistake", 3, [], 0.0)
+    test("fetch_entries: limit applied", len(results) == 3)
+
+
+def test_fetch_entries_min_confidence():
+    db = _make_db()
+    _insert(db, [
+        {"category": "mistake", "title": "High", "confidence": 0.9},
+        {"category": "mistake", "title": "Low", "confidence": 0.2},
+    ])
+    results = ec._fetch_entries(db, "mistake", 10, [], 0.5)
+    test("fetch_entries: min_confidence filters low entries", len(results) == 1)
+    test("fetch_entries: min_confidence keeps qualifying entry", results[0]["title"] == "High")
+
+
+def test_fetch_entries_tags_filter():
+    db = _make_db()
+    _insert(db, [
+        {"category": "pattern", "title": "Docker P", "tags": "docker,ci", "confidence": 0.8},
+        {"category": "pattern", "title": "Other P", "tags": "python", "confidence": 0.9},
+    ])
+    results = ec._fetch_entries(db, "pattern", 10, ["docker"], 0.0)
+    test("fetch_entries: tag filter keeps matching entry", len(results) == 1)
+    test("fetch_entries: tag filter correct title", results[0]["title"] == "Docker P")
+
+
+def test_fetch_entries_tags_filter_no_match():
+    db = _make_db()
+    _insert(db, [{"category": "mistake", "title": "M1", "tags": "python", "confidence": 0.9}])
+    results = ec._fetch_entries(db, "mistake", 10, ["java"], 0.0)
+    test("fetch_entries: unmatched tag returns empty", results == [])
+
+
+# ---------------------------------------------------------------------------
+# Tests: export_cerebrum (markdown output)
+# ---------------------------------------------------------------------------
+
+def test_export_cerebrum_markdown_contains_sections():
+    db = _make_db()
+    _insert(db, [
+        {"category": "mistake", "title": "Do not foo", "confidence": 0.9},
+        {"category": "pattern", "title": "Always bar", "confidence": 0.9},
+        {"category": "decision", "title": "Use baz", "confidence": 0.9},
+    ])
+    text = ec.export_cerebrum(
+        db,
+        sections=["mistakes", "learnings", "decisions"],
+        limit=100,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="markdown",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    test("markdown: contains Do-Not-Repeat heading", "Do-Not-Repeat" in text)
+    test("markdown: contains Key Learnings heading", "Key Learnings" in text)
+    test("markdown: contains Decision Log heading", "Decision Log" in text)
+    test("markdown: contains mistake title", "Do not foo" in text)
+    test("markdown: contains pattern title", "Always bar" in text)
+    test("markdown: contains decision title", "Use baz" in text)
+
+
+def test_export_cerebrum_markdown_header():
+    db = _make_db()
+    text = ec.export_cerebrum(
+        db,
+        sections=["mistakes"],
+        limit=100,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="markdown",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    test("markdown: starts with CEREBRUM heading", text.startswith("# CEREBRUM"))
+    test("markdown: contains generated_at comment", "2026-01-01T00:00:00Z" in text)
+
+
+def test_export_cerebrum_markdown_empty_section():
+    db = _make_db()
+    text = ec.export_cerebrum(
+        db,
+        sections=["decisions"],
+        limit=100,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="markdown",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    test("markdown: empty section shows placeholder", "No entries found" in text)
+
+
+# ---------------------------------------------------------------------------
+# Tests: export_cerebrum (JSON output)
+# ---------------------------------------------------------------------------
+
+def test_export_cerebrum_json_structure():
+    db = _make_db()
+    _insert(db, [
+        {"category": "mistake", "title": "JSON M", "confidence": 0.9},
+    ])
+    text = ec.export_cerebrum(
+        db,
+        sections=["mistakes"],
+        limit=100,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="json",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    data = json.loads(text)
+    test("json: generated_at field present", "generated_at" in data)
+    test("json: sections key present", "sections" in data)
+    test("json: mistakes section present", "mistakes" in data["sections"])
+    test("json: mistakes section has entry", len(data["sections"]["mistakes"]) == 1)
+    test("json: entry has title", data["sections"]["mistakes"][0]["title"] == "JSON M")
+
+
+def test_export_cerebrum_json_section_filter():
+    db = _make_db()
+    _insert(db, [
+        {"category": "mistake", "title": "M", "confidence": 0.9},
+        {"category": "decision", "title": "D", "confidence": 0.9},
+    ])
+    text = ec.export_cerebrum(
+        db,
+        sections=["mistakes"],
+        limit=100,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="json",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    data = json.loads(text)
+    test("json: only requested sections present", list(data["sections"].keys()) == ["mistakes"])
+
+
+# ---------------------------------------------------------------------------
+# Tests: section selection
+# ---------------------------------------------------------------------------
+
+def test_preferences_section_uses_pattern_category():
+    db = _make_db()
+    _insert(db, [
+        {"category": "pattern", "title": "Style rule", "confidence": 0.9},
+        {"category": "mistake", "title": "Should not appear", "confidence": 0.9},
+    ])
+    text = ec.export_cerebrum(
+        db,
+        sections=["preferences"],
+        limit=100,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="markdown",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    test("preferences section: contains pattern entry", "Style rule" in text)
+    test("preferences section: does not contain mistake entry", "Should not appear" not in text)
+
+
+# ---------------------------------------------------------------------------
+# Tests: render helpers
+# ---------------------------------------------------------------------------
+
+def test_render_entry_markdown_fields():
+    entry = {
+        "title": "Test entry",
+        "content": "Test content here",
+        "tags": "docker,ci",
+        "confidence": 0.85,
+        "occurrence_count": 3,
+        "wing": "backend",
+        "room": "api",
+        "last_seen": "2025-06-15",
+        "session_id": "abc12345",
+    }
+    lines = ec._render_entry_markdown(entry, 1)
+    joined = "\n".join(lines)
+    test("render_entry: title in output", "Test entry" in joined)
+    test("render_entry: tags in output", "docker,ci" in joined)
+    test("render_entry: confidence in output", "0.85" in joined)
+    test("render_entry: occurrence count shown", "3" in joined)
+    test("render_entry: domain shown", "backend" in joined)
+    test("render_entry: content shown", "Test content here" in joined)
+
+
+def test_render_entry_markdown_single_occurrence_hidden():
+    entry = {
+        "title": "Entry",
+        "content": "",
+        "tags": "",
+        "confidence": 0.5,
+        "occurrence_count": 1,
+        "wing": "",
+        "room": "",
+        "last_seen": "",
+        "session_id": "x",
+    }
+    lines = ec._render_entry_markdown(entry, 1)
+    joined = "\n".join(lines)
+    test("render_entry: single occurrence not shown", "Occurrences" not in joined)
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI main() — uses temp DB file
+# ---------------------------------------------------------------------------
+
+def test_main_stdout_markdown(tmp_db_path):
+    """main() returns 0 and produces markdown output."""
+    import io
+    import contextlib
+
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
+        rc = ec.main(["--db", str(tmp_db_path)])
+    test("main: returns 0", rc == 0)
+    output = captured.getvalue()
+    test("main: markdown output starts with CEREBRUM heading", "CEREBRUM" in output)
+
+
+def test_main_json_stdout(tmp_db_path):
+    import io
+    import contextlib
+
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
+        rc = ec.main(["--format", "json", "--db", str(tmp_db_path)])
+    test("main json: returns 0", rc == 0)
+    data = json.loads(captured.getvalue())
+    test("main json: valid JSON with sections", "sections" in data)
+
+
+def test_main_output_file(tmp_db_path, tmp_path):
+    out = tmp_path / "CEREBRUM.md"
+    rc = ec.main(["--output", str(out), "--db", str(tmp_db_path)])
+    test("main file: returns 0", rc == 0)
+    test("main file: output file created", out.exists())
+    content = out.read_text(encoding="utf-8")
+    test("main file: content is markdown", "CEREBRUM" in content)
+
+
+def test_main_sections_filter(tmp_db_path):
+    import io
+    import contextlib
+
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
+        rc = ec.main(["--sections", "mistakes", "--db", str(tmp_db_path)])
+    test("main sections: returns 0", rc == 0)
+    output = captured.getvalue()
+    test("main sections: only requested section", "Do-Not-Repeat" in output)
+    test("main sections: other section absent", "Key Learnings" not in output)
+
+
+def test_main_invalid_section(tmp_db_path):
+    try:
+        rc = ec.main(["--sections", "nonexistent", "--db", str(tmp_db_path)])
+        test("main invalid section: returns non-zero", rc != 0)
+    except SystemExit as e:
+        test("main invalid section: returns non-zero", e.code != 0)
+
+
+def test_main_bad_limit(tmp_db_path):
+    try:
+        rc = ec.main(["--limit", "0", "--db", str(tmp_db_path)])
+        test("main bad limit: returns non-zero", rc != 0)
+    except SystemExit as e:
+        test("main bad limit: returns non-zero", e.code != 0)
+
+
+def test_main_bad_confidence(tmp_db_path):
+    try:
+        rc = ec.main(["--min-confidence", "1.5", "--db", str(tmp_db_path)])
+        test("main bad confidence: returns non-zero", rc != 0)
+    except SystemExit as e:
+        test("main bad confidence: returns non-zero", e.code != 0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: sk.py CLI wiring
+# ---------------------------------------------------------------------------
+
+def test_sk_dispatch_export_cerebrum(tmp_db_path, tmp_path):
+    """sk.py routes export-cerebrum and cerebrum to export-cerebrum.py."""
+    sk = _load("sk", "sk.py")
+    out = tmp_path / "CEREBRUM_sk.md"
+    rc = sk.main(["export-cerebrum", "--output", str(out), "--db", str(tmp_db_path)])
+    test("sk dispatch export-cerebrum: returns 0", rc == 0)
+    test("sk dispatch export-cerebrum: file created", out.exists())
+
+
+def test_sk_dispatch_cerebrum_alias(tmp_db_path, tmp_path):
+    """sk.py 'cerebrum' alias also works."""
+    sk = _load("sk", "sk.py")
+    out = tmp_path / "CEREBRUM_alias.md"
+    rc = sk.main(["cerebrum", "--output", str(out), "--db", str(tmp_db_path)])
+    test("sk dispatch cerebrum alias: returns 0", rc == 0)
+    test("sk dispatch cerebrum alias: file created", out.exists())
+
+
+def test_sk_help_contains_export_cerebrum():
+    sk = _load("sk", "sk.py")
+    import io, contextlib
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
+        sk.main(["--help"])
+    output = captured.getvalue()
+    test("sk help: export-cerebrum listed", "export-cerebrum" in output)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures helper and runner
+# ---------------------------------------------------------------------------
+
+def _make_temp_db(tmp_path: Path) -> Path:
+    """Create a minimal temporary knowledge.db for CLI tests."""
+    db_path = tmp_path / "knowledge.db"
+    db = sqlite3.connect(str(db_path))
+    db.row_factory = sqlite3.Row
+    db.execute(_KE_SCHEMA)
+    db.executemany(
+        """INSERT INTO knowledge_entries
+           (category, title, content, tags, confidence, occurrence_count,
+            first_seen, last_seen, session_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        [
+            ("mistake", "Test mistake", "Content", "test", 0.8, 1, "2025-01-01", "2025-01-01", "s1"),
+            ("pattern", "Test pattern", "Content", "test", 0.7, 1, "2025-01-01", "2025-01-01", "s1"),
+            ("decision", "Test decision", "Content", "test", 0.9, 2, "2025-01-01", "2025-01-01", "s1"),
+        ],
+    )
+    db.commit()
+    db.close()
+    return db_path
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _tmp = Path(tmpdir)
+        _tmp_db = _make_temp_db(_tmp)
+
+        print("\n=== export-cerebrum.py tests ===\n")
+
+        # DB-only tests (no temp file needed)
+        test_fetch_entries_basic()
+        test_fetch_entries_limit()
+        test_fetch_entries_min_confidence()
+        test_fetch_entries_tags_filter()
+        test_fetch_entries_tags_filter_no_match()
+        test_export_cerebrum_markdown_contains_sections()
+        test_export_cerebrum_markdown_header()
+        test_export_cerebrum_markdown_empty_section()
+        test_export_cerebrum_json_structure()
+        test_export_cerebrum_json_section_filter()
+        test_preferences_section_uses_pattern_category()
+        test_render_entry_markdown_fields()
+        test_render_entry_markdown_single_occurrence_hidden()
+
+        # CLI tests (need temp db + tmp_path)
+        _out_dir = _tmp / "output_file"
+        _out_dir.mkdir(exist_ok=True)
+        test_main_stdout_markdown(_tmp_db)
+        test_main_json_stdout(_tmp_db)
+        test_main_output_file(_tmp_db, _out_dir)
+        test_main_sections_filter(_tmp_db)
+        test_main_invalid_section(_tmp_db)
+        test_main_bad_limit(_tmp_db)
+        test_main_bad_confidence(_tmp_db)
+
+        # sk.py wiring tests
+        _sk_direct = _tmp / "sk_direct"
+        _sk_direct.mkdir(exist_ok=True)
+        test_sk_dispatch_export_cerebrum(_tmp_db, _sk_direct)
+        _sk_alias = _tmp / "sk_alias"
+        _sk_alias.mkdir(exist_ok=True)
+        test_sk_dispatch_cerebrum_alias(_tmp_db, _sk_alias)
+        test_sk_help_contains_export_cerebrum()
+
+        print(f"\nResults: {_PASS} passed, {_FAIL} failed")
+        sys.exit(0 if _FAIL == 0 else 1)

--- a/tests/test_export_cerebrum.py
+++ b/tests/test_export_cerebrum.py
@@ -432,8 +432,290 @@ def test_sk_help_contains_export_cerebrum():
 
 
 # ---------------------------------------------------------------------------
-# Fixtures helper and runner
+# Tests: renormalized limit allocation (blocker-2 regressions)
 # ---------------------------------------------------------------------------
+
+def test_single_section_uses_full_limit():
+    """--sections mistakes --limit 200 should return up to 200 entries, not just ~60."""
+    db = _make_db()
+    # Insert 150 mistake entries — all should be returned when limit=200 and only
+    # the mistakes section is active (renormalized fraction = 1.0).
+    _insert(db, [{"category": "mistake", "title": f"M{i}", "confidence": 0.5} for i in range(150)])
+    text = ec.export_cerebrum(
+        db,
+        sections=["mistakes"],
+        limit=200,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="json",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    data = json.loads(text)
+    count = len(data["sections"]["mistakes"])
+    test("single_section_full_limit: all 150 entries returned (not capped at 60)", count == 150)
+
+
+def test_subset_sections_proportional_allocation():
+    """With --sections mistakes,decisions --limit 200 the weight ratio is preserved."""
+    db = _make_db()
+    # Insert plenty of each category so limits are the binding constraint.
+    _insert(db, [{"category": "mistake", "title": f"M{i}", "confidence": 0.5} for i in range(200)])
+    _insert(db, [{"category": "decision", "title": f"D{i}", "confidence": 0.5} for i in range(200)])
+    # mistakes fraction=0.30, decisions fraction=0.15 → ratio 2:1
+    # total_fraction = 0.45; mistakes_norm = 0.30/0.45 ≈ 0.667, decisions_norm = 0.15/0.45 ≈ 0.333
+    text = ec.export_cerebrum(
+        db,
+        sections=["mistakes", "decisions"],
+        limit=200,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="json",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    data = json.loads(text)
+    m_count = len(data["sections"]["mistakes"])
+    d_count = len(data["sections"]["decisions"])
+    # Combined they should use most of the 200 budget.
+    test("subset_proportional: combined count within budget", m_count + d_count <= 200)
+    # Mistakes should be allocated roughly twice as many slots as decisions.
+    test("subset_proportional: mistakes gets more entries than decisions", m_count > d_count)
+    # Neither section should be empty.
+    test("subset_proportional: decisions section non-empty", d_count >= 1)
+
+
+# ---------------------------------------------------------------------------
+# Tests: preferences / learnings distinct (blocker-1 regressions)
+# ---------------------------------------------------------------------------
+
+def test_preferences_learnings_no_overlap_default_export():
+    """Default export must not emit the same entry in both preferences and learnings."""
+    db = _make_db()
+    # Insert patterns: some with preference-hint tags, some without.
+    _insert(db, [
+        {"category": "pattern", "title": "Style guide rule", "tags": "style,python", "confidence": 0.9},
+        {"category": "pattern", "title": "Naming rule", "tags": "naming", "confidence": 0.85},
+        {"category": "pattern", "title": "General pattern A", "tags": "backend", "confidence": 0.8},
+        {"category": "pattern", "title": "General pattern B", "tags": "ci", "confidence": 0.75},
+    ])
+    text = ec.export_cerebrum(
+        db,
+        sections=["preferences", "learnings"],
+        limit=200,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="json",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    data = json.loads(text)
+    pref_titles = {e["title"] for e in data["sections"].get("preferences", [])}
+    learn_titles = {e["title"] for e in data["sections"].get("learnings", [])}
+    overlap = pref_titles & learn_titles
+    test("pref_learnings_no_overlap: no entry appears in both sections", overlap == set())
+
+
+def test_preferences_contains_preference_tagged_entries():
+    """Preferences section must contain entries with preference-hint tags."""
+    db = _make_db()
+    _insert(db, [
+        {"category": "pattern", "title": "Snake case naming", "tags": "naming,python", "confidence": 0.9},
+        {"category": "pattern", "title": "Unrelated pattern", "tags": "docker", "confidence": 0.8},
+    ])
+    text = ec.export_cerebrum(
+        db,
+        sections=["preferences", "learnings"],
+        limit=200,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="json",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    data = json.loads(text)
+    pref_titles = {e["title"] for e in data["sections"].get("preferences", [])}
+    learn_titles = {e["title"] for e in data["sections"].get("learnings", [])}
+    test("pref_tagged: naming entry in preferences", "Snake case naming" in pref_titles)
+    test("pref_tagged: naming entry NOT in learnings", "Snake case naming" not in learn_titles)
+    test("pref_tagged: unrelated pattern in learnings", "Unrelated pattern" in learn_titles)
+    test("pref_tagged: unrelated pattern NOT in preferences", "Unrelated pattern" not in pref_titles)
+
+
+def test_is_preference_entry_heuristic():
+    """_is_preference_entry must classify by tags_hint keywords in tags and title."""
+    test("heuristic: style tag → preference", ec._is_preference_entry({"tags": "style", "title": "X"}))
+    test("heuristic: naming tag → preference", ec._is_preference_entry({"tags": "naming,python", "title": "X"}))
+    test("heuristic: convention in title → preference", ec._is_preference_entry({"tags": "", "title": "Follow naming convention"}))
+    test("heuristic: unrelated tags → NOT preference", not ec._is_preference_entry({"tags": "backend,ci", "title": "General rule"}))
+    test("heuristic: empty tags and title → NOT preference", not ec._is_preference_entry({"tags": "", "title": ""}))
+
+
+def test_pref_overflow_not_in_learnings():
+    """Preference-like entries beyond pref_limit must NOT appear in learnings.
+
+    Regression for the blocker where additional heuristic-matching entries above
+    the preferences cap were bleeding into the learnings section.  Uses limit=4 so
+    pref_limit ≈ 1 (25 % of 4), leaving 5 style-tagged overflow entries that must
+    be excluded from learnings.
+    """
+    db = _make_db()
+    # 6 preference-like pattern entries (style tag triggers the heuristic)
+    _insert(db, [
+        {"category": "pattern", "title": f"Style rule {i}", "tags": "style", "confidence": 0.9 - i * 0.01}
+        for i in range(6)
+    ])
+    # 3 non-preference pattern entries — these are the only ones allowed in learnings
+    _insert(db, [
+        {"category": "pattern", "title": f"General pattern {i}", "tags": "backend", "confidence": 0.8 - i * 0.01}
+        for i in range(3)
+    ])
+    text = ec.export_cerebrum(
+        db,
+        sections=["preferences", "learnings"],
+        limit=4,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="json",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    data = json.loads(text)
+    learn_titles = {e["title"] for e in data["sections"].get("learnings", [])}
+    style_in_learnings = {t for t in learn_titles if "Style rule" in t}
+    test("pref_overflow: no style/pref entries bleed into learnings", style_in_learnings == set())
+
+
+def test_is_preference_entry_no_false_positives():
+    """Titles containing hint keywords only as substrings must NOT match.
+
+    Regression for the word-boundary fix: substring matches like
+    'renaming' ⊃ 'naming' and 'unconventional' ⊃ 'convention' must be
+    rejected; only whole-word occurrences of a hint trigger classification.
+    """
+    test(
+        "heuristic FP: 'renaming' does not match hint 'naming'",
+        not ec._is_preference_entry({"tags": "", "title": "Variable renaming technique"}),
+    )
+    test(
+        "heuristic FP: 'unconventional' does not match hint 'convention'",
+        not ec._is_preference_entry({"tags": "", "title": "Unconventional solution"}),
+    )
+    # Standalone hint words must still match.
+    test(
+        "heuristic FP: standalone 'naming' in title → preference",
+        ec._is_preference_entry({"tags": "", "title": "Naming rule for variables"}),
+    )
+    test(
+        "heuristic FP: standalone 'convention' in title → preference",
+        ec._is_preference_entry({"tags": "", "title": "Follow this convention always"}),
+    )
+    # Only a preference-hint tag (not a substring) should also still fire.
+    test(
+        "heuristic FP: exact 'naming' tag still classifies as preference",
+        ec._is_preference_entry({"tags": "naming", "title": "Variable renaming technique"}),
+    )
+
+
+def test_pref_overflow_exceeds_old_cap():
+    """Hundreds of preference-like entries must not bleed into learnings.
+
+    Regression for the capped-overfetch bug: with limit=10, pref_limit ≈ 4 and
+    the old cap was pref_limit*5+20 = 40.  Inserting 300 style-tagged pattern
+    entries means the old code missed 260 of them and they leaked into learnings.
+    """
+    db = _make_db()
+    # 300 preference-like pattern entries (all trigger the style-tag heuristic).
+    _insert(db, [
+        {
+            "category": "pattern",
+            "title": f"Style guide entry {i}",
+            "tags": "style",
+            "confidence": round(0.9 - i * 0.001, 4),
+        }
+        for i in range(300)
+    ])
+    # 10 non-preference pattern entries — the only ones allowed in learnings.
+    _insert(db, [
+        {
+            "category": "pattern",
+            "title": f"General best practice {i}",
+            "tags": "backend",
+            "confidence": round(0.5 - i * 0.001, 4),
+        }
+        for i in range(10)
+    ])
+    text = ec.export_cerebrum(
+        db,
+        sections=["preferences", "learnings"],
+        limit=10,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="json",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    data = json.loads(text)
+    learn_titles = {e["title"] for e in data["sections"].get("learnings", [])}
+    style_leaked = {t for t in learn_titles if "Style guide entry" in t}
+    test(
+        "pref_overflow_large: none of the 300 style entries leak into learnings",
+        style_leaked == set(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: --limit total cap (fix-2 regressions)
+# ---------------------------------------------------------------------------
+
+def test_limit_one_total_cap():
+    """limit=1 must export exactly 1 entry in total, not 4 (one per section)."""
+    db = _make_db()
+    _insert(db, [
+        {"category": "mistake", "title": f"M{i}", "confidence": 0.5} for i in range(5)
+    ])
+    _insert(db, [
+        {"category": "pattern", "title": f"P{i}", "tags": "style", "confidence": 0.5}
+        for i in range(5)
+    ])
+    _insert(db, [
+        {"category": "decision", "title": f"D{i}", "confidence": 0.5} for i in range(5)
+    ])
+    text = ec.export_cerebrum(
+        db,
+        sections=["preferences", "learnings", "mistakes", "decisions"],
+        limit=1,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="json",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    data = json.loads(text)
+    total = sum(
+        len(data["sections"].get(s, []))
+        for s in ["preferences", "learnings", "mistakes", "decisions"]
+    )
+    test("limit_one_total_cap: total exported is exactly 1 (not 4)", total == 1)
+
+
+def test_limit_total_cap_two_sections():
+    """limit=3 with mistakes+decisions must export exactly 3 entries total."""
+    db = _make_db()
+    _insert(db, [
+        {"category": "mistake", "title": f"M{i}", "confidence": 0.5} for i in range(10)
+    ])
+    _insert(db, [
+        {"category": "decision", "title": f"D{i}", "confidence": 0.5} for i in range(10)
+    ])
+    text = ec.export_cerebrum(
+        db,
+        sections=["mistakes", "decisions"],
+        limit=3,
+        tags_filter=[],
+        min_confidence=0.0,
+        fmt="json",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    data = json.loads(text)
+    total = sum(len(data["sections"].get(s, [])) for s in ["mistakes", "decisions"])
+    test("limit_cap_two_sections: total is exactly 3", total == 3)
+
+
+
 
 def _make_temp_db(tmp_path: Path) -> Path:
     """Create a minimal temporary knowledge.db for CLI tests."""
@@ -500,6 +782,25 @@ if __name__ == "__main__":
         _sk_alias.mkdir(exist_ok=True)
         test_sk_dispatch_cerebrum_alias(_tmp_db, _sk_alias)
         test_sk_help_contains_export_cerebrum()
+
+        # Blocker-2 regressions: renormalized limit allocation
+        test_single_section_uses_full_limit()
+        test_subset_sections_proportional_allocation()
+
+        # Blocker-1 regressions: preferences/learnings must be distinct
+        test_preferences_learnings_no_overlap_default_export()
+        test_preferences_contains_preference_tagged_entries()
+        test_is_preference_entry_heuristic()
+        # Blocker: pref overflow entries must not bleed into learnings
+        test_pref_overflow_not_in_learnings()
+        # New regressions: word-boundary title matching (issue 2)
+        test_is_preference_entry_no_false_positives()
+        # New regressions: overflow exceeds old capped-overfetch cap (issue 1)
+        test_pref_overflow_exceeds_old_cap()
+
+        # Limit total-cap regressions (fix-2)
+        test_limit_one_total_cap()
+        test_limit_total_cap_two_sections()
 
         print(f"\nResults: {_PASS} passed, {_FAIL} failed")
         sys.exit(0 if _FAIL == 0 else 1)

--- a/tests/test_learn_cerebrum_autoupdate.py
+++ b/tests/test_learn_cerebrum_autoupdate.py
@@ -37,6 +37,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+import tempfile
 import unittest.mock
 from contextlib import ExitStack
 from pathlib import Path
@@ -624,6 +625,31 @@ def test_from_file_no_entries_exits_nonzero():
     test("from_file_no_entries_exit: exit code is non-zero", code is not None and code != 0)
 
 
+def test_import_from_file_not_found_uses_stderr():
+    """File-not-found diagnostics should go to stderr, not stdout."""
+    captured_out = io.StringIO()
+    captured_err = io.StringIO()
+    with unittest.mock.patch("sys.stdout", captured_out), unittest.mock.patch("sys.stderr", captured_err):
+        rv = learn.import_from_file("nonexistent.md")
+    test("from_file_not_found_stderr: returns 0", rv == 0)
+    test("from_file_not_found_stderr: stdout stays empty", captured_out.getvalue() == "")
+    test("from_file_not_found_stderr: stderr has message", "Error: File not found" in captured_err.getvalue())
+
+
+def test_import_from_file_no_entries_uses_stderr():
+    """No-entry diagnostics should go to stderr, not stdout."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "no-entries.md"
+        path.write_text("plain text without headers\n", encoding="utf-8")
+        captured_out = io.StringIO()
+        captured_err = io.StringIO()
+        with unittest.mock.patch("sys.stdout", captured_out), unittest.mock.patch("sys.stderr", captured_err):
+            rv = learn.import_from_file(str(path))
+    test("from_file_no_entries_stderr: returns 0", rv == 0)
+    test("from_file_no_entries_stderr: stdout stays empty", captured_out.getvalue() == "")
+    test("from_file_no_entries_stderr: stderr has message", "No entries found" in captured_err.getvalue())
+
+
 # ===========================================================================
 # Test 23 — --from-file with no filepath argument → exit non-zero
 # ===========================================================================
@@ -797,6 +823,8 @@ def _run_all():
     # Exit-code regressions: failed --from-file must exit non-zero
     test_from_file_not_found_exits_nonzero()
     test_from_file_no_entries_exits_nonzero()
+    test_import_from_file_not_found_uses_stderr()
+    test_import_from_file_no_entries_uses_stderr()
     # Bug: --from-file with no filepath must exit non-zero
     test_from_file_missing_arg_exits_nonzero()
     # Fix-1 regressions: header-only import must exit 0

--- a/tests/test_learn_cerebrum_autoupdate.py
+++ b/tests/test_learn_cerebrum_autoupdate.py
@@ -1,0 +1,816 @@
+#!/usr/bin/env python3
+"""
+tests/test_learn_cerebrum_autoupdate.py — Regression tests for learn.py --update-cerebrum.
+
+Verifies the opt-in auto-update path that regenerates CEREBRUM.md after a
+successful learn write.  Uses import-level mocking so no real knowledge.db
+is touched and no real subprocess is spawned.
+
+Scenarios covered:
+  1. --update-cerebrum absent  → subprocess.run NOT called (opt-in only)
+  2. --update-cerebrum present + successful write → subprocess.run called
+  3. --cerebrum-output honoured in subprocess args
+  4. --cerebrum-sections honoured in subprocess args (configurable sections)
+  5. export subprocess failure (non-zero) → main() exits non-zero
+  6. entry rejected by injection scan (entry_id == -1) → auto-update NOT triggered
+  7. default output path is CEREBRUM.md when --cerebrum-output not specified
+  8. --sections absent → --sections NOT forwarded to subprocess
+  9. --update-cerebrum works with --json mode
+ 10. _auto_update_cerebrum unit: correct cmd shape, sections=None
+ 11. _auto_update_cerebrum unit: sections forwarded
+ 12. _auto_update_cerebrum unit: subprocess exception → returns 1
+ 13. --from-file + --update-cerebrum → subprocess IS called (issue-1 regression)
+ 14. --from-file without --update-cerebrum → subprocess NOT called
+ 15. JSON mode: subprocess.run called with stdout=DEVNULL (issue-2 regression)
+ 16. _auto_update_cerebrum unit: TimeoutExpired → returns 1 (issue-3 regression)
+ 17. timeout from main() path → non-zero exit code (issue-3 integration)
+ 18. --from-file + --json + --update-cerebrum → stdout=DEVNULL (blocker-1 regression)
+ 19. --from-file file-not-found → auto-update NOT triggered (blocker-2 regression)
+ 20. --from-file no-entries → auto-update NOT triggered (blocker-2 regression)
+ 21. --from-file file-not-found → exit non-zero
+ 22. --from-file no importable entries → exit non-zero
+"""
+
+import importlib.util
+import io
+import os
+import sqlite3
+import subprocess
+import sys
+import unittest.mock
+from contextlib import ExitStack
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+_HERE = Path(__file__).parent.parent
+
+# ---------------------------------------------------------------------------
+# Load module under test
+# ---------------------------------------------------------------------------
+
+def _load(name: str, rel_path: str):
+    spec = importlib.util.spec_from_file_location(name, str(_HERE / rel_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+learn = _load("learn_for_cerebrum_test", "learn.py")
+
+# ---------------------------------------------------------------------------
+# Simple test harness (consistent with other test files in this repo)
+# ---------------------------------------------------------------------------
+_PASS = 0
+_FAIL = 0
+
+
+def test(name: str, expr: bool) -> None:
+    global _PASS, _FAIL
+    if expr:
+        _PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        _FAIL += 1
+        print(f"  FAIL  {name}")
+
+
+# ---------------------------------------------------------------------------
+# Minimal SQLite schema matching knowledge_entries expectations in learn.py
+# ---------------------------------------------------------------------------
+
+_SCHEMA_STMTS = [
+    """CREATE TABLE knowledge_entries (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT, category TEXT, title TEXT, stable_id TEXT,
+        content TEXT, tags TEXT DEFAULT '', confidence REAL DEFAULT 0.5,
+        occurrence_count INTEGER DEFAULT 1,
+        first_seen TEXT, last_seen TEXT, wing TEXT DEFAULT '', room TEXT DEFAULT '',
+        facts TEXT DEFAULT '[]', est_tokens INTEGER DEFAULT 0,
+        task_id TEXT DEFAULT '', affected_files TEXT DEFAULT '[]')""",
+    """CREATE TABLE ke_fts (
+        rowid INTEGER PRIMARY KEY, title TEXT, content TEXT, tags TEXT,
+        category TEXT, wing TEXT, room TEXT, facts TEXT)""",
+    """CREATE TABLE sync_state (
+        key TEXT PRIMARY KEY, value TEXT,
+        updated_at TEXT DEFAULT CURRENT_TIMESTAMP)""",
+    """CREATE TABLE sync_table_policies (
+        table_name TEXT PRIMARY KEY, sync_scope TEXT)""",
+]
+
+
+def _make_db() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    for stmt in _SCHEMA_STMTS:
+        db.execute(stmt)
+    db.commit()
+    return db
+
+
+def _seed_entry(db: sqlite3.Connection, entry_id: int = 42) -> None:
+    """Insert a minimal knowledge entry so JSON-mode fetch doesn't return None."""
+    db.execute(
+        "INSERT INTO knowledge_entries "
+        "(id, category, title, content, tags, confidence, session_id, task_id, "
+        "affected_files, facts, occurrence_count, last_seen) "
+        "VALUES (?, 'pattern', 'Test Title', 'Test content', '', 0.7, 'sess1', "
+        "'', '[]', '[]', 1, '2025-01-01')",
+        (entry_id,),
+    )
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Test helper: run learn.main() with patched DB, with_retry, and subprocess
+# ---------------------------------------------------------------------------
+
+class _FakeSubprocessResult:
+    def __init__(self, returncode: int = 0):
+        self.returncode = returncode
+
+
+def _run_learn(
+    argv: list[str],
+    *,
+    entry_id_return: int = 42,
+    subprocess_returncode: int = 0,
+    suppress_io: bool = True,
+) -> tuple[list[list[str]], int | None]:
+    """
+    Invoke learn.main() with fully mocked I/O dependencies.
+
+    Returns:
+        (subprocess_calls, exit_code)
+        subprocess_calls: list of cmd lists passed to subprocess.run
+        exit_code: None if main() returned normally, int if SystemExit was raised
+    """
+    subprocess_calls: list[list[str]] = []
+
+    def fake_subprocess_run(cmd, **kwargs):
+        subprocess_calls.append(list(cmd))
+        return _FakeSubprocessResult(subprocess_returncode)
+
+    # DB for get_db() — seeded with entry so JSON mode can fetch it
+    shared_db = _make_db()
+    if entry_id_return >= 0:
+        _seed_entry(shared_db, entry_id_return)
+
+    def fake_get_db():
+        # Return a fresh connection over the same in-memory DB (not possible with
+        # :memory:, so we return the same connection object — sufficient for tests
+        # because the tests are single-threaded).
+        return shared_db
+
+    def fake_with_retry(func, *args, **kwargs):
+        # Skip the real add_entry; return the configured entry_id
+        return entry_id_return
+
+    exit_code: int | None = None
+
+    null_io = io.StringIO()
+
+    ctx_managers = [
+        unittest.mock.patch.object(learn, "with_retry", fake_with_retry),
+        unittest.mock.patch.object(learn, "get_db", fake_get_db),
+        unittest.mock.patch.object(learn.subprocess, "run", fake_subprocess_run),
+    ]
+    if suppress_io:
+        ctx_managers += [
+            unittest.mock.patch("sys.stdout", null_io),
+            unittest.mock.patch("sys.stderr", null_io),
+        ]
+
+    full_argv = ["learn.py"] + argv
+    with unittest.mock.patch.object(sys, "argv", full_argv):
+        with ExitStack() as stack:
+            for cm in ctx_managers:
+                stack.enter_context(cm)
+            try:
+                learn.main()
+            except SystemExit as exc:
+                exit_code = exc.code
+
+    return subprocess_calls, exit_code
+
+
+# ===========================================================================
+# Test 1 — opt-in only: no --update-cerebrum → subprocess NOT called
+# ===========================================================================
+
+def test_no_autoupdate_without_flag():
+    calls, code = _run_learn(["--pattern", "Title", "Some content", "--skip-gate", "--skip-scan"])
+    test("no_autoupdate: subprocess.run not called without flag", len(calls) == 0)
+    test("no_autoupdate: exit code is None (normal return)", code is None)
+
+
+# ===========================================================================
+# Test 2 — --update-cerebrum triggers subprocess.run with correct script
+# ===========================================================================
+
+def test_autoupdate_triggers_subprocess():
+    calls, code = _run_learn([
+        "--pattern", "Title", "Some content",
+        "--update-cerebrum", "--skip-gate", "--skip-scan",
+    ])
+    test("autoupdate: subprocess.run called once", len(calls) == 1)
+    test("autoupdate: export-cerebrum.py in cmd", any("export-cerebrum.py" in str(a) for a in calls[0]))
+    test("autoupdate: --output in cmd", "--output" in calls[0])
+    test("autoupdate: exit code is None (success)", code is None)
+
+
+# ===========================================================================
+# Test 3 — --cerebrum-output is forwarded to subprocess
+# ===========================================================================
+
+def test_cerebrum_output_flag_forwarded():
+    calls, _ = _run_learn([
+        "--pattern", "Title", "Some content",
+        "--update-cerebrum", "--cerebrum-output", "docs/CEREBRUM.md",
+        "--skip-gate", "--skip-scan",
+    ])
+    test("cerebrum_output: subprocess called", len(calls) == 1)
+    output_idx = calls[0].index("--output") if "--output" in calls[0] else -1
+    test("cerebrum_output: --output present in cmd", output_idx != -1)
+    actual_path = calls[0][output_idx + 1] if output_idx != -1 else ""
+    test("cerebrum_output: custom path passed through", actual_path == "docs/CEREBRUM.md")
+
+
+# ===========================================================================
+# Test 4 — --cerebrum-sections is forwarded (configurable sections)
+# ===========================================================================
+
+def test_cerebrum_sections_flag_forwarded():
+    calls, _ = _run_learn([
+        "--mistake", "Title", "Some mistake content",
+        "--update-cerebrum", "--cerebrum-sections", "mistakes,decisions",
+        "--skip-gate", "--skip-scan",
+    ])
+    test("cerebrum_sections: subprocess called", len(calls) == 1)
+    test("cerebrum_sections: --sections in cmd", "--sections" in calls[0])
+    sections_idx = calls[0].index("--sections") if "--sections" in calls[0] else -1
+    actual_sections = calls[0][sections_idx + 1] if sections_idx != -1 else ""
+    test("cerebrum_sections: correct value forwarded", actual_sections == "mistakes,decisions")
+
+
+# ===========================================================================
+# Test 5 — export subprocess failure → main() exits non-zero
+# ===========================================================================
+
+def test_autoupdate_failure_surfaces_exit_code():
+    calls, code = _run_learn(
+        [
+            "--pattern", "Title", "Some content",
+            "--update-cerebrum", "--skip-gate", "--skip-scan",
+        ],
+        subprocess_returncode=1,
+    )
+    test("failure: subprocess.run called", len(calls) == 1)
+    test("failure: exit code is non-zero", code is not None and code != 0)
+
+
+# ===========================================================================
+# Test 6 — rejected entry (injection scan) → auto-update NOT triggered
+# ===========================================================================
+
+def test_rejected_entry_skips_autoupdate():
+    calls, code = _run_learn(
+        [
+            "--pattern", "Title", "Some content",
+            "--update-cerebrum", "--skip-gate", "--skip-scan",
+        ],
+        entry_id_return=-1,
+    )
+    test("rejected: subprocess.run NOT called", len(calls) == 0)
+
+
+# ===========================================================================
+# Test 7 — default output path is CEREBRUM.md
+# ===========================================================================
+
+def test_default_output_path_is_cerebrum_md():
+    calls, _ = _run_learn([
+        "--pattern", "Title", "Some content",
+        "--update-cerebrum", "--skip-gate", "--skip-scan",
+    ])
+    test("default_output: subprocess called", len(calls) == 1)
+    output_idx = calls[0].index("--output") if "--output" in calls[0] else -1
+    actual_path = calls[0][output_idx + 1] if output_idx != -1 else ""
+    test("default_output: path is CEREBRUM.md", actual_path == "CEREBRUM.md")
+
+
+# ===========================================================================
+# Test 8 — --sections absent → --sections NOT forwarded to subprocess
+# ===========================================================================
+
+def test_no_sections_flag_when_not_specified():
+    calls, _ = _run_learn([
+        "--pattern", "Title", "Some content",
+        "--update-cerebrum", "--skip-gate", "--skip-scan",
+    ])
+    test("no_sections: --sections not added when not specified", "--sections" not in calls[0])
+
+
+# ===========================================================================
+# Test 9 — --update-cerebrum works with --json mode
+# ===========================================================================
+
+def test_autoupdate_with_json_mode():
+    calls, code = _run_learn([
+        "--pattern", "Title", "Some content",
+        "--update-cerebrum", "--json", "--skip-gate", "--skip-scan",
+    ])
+    test("json_mode: subprocess.run called", len(calls) == 1)
+    test("json_mode: exit code None (success)", code is None)
+
+
+# ===========================================================================
+# Test 10 — _auto_update_cerebrum unit: correct cmd shape, sections=None
+# ===========================================================================
+
+def test_auto_update_cerebrum_unit_no_sections():
+    """Direct unit test of the _auto_update_cerebrum helper."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _FakeSubprocessResult(0)
+
+    with unittest.mock.patch.object(learn.subprocess, "run", fake_run):
+        rc = learn._auto_update_cerebrum("OUT.md", None)
+
+    test("unit_no_sections: returns 0 on success", rc == 0)
+    test("unit_no_sections: --output present", "--output" in calls[0])
+    test("unit_no_sections: --sections absent", "--sections" not in calls[0])
+    output_idx = calls[0].index("--output")
+    test("unit_no_sections: output path correct", calls[0][output_idx + 1] == "OUT.md")
+
+
+# ===========================================================================
+# Test 11 — _auto_update_cerebrum unit: sections forwarded
+# ===========================================================================
+
+def test_auto_update_cerebrum_unit_with_sections():
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _FakeSubprocessResult(0)
+
+    with unittest.mock.patch.object(learn.subprocess, "run", fake_run):
+        rc = learn._auto_update_cerebrum("X.md", "learnings,mistakes")
+
+    test("unit_with_sections: returns 0", rc == 0)
+    test("unit_with_sections: --sections present", "--sections" in calls[0])
+    sec_idx = calls[0].index("--sections")
+    test("unit_with_sections: sections value correct", calls[0][sec_idx + 1] == "learnings,mistakes")
+
+
+# ===========================================================================
+# Test 12 — _auto_update_cerebrum unit: subprocess exception → returns 1
+# ===========================================================================
+
+def test_auto_update_cerebrum_exception_returns_1():
+    def fake_run(cmd, **kwargs):
+        raise OSError("exporter not found")
+
+    with unittest.mock.patch.object(learn.subprocess, "run", fake_run), \
+         unittest.mock.patch("sys.stderr", io.StringIO()):
+        rc = learn._auto_update_cerebrum("OUT.md", None)
+
+    test("unit_exception: returns 1 on OSError", rc == 1)
+
+
+# ===========================================================================
+# Test 13 — --from-file + --update-cerebrum → subprocess IS called (issue 1)
+# ===========================================================================
+
+def _run_learn_from_file(
+    argv: list[str],
+    *,
+    subprocess_returncode: int = 0,
+    fake_import_return: int = 1,
+) -> tuple[list[list[str]], int | None]:
+    """Helper for --from-file tests: mocks import_from_file and subprocess.run.
+
+    fake_import_return controls what import_from_file returns:
+      >0  → success (auto-update may run)
+       0  → failure (auto-update must NOT run)
+    """
+    subprocess_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        subprocess_calls.append(list(cmd))
+        return _FakeSubprocessResult(subprocess_returncode)
+
+    _import_rv = fake_import_return
+
+    def fake_import(path: str) -> int:
+        return _import_rv
+
+    exit_code: int | None = None
+    full_argv = ["learn.py"] + argv
+
+    with ExitStack() as stack:
+        stack.enter_context(unittest.mock.patch.object(learn.subprocess, "run", fake_run))
+        stack.enter_context(unittest.mock.patch.object(learn, "import_from_file", fake_import))
+        stack.enter_context(unittest.mock.patch("sys.stdout", io.StringIO()))
+        stack.enter_context(unittest.mock.patch("sys.stderr", io.StringIO()))
+        stack.enter_context(unittest.mock.patch.object(sys, "argv", full_argv))
+        try:
+            learn.main()
+        except SystemExit as exc:
+            exit_code = exc.code
+
+    return subprocess_calls, exit_code
+
+
+def test_from_file_with_autoupdate():
+    """--from-file + --update-cerebrum must trigger the cerebrum refresh."""
+    calls, code = _run_learn_from_file([
+        "--from-file", "notes.md", "--update-cerebrum",
+    ], fake_import_return=1)
+    test("from_file_autoupdate: subprocess called once", len(calls) == 1)
+    test("from_file_autoupdate: export-cerebrum.py in cmd",
+         any("export-cerebrum.py" in str(a) for a in calls[0]))
+    test("from_file_autoupdate: exit code None (success)", code is None)
+
+
+# ===========================================================================
+# Test 14 — --from-file alone → subprocess NOT called
+# ===========================================================================
+
+def test_from_file_without_autoupdate():
+    """--from-file without --update-cerebrum must NOT trigger the refresh."""
+    calls, _ = _run_learn_from_file(["--from-file", "notes.md"])
+    test("from_file_no_autoupdate: subprocess.run not called", len(calls) == 0)
+
+
+# ===========================================================================
+# Test 15 — JSON mode subprocess stdout must be DEVNULL (issue 2)
+# ===========================================================================
+
+def test_json_mode_subprocess_stdout_is_devnull():
+    """In JSON mode, subprocess.run must receive stdout=DEVNULL."""
+    captured_kwargs: list[dict] = []
+
+    def fake_run(cmd, **kwargs):
+        captured_kwargs.append(kwargs)
+        return _FakeSubprocessResult(0)
+
+    shared_db = _make_db()
+    _seed_entry(shared_db, 42)
+
+    with ExitStack() as stack:
+        stack.enter_context(unittest.mock.patch.object(learn, "with_retry", lambda f, *a, **kw: 42))
+        stack.enter_context(unittest.mock.patch.object(learn, "get_db", lambda: shared_db))
+        stack.enter_context(unittest.mock.patch.object(learn.subprocess, "run", fake_run))
+        stack.enter_context(unittest.mock.patch("sys.stdout", io.StringIO()))
+        stack.enter_context(unittest.mock.patch("sys.stderr", io.StringIO()))
+        stack.enter_context(unittest.mock.patch.object(sys, "argv", [
+            "learn.py", "--pattern", "Title", "Content",
+            "--update-cerebrum", "--json", "--skip-gate", "--skip-scan",
+        ]))
+        try:
+            learn.main()
+        except SystemExit:
+            pass
+
+    test("json_stdout: subprocess was called", len(captured_kwargs) == 1)
+    test("json_stdout: stdout=DEVNULL passed to subprocess.run",
+         captured_kwargs[0].get("stdout") == subprocess.DEVNULL)
+
+
+# ===========================================================================
+# Test 16 — _auto_update_cerebrum unit: TimeoutExpired → returns 1 (issue 3)
+# ===========================================================================
+
+def test_auto_update_cerebrum_timeout_returns_1():
+    """TimeoutExpired from subprocess must be caught and return 1."""
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, 120)
+
+    with unittest.mock.patch.object(learn.subprocess, "run", fake_run), \
+         unittest.mock.patch("sys.stderr", io.StringIO()):
+        rc = learn._auto_update_cerebrum("OUT.md", None)
+
+    test("unit_timeout: returns 1 on TimeoutExpired", rc == 1)
+
+
+# ===========================================================================
+# Test 17 — timeout surfaces as non-zero exit from main() (issue 3 integration)
+# ===========================================================================
+
+def test_autoupdate_timeout_surfaces_exit_code():
+    """Timeout in the exporter subprocess must propagate as a non-zero exit."""
+    subprocess_calls: list[list[str]] = []
+
+    def fake_run_timeout(cmd, **kwargs):
+        subprocess_calls.append(list(cmd))
+        raise subprocess.TimeoutExpired(cmd, 120)
+
+    shared_db = _make_db()
+    _seed_entry(shared_db, 42)
+
+    exit_code: int | None = None
+    with ExitStack() as stack:
+        stack.enter_context(unittest.mock.patch.object(learn, "with_retry", lambda f, *a, **kw: 42))
+        stack.enter_context(unittest.mock.patch.object(learn, "get_db", lambda: shared_db))
+        stack.enter_context(unittest.mock.patch.object(learn.subprocess, "run", fake_run_timeout))
+        stack.enter_context(unittest.mock.patch("sys.stdout", io.StringIO()))
+        stack.enter_context(unittest.mock.patch("sys.stderr", io.StringIO()))
+        stack.enter_context(unittest.mock.patch.object(sys, "argv", [
+            "learn.py", "--pattern", "Title", "Content",
+            "--update-cerebrum", "--skip-gate", "--skip-scan",
+        ]))
+        try:
+            learn.main()
+        except SystemExit as exc:
+            exit_code = exc.code
+
+    test("timeout_integration: subprocess called", len(subprocess_calls) == 1)
+    test("timeout_integration: exit code non-zero", exit_code is not None and exit_code != 0)
+
+
+# ===========================================================================
+# Test 18 — --from-file + --json + --update-cerebrum → stdout=DEVNULL (blocker 1)
+# ===========================================================================
+
+def test_from_file_json_mode_subprocess_stdout_is_devnull():
+    """--from-file + --json + --update-cerebrum must forward stdout=DEVNULL to subprocess."""
+    captured_kwargs: list[dict] = []
+
+    def fake_run(cmd, **kwargs):
+        captured_kwargs.append(kwargs)
+        return _FakeSubprocessResult(0)
+
+    def fake_import(path: str) -> int:
+        return 1  # pretend the import succeeded
+
+    exit_code: int | None = None
+    full_argv = ["learn.py", "--from-file", "notes.md", "--json", "--update-cerebrum"]
+
+    with ExitStack() as stack:
+        stack.enter_context(unittest.mock.patch.object(learn.subprocess, "run", fake_run))
+        stack.enter_context(unittest.mock.patch.object(learn, "import_from_file", fake_import))
+        stack.enter_context(unittest.mock.patch("sys.stdout", io.StringIO()))
+        stack.enter_context(unittest.mock.patch("sys.stderr", io.StringIO()))
+        stack.enter_context(unittest.mock.patch.object(sys, "argv", full_argv))
+        try:
+            learn.main()
+        except SystemExit as exc:
+            exit_code = exc.code
+
+    test("from_file_json_devnull: subprocess was called", len(captured_kwargs) == 1)
+    test("from_file_json_devnull: stdout=DEVNULL forwarded to subprocess.run",
+         captured_kwargs[0].get("stdout") == subprocess.DEVNULL)
+    test("from_file_json_devnull: exit code None (success)", exit_code is None)
+
+
+# ===========================================================================
+# Test 19 — --from-file file-not-found → auto-update must NOT run (blocker 2)
+# ===========================================================================
+
+def test_from_file_not_found_skips_autoupdate():
+    """When import_from_file returns 0 (file not found), auto-update must NOT trigger."""
+    calls, _ = _run_learn_from_file(
+        ["--from-file", "nonexistent.md", "--update-cerebrum"],
+        fake_import_return=0,
+    )
+    test("from_file_not_found: subprocess.run NOT called", len(calls) == 0)
+
+
+# ===========================================================================
+# Test 20 — --from-file no-entries → auto-update must NOT run (blocker 2)
+# ===========================================================================
+
+def test_from_file_no_entries_skips_autoupdate():
+    """When import_from_file returns 0 (no entries found), auto-update must NOT trigger."""
+    calls, _ = _run_learn_from_file(
+        ["--from-file", "empty.md", "--update-cerebrum"],
+        fake_import_return=0,
+    )
+    test("from_file_no_entries: subprocess.run NOT called", len(calls) == 0)
+
+
+# ===========================================================================
+# Test 21 — --from-file file-not-found → exit non-zero
+# ===========================================================================
+
+def test_from_file_not_found_exits_nonzero():
+    """File not found must cause main() to exit non-zero (not silently succeed)."""
+    calls, code = _run_learn_from_file(
+        ["--from-file", "nonexistent.md"],
+        fake_import_return=0,
+    )
+    test("from_file_not_found_exit: subprocess.run NOT called", len(calls) == 0)
+    test("from_file_not_found_exit: exit code is non-zero", code is not None and code != 0)
+
+
+# ===========================================================================
+# Test 22 — --from-file no importable entries → exit non-zero
+# ===========================================================================
+
+def test_from_file_no_entries_exits_nonzero():
+    """No importable entries must cause main() to exit non-zero (not silently succeed)."""
+    calls, code = _run_learn_from_file(
+        ["--from-file", "empty.md"],
+        fake_import_return=0,
+    )
+    test("from_file_no_entries_exit: subprocess.run NOT called", len(calls) == 0)
+    test("from_file_no_entries_exit: exit code is non-zero", code is not None and code != 0)
+
+
+# ===========================================================================
+# Test 23 — --from-file with no filepath argument → exit non-zero
+# ===========================================================================
+
+def test_from_file_missing_arg_exits_nonzero():
+    """--from-file with no following argument must exit non-zero."""
+    exit_code: int | None = None
+    with ExitStack() as stack:
+        stack.enter_context(unittest.mock.patch("sys.stdout", io.StringIO()))
+        stack.enter_context(unittest.mock.patch("sys.stderr", io.StringIO()))
+        stack.enter_context(unittest.mock.patch.object(sys, "argv", ["learn.py", "--from-file"]))
+        try:
+            learn.main()
+        except SystemExit as exc:
+            exit_code = exc.code
+    test("from_file_missing_arg: exit code is non-zero", exit_code is not None and exit_code != 0)
+
+
+# ===========================================================================
+# Test 24 — header-only import (return -1) → exit 0, no auto-update (fix-1)
+# ===========================================================================
+
+def test_from_file_header_only_exits_zero():
+    """import_from_file returning -1 (headers parsed, no body) must exit 0."""
+    calls, code = _run_learn_from_file(
+        ["--from-file", "notes.md"],
+        fake_import_return=-1,
+    )
+    test("header_only_exit: subprocess.run NOT called", len(calls) == 0)
+    test("header_only_exit: exit code is None (success)", code is None)
+
+
+def test_from_file_header_only_skips_autoupdate():
+    """Header-only import must not trigger auto-update even when --update-cerebrum is set."""
+    calls, code = _run_learn_from_file(
+        ["--from-file", "notes.md", "--update-cerebrum"],
+        fake_import_return=-1,
+    )
+    test("header_only_autoupdate: subprocess.run NOT called", len(calls) == 0)
+    test("header_only_autoupdate: exit code is None (success)", code is None)
+
+
+# ===========================================================================
+# Test 26 — malformed --cerebrum-output (next token is a flag) (fix-4)
+# ===========================================================================
+
+def test_cerebrum_output_flag_no_swallow():
+    """--cerebrum-output followed immediately by another flag must not swallow that flag."""
+    calls, _ = _run_learn([
+        "--pattern", "Title", "Some content",
+        "--update-cerebrum", "--cerebrum-output", "--cerebrum-sections", "mistakes",
+        "--skip-gate", "--skip-scan",
+    ])
+    test("no_swallow_output: subprocess called", len(calls) == 1)
+    output_idx = calls[0].index("--output") if "--output" in calls[0] else -1
+    actual_output = calls[0][output_idx + 1] if output_idx != -1 else ""
+    # --cerebrum-output had a flag as next token → must fall back to default CEREBRUM.md
+    test("no_swallow_output: output is CEREBRUM.md (not the swallowed flag)", actual_output == "CEREBRUM.md")
+    # --cerebrum-sections "mistakes" must still be parsed correctly
+    test("no_swallow_output: --sections present in cmd", "--sections" in calls[0])
+    sec_idx = calls[0].index("--sections") if "--sections" in calls[0] else -1
+    actual_sections = calls[0][sec_idx + 1] if sec_idx != -1 else ""
+    test("no_swallow_output: sections value is 'mistakes'", actual_sections == "mistakes")
+
+
+def test_cerebrum_output_flag_no_content_pollution():
+    """Malformed --cerebrum-output must not leak later values into stored content."""
+    captured: dict[str, str] = {}
+
+    def fake_with_retry(func, *args, **kwargs):
+        captured["content"] = args[2]
+        return 42
+
+    with ExitStack() as stack:
+        stack.enter_context(unittest.mock.patch.object(learn, "with_retry", fake_with_retry))
+        stack.enter_context(
+            unittest.mock.patch.object(
+                learn.subprocess,
+                "run",
+                lambda cmd, **kwargs: _FakeSubprocessResult(0),
+            )
+        )
+        stack.enter_context(unittest.mock.patch("sys.stdout", io.StringIO()))
+        stack.enter_context(unittest.mock.patch("sys.stderr", io.StringIO()))
+        stack.enter_context(
+            unittest.mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "learn.py",
+                    "--pattern",
+                    "Title",
+                    "Some content",
+                    "--update-cerebrum",
+                    "--cerebrum-output",
+                    "--cerebrum-sections",
+                    "mistakes",
+                    "--skip-gate",
+                    "--skip-scan",
+                ],
+            )
+        )
+        learn.main()
+
+    test("no_swallow_output: content preserved", captured.get("content") == "Some content")
+
+
+def test_cerebrum_sections_flag_no_value():
+    """--cerebrum-sections followed by another flag must not forward a flag token as value."""
+    calls, _ = _run_learn([
+        "--pattern", "Title", "Some content",
+        "--update-cerebrum", "--cerebrum-sections", "--skip-gate", "--skip-scan",
+    ])
+    test("no_swallow_sections: subprocess called", len(calls) == 1)
+    # --cerebrum-sections next token is --skip-gate (a flag) → sections must be None → not forwarded
+    test("no_swallow_sections: --sections NOT in cmd", "--sections" not in calls[0])
+
+
+# ===========================================================================
+# Test 28 — malformed --cerebrum-output in --from-file path (fix-4)
+# ===========================================================================
+
+def test_from_file_cerebrum_output_no_swallow():
+    """In the --from-file path, --cerebrum-output followed by a flag must fall back to default."""
+    calls, code = _run_learn_from_file([
+        "--from-file", "notes.md", "--update-cerebrum",
+        "--cerebrum-output", "--cerebrum-sections", "mistakes",
+    ], fake_import_return=1)
+    test("from_file_no_swallow: subprocess called", len(calls) == 1)
+    output_idx = calls[0].index("--output") if "--output" in calls[0] else -1
+    actual_output = calls[0][output_idx + 1] if output_idx != -1 else ""
+    test("from_file_no_swallow: output is CEREBRUM.md", actual_output == "CEREBRUM.md")
+    test("from_file_no_swallow: --sections in cmd", "--sections" in calls[0])
+    sec_idx = calls[0].index("--sections") if "--sections" in calls[0] else -1
+    actual_sections = calls[0][sec_idx + 1] if sec_idx != -1 else ""
+    test("from_file_no_swallow: sections value is 'mistakes'", actual_sections == "mistakes")
+    test("from_file_no_swallow: exit code None (success)", code is None)
+
+
+# ===========================================================================
+# Entry point
+# ===========================================================================
+
+def _run_all():
+    print("\n=== test_learn_cerebrum_autoupdate ===\n")
+    test_no_autoupdate_without_flag()
+    test_autoupdate_triggers_subprocess()
+    test_cerebrum_output_flag_forwarded()
+    test_cerebrum_sections_flag_forwarded()
+    test_autoupdate_failure_surfaces_exit_code()
+    test_rejected_entry_skips_autoupdate()
+    test_default_output_path_is_cerebrum_md()
+    test_no_sections_flag_when_not_specified()
+    test_autoupdate_with_json_mode()
+    test_auto_update_cerebrum_unit_no_sections()
+    test_auto_update_cerebrum_unit_with_sections()
+    test_auto_update_cerebrum_exception_returns_1()
+    # Issue-1 regression: --from-file + --update-cerebrum contract
+    test_from_file_with_autoupdate()
+    test_from_file_without_autoupdate()
+    # Issue-2 regression: JSON mode stdout contract
+    test_json_mode_subprocess_stdout_is_devnull()
+    # Blocker-1 regression: --from-file + --json + --update-cerebrum → stdout=DEVNULL
+    test_from_file_json_mode_subprocess_stdout_is_devnull()
+    # Issue-3 regression: timeout handling
+    test_auto_update_cerebrum_timeout_returns_1()
+    test_autoupdate_timeout_surfaces_exit_code()
+    # Blocker-2 regressions: failed import must not trigger auto-update
+    test_from_file_not_found_skips_autoupdate()
+    test_from_file_no_entries_skips_autoupdate()
+    # Exit-code regressions: failed --from-file must exit non-zero
+    test_from_file_not_found_exits_nonzero()
+    test_from_file_no_entries_exits_nonzero()
+    # Bug: --from-file with no filepath must exit non-zero
+    test_from_file_missing_arg_exits_nonzero()
+    # Fix-1 regressions: header-only import must exit 0
+    test_from_file_header_only_exits_zero()
+    test_from_file_header_only_skips_autoupdate()
+    # Fix-4 regressions: malformed flag ordering must not swallow next flag as value
+    test_cerebrum_output_flag_no_swallow()
+    test_cerebrum_output_flag_no_content_pollution()
+    test_cerebrum_sections_flag_no_value()
+    test_from_file_cerebrum_output_no_swallow()
+
+    print(f"\n  {_PASS} passed, {_FAIL} failed\n")
+    return _FAIL
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## Summary
- add sk export-cerebrum markdown export with configurable sections and total-cap allocation
- add learn.py --update-cerebrum with configurable output and sections handling
- add regressions for from-file flows, malformed flags, section limits, and preference classification

Closes #87