### PR TITLE
feat: pause active goals on session end

### DIFF
--- a/hooks/rules/session_lifecycle.py
+++ b/hooks/rules/session_lifecycle.py
@@ -129,7 +129,8 @@ def _pause_active_goal(reason: str) -> None:
                 raise _GoalAbsent()
             prev = state.get("status", "")
             captured["prev_status"] = prev
-            captured["title"] = state.get("title") or state.get("id") or ""
+            captured["goal_id"] = state.get("goal_id") or ""
+            captured["title"] = state.get("title") or ""
             if prev in _PAUSE_STATES:
                 state["status"] = "paused"
                 state["paused_at"] = paused_at
@@ -146,10 +147,11 @@ def _pause_active_goal(reason: str) -> None:
 
         breadcrumb_path = goal_path.parent / _BREADCRUMB_FILENAME
         breadcrumb = {
-            "goal_id": captured.get("title") or str(goal_path),
+            "goal_id": captured.get("goal_id") or "",
+            "goal_title": captured.get("title") or "",
             "goal_path": str(goal_path),
             "pause_reason": f"session_end:{reason}",
-            "resume_command": "python ~/.copilot/tools/tentacle.py goal resume",
+            "resume_command": "sk tentacle goal resume",
             "paused_at": paused_at,
             "previous_status": captured["prev_status"],
         }
@@ -159,6 +161,17 @@ def _pause_active_goal(reason: str) -> None:
 
 
 class SessionEndRule(Rule):
+    """Rule that runs on sessionEnd to clean up markers, log the session close,
+    and pause any in-flight goal loop.
+
+    Responsibilities:
+    - Delete session-scoped marker files for the ending session.
+    - Append an entry to the session log.
+    - Pause an active/awaiting-gate goal (via _pause_active_goal) and write a
+      goal-resume-breadcrumb.json alongside goal.json so the next session can
+      quickly identify and resume the interrupted work.
+    """
+
     name = "session-end"
     events = ["sessionEnd"]
 

--- a/hooks/rules/session_lifecycle.py
+++ b/hooks/rules/session_lifecycle.py
@@ -153,15 +153,12 @@ def _pause_active_goal(reason: str) -> None:
             "paused_at": paused_at,
             "previous_status": captured["prev_status"],
         }
-        breadcrumb_path.write_text(
-            _json.dumps(breadcrumb, indent=2) + "\n", encoding="utf-8"
-        )
+        breadcrumb_path.write_text(_json.dumps(breadcrumb, indent=2) + "\n", encoding="utf-8")
     except Exception:
         pass  # fail-open: never let goal-pause crash the session-end hook
 
 
 class SessionEndRule(Rule):
-
     name = "session-end"
     events = ["sessionEnd"]
 

--- a/hooks/rules/session_lifecycle.py
+++ b/hooks/rules/session_lifecycle.py
@@ -1,8 +1,10 @@
 """Session lifecycle rules."""
 
+import json as _json
 import os
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 from . import Rule
@@ -34,6 +36,22 @@ _ID_KEYS = {
     "agent_id",
 }
 _SAFE_TOKEN = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+# Goal statuses that are in-flight and should be paused on session end.
+_PAUSE_STATES: frozenset[str] = frozenset({"active", "awaiting-gate"})
+
+# Filename written alongside goal.json as a resume hint.
+_BREADCRUMB_FILENAME = "goal-resume-breadcrumb.json"
+
+
+class _GoalAbsent(Exception):
+    """Raised inside _mutate to abort _goal_transact when goal is absent or malformed.
+
+    TOCTOU guard: goal_path.exists() may pass before _goal_transact acquires the
+    lock, but if the file disappears or becomes malformed in that window,
+    _goal_load returns {}.  Raising this exception from _mutate prevents
+    _goal_write from recreating goal.json with an empty/skeletal state.
+    """
 
 
 def _extract_stop_hints(payload):
@@ -75,8 +93,74 @@ def _iter_active_entries(marker_data):
     return normalized
 
 
+def _pause_active_goal(reason: str) -> None:
+    """Pause an in-flight goal on session end and write a resume breadcrumb.
+
+    Fail-open: any error, missing tentacles_dir, lock timeout, missing
+    goal.json, or a goal that is already in a terminal state → silent no-op.
+
+    Terminal states that are preserved unchanged:
+        completed, abandoned, paused, needs-human
+    In-flight states that trigger a pause:
+        active, awaiting-gate
+    """
+    if _tentacle_mod is None:
+        return
+    try:
+        tentacles = _tentacle_mod.get_tentacles_dir()
+    except BaseException:
+        # get_tentacles_dir() may call sys.exit(1) when not in a git repo.
+        # Catch SystemExit (BaseException) to stay fail-open.
+        return
+    try:
+        goal_path = _tentacle_mod._goal_path(tentacles)
+        if not goal_path.exists():
+            return
+
+        paused_at = datetime.now(timezone.utc).isoformat()
+        captured: dict = {}
+
+        def _mutate(state: dict) -> None:
+            # TOCTOU guard: _goal_load returns {} when goal.json disappeared or
+            # became malformed between our exists() check and the transaction.
+            # Raise _GoalAbsent so _goal_transact propagates the exception
+            # without calling _goal_write, preventing goal.json recreation.
+            if not state:
+                raise _GoalAbsent()
+            prev = state.get("status", "")
+            captured["prev_status"] = prev
+            captured["title"] = state.get("title") or state.get("id") or ""
+            if prev in _PAUSE_STATES:
+                state["status"] = "paused"
+                state["paused_at"] = paused_at
+                state["pause_reason"] = f"session_end:{reason}"
+                state["updated_at"] = paused_at
+
+        try:
+            _tentacle_mod._goal_transact(tentacles, _mutate)
+        except _GoalAbsent:
+            return  # goal absent/malformed inside transaction — no-op, fail-open
+
+        if captured.get("prev_status") not in _PAUSE_STATES:
+            return  # terminal or absent goal — no breadcrumb needed
+
+        breadcrumb_path = goal_path.parent / _BREADCRUMB_FILENAME
+        breadcrumb = {
+            "goal_id": captured.get("title") or str(goal_path),
+            "goal_path": str(goal_path),
+            "pause_reason": f"session_end:{reason}",
+            "resume_command": "python ~/.copilot/tools/tentacle.py goal resume",
+            "paused_at": paused_at,
+            "previous_status": captured["prev_status"],
+        }
+        breadcrumb_path.write_text(
+            _json.dumps(breadcrumb, indent=2) + "\n", encoding="utf-8"
+        )
+    except Exception:
+        pass  # fail-open: never let goal-pause crash the session-end hook
+
+
 class SessionEndRule(Rule):
-    """Clean up markers on session end."""
 
     name = "session-end"
     events = ["sessionEnd"]
@@ -107,6 +191,9 @@ class SessionEndRule(Rule):
                 fh.write(f"Session ended ({session_id[:8]}): {reason}\n")
         except Exception:
             pass
+
+        # Pause any in-flight goal and write a resume breadcrumb.
+        _pause_active_goal(reason)
 
         return None
 

--- a/hooks/session-end.py
+++ b/hooks/session-end.py
@@ -100,9 +100,7 @@ def _pause_active_goal(reason: str) -> None:
             "paused_at": paused_at,
             "previous_status": captured["prev_status"],
         }
-        breadcrumb_path.write_text(
-            json.dumps(breadcrumb, indent=2) + "\n", encoding="utf-8"
-        )
+        breadcrumb_path.write_text(json.dumps(breadcrumb, indent=2) + "\n", encoding="utf-8")
     except Exception:
         pass
 

--- a/hooks/session-end.py
+++ b/hooks/session-end.py
@@ -14,6 +14,7 @@ import json
 import os
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 if os.name == "nt":
@@ -24,6 +25,86 @@ if os.name == "nt":
 MARKERS_DIR = Path.home() / ".copilot" / "markers"
 _env_state = os.environ.get("COPILOT_SESSION_STATE")
 SESSION_STATE = Path(_env_state) if _env_state else Path.home() / ".copilot" / "session-state"
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+try:
+    import tentacle as _tentacle_mod  # type: ignore
+except Exception:
+    _tentacle_mod = None
+
+_PAUSE_STATES: frozenset[str] = frozenset({"active", "awaiting-gate"})
+_BREADCRUMB_FILENAME = "goal-resume-breadcrumb.json"
+
+
+class _GoalAbsent(Exception):
+    """Raised inside _mutate to abort _goal_transact when goal is absent or malformed.
+
+    TOCTOU guard: goal_path.exists() may pass before _goal_transact acquires the
+    lock, but if the file disappears or becomes malformed in that window,
+    _goal_load returns {}.  Raising this exception from _mutate prevents
+    _goal_write from recreating goal.json with an empty/skeletal state.
+    """
+
+
+def _pause_active_goal(reason: str) -> None:
+    """Pause an in-flight goal on session end and write a resume breadcrumb.
+
+    Fail-open: any error, missing goal.json, lock timeout, or terminal state → no-op.
+    """
+    if _tentacle_mod is None:
+        return
+    try:
+        tentacles = _tentacle_mod.get_tentacles_dir()
+    except BaseException:
+        return
+    try:
+        goal_path = _tentacle_mod._goal_path(tentacles)
+        if not goal_path.exists():
+            return
+
+        paused_at = datetime.now(timezone.utc).isoformat()
+        captured: dict = {}
+
+        def _mutate(state: dict) -> None:
+            # TOCTOU guard: _goal_load returns {} when goal.json disappeared or
+            # became malformed between our exists() check and the transaction.
+            # Raise _GoalAbsent so _goal_transact propagates the exception
+            # without calling _goal_write, preventing goal.json recreation.
+            if not state:
+                raise _GoalAbsent()
+            prev = state.get("status", "")
+            captured["prev_status"] = prev
+            captured["title"] = state.get("title") or state.get("id") or ""
+            if prev in _PAUSE_STATES:
+                state["status"] = "paused"
+                state["paused_at"] = paused_at
+                state["pause_reason"] = f"session_end:{reason}"
+                state["updated_at"] = paused_at
+
+        try:
+            _tentacle_mod._goal_transact(tentacles, _mutate)
+        except _GoalAbsent:
+            return  # goal absent/malformed inside transaction — no-op, fail-open
+
+        if captured.get("prev_status") not in _PAUSE_STATES:
+            return
+
+        breadcrumb_path = goal_path.parent / _BREADCRUMB_FILENAME
+        breadcrumb = {
+            "goal_id": captured.get("title") or str(goal_path),
+            "goal_path": str(goal_path),
+            "pause_reason": f"session_end:{reason}",
+            "resume_command": "python ~/.copilot/tools/tentacle.py goal resume",
+            "paused_at": paused_at,
+            "previous_status": captured["prev_status"],
+        }
+        breadcrumb_path.write_text(
+            json.dumps(breadcrumb, indent=2) + "\n", encoding="utf-8"
+        )
+    except Exception:
+        pass
 
 
 def _has_checkpoints(session_id: str) -> bool:
@@ -68,6 +149,9 @@ def main():
             fh.write(f"Session ended: {reason}\n")
     except Exception:
         pass
+
+    # Pause any in-flight goal and write a resume breadcrumb.
+    _pause_active_goal(reason)
 
     # Opt-in checkpoint reminder: log a hint if no checkpoints were saved.
     # Activated by setting COPILOT_CHECKPOINT_REMIND=1 in the environment.

--- a/hooks/session-end.py
+++ b/hooks/session-end.py
@@ -76,7 +76,8 @@ def _pause_active_goal(reason: str) -> None:
                 raise _GoalAbsent()
             prev = state.get("status", "")
             captured["prev_status"] = prev
-            captured["title"] = state.get("title") or state.get("id") or ""
+            captured["goal_id"] = state.get("goal_id") or ""
+            captured["title"] = state.get("title") or ""
             if prev in _PAUSE_STATES:
                 state["status"] = "paused"
                 state["paused_at"] = paused_at
@@ -93,10 +94,11 @@ def _pause_active_goal(reason: str) -> None:
 
         breadcrumb_path = goal_path.parent / _BREADCRUMB_FILENAME
         breadcrumb = {
-            "goal_id": captured.get("title") or str(goal_path),
+            "goal_id": captured.get("goal_id") or "",
+            "goal_title": captured.get("title") or "",
             "goal_path": str(goal_path),
             "pause_reason": f"session_end:{reason}",
-            "resume_command": "python ~/.copilot/tools/tentacle.py goal resume",
+            "resume_command": "sk tentacle goal resume",
             "paused_at": paused_at,
             "previous_status": captured["prev_status"],
         }

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -2095,6 +2095,22 @@ impl HookRule for VerificationGatePostRule {
 ///     and HMAC-signed knowledge-health counters.
 ///   - Checkpoint reminder: reads `COPILOT_CHECKPOINT_REMIND` env var and
 ///     emits a reminder — low value to port alone.
+///   - Goal pause + resume breadcrumb (issue #184): reads `goal.json` via
+///     `_goal_transact`, transitions `active`/`awaiting-gate` goals to
+///     `paused`, and writes `.octogent/goal-resume-breadcrumb.json`.
+///     Porting this to Rust would require reimplementing the full tentacle.py
+///     goal-lock discipline and file-format contract, which creates a
+///     dual-writer drift risk.  The behavior is therefore intentionally kept
+///     in the Python layer (`hooks/rules/session_lifecycle.py::SessionEndRule`
+///     and `hooks/session-end.py`).
+///
+///     **Routing boundary for default Rust-binary installs:** `sessionEnd` is
+///     in `NATIVE_EVENTS`, so the native Rust rule runs for managed events.
+///     The Python `session_lifecycle.py::SessionEndRule` runs separately only
+///     when the Python `sk.py` shim calls `hook_runner.py`.  Operators using
+///     a pure native binary (no Python shim) do not get goal-pause
+///     automatically; they can run `python ~/.copilot/tools/tentacle.py goal
+///     resume` manually after a session restart to reactivate a paused goal.
 pub struct SessionEndRule;
 
 /// The set of marker filenames that are permanent and must never be deleted

--- a/tests/test_hook_compat.py
+++ b/tests/test_hook_compat.py
@@ -2210,8 +2210,8 @@ def test_session_lifecycle_has_goal_pause():
     )
     test(
         "session_lifecycle.py writes resume_command in breadcrumb",
-        "resume_command" in content and "tentacle.py goal resume" in content,
-        "breadcrumb must include resume_command pointing to tentacle.py goal resume",
+        "resume_command" in content and "sk tentacle goal resume" in content,
+        "breadcrumb must include resume_command pointing to sk tentacle goal resume",
     )
 
 

--- a/tests/test_hook_compat.py
+++ b/tests/test_hook_compat.py
@@ -2173,6 +2173,126 @@ test_hook_runner_still_exists_for_python_shim()
 test_rules_rs_documents_syntax_gate_and_native_flip()
 
 
+# ── sessionEnd goal-pause: managed/native boundary (issue #184) ──────────────
+
+print("\n── sessionEnd goal-pause: managed/native boundary (#184) ────────────────")
+
+SESSION_LIFECYCLE = REPO / "hooks" / "rules" / "session_lifecycle.py"
+SESSION_END_PY = REPO / "hooks" / "session-end.py"
+RULES_RS = REPO / "sk-rust" / "src" / "hooks" / "rules.rs"
+
+
+def test_session_lifecycle_has_goal_pause():
+    """session_lifecycle.py must implement _pause_active_goal."""
+    if not SESSION_LIFECYCLE.exists():
+        test("hooks/rules/session_lifecycle.py exists", False, str(SESSION_LIFECYCLE))
+        return
+    content = SESSION_LIFECYCLE.read_text(encoding="utf-8")
+    test(
+        "session_lifecycle.py defines _pause_active_goal",
+        "_pause_active_goal" in content,
+        "session_lifecycle.py must define _pause_active_goal for issue #184",
+    )
+    test(
+        "session_lifecycle.py defines _PAUSE_STATES",
+        "_PAUSE_STATES" in content,
+        "session_lifecycle.py must define _PAUSE_STATES frozenset",
+    )
+    test(
+        "session_lifecycle.py defines _BREADCRUMB_FILENAME",
+        "_BREADCRUMB_FILENAME" in content,
+        "session_lifecycle.py must define _BREADCRUMB_FILENAME constant",
+    )
+    test(
+        "session_lifecycle.py calls _goal_transact for goal pause",
+        "_goal_transact" in content,
+        "session_lifecycle.py must use _goal_transact for atomic goal pause",
+    )
+    test(
+        "session_lifecycle.py writes resume_command in breadcrumb",
+        "resume_command" in content and "tentacle.py goal resume" in content,
+        "breadcrumb must include resume_command pointing to tentacle.py goal resume",
+    )
+
+
+def test_session_end_py_has_goal_pause():
+    """Legacy hooks/session-end.py must also implement goal pause."""
+    if not SESSION_END_PY.exists():
+        test("hooks/session-end.py exists", False, str(SESSION_END_PY))
+        return
+    content = SESSION_END_PY.read_text(encoding="utf-8")
+    test(
+        "session-end.py defines _pause_active_goal",
+        "_pause_active_goal" in content,
+        "session-end.py (legacy path) must also implement _pause_active_goal",
+    )
+    test(
+        "session-end.py imports tentacle module",
+        "import tentacle as _tentacle_mod" in content,
+        "session-end.py must import tentacle module for goal helpers",
+    )
+    test(
+        "session-end.py calls _pause_active_goal in main",
+        "_pause_active_goal(reason)" in content,
+        "session-end.py main() must call _pause_active_goal(reason)",
+    )
+
+
+def test_rules_rs_documents_goal_pause_boundary():
+    """rules.rs must document that goal pause is Python-only (issue #184)."""
+    if not RULES_RS.exists():
+        test("sk-rust/src/hooks/rules.rs exists", False, str(RULES_RS))
+        return
+    content = RULES_RS.read_text(encoding="utf-8")
+    test(
+        "rules.rs documents goal pause as Python-only (#184)",
+        "184" in content or ("goal pause" in content.lower() and "python" in content.lower()),
+        "rules.rs SessionEndRule must document that goal pause is Python-only",
+    )
+    test(
+        "rules.rs notes routing boundary for native-binary installs",
+        "native" in content and "goal" in content and "python" in content.lower(),
+        "rules.rs must note the native/Python boundary for sessionEnd goal-pause",
+    )
+    test(
+        "rules.rs SessionEndRule still in NATIVE_EVENTS (sessionEnd routing unchanged)",
+        "sessionEnd" in content,
+        "rules.rs must still handle sessionEnd natively",
+    )
+
+
+def test_goal_pause_preserves_terminal_states():
+    """Structural test: _PAUSE_STATES must not include terminal states."""
+    sys.path.insert(0, str(REPO / "hooks"))
+    try:
+        from rules.session_lifecycle import _PAUSE_STATES
+        terminal = {"completed", "abandoned", "paused", "needs-human"}
+        overlap = _PAUSE_STATES & terminal
+        test(
+            "_PAUSE_STATES does not include terminal states",
+            len(overlap) == 0,
+            f"_PAUSE_STATES overlaps with terminal states: {overlap}",
+        )
+        test(
+            "_PAUSE_STATES includes active",
+            "active" in _PAUSE_STATES,
+            "_PAUSE_STATES must include 'active'",
+        )
+        test(
+            "_PAUSE_STATES includes awaiting-gate",
+            "awaiting-gate" in _PAUSE_STATES,
+            "_PAUSE_STATES must include 'awaiting-gate'",
+        )
+    except ImportError as e:
+        test("_PAUSE_STATES importable from session_lifecycle", False, str(e))
+
+
+test_session_lifecycle_has_goal_pause()
+test_session_end_py_has_goal_pause()
+test_rules_rs_documents_goal_pause_boundary()
+test_goal_pause_preserves_terminal_states()
+
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 print(f"\n{'=' * 50}")

--- a/tests/test_hook_rules_more.py
+++ b/tests/test_hook_rules_more.py
@@ -329,7 +329,274 @@ test("SessionEndRule events", "sessionEnd" in rule.events)
 
 
 # ══════════════════════════════════════════════════════════════════════
-#  Section 4: SubagentStopRule
+#  Section 3b: SessionEndRule — goal pause + breadcrumb
+# ══════════════════════════════════════════════════════════════════════
+
+print("\n🔚 Section 3b: SessionEndRule — goal pause + breadcrumb")
+
+import rules.session_lifecycle as _sl_mod2
+from rules.session_lifecycle import _pause_active_goal, _PAUSE_STATES, _BREADCRUMB_FILENAME
+
+_rule_se = SessionEndRule()
+
+# Helpers to build an in-memory mock for _tentacle_mod
+_GOAL_ACTIVE = "active"
+_GOAL_AWAITING = "awaiting-gate"
+_GOAL_PAUSED = "paused"
+_GOAL_COMPLETED = "completed"
+_GOAL_ABANDONED = "abandoned"
+
+
+def _make_fake_tentacle(tmp_dir: Path, initial_status: str, title: str = "Test Goal"):
+    """Return a minimal _tentacle_mod-like mock backed by a real tmp directory."""
+    octogent = tmp_dir / ".octogent"
+    tentacles_dir = octogent / "tentacles"
+    tentacles_dir.mkdir(parents=True, exist_ok=True)
+    goal_path = octogent / "goal.json"
+    initial_state = {"title": title, "status": initial_status, "id": "test-goal-1"}
+    goal_path.write_text(json.dumps(initial_state, indent=2), encoding="utf-8")
+
+    class FakeTentacle:
+        @staticmethod
+        def get_tentacles_dir(*_, **__):
+            return tentacles_dir
+
+        @staticmethod
+        def _goal_path(td):
+            return octogent / "goal.json"
+
+        @staticmethod
+        def _goal_load(td):
+            try:
+                return json.loads(goal_path.read_text(encoding="utf-8"))
+            except Exception:
+                return {}
+
+        @staticmethod
+        def _goal_write(td, state):
+            import os as _os
+            tmp_p = goal_path.with_suffix(".json.tmp")
+            tmp_p.write_text(json.dumps(state, indent=2), encoding="utf-8")
+            _os.replace(tmp_p, goal_path)
+
+        @staticmethod
+        def _goal_transact(td, mutate_fn):
+            state = FakeTentacle._goal_load(td)
+            mutate_fn(state)
+            FakeTentacle._goal_write(td, state)
+            return state
+
+    return FakeTentacle(), goal_path, octogent
+
+
+# 3b-1: active goal → paused + breadcrumb written
+_tmp_3b = Path(tempfile.mkdtemp(prefix="test-se-goal-"))
+try:
+    fake_mod, gp, octogent = _make_fake_tentacle(_tmp_3b, _GOAL_ACTIVE, "My Active Goal")
+    with patch.object(_sl_mod2, "_tentacle_mod", fake_mod):
+        _pause_active_goal("user_exit")
+
+    paused_state = json.loads(gp.read_text(encoding="utf-8"))
+    test("active goal → status becomes paused", paused_state.get("status") == _GOAL_PAUSED)
+    test("active goal → paused_at written", "paused_at" in paused_state)
+    test(
+        "active goal → pause_reason contains session_end",
+        "session_end" in paused_state.get("pause_reason", ""),
+    )
+
+    bc_path = octogent / _BREADCRUMB_FILENAME
+    test("active goal → breadcrumb file written", bc_path.exists())
+    if bc_path.exists():
+        bc = json.loads(bc_path.read_text(encoding="utf-8"))
+        test("breadcrumb has goal_id", "goal_id" in bc and bc["goal_id"])
+        test("breadcrumb has goal_path", "goal_path" in bc)
+        test("breadcrumb has pause_reason", "session_end" in bc.get("pause_reason", ""))
+        test("breadcrumb has resume_command", "tentacle.py goal resume" in bc.get("resume_command", ""))
+        test("breadcrumb has paused_at", "paused_at" in bc)
+        test("breadcrumb previous_status is active", bc.get("previous_status") == _GOAL_ACTIVE)
+finally:
+    shutil.rmtree(_tmp_3b, ignore_errors=True)
+
+# 3b-2: awaiting-gate goal → paused + breadcrumb written
+_tmp_3b2 = Path(tempfile.mkdtemp(prefix="test-se-goal-ag-"))
+try:
+    fake_mod, gp, octogent = _make_fake_tentacle(_tmp_3b2, _GOAL_AWAITING, "Awaiting Gate")
+    with patch.object(_sl_mod2, "_tentacle_mod", fake_mod):
+        _pause_active_goal("normal_exit")
+
+    paused_state = json.loads(gp.read_text(encoding="utf-8"))
+    test("awaiting-gate goal → status becomes paused", paused_state.get("status") == _GOAL_PAUSED)
+
+    bc_path = octogent / _BREADCRUMB_FILENAME
+    test("awaiting-gate goal → breadcrumb written", bc_path.exists())
+    if bc_path.exists():
+        bc = json.loads(bc_path.read_text(encoding="utf-8"))
+        test(
+            "awaiting-gate breadcrumb previous_status is awaiting-gate",
+            bc.get("previous_status") == _GOAL_AWAITING,
+        )
+finally:
+    shutil.rmtree(_tmp_3b2, ignore_errors=True)
+
+# 3b-3: terminal state (completed) → preserved, no breadcrumb
+_tmp_3b3 = Path(tempfile.mkdtemp(prefix="test-se-goal-comp-"))
+try:
+    fake_mod, gp, octogent = _make_fake_tentacle(_tmp_3b3, _GOAL_COMPLETED)
+    with patch.object(_sl_mod2, "_tentacle_mod", fake_mod):
+        _pause_active_goal("user_exit")
+
+    state = json.loads(gp.read_text(encoding="utf-8"))
+    test("completed goal → status unchanged", state.get("status") == _GOAL_COMPLETED)
+    bc_path = octogent / _BREADCRUMB_FILENAME
+    test("completed goal → no breadcrumb written", not bc_path.exists())
+finally:
+    shutil.rmtree(_tmp_3b3, ignore_errors=True)
+
+# 3b-4: terminal state (abandoned) → preserved, no breadcrumb
+_tmp_3b4 = Path(tempfile.mkdtemp(prefix="test-se-goal-aband-"))
+try:
+    fake_mod, gp, octogent = _make_fake_tentacle(_tmp_3b4, _GOAL_ABANDONED)
+    with patch.object(_sl_mod2, "_tentacle_mod", fake_mod):
+        _pause_active_goal("user_exit")
+
+    state = json.loads(gp.read_text(encoding="utf-8"))
+    test("abandoned goal → status unchanged", state.get("status") == _GOAL_ABANDONED)
+    bc_path = octogent / _BREADCRUMB_FILENAME
+    test("abandoned goal → no breadcrumb written", not bc_path.exists())
+finally:
+    shutil.rmtree(_tmp_3b4, ignore_errors=True)
+
+# 3b-5: already-paused goal → preserved, no new breadcrumb
+_tmp_3b5 = Path(tempfile.mkdtemp(prefix="test-se-goal-paused-"))
+try:
+    fake_mod, gp, octogent = _make_fake_tentacle(_tmp_3b5, _GOAL_PAUSED)
+    with patch.object(_sl_mod2, "_tentacle_mod", fake_mod):
+        _pause_active_goal("user_exit")
+
+    state = json.loads(gp.read_text(encoding="utf-8"))
+    test("paused goal → status unchanged (already paused)", state.get("status") == _GOAL_PAUSED)
+    bc_path = octogent / _BREADCRUMB_FILENAME
+    test("paused goal → no redundant breadcrumb", not bc_path.exists())
+finally:
+    shutil.rmtree(_tmp_3b5, ignore_errors=True)
+
+# 3b-6: no goal.json → fail-open (no crash)
+_tmp_3b6 = Path(tempfile.mkdtemp(prefix="test-se-goal-none-"))
+try:
+    octogent6 = _tmp_3b6 / ".octogent"
+    tentacles6 = octogent6 / "tentacles"
+    tentacles6.mkdir(parents=True, exist_ok=True)
+
+    class _FakeNoGoal:
+        @staticmethod
+        def get_tentacles_dir(*_, **__):
+            return tentacles6
+
+        @staticmethod
+        def _goal_path(td):
+            return octogent6 / "goal.json"  # does not exist
+
+    try:
+        with patch.object(_sl_mod2, "_tentacle_mod", _FakeNoGoal()):
+            _pause_active_goal("user_exit")
+        test("no goal.json → fail-open (no crash)", True)
+    except Exception as exc:
+        test("no goal.json → fail-open (no crash)", False, str(exc))
+finally:
+    shutil.rmtree(_tmp_3b6, ignore_errors=True)
+
+# 3b-7: _tentacle_mod is None → fail-open
+try:
+    with patch.object(_sl_mod2, "_tentacle_mod", None):
+        _pause_active_goal("user_exit")
+    test("_tentacle_mod=None → fail-open (no crash)", True)
+except Exception as exc:
+    test("_tentacle_mod=None → fail-open (no crash)", False, str(exc))
+
+# 3b-8: SessionEndRule.evaluate with active goal → pauses goal
+_tmp_3b8 = Path(tempfile.mkdtemp(prefix="test-se-rule-active-"))
+try:
+    fake_mod8, gp8, octogent8 = _make_fake_tentacle(_tmp_3b8, _GOAL_ACTIVE, "Rule Goal")
+    _tmp_markers8 = Path(tempfile.mkdtemp(prefix="test-se-markers8-"))
+    with (
+        patch.object(_sl_mod2, "_tentacle_mod", fake_mod8),
+        patch.object(_sl_mod2, "MARKERS_DIR", _tmp_markers8),
+        patch.dict(os.environ, {"COPILOT_AGENT_SESSION_ID": "testse8"}),
+    ):
+        result8 = _rule_se.evaluate("sessionEnd", {"reason": "normal_exit"})
+
+    test("SessionEndRule.evaluate with active goal → returns None", result8 is None)
+    state8 = json.loads(gp8.read_text(encoding="utf-8"))
+    test("SessionEndRule.evaluate → active goal paused", state8.get("status") == _GOAL_PAUSED)
+finally:
+    shutil.rmtree(_tmp_3b8, ignore_errors=True)
+    shutil.rmtree(_tmp_markers8, ignore_errors=True)
+
+# 3b-9: TOCTOU — exists() passes but _goal_load returns {} inside transaction
+#        Fix: _mutate raises _GoalAbsent → _goal_write never called → no corrupt state
+_tmp_3b9 = Path(tempfile.mkdtemp(prefix="test-se-goal-toctou-"))
+try:
+    octogent9 = _tmp_3b9 / ".octogent"
+    tentacles9 = octogent9 / "tentacles"
+    tentacles9.mkdir(parents=True, exist_ok=True)
+    goal_path9 = octogent9 / "goal.json"
+    # Write a valid active goal so exists() check passes at the outer level.
+    original_content = json.dumps({"title": "TOCTOU Goal", "status": "active", "id": "toctou-1"}, indent=2)
+    goal_path9.write_text(original_content, encoding="utf-8")
+
+    write_call_args: list = []
+
+    class _FakeToctou9:
+        """Simulates the TOCTOU window: goal_path().exists() is True, but
+        _goal_transact sees {} because the file was deleted (or went malformed)
+        between the outer exists() check and the lock acquisition."""
+
+        @staticmethod
+        def get_tentacles_dir(*_, **__):
+            return tentacles9
+
+        @staticmethod
+        def _goal_path(td):
+            return goal_path9
+
+        @staticmethod
+        def _goal_transact(td, mutate_fn):
+            # Simulate _goal_load returning {} as if the file vanished.
+            empty_state: dict = {}
+            mutate_fn(empty_state)  # expect _GoalAbsent to propagate here
+            # If we reach this point, mutate_fn did NOT raise — record the write.
+            write_call_args.append(dict(empty_state))
+            goal_path9.write_text(json.dumps(empty_state, indent=2), encoding="utf-8")
+            return empty_state
+
+    try:
+        with patch.object(_sl_mod2, "_tentacle_mod", _FakeToctou9()):
+            _pause_active_goal("user_exit")
+        test("TOCTOU: empty state inside transaction → no crash (fail-open)", True)
+    except Exception as exc:
+        test("TOCTOU: empty state inside transaction → no crash (fail-open)", False, str(exc))
+
+    # _goal_write must NOT have been called (write_call_args stays empty because
+    # _GoalAbsent propagated out of _goal_transact before the write line).
+    test(
+        "TOCTOU: empty state inside transaction → _goal_write not reached",
+        len(write_call_args) == 0,
+        f"write was called with: {write_call_args}",
+    )
+
+    # goal.json must not have been overwritten with empty or skeletal content.
+    current_content = goal_path9.read_text(encoding="utf-8")
+    test(
+        "TOCTOU: goal.json not overwritten with empty state",
+        current_content == original_content,
+        f"content changed to: {current_content[:120]}",
+    )
+
+    # No breadcrumb should be written.
+    bc_path9 = octogent9 / _BREADCRUMB_FILENAME
+    test("TOCTOU: no breadcrumb written when goal absent inside transaction", not bc_path9.exists())
+finally:
+    shutil.rmtree(_tmp_3b9, ignore_errors=True)
 # ══════════════════════════════════════════════════════════════════════
 
 print("\n🛑 Section 4: SubagentStopRule")

--- a/tests/test_hook_rules_more.py
+++ b/tests/test_hook_rules_more.py
@@ -353,7 +353,7 @@ def _make_fake_tentacle(tmp_dir: Path, initial_status: str, title: str = "Test G
     tentacles_dir = octogent / "tentacles"
     tentacles_dir.mkdir(parents=True, exist_ok=True)
     goal_path = octogent / "goal.json"
-    initial_state = {"title": title, "status": initial_status, "id": "test-goal-1"}
+    initial_state = {"title": title, "status": initial_status, "goal_id": "test-goal-1"}
     goal_path.write_text(json.dumps(initial_state, indent=2), encoding="utf-8")
 
     class FakeTentacle:
@@ -408,10 +408,11 @@ try:
     test("active goal → breadcrumb file written", bc_path.exists())
     if bc_path.exists():
         bc = json.loads(bc_path.read_text(encoding="utf-8"))
-        test("breadcrumb has goal_id", "goal_id" in bc and bc["goal_id"])
+        test("breadcrumb has goal_id", "goal_id" in bc and bc["goal_id"] == "test-goal-1")
+        test("breadcrumb has goal_title", "goal_title" in bc and bc.get("goal_title") == "My Active Goal")
         test("breadcrumb has goal_path", "goal_path" in bc)
         test("breadcrumb has pause_reason", "session_end" in bc.get("pause_reason", ""))
-        test("breadcrumb has resume_command", "tentacle.py goal resume" in bc.get("resume_command", ""))
+        test("breadcrumb has resume_command", bc.get("resume_command") == "sk tentacle goal resume")
         test("breadcrumb has paused_at", "paused_at" in bc)
         test("breadcrumb previous_status is active", bc.get("previous_status") == _GOAL_ACTIVE)
 finally:
@@ -541,7 +542,7 @@ try:
     tentacles9.mkdir(parents=True, exist_ok=True)
     goal_path9 = octogent9 / "goal.json"
     # Write a valid active goal so exists() check passes at the outer level.
-    original_content = json.dumps({"title": "TOCTOU Goal", "status": "active", "id": "toctou-1"}, indent=2)
+    original_content = json.dumps({"title": "TOCTOU Goal", "status": "active", "goal_id": "toctou-1"}, indent=2)
     goal_path9.write_text(original_content, encoding="utf-8")
 
     write_call_args: list = []

--- a/tests/test_hook_runner_entrypoints.py
+++ b/tests/test_hook_runner_entrypoints.py
@@ -365,6 +365,12 @@ r = _run("sessionEnd", {"reason": "unexpected_disconnect"})
 test("sessionEnd with unexpected_disconnect → no crash", r.returncode == 0,
      f"rc={r.returncode} stderr={r.stderr[:200]}")
 
+# 8c. sessionEnd with no goal.json present → no crash (fail-open path)
+#     Even though there is no active goal, the hook must exit 0.
+r = _run("sessionEnd", {"reason": "no_active_goal"})
+test("sessionEnd with no active goal → no crash (exit 0)", r.returncode == 0,
+     f"rc={r.returncode} stderr={r.stderr[:200]}")
+
 
 # ══════════════════════════════════════════════════════════════════════
 #  Section 9: Multiple rules in sequence (no interference)


### PR DESCRIPTION
Closes #184

## Summary
- pause active goals during session-end handling with fail-open goal state updates
- write resume breadcrumbs for later recovery without widening into banner work
- add regression coverage for pause, breadcrumb, and TOCTOU-safe no-goal paths