### PR TITLE
feat: add recency-weighted briefing ranking

### DIFF
--- a/briefing.py
+++ b/briefing.py
@@ -1093,9 +1093,7 @@ def _get_briefing_half_life(db: sqlite3.Connection) -> float:
     Falls back to 30.0 days when the key is absent or the table does not exist.
     """
     try:
-        row = db.execute(
-            "SELECT value FROM wakeup_config WHERE key='briefing_recency_half_life'"
-        ).fetchone()
+        row = db.execute("SELECT value FROM wakeup_config WHERE key='briefing_recency_half_life'").fetchone()
         if row and row[0]:
             v = float(row[0])
             return v if v > 0 else 30.0
@@ -1137,11 +1135,7 @@ def search_knowledge_entries(
     has_intensity = _ke_has_intensity(db)
     order_by = _intensity_order_expr("ke") if has_intensity else "ke.confidence DESC, rank"
     # Extra columns fetched so Python-level recency composite scoring has intensity + age.
-    _rec_cols = (
-        ", COALESCE(ke.intensity, 0.5) as intensity, ke.last_seen"
-        if has_intensity
-        else ", ke.last_seen"
-    )
+    _rec_cols = ", COALESCE(ke.intensity, 0.5) as intensity, ke.last_seen" if has_intensity else ", ke.last_seen"
 
     results = []
     try:

--- a/briefing.py
+++ b/briefing.py
@@ -29,6 +29,7 @@ Use --wakeup for ultra-compact AI wake-up context (~170 tokens).
 Use --full for complete content with tags, confidence scores, and full text.
 """
 
+import datetime
 import hashlib
 import json
 import math
@@ -1066,6 +1067,66 @@ def _intensity_order_expr(alias: str = "ke") -> str:
     return f"COALESCE({alias}.intensity, 0.5) DESC, {alias}.confidence DESC, rank"
 
 
+def _recency_decay(last_seen_str: str | None, half_life_days: float = 30.0) -> float:
+    """Exponential decay weight for an entry's age.
+
+    Returns a value in (0, 1]: 1.0 for a just-created entry, approaching 0 for
+    a very old one.  An entry exactly ``half_life_days`` old scores 0.5.
+    Returns 1.0 (fail-open) when the timestamp is absent or unparseable.
+    """
+    if not last_seen_str or half_life_days <= 0:
+        return 1.0
+    try:
+        ts_str = str(last_seen_str)[:19].replace("T", " ")
+        ts = datetime.datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S")
+        now_utc = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        age_days = max(0.0, (now_utc - ts).total_seconds() / 86400.0)
+        return 0.5 ** (age_days / half_life_days)
+    except Exception:
+        return 1.0
+
+
+def _get_briefing_half_life(db: sqlite3.Connection) -> float:
+    """Return the configured recency half-life in days.
+
+    Reads ``briefing_recency_half_life`` from the ``wakeup_config`` table.
+    Falls back to 30.0 days when the key is absent or the table does not exist.
+    """
+    try:
+        row = db.execute(
+            "SELECT value FROM wakeup_config WHERE key='briefing_recency_half_life'"
+        ).fetchone()
+        if row and row[0]:
+            v = float(row[0])
+            return v if v > 0 else 30.0
+    except Exception:
+        pass
+    return 30.0
+
+
+def _recency_composite_score(entry: dict, half_life_days: float) -> float:
+    """Composite ranking score = intensity * recency_decay.
+
+    Preserves the #88 intensity-first contract: for entries with equal age,
+    the higher-intensity entry always scores higher.  Recency decay then
+    boosts genuinely fresh entries relative to equally-intense stale ones.
+    When intensity is absent (pre-v21 DB rows), falls back to the entry's
+    confidence value so the existing confidence-based ordering is preserved.
+    Defaults to 0.5 only when both intensity and confidence are absent.
+    """
+    intensity_raw = entry.get("intensity")
+    if intensity_raw is not None:
+        intensity = float(intensity_raw)
+    else:
+        # Pre-v21 rows have no intensity column; use confidence to preserve
+        # the existing confidence-based ordering instead of collapsing all
+        # no-intensity rows to the same constant.
+        confidence_raw = entry.get("confidence")
+        intensity = float(confidence_raw) if confidence_raw is not None else 0.5
+    decay = _recency_decay(entry.get("last_seen"), half_life_days)
+    return intensity * decay
+
+
 def search_knowledge_entries(
     db: sqlite3.Connection, query: str, category: str, limit: int = 3, min_confidence: float = 0.0
 ) -> list[dict]:
@@ -1075,6 +1136,12 @@ def search_knowledge_entries(
 
     has_intensity = _ke_has_intensity(db)
     order_by = _intensity_order_expr("ke") if has_intensity else "ke.confidence DESC, rank"
+    # Extra columns fetched so Python-level recency composite scoring has intensity + age.
+    _rec_cols = (
+        ", COALESCE(ke.intensity, 0.5) as intensity, ke.last_seen"
+        if has_intensity
+        else ", ke.last_seen"
+    )
 
     results = []
     try:
@@ -1088,7 +1155,7 @@ def search_knowledge_entries(
                    d.doc_type as source_doc_type,
                    d.title as source_doc_title,
                    d.file_path as source_doc_file_path,
-                   d.seq as source_doc_seq
+                   d.seq as source_doc_seq{_rec_cols}
             FROM ke_fts fts
             JOIN knowledge_entries ke ON fts.rowid = ke.id
             LEFT JOIN documents d ON ke.document_id = d.id
@@ -1106,7 +1173,7 @@ def search_knowledge_entries(
             rows = db.execute(
                 f"""
                 SELECT ke.id, ke.title, ke.content, ke.tags,
-                       ke.confidence, ke.session_id, ke.occurrence_count
+                       ke.confidence, ke.session_id, ke.occurrence_count{_rec_cols}
                 FROM ke_fts fts
                 JOIN knowledge_entries ke ON fts.rowid = ke.id
                 WHERE ke_fts MATCH ?
@@ -1135,7 +1202,7 @@ def search_knowledge_entries(
                        d.doc_type as source_doc_type,
                        d.title as source_doc_title,
                        d.file_path as source_doc_file_path,
-                       d.seq as source_doc_seq
+                       d.seq as source_doc_seq{_rec_cols}
                 FROM ke_fts fts
                 JOIN knowledge_entries ke ON fts.rowid = ke.id
                 LEFT JOIN documents d ON ke.document_id = d.id
@@ -1153,7 +1220,7 @@ def search_knowledge_entries(
                 rows = db.execute(
                     f"""
                     SELECT ke.id, ke.title, ke.content, ke.tags,
-                           ke.confidence, ke.session_id, ke.occurrence_count
+                           ke.confidence, ke.session_id, ke.occurrence_count{_rec_cols}
                     FROM ke_fts fts
                     JOIN knowledge_entries ke ON fts.rowid = ke.id
                     WHERE ke_fts MATCH ?
@@ -1203,13 +1270,17 @@ def search_semantic(
         if query_vector:
             vec_results = vector_search(db, query_vector, source_type="knowledge", limit=limit * 3)
             results = []
+            # Fetch intensity so _recency_composite_score honours the #88 contract for
+            # semantic-only hits; guard against pre-v21 DBs that lack the column.
+            _has_intensity = _ke_has_intensity(db)
+            _intensity_col = ", COALESCE(intensity, 0.5) as intensity" if _has_intensity else ""
             for st, sid, score in vec_results:
                 if score < 0.3:
                     continue
                 row = db.execute(
-                    """
+                    f"""
                     SELECT id, title, content, tags, confidence,
-                           session_id, occurrence_count, category
+                           session_id, occurrence_count, category, last_seen{_intensity_col}
                     FROM knowledge_entries WHERE id = ? AND category = ?
                     AND confidence >= ?
                 """,
@@ -1498,14 +1569,18 @@ def generate_briefing(
     db = get_db()
     rewritten_query = _rewrite_query_local(query)
     active_mode, categories, per_cat_limit = _mode_category_config(limit, mode, query, infer_auto=infer_auto_mode)
+    half_life = _get_briefing_half_life(db)
 
     briefing_data = {}
     global_seen_titles = set()  # Cross-category dedup
 
     for cat in categories:
-        # Combine FTS5 + semantic results, deduplicate
+        # Combine FTS5 + semantic results, deduplicate.
+        # Fetch a wider candidate pool so recency weighting can surface better
+        # recent entries that would otherwise be hidden by the SQL LIMIT.
         cat_limit = per_cat_limit.get(cat, limit)
-        fts_results = search_knowledge_entries(db, rewritten_query, cat, cat_limit, min_confidence=min_confidence)
+        fetch_limit = max(cat_limit * 2, cat_limit + 6)
+        fts_results = search_knowledge_entries(db, rewritten_query, cat, fetch_limit, min_confidence=min_confidence)
         sem_results = search_semantic(db, query, cat, cat_limit, min_confidence=min_confidence)
 
         merged = []
@@ -1515,6 +1590,9 @@ def generate_briefing(
                 global_seen_titles.add(title)
                 merged.append(r)
 
+        # Rerank by composite recency score before truncating so that a recent
+        # entry can always surface ahead of an equally-intense stale one.
+        merged.sort(key=lambda e: _recency_composite_score(e, half_life), reverse=True)
         briefing_data[cat] = merged[:cat_limit]
 
     # Past related work

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -24,6 +24,7 @@ import importlib.util
 import os
 import sqlite3
 import sys
+import tempfile
 import textwrap
 from pathlib import Path
 
@@ -309,8 +310,6 @@ test("zero half_life returns 1.0", _b._recency_decay(_old_30, half_life_days=0.0
 
 print("\n⚙️  _get_briefing_half_life  (issue #89)")
 
-REPO = Path(__file__).parent.parent
-
 
 def _make_cfg_db(path, half_life=None):
     """Create a minimal DB with optional wakeup_config entry."""
@@ -466,13 +465,8 @@ def _ins(db, title, content, category, confidence, intensity, last_seen):
     return eid
 
 
-import importlib.util as _ilu
-
-_rnk_db_path = REPO / "_test_briefing_ranking.db"
-try:
-    _rnk_db_path.unlink(missing_ok=True)
-except Exception:
-    pass
+_rnk_tmpdir = tempfile.TemporaryDirectory()
+_rnk_db_path = Path(_rnk_tmpdir.name) / "ranking.db"
 
 _rdb = _make_ranking_db(_rnk_db_path)
 _now2 = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
@@ -533,23 +527,26 @@ test("wakeup_config half-life=7 returned correctly",
      _hl_from_cfg == 7.0, f"got {_hl_from_cfg}")
 
 try:
-    _rnk_db_path.unlink(missing_ok=True)
+    _rnk_tmpdir.cleanup()
 except Exception:
     pass
 
 
-# ── 14. generate_briefing merged rerank path — semantic-intensity regression ──
+# ── 14. generate_briefing merged rerank path — mocked FTS+semantic ordering ──
 #
-# Regression for issue #89 blocker: search_semantic used to omit `intensity`
-# from its SELECT, causing semantic-only hits to be silently scored using the
-# confidence fallback in _recency_composite_score instead of their real intensity.
+# Verifies the _recency_composite_score contract in generate_briefing's merged
+# rerank step using fully-mocked search functions (both FTS and semantic are
+# replaced by return_value mocks — no real DB query or vector lookup occurs).
 #
-# The scenario uses SAME-RECENCY entries so that ordering depends purely on
-# intensity.  The FTS entry has intensity=0.75 and the semantic entry has
-# real intensity=0.85.  When intensity is carried correctly the semantic entry
-# wins (0.85 > 0.75).  When intensity is missing the confidence fallback kicks in
-# (confidence=0.65 < FTS 0.75) — the ordering FLIPS and the test fails.  That
-# means this test will catch a regression if search_semantic drops intensity.
+# The scenario uses SAME-RECENCY entries so ordering depends purely on intensity:
+#   FTS entry (intensity=0.75) vs semantic entry (intensity=0.85 or missing).
+# When intensity is present the semantic entry wins (0.85 > 0.75).
+# When intensity is absent the confidence fallback (0.65) < FTS intensity (0.75)
+# — the ordering FLIPS, confirming that _recency_composite_score uses the field
+# correctly.
+#
+# Note: this section does NOT prove that the real search_semantic() SELECT
+# carries intensity from the DB — that guarantee is provided by Section 15.
 
 print("\n🔗 generate_briefing merged rerank — semantic-intensity regression  (issue #89)")
 

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -12,13 +12,19 @@ Covers:
   - _estimate_tokens() ceiling math
   - _safe_int_list() type coercion
   - _normalize_feedback_query() normalizes and truncates
+  - _recency_decay() exponential decay with half-life (issue #89)
+  - _get_briefing_half_life() config read with default (issue #89)
+  - _recency_composite_score() intensity × decay (issue #89)
 
 Run: python3 tests/test_briefing.py
 """
 
+import datetime
 import importlib.util
 import os
+import sqlite3
 import sys
+import textwrap
 from pathlib import Path
 
 if os.name == "nt":
@@ -249,6 +255,505 @@ test("strips whitespace", _b._normalize_feedback_query("  hello  ") == "hello")
 test("collapses spaces", _b._normalize_feedback_query("hello   world") == "hello world")
 test("None → empty string", _b._normalize_feedback_query(None) == "")
 test("truncates at 500", len(_b._normalize_feedback_query("x" * 600)) == 500)
+
+
+# ── 10. _recency_decay ────────────────────────────────────────────────────────
+
+print("\n⏳ _recency_decay  (issue #89)")
+
+_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+
+# Fresh entry (just created) → decay close to 1.0
+_fresh_ts = _now.strftime("%Y-%m-%d %H:%M:%S")
+_fresh_score = _b._recency_decay(_fresh_ts, half_life_days=30.0)
+test("fresh entry decay is close to 1.0", 0.99 <= _fresh_score <= 1.0,
+     f"got {_fresh_score}")
+
+# Entry exactly 30 days old → decay == 0.5 (by definition of half-life)
+_old_30 = (_now - datetime.timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
+_score_30 = _b._recency_decay(_old_30, half_life_days=30.0)
+test("30-day-old entry decays to 0.5", abs(_score_30 - 0.5) < 0.01,
+     f"got {_score_30:.4f}")
+
+# Entry 60 days old → decay == 0.25 (two half-lives)
+_old_60 = (_now - datetime.timedelta(days=60)).strftime("%Y-%m-%d %H:%M:%S")
+_score_60 = _b._recency_decay(_old_60, half_life_days=30.0)
+test("60-day-old entry decays to ~0.25", abs(_score_60 - 0.25) < 0.02,
+     f"got {_score_60:.4f}")
+
+# None last_seen → fail-open returns 1.0
+test("None last_seen returns 1.0", _b._recency_decay(None, 30.0) == 1.0)
+
+# Empty string → fail-open returns 1.0
+test("empty last_seen returns 1.0", _b._recency_decay("", 30.0) == 1.0)
+
+# Unparseable string → fail-open returns 1.0
+test("garbage last_seen returns 1.0", _b._recency_decay("not-a-date", 30.0) == 1.0)
+
+# T-separated ISO format also accepted
+_iso_ts = (_now - datetime.timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%S")
+_iso_score = _b._recency_decay(_iso_ts, half_life_days=30.0)
+test("ISO T-separated format accepted", abs(_iso_score - 0.5) < 0.01,
+     f"got {_iso_score:.4f}")
+
+# Shorter half-life → faster decay
+_score_short = _b._recency_decay(_old_30, half_life_days=15.0)
+test("shorter half-life gives lower score for same age", _score_short < _score_30,
+     f"hl15={_score_short:.4f} vs hl30={_score_30:.4f}")
+
+# half_life_days <= 0 → returns 1.0 (guard)
+test("zero half_life returns 1.0", _b._recency_decay(_old_30, half_life_days=0.0) == 1.0)
+
+
+# ── 11. _get_briefing_half_life ───────────────────────────────────────────────
+
+print("\n⚙️  _get_briefing_half_life  (issue #89)")
+
+REPO = Path(__file__).parent.parent
+
+
+def _make_cfg_db(path, half_life=None):
+    """Create a minimal DB with optional wakeup_config entry."""
+    db = sqlite3.connect(str(path))
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS wakeup_config (key TEXT PRIMARY KEY, value TEXT)"
+    )
+    if half_life is not None:
+        db.execute(
+            "INSERT OR REPLACE INTO wakeup_config (key, value) VALUES (?, ?)",
+            ("briefing_recency_half_life", str(half_life)),
+        )
+    db.commit()
+    return db
+
+
+# Default when key is absent
+_hl_db_default = _make_cfg_db(":memory:")
+test("default half-life is 30.0 when key absent",
+     _b._get_briefing_half_life(_hl_db_default) == 30.0)
+_hl_db_default.close()
+
+# Custom value read correctly
+_hl_db_custom = _make_cfg_db(":memory:", half_life=60.0)
+test("custom half-life read from wakeup_config",
+     _b._get_briefing_half_life(_hl_db_custom) == 60.0)
+_hl_db_custom.close()
+
+# Value 0 → falls back to 30.0
+_hl_db_zero = _make_cfg_db(":memory:", half_life=0)
+test("half-life=0 in config returns default 30.0",
+     _b._get_briefing_half_life(_hl_db_zero) == 30.0)
+_hl_db_zero.close()
+
+# No wakeup_config table → fails open to 30.0
+_hl_db_no_tbl = sqlite3.connect(":memory:")
+test("missing wakeup_config table returns default 30.0",
+     _b._get_briefing_half_life(_hl_db_no_tbl) == 30.0)
+_hl_db_no_tbl.close()
+
+
+# ── 12. _recency_composite_score ─────────────────────────────────────────────
+
+print("\n🎯 _recency_composite_score  (issue #89)")
+
+_now_str = _now.strftime("%Y-%m-%d %H:%M:%S")
+_old_30_str = (_now - datetime.timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
+
+# High-intensity fresh entry beats low-intensity fresh entry (preserves #88)
+_fresh_hi = {"intensity": 0.9, "last_seen": _now_str}
+_fresh_lo = {"intensity": 0.3, "last_seen": _now_str}
+test("#88 contract: high-intensity fresh beats low-intensity fresh",
+     _b._recency_composite_score(_fresh_hi, 30.0) > _b._recency_composite_score(_fresh_lo, 30.0))
+
+# Counterexample preserved: intensity=0.6 beats intensity=0.4 for same age
+_ce_a = {"intensity": 0.6, "last_seen": _now_str}
+_ce_b = {"intensity": 0.4, "last_seen": _now_str}
+test("#88 counterexample: intensity=0.6 > intensity=0.4 same age",
+     _b._recency_composite_score(_ce_a, 30.0) > _b._recency_composite_score(_ce_b, 30.0))
+
+# Recency effect: recent low-intensity can beat old high-intensity
+_stale_hi = {"intensity": 0.8, "last_seen": _old_30_str}
+_recent_lo = {"intensity": 0.6, "last_seen": _now_str}
+# stale_hi score = 0.8 * 0.5 = 0.40; recent_lo score = 0.6 * ~1.0 = ~0.60
+test("recency: recent low-intensity can beat stale high-intensity",
+     _b._recency_composite_score(_recent_lo, 30.0) > _b._recency_composite_score(_stale_hi, 30.0))
+
+# Missing intensity and no confidence → defaults to 0.5
+_no_intensity = {"last_seen": _now_str}
+_score_ni = _b._recency_composite_score(_no_intensity, 30.0)
+test("missing intensity (no confidence) defaults to 0.5 in composite score",
+     abs(_score_ni - 0.5) < 0.01, f"got {_score_ni:.4f}")
+
+# Missing intensity but confidence present → confidence used as fallback (pre-v21 ordering)
+_no_intensity_with_conf = {"confidence": 0.8, "last_seen": _now_str}
+_score_ni_conf = _b._recency_composite_score(_no_intensity_with_conf, 30.0)
+test("missing intensity: confidence used as fallback when present",
+     abs(_score_ni_conf - 0.8) < 0.01, f"got {_score_ni_conf:.4f}")
+
+# Two pre-v21 rows (no intensity): higher confidence should rank higher
+_pre21_hi = {"confidence": 0.85, "last_seen": _now_str}
+_pre21_lo = {"confidence": 0.55, "last_seen": _now_str}
+test("pre-v21 rows: higher confidence ranks higher (ordering preserved)",
+     _b._recency_composite_score(_pre21_hi, 30.0) > _b._recency_composite_score(_pre21_lo, 30.0))
+
+# Missing last_seen → decay=1.0, so composite = intensity * 1.0
+_no_date = {"intensity": 0.7}
+_score_nd = _b._recency_composite_score(_no_date, 30.0)
+test("missing last_seen treated as fresh (decay=1.0)",
+     abs(_score_nd - 0.7) < 0.01, f"got {_score_nd:.4f}")
+
+
+# ── 13. End-to-end ranking with wakeup_config half-life  ─────────────────────
+
+print("\n🔗 Ranking integration — recency rerank in generate_briefing context  (issue #89)")
+
+
+def _make_ranking_db(path):
+    """Create a test DB with intensity, valence, last_seen, wakeup_config."""
+    db = sqlite3.connect(str(path))
+    db.row_factory = sqlite3.Row
+    db.executescript(textwrap.dedent("""
+        CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY, name TEXT DEFAULT '');
+        CREATE TABLE IF NOT EXISTS knowledge_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL DEFAULT '',
+            category TEXT NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            topic_key TEXT,
+            tags TEXT DEFAULT '',
+            confidence REAL DEFAULT 0.7,
+            wing TEXT DEFAULT '',
+            room TEXT DEFAULT '',
+            occurrence_count INTEGER DEFAULT 1,
+            first_seen TEXT DEFAULT (datetime('now')),
+            last_seen TEXT DEFAULT (datetime('now')),
+            facts TEXT DEFAULT '[]',
+            est_tokens INTEGER DEFAULT 0,
+            task_id TEXT DEFAULT '',
+            affected_files TEXT DEFAULT '[]',
+            stable_id TEXT,
+            valence TEXT DEFAULT '',
+            intensity REAL DEFAULT 0.5
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS ke_fts USING fts5(
+            title, content, tags, category, wing, room, facts,
+            error_type, root_cause,
+            tokenize='porter unicode61 remove_diacritics 2'
+        );
+        CREATE TABLE IF NOT EXISTS wakeup_config (key TEXT PRIMARY KEY, value TEXT);
+    """))
+    return db
+
+
+def _ins(db, title, content, category, confidence, intensity, last_seen):
+    """Insert a knowledge entry and sync FTS."""
+    cur = db.execute(
+        """
+        INSERT INTO knowledge_entries
+            (session_id, category, title, content, confidence, intensity, last_seen, first_seen)
+        VALUES ('', ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (category, title, content, confidence, intensity, last_seen, last_seen),
+    )
+    eid = cur.lastrowid
+    db.execute(
+        "INSERT INTO ke_fts (rowid, title, content, tags, category, wing, room, facts, error_type, root_cause) "
+        "VALUES (?, ?, ?, '', ?, '', '', '', '', '')",
+        (eid, title, content, category),
+    )
+    db.commit()
+    return eid
+
+
+import importlib.util as _ilu
+
+_rnk_db_path = REPO / "_test_briefing_ranking.db"
+try:
+    _rnk_db_path.unlink(missing_ok=True)
+except Exception:
+    pass
+
+_rdb = _make_ranking_db(_rnk_db_path)
+_now2 = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+_ts_fresh = _now2.strftime("%Y-%m-%d %H:%M:%S")
+_ts_stale = (_now2 - datetime.timedelta(days=60)).strftime("%Y-%m-%d %H:%M:%S")
+
+# Entry A: high intensity (0.8) but 60 days stale
+_ins(_rdb, "stale high intensity mistake", "stale bug old issue", "mistake", 0.8, 0.8, _ts_stale)
+# Entry B: lower intensity (0.6) but fresh
+_ins(_rdb, "recent moderate intensity mistake", "fresh bug recent issue", "mistake", 0.7, 0.6, _ts_fresh)
+_rdb.close()
+
+# Use search_knowledge_entries with this DB directly
+import sqlite3 as _sq
+_test_conn = _sq.connect(str(_rnk_db_path))
+_test_conn.row_factory = _sq.Row
+_entries = _b.search_knowledge_entries(_test_conn, "bug issue", "mistake", limit=5)
+_test_conn.close()
+
+# Verify both entries are returned
+_titles = [e.get("title", "") for e in _entries]
+test("ranking test: both entries returned",
+     len(_entries) >= 2,
+     f"got {len(_entries)} entries: {_titles}")
+
+# Verify last_seen is present in results
+test("last_seen present in FTS results", all("last_seen" in e for e in _entries),
+     f"missing in: {[e.get('title') for e in _entries if 'last_seen' not in e]}")
+
+# Verify intensity is present in results (from COALESCE select)
+test("intensity present in FTS results", all("intensity" in e for e in _entries),
+     f"missing in: {[e.get('title') for e in _entries if 'intensity' not in e]}")
+
+# With default half-life 30 days: stale_hi score = 0.8 * 0.5^2 = 0.2, fresh_lo = 0.6 * ~1 = ~0.6
+# fresh entry should rank first after recency reranking
+if len(_entries) >= 2:
+    _sorted = sorted(_entries, key=lambda e: _b._recency_composite_score(e, 30.0), reverse=True)
+    test("recency rerank: recent moderate-intensity ranks above stale high-intensity",
+         _sorted[0].get("title", "").startswith("recent"),
+         f"top title: {_sorted[0].get('title')}")
+
+# With very long half-life (365 days): recency barely matters, intensity wins
+if len(_entries) >= 2:
+    _sorted_hl = sorted(_entries, key=lambda e: _b._recency_composite_score(e, 365.0), reverse=True)
+    test("very long half-life: high-intensity still wins (intensity-first preserved)",
+         _sorted_hl[0].get("title", "").startswith("stale"),
+         f"top title: {_sorted_hl[0].get('title')}")
+
+# Custom half-life via wakeup_config
+_cfg_conn = _sq.connect(str(_rnk_db_path))
+_cfg_conn.row_factory = _sq.Row
+_cfg_conn.execute("CREATE TABLE IF NOT EXISTS wakeup_config (key TEXT PRIMARY KEY, value TEXT)")
+_cfg_conn.execute("INSERT OR REPLACE INTO wakeup_config (key, value) VALUES ('briefing_recency_half_life', '7')")
+_cfg_conn.commit()
+_hl_from_cfg = _b._get_briefing_half_life(_cfg_conn)
+_cfg_conn.close()
+test("wakeup_config half-life=7 returned correctly",
+     _hl_from_cfg == 7.0, f"got {_hl_from_cfg}")
+
+try:
+    _rnk_db_path.unlink(missing_ok=True)
+except Exception:
+    pass
+
+
+# ── 14. generate_briefing merged rerank path — semantic-intensity regression ──
+#
+# Regression for issue #89 blocker: search_semantic used to omit `intensity`
+# from its SELECT, causing semantic-only hits to be silently scored using the
+# confidence fallback in _recency_composite_score instead of their real intensity.
+#
+# The scenario uses SAME-RECENCY entries so that ordering depends purely on
+# intensity.  The FTS entry has intensity=0.75 and the semantic entry has
+# real intensity=0.85.  When intensity is carried correctly the semantic entry
+# wins (0.85 > 0.75).  When intensity is missing the confidence fallback kicks in
+# (confidence=0.65 < FTS 0.75) — the ordering FLIPS and the test fails.  That
+# means this test will catch a regression if search_semantic drops intensity.
+
+print("\n🔗 generate_briefing merged rerank — semantic-intensity regression  (issue #89)")
+
+import unittest.mock as _mock
+
+_gb_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+_gb_fresh = _gb_now.strftime("%Y-%m-%d %H:%M:%S")
+
+# Same-recency scenario — both entries have the same fresh timestamp.
+# Scores at 30-day half-life (decay ≈ 1.0 for age≈0):
+#   FTS entry  : intensity=0.75               → composite ≈ 0.75
+#   sem FIX    : intensity=0.85               → composite ≈ 0.85  (wins — higher than FTS)
+#   sem BUG    : intensity missing, conf=0.65 → composite ≈ 0.65  (loses — ordering FLIPS)
+
+_gb_fts_same_recency = {
+    "id": 10, "title": "gb fts same recency", "content": "c",
+    "category": "mistake", "confidence": 0.8,
+    "intensity": 0.75, "last_seen": _gb_fresh,
+}
+# post-fix semantic result: intensity present (real value 0.85 > FTS 0.75 → wins)
+_gb_sem_fresh_fix = {
+    "id": 20, "title": "gb sem fresh fix", "content": "c",
+    "category": "mistake", "confidence": 0.7,
+    "intensity": 0.85, "last_seen": _gb_fresh,
+}
+# pre-fix (bug) semantic result: intensity absent (confidence fallback 0.65 < FTS 0.75 → loses)
+_gb_sem_fresh_bug = {
+    "id": 20, "title": "gb sem fresh fix", "content": "c",
+    "category": "mistake", "confidence": 0.65,
+    "last_seen": _gb_fresh,           # no 'intensity' key — the old bug
+}
+
+# Verify pre-conditions: the ordering must flip between fix and bug.
+_score_fts_same   = _b._recency_composite_score(_gb_fts_same_recency, 30.0)
+_score_sem_fix    = _b._recency_composite_score(_gb_sem_fresh_fix, 30.0)
+_score_sem_bug    = _b._recency_composite_score(_gb_sem_fresh_bug, 30.0)
+test("pre-conditions: fix sem score > FTS score (semantic wins when intensity present)",
+     _score_sem_fix > _score_fts_same,
+     f"sem_fix={_score_sem_fix:.3f} fts={_score_fts_same:.3f}")
+test("pre-conditions: bug sem score < FTS score (semantic loses — confidence fallback 0.65 < FTS 0.75)",
+     _score_sem_bug < _score_fts_same,
+     f"sem_bug={_score_sem_bug:.3f} fts={_score_fts_same:.3f}")
+
+
+def _fresh_gb_db():
+    """In-memory DB with only the tables generate_briefing needs for this test."""
+    _db = sqlite3.connect(":memory:")
+    _db.row_factory = sqlite3.Row
+    _db.executescript("""
+        CREATE TABLE wakeup_config (key TEXT PRIMARY KEY, value TEXT);
+        INSERT INTO wakeup_config VALUES ('briefing_recency_half_life', '30');
+    """)
+    return _db
+
+
+def _run_gb_with_mocks(fts_entries, sem_entries):
+    """Call generate_briefing with mocked FTS+semantic and return parsed JSON."""
+    with _mock.patch.object(_b, "get_db", side_effect=_fresh_gb_db), \
+         _mock.patch.object(_b, "search_knowledge_entries",
+                            return_value=fts_entries), \
+         _mock.patch.object(_b, "search_semantic",
+                            return_value=sem_entries), \
+         _mock.patch.object(_b, "search_past_work", return_value=[]), \
+         _mock.patch.object(_b, "blast_radius", return_value=[]), \
+         _mock.patch.object(_b, "_upsert_entry_recall_stats", return_value=None), \
+         _mock.patch.object(_b, "_detect_session_id", return_value=""):
+        return _b.generate_briefing(
+            "test query", limit=2, fmt="json", min_confidence=0.0,
+            mode="mistake", infer_auto_mode=False,
+        )
+
+
+import json as _json
+
+def _parse_entries(out):
+    data = _json.loads(out)
+    return (
+        data.get("sections", {}).get("mistake", {}).get("entries", [])
+        or data.get("entries", {}).get("mistake", [])
+    )
+
+# ── Fix scenario: semantic entry carries its real intensity (0.6 > 0.55) → wins ──
+try:
+    _gb_out_fix = _run_gb_with_mocks([_gb_fts_same_recency], [_gb_sem_fresh_fix])
+    _gb_titles_fix = [e.get("title", "") for e in _parse_entries(_gb_out_fix)]
+    test("generate_briefing fix-path: semantic entry ranks first when intensity is present",
+         bool(_gb_titles_fix) and _gb_titles_fix[0] == "gb sem fresh fix",
+         f"order={_gb_titles_fix}")
+except Exception as _e:
+    test("generate_briefing fix-path: ran without exception", False, str(_e))
+
+# ── Bug scenario: semantic entry missing intensity → confidence fallback 0.65 < FTS 0.75 → ordering flips ──
+# This test FAILS if search_semantic regresses and drops intensity again:
+# the sem entry would silently use confidence=0.65, score below the FTS entry (0.75), and rank second.
+try:
+    _gb_out_bug = _run_gb_with_mocks([_gb_fts_same_recency], [_gb_sem_fresh_bug])
+    _gb_titles_bug = [e.get("title", "") for e in _parse_entries(_gb_out_bug)]
+    # With missing intensity the confidence fallback (0.65) < FTS intensity (0.75) → FTS ranks first, sem second.
+    test("generate_briefing bug-path: ordering flips — FTS ranks first when semantic intensity is missing",
+         bool(_gb_titles_bug) and _gb_titles_bug[0] == "gb fts same recency",
+         f"order={_gb_titles_bug}")
+except Exception as _e:
+    test("generate_briefing bug-path: ran without exception", False, str(_e))
+
+
+# ── 15. search_semantic — real vector-search path carries intensity from DB ──
+#
+# Regression: calls the REAL search_semantic() (not mocked) with mocks only
+# around the embedding/vector machinery so no API key or sklearn is needed.
+# Proves that the returned dicts carry `intensity` from the knowledge_entries
+# row, not a default or a missing field.
+
+print("\n🔗 search_semantic — real vector-search path intensity regression  (issue #89)")
+
+import types as _types
+
+
+def _make_sem_test_db():
+    """In-memory DB with knowledge_entries (intensity column) for Section 15."""
+    _db = sqlite3.connect(":memory:")
+    _db.row_factory = sqlite3.Row
+    _db.executescript("""
+        CREATE TABLE knowledge_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT DEFAULT '',
+            category TEXT NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            topic_key TEXT,
+            tags TEXT DEFAULT '',
+            confidence REAL DEFAULT 0.7,
+            wing TEXT DEFAULT '',
+            room TEXT DEFAULT '',
+            occurrence_count INTEGER DEFAULT 1,
+            first_seen TEXT DEFAULT (datetime('now')),
+            last_seen TEXT DEFAULT (datetime('now')),
+            facts TEXT DEFAULT '[]',
+            est_tokens INTEGER DEFAULT 0,
+            intensity REAL,
+            valence TEXT,
+            document_id INTEGER,
+            source_section TEXT,
+            source_file TEXT,
+            start_line INTEGER,
+            end_line INTEGER,
+            code_language TEXT,
+            code_snippet TEXT
+        );
+    """)
+    return _db
+
+
+_sem_db = _make_sem_test_db()
+_sem_db.execute(
+    "INSERT INTO knowledge_entries "
+    "(session_id, category, title, content, confidence, intensity, last_seen) "
+    "VALUES (?, ?, ?, ?, ?, ?, datetime('now'))",
+    ("s-sem-test", "mistake", "sem-intensity-test entry", "content here", 0.7, 0.85),
+)
+_sem_db.commit()
+_sem_entry_id = int(_sem_db.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+
+def _build_mock_embed_module(entry_id_to_return: int):
+    """Return a mock embed module that yields one vector-search hit."""
+    _mod = _types.ModuleType("embed")
+    _mod.load_config = lambda: {"provider": "openai"}
+    _mod.ensure_embedding_tables = lambda db: None
+    _mod.resolve_provider = lambda config: ("openai", {"api_key": "test", "model": "ada"})
+    _mod.call_embedding_api = lambda texts, pc: [[0.1, 0.9] for _ in texts]
+    _mod.vector_search = (
+        lambda db, qv, source_type, limit: [("knowledge", entry_id_to_return, 0.95)]
+    )
+    _mod.search_tfidf = lambda q, model, limit: []
+    return _mod
+
+
+_saved_embed = sys.modules.get("embed")
+sys.modules["embed"] = _build_mock_embed_module(_sem_entry_id)
+
+try:
+    _sem_results = _b.search_semantic(_sem_db, "test query", "mistake", limit=5)
+    test("search_semantic: returns at least one result via real vector path",
+         len(_sem_results) >= 1, f"got {len(_sem_results)} results")
+    if _sem_results:
+        _sr = _sem_results[0]
+        test("search_semantic: result has intensity field from DB",
+             "intensity" in _sr, f"keys: {list(_sr.keys())}")
+        test("search_semantic: intensity value matches stored DB value (0.85)",
+             abs(float(_sr.get("intensity", -1)) - 0.85) < 0.01,
+             f"got intensity={_sr.get('intensity')}")
+        test("search_semantic: result has last_seen field",
+             "last_seen" in _sr, f"keys: {list(_sr.keys())}")
+except Exception as _e:
+    test("search_semantic real path: ran without exception", False, str(_e))
+finally:
+    if _saved_embed is not None:
+        sys.modules["embed"] = _saved_embed
+    elif "embed" in sys.modules:
+        del sys.modules["embed"]
+    try:
+        _sem_db.close()
+    except Exception:
+        pass
 
 
 # ── Summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add recency decay and configurable half-life to briefing ranking
- preserve intensity and confidence fallback behavior across v21 and pre-v21 schemas
- add regressions for merged rerank and real semantic intensity propagation

Closes #89