### PR TITLE
feat: inject paused-goal resume hints

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -29,7 +29,7 @@ hooks/
 
 | Rule | Event | Description |
 |------|-------|-------------|
-| `auto-briefing` | sessionStart | Auto-runs briefing.py + refreshes codebase-map.py, creates HMAC-signed marker |
+| `auto-briefing` | sessionStart | Auto-runs briefing.py + refreshes codebase-map.py, creates HMAC-signed marker; also surfaces paused-goal resume banner from `.octogent/goal-resume-breadcrumb.json` when a goal was paused at last session end (issue #185) |
 | `integrity` | sessionStart | Verifies hook files via SHA256 manifest |
 | `session-end` | sessionEnd | Cleans up marker files, writes session.log entry, opt-in checkpoint reminder (`COPILOT_CHECKPOINT_REMIND=1`) |
 | `recurrence-detector` | sessionEnd | Detects briefed mistakes that recurred in the same session; increments `recurrence_after_briefing` counter |
@@ -183,7 +183,7 @@ This section documents precisely which Python hook rules have been ported to the
 | Rule | Event(s) | Status | Notes |
 |------|----------|--------|-------|
 | `session-start` | sessionStart | ✅ Native (informational) | Emits "[sk] Session started" acknowledgement only; `AutoBriefingRule` and `IntegrityRule` follow in registration order |
-| `auto-briefing` | sessionStart | ✅ **Native (wave9)** | `AutoBriefingRule` spawns `briefing.py` via `python_exe()`, signs HMAC `briefing-done` + `codebase-map-ran` markers on completion; 10s bounded timeout (same cap as Python path); fail-open if `briefing.py` absent; HMAC write uses `marker_auth::sign_marker` |
+| `auto-briefing` | sessionStart | ✅ **Native (wave9)** | `AutoBriefingRule` spawns `briefing.py` via `python_exe()`, signs HMAC `briefing-done` + `codebase-map-ran` markers on completion; 10s bounded timeout (same cap as Python path); fail-open if `briefing.py` absent; HMAC write uses `marker_auth::sign_marker`. **wave16 (#185):** prepends paused-goal resume banner (from `.octogent/goal-resume-breadcrumb.json`) before the `📋 Session briefing` header; staleness-checked via `goal.json`; fail-open |
 | `integrity` | sessionStart | ✅ **Native (wave9)** | `IntegrityRule` reads SHA256 hook-file manifest at `~/.copilot/hooks/integrity-manifest.json`; refreshes manifest when files change; emits integrity-verified or refresh notice; informational only; fail-open |
 | `subagent-git-guard` | preToolUse | ✅ Native (deny-capable, wave6 hardened) | Blocks `git commit/push` when dispatched-subagent marker is fresh; verifies HMAC marker authenticity when a secret exists, but stays backward-compatible without a secret |
 | `block-edit-dist` | preToolUse | ✅ Native (deny-capable, wave6; managed Rust path active in wave13) | Blocks `edit`/`create` targeting `browse-ui/dist/` on the direct Rust path and, after the wave13 routing flip, on managed `sk hooks run preToolUse` for Rust-binary installs. The Python `sk.py` shim still routes through `hook_runner.py`. |
@@ -231,6 +231,12 @@ As of wave9, **`sessionStart`** is also routed natively:
      **10-second bounded timeout** (matching the Python path's `BRIEFING_TIMEOUT_SEC = 10`
      constant); a timeout is treated as pass-through (the rule does not block the session).
      Fail-open: if `briefing.py` is absent, the rule emits no output and returns `None`.
+     **wave16 (#185):** before the `📋 Session briefing` header, reads
+     `.octogent/goal-resume-breadcrumb.json` (written by session-end when a goal is paused)
+     and surfaces a concise `⏸ Paused goal: <title>  (<reason>)` / `▶ Run: sk tentacle goal
+     resume` banner.  Staleness check: if `goal.json` status ≠ `"paused"`, banner is
+     suppressed.  Fail-open: goal.json absent or unreadable → banner shown.  Breadcrumb
+     absent or unreadable → no banner.
   3. `IntegrityRule` — reads `~/.copilot/hooks/integrity-manifest.json`; refreshes the
      manifest when hook files have changed since the last check; emits a verified or
      refresh notice.  Informational only — never blocks.  Fail-open on missing manifest

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -92,7 +92,7 @@ sk scout status                     # scout-status.py
 
 | Event | Native behavior |
 |-------|----------------|
-| `sessionStart` | `AutoBriefingRule` (spawns `briefing.py`, 10s timeout, signs HMAC markers) + `IntegrityRule` (SHA256 manifest) |
+| `sessionStart` | `AutoBriefingRule` (spawns `briefing.py`, 10s timeout, signs HMAC markers; prepends paused-goal resume banner from `.octogent/goal-resume-breadcrumb.json` — wave16 #185) + `IntegrityRule` (SHA256 manifest) |
 | `sessionEnd` | `SessionEndRule` (marker cleanup + `session.log`) + `RecurrenceDetectorRule` |
 | `preToolUse` | All deny-capable rules active: `subagent-git-guard`, `block-edit-dist`, `block-unsafe-html`, `pnpm-lockfile-guard`, `read-before-edit`, `VerificationGatePreRule`, `EnforceBriefingRule`, `EnforceLearnRule`, `TentacleEnforceRule`, `SyntaxGateRule` |
 | `postToolUse` | All 7 rules: `TrackEditsRule`, `LearnReminderRule`, `TestReminderRule`, `NextjsTypecheckReminderRule`, `VerificationGatePostRule`, `ReadBeforeEditRule`, `TentacleSuggestRule` |

--- a/hooks/auto-briefing.py
+++ b/hooks/auto-briefing.py
@@ -32,6 +32,14 @@ CODEBASE_MAP = TOOLS_DIR / "codebase-map.py"
 MARKERS_DIR = Path.home() / ".copilot" / "markers"
 MARKER = MARKERS_DIR / "briefing-done"
 
+# Goal resume breadcrumb (written by session-end when a goal was in-flight).
+_BREADCRUMB_FILENAME = "goal-resume-breadcrumb.json"
+_PAUSE_REASON_LABELS = {
+    "session_end": "session end",
+    "compaction": "context compaction",
+    "quota": "quota limit",
+}
+
 # MEMORY.md injection config (mirrors hooks/rules/briefing.py)
 # Primary config: ~/.copilot/hooks-config.json using issue #161 key names:
 #   memory_inject_enabled      — bool, default true
@@ -106,6 +114,73 @@ def _load_memory_md(cwd=None, max_age_secs=None, token_budget=None):
         return None
 
 
+def _format_pause_reason(raw: str) -> str:
+    """Return a short human-readable label for a raw pause_reason string."""
+    prefix = raw.split(":")[0].strip() if raw else ""
+    return _PAUSE_REASON_LABELS.get(prefix, "paused")
+
+
+def _load_goal_resume_hint(project_root: "Path | None" = None) -> "list[str] | None":
+    """Read the paused-goal breadcrumb and return concise banner lines.
+
+    Returns None (fail-open) when:
+      - breadcrumb file is absent,
+      - the goal is no longer in 'paused' state (stale / already resumed),
+      - any error occurs (fail-open).
+
+    The banner is intended to appear BEFORE the normal briefing header so the
+    operator sees the resume hint immediately at session start.
+
+    Future-compatible: ``pause_reason`` prefixes "compaction" and "quota" are
+    mapped to short labels even though those pause paths are not yet implemented.
+    """
+    try:
+        if project_root is None:
+            project_root = Path.cwd()
+
+        bc_path = project_root / ".octogent" / _BREADCRUMB_FILENAME
+        if not bc_path.is_file():
+            return None
+
+        bc = json.loads(bc_path.read_text(encoding="utf-8"))
+        # Trim each field independently so whitespace-only goal_title falls
+        # back to goal_id before the final "(untitled goal)" sentinel.
+        goal_title = (bc.get("goal_title") or "").strip() or (bc.get("goal_id") or "").strip() or "(untitled goal)"
+        resume_cmd = bc.get("resume_command") or "sk tentacle goal resume"
+
+        # Staleness check: if goal.json status is no longer 'paused', suppress.
+        goal_json_str = bc.get("goal_path") or ""
+        goal_json_path: Path
+        if goal_json_str:
+            goal_json_path = Path(goal_json_str)
+        else:
+            goal_json_path = project_root / ".octogent" / "goal.json"
+
+        if goal_json_path.is_file():
+            try:
+                state = json.loads(goal_json_path.read_text(encoding="utf-8"))
+                if state.get("status") != "paused":
+                    return None  # goal resumed or in terminal state — suppress
+            except Exception:
+                pass  # can't read → show banner (fail-open)
+
+        pause_reason_raw = bc.get("pause_reason", "")
+        # Normalize to str so non-string values (int, list, None) fall back to
+        # the generic "paused" label instead of raising AttributeError and
+        # dropping the banner via the outer fail-open catch.  Mirrors Rust's
+        # .as_str().unwrap_or("") which also coerces non-string JSON values.
+        pause_reason = pause_reason_raw if isinstance(pause_reason_raw, str) else ""
+        reason_label = _format_pause_reason(pause_reason)
+        sep = "  " + "\u2500" * 33
+        return [
+            f"\n  \u23f8  Paused goal: {goal_title}  ({reason_label})",
+            f"  \u25b6  Run: {resume_cmd}",
+            sep,
+        ]
+    except Exception:
+        return None  # always fail-open
+
+
 def _try_refresh_codebase_map():
     """Regenerate codebase-map.md in the session files/ dir.
 
@@ -143,6 +218,7 @@ def main():
         return
 
     project = ""
+    project_root: Path | None = None
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -151,11 +227,18 @@ def main():
             timeout=5,
         )
         if result.returncode == 0:
-            project = Path(result.stdout.strip()).name
+            project_root = Path(result.stdout.strip())
+            project = project_root.name
     except Exception:
         pass
     if not project:
         project = Path.cwd().name
+
+    # PREPEND: paused-goal resume hint BEFORE the main briefing header.
+    resume_hint = _load_goal_resume_hint(project_root)
+    if resume_hint:
+        for line in resume_hint:
+            print(line)
 
     print(f"\n  📋 Session briefing for: {project}")
     print("  ─────────────────────────────────")

--- a/hooks/auto-briefing.py
+++ b/hooks/auto-briefing.py
@@ -123,10 +123,14 @@ def _format_pause_reason(raw: str) -> str:
 def _load_goal_resume_hint(project_root: "Path | None" = None) -> "list[str] | None":
     """Read the paused-goal breadcrumb and return concise banner lines.
 
-    Returns None (fail-open) when:
-      - breadcrumb file is absent,
-      - the goal is no longer in 'paused' state (stale / already resumed),
-      - any error occurs (fail-open).
+    Returns None (suppresses the banner) when:
+      - the breadcrumb file is absent,
+      - the goal is no longer in 'paused' state (stale / already resumed), or
+      - breadcrumb read / parse / type errors occur (outer except swallows them
+        and treats the file as absent).
+
+    Shows the banner (fail-open) when ``goal.json`` cannot be read or parsed —
+    the staleness check is skipped so the operator still sees the resume hint.
 
     The banner is intended to appear BEFORE the normal briefing header so the
     operator sees the resume hint immediately at session start.
@@ -143,13 +147,23 @@ def _load_goal_resume_hint(project_root: "Path | None" = None) -> "list[str] | N
             return None
 
         bc = json.loads(bc_path.read_text(encoding="utf-8"))
-        # Trim each field independently so whitespace-only goal_title falls
-        # back to goal_id before the final "(untitled goal)" sentinel.
-        goal_title = (bc.get("goal_title") or "").strip() or (bc.get("goal_id") or "").strip() or "(untitled goal)"
-        resume_cmd = bc.get("resume_command") or "sk tentacle goal resume"
+        # Guard each field with isinstance so non-string truthy values (int,
+        # list, dict) fall back safely instead of raising AttributeError and
+        # letting the outer except suppress the banner.  Mirrors Rust's
+        # .and_then(|v| v.as_str()) which silently skips non-string JSON values.
+        _gt_raw = bc.get("goal_title")
+        _gi_raw = bc.get("goal_id")
+        goal_title = (
+            (_gt_raw.strip() if isinstance(_gt_raw, str) else "")
+            or (_gi_raw.strip() if isinstance(_gi_raw, str) else "")
+            or "(untitled goal)"
+        )
+        _rc_raw = bc.get("resume_command")
+        resume_cmd = (_rc_raw.strip() if isinstance(_rc_raw, str) else "") or "sk tentacle goal resume"
 
         # Staleness check: if goal.json status is no longer 'paused', suppress.
-        goal_json_str = bc.get("goal_path") or ""
+        _gp_raw = bc.get("goal_path")
+        goal_json_str = _gp_raw if isinstance(_gp_raw, str) else ""
         goal_json_path: Path
         if goal_json_str:
             goal_json_path = Path(goal_json_str)

--- a/hooks/rules/briefing.py
+++ b/hooks/rules/briefing.py
@@ -126,6 +126,81 @@ except ImportError:
 MARKER = MARKERS_DIR / "briefing-done"
 BRIEFING_SCRIPT = TOOLS_DIR / "briefing.py"
 
+# Goal resume breadcrumb helpers (issue #185)
+_BREADCRUMB_FILENAME = "goal-resume-breadcrumb.json"
+_PAUSE_REASON_LABELS = {
+    "session_end": "session end",
+    "compaction": "context compaction",
+    "quota": "quota limit",
+}
+
+
+def _format_pause_reason(raw: str) -> str:
+    """Return a short human-readable label for a raw pause_reason string."""
+    prefix = raw.split(":")[0].strip() if raw else ""
+    return _PAUSE_REASON_LABELS.get(prefix, "paused")
+
+
+def _load_goal_resume_hint(project_root: "Path | None" = None) -> "list[str] | None":
+    """Read the paused-goal breadcrumb and return concise banner lines.
+
+    Returns None (fail-open) when:
+      - breadcrumb file is absent,
+      - the goal is no longer in 'paused' state (stale / already resumed),
+      - any error occurs (fail-open).
+
+    The banner is intended to appear BEFORE the normal briefing header so the
+    operator sees the resume hint immediately at session start.
+
+    Future-compatible: ``pause_reason`` prefixes "compaction" and "quota" are
+    mapped to short labels even though those pause paths are not yet implemented.
+    """
+    try:
+        if project_root is None:
+            project_root = Path.cwd()
+
+        bc_path = project_root / ".octogent" / _BREADCRUMB_FILENAME
+        if not bc_path.is_file():
+            return None
+
+        bc = json.loads(bc_path.read_text(encoding="utf-8"))
+        # Trim each field independently so whitespace-only goal_title falls
+        # back to goal_id before the final "(untitled goal)" sentinel.
+        goal_title = (bc.get("goal_title") or "").strip() or (bc.get("goal_id") or "").strip() or "(untitled goal)"
+        resume_cmd = bc.get("resume_command") or "sk tentacle goal resume"
+
+        # Staleness check: if goal.json status is no longer 'paused', suppress.
+        goal_json_str = bc.get("goal_path") or ""
+        goal_json_path: Path
+        if goal_json_str:
+            goal_json_path = Path(goal_json_str)
+        else:
+            goal_json_path = project_root / ".octogent" / "goal.json"
+
+        if goal_json_path.is_file():
+            try:
+                state = json.loads(goal_json_path.read_text(encoding="utf-8"))
+                if state.get("status") != "paused":
+                    return None  # goal resumed or in terminal state — suppress
+            except Exception:
+                pass  # can't read → show banner (fail-open)
+
+        pause_reason_raw = bc.get("pause_reason", "")
+        # Normalize to str so non-string values (int, list, None) fall back to
+        # the generic "paused" label instead of raising AttributeError and
+        # dropping the banner via the outer fail-open catch.  Mirrors Rust's
+        # .as_str().unwrap_or("") which also coerces non-string JSON values.
+        pause_reason = pause_reason_raw if isinstance(pause_reason_raw, str) else ""
+        reason_label = _format_pause_reason(pause_reason)
+        sep = "  " + "\u2500" * 33
+        return [
+            f"\n  \u23f8  Paused goal: {goal_title}  ({reason_label})",
+            f"  \u25b6  Run: {resume_cmd}",
+            sep,
+        ]
+    except Exception:
+        return None  # always fail-open
+
 
 class AutoBriefingRule(Rule):
     """Run briefing.py at session start and create HMAC-signed marker."""
@@ -195,6 +270,7 @@ class AutoBriefingRule(Rule):
             return None
 
         project = ""
+        project_root: Path | None = None
         try:
             result = subprocess.run(
                 ["git", "rev-parse", "--show-toplevel"],
@@ -203,13 +279,21 @@ class AutoBriefingRule(Rule):
                 timeout=5,
             )
             if result.returncode == 0:
-                project = Path(result.stdout.strip()).name
+                project_root = Path(result.stdout.strip())
+                project = project_root.name
         except Exception:
             pass
         if not project:
             project = Path.cwd().name
 
-        lines = [
+        lines: list[str] = []
+
+        # PREPEND: paused-goal resume hint BEFORE the main briefing header.
+        resume_hint = _load_goal_resume_hint(project_root)
+        if resume_hint:
+            lines.extend(resume_hint)
+
+        lines += [
             f"\n  \U0001f4cb Session briefing for: {project}",
             "  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
         ]

--- a/hooks/rules/briefing.py
+++ b/hooks/rules/briefing.py
@@ -144,10 +144,14 @@ def _format_pause_reason(raw: str) -> str:
 def _load_goal_resume_hint(project_root: "Path | None" = None) -> "list[str] | None":
     """Read the paused-goal breadcrumb and return concise banner lines.
 
-    Returns None (fail-open) when:
-      - breadcrumb file is absent,
-      - the goal is no longer in 'paused' state (stale / already resumed),
-      - any error occurs (fail-open).
+    Returns None (suppresses the banner) when:
+      - the breadcrumb file is absent,
+      - the goal is no longer in 'paused' state (stale / already resumed), or
+      - breadcrumb read / parse / type errors occur (outer except swallows them
+        and treats the file as absent).
+
+    Shows the banner (fail-open) when ``goal.json`` cannot be read or parsed —
+    the staleness check is skipped so the operator still sees the resume hint.
 
     The banner is intended to appear BEFORE the normal briefing header so the
     operator sees the resume hint immediately at session start.
@@ -164,13 +168,23 @@ def _load_goal_resume_hint(project_root: "Path | None" = None) -> "list[str] | N
             return None
 
         bc = json.loads(bc_path.read_text(encoding="utf-8"))
-        # Trim each field independently so whitespace-only goal_title falls
-        # back to goal_id before the final "(untitled goal)" sentinel.
-        goal_title = (bc.get("goal_title") or "").strip() or (bc.get("goal_id") or "").strip() or "(untitled goal)"
-        resume_cmd = bc.get("resume_command") or "sk tentacle goal resume"
+        # Guard each field with isinstance so non-string truthy values (int,
+        # list, dict) fall back safely instead of raising AttributeError and
+        # letting the outer except suppress the banner.  Mirrors Rust's
+        # .and_then(|v| v.as_str()) which silently skips non-string JSON values.
+        _gt_raw = bc.get("goal_title")
+        _gi_raw = bc.get("goal_id")
+        goal_title = (
+            (_gt_raw.strip() if isinstance(_gt_raw, str) else "")
+            or (_gi_raw.strip() if isinstance(_gi_raw, str) else "")
+            or "(untitled goal)"
+        )
+        _rc_raw = bc.get("resume_command")
+        resume_cmd = (_rc_raw.strip() if isinstance(_rc_raw, str) else "") or "sk tentacle goal resume"
 
         # Staleness check: if goal.json status is no longer 'paused', suppress.
-        goal_json_str = bc.get("goal_path") or ""
+        _gp_raw = bc.get("goal_path")
+        goal_json_str = _gp_raw if isinstance(_gp_raw, str) else ""
         goal_json_path: Path
         if goal_json_str:
             goal_json_path = Path(goal_json_str)

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -378,8 +378,13 @@ fn format_pause_reason(raw: &str) -> &'static str {
 /// Read `.octogent/goal-resume-breadcrumb.json` relative to `project_root`
 /// and return a short banner if the goal is still paused.
 ///
-/// Returns `None` (fail-open) when the breadcrumb is absent, the goal is
-/// already resumed / in a terminal state, or any error occurs.
+/// Returns `None` (suppresses the banner) when:
+///   - the breadcrumb file is absent,
+///   - the goal is already resumed / in a terminal state, or
+///   - breadcrumb read / parse / type errors occur (treated as absent).
+///
+/// Shows the banner (fail-open) when `goal.json` cannot be read or parsed —
+/// the staleness check is skipped so the operator still sees the resume hint.
 ///
 /// Mirrors `hooks/rules/briefing.py::_load_goal_resume_hint()`.
 fn load_goal_resume_hint(project_root: Option<&Path>) -> Option<Vec<String>> {
@@ -423,6 +428,7 @@ fn load_goal_resume_hint(project_root: Option<&Path>) -> Option<Vec<String>> {
     let resume_cmd = bc
         .get("resume_command")
         .and_then(|v| v.as_str())
+        .map(str::trim)
         .filter(|s| !s.is_empty())
         .unwrap_or("sk tentacle goal resume");
 
@@ -6352,6 +6358,91 @@ mod tests {
             assert!(
                 combined.contains("paused"),
                 "non-string pause_reason ({tag:?}) must fall back to 'paused' label; got: {combined:?}"
+            );
+            let _ = fs::remove_dir_all(&tmp);
+        }
+    }
+
+    /// Non-string resume_command in breadcrumb → falls back to default "sk tentacle goal resume".
+    /// Regression for issue #185 review: non-string values (int, array, null, object) must not
+    /// produce a spurious or empty resume command; the default must be shown in the banner.
+    #[test]
+    fn auto_briefing_resume_hint_non_string_resume_command_falls_back_to_default() {
+        use std::fs;
+        for (tag, rc_val) in &[
+            ("number", "42"),
+            ("array", r#"["sk","tentacle"]"#),
+            ("null", "null"),
+            ("object", r#"{"cmd":"x"}"#),
+        ] {
+            let tmp = resume_test_dir(&format!("resume_cmd_nonstr_{}", tag));
+            let octogent = tmp.join(".octogent");
+            let _ = fs::create_dir_all(&octogent);
+            fs::write(
+                octogent.join("goal.json"),
+                r#"{"status": "paused", "goal_id": "grc"}"#,
+            )
+            .unwrap();
+            let bc_json = format!(
+                r#"{{"goal_id":"grc","goal_title":"RC Test","goal_path":"{goal_path}","pause_reason":"session_end","resume_command":{rc},"paused_at":"2026-01-01T00:00:00Z","previous_status":"active"}}"#,
+                goal_path = octogent
+                    .join("goal.json")
+                    .to_string_lossy()
+                    .replace('\\', "\\\\"),
+                rc = rc_val,
+            );
+            fs::write(octogent.join(BREADCRUMB_FILENAME), &bc_json).unwrap();
+            let result = load_goal_resume_hint(Some(&tmp));
+            assert!(
+                result.is_some(),
+                "non-string resume_command ({tag:?}) must still show banner; got: {result:?}"
+            );
+            let combined = result.unwrap().join("\n");
+            assert!(
+                combined.contains("sk tentacle goal resume"),
+                "non-string resume_command ({tag:?}) must fall back to default; got: {combined:?}"
+            );
+            let _ = fs::remove_dir_all(&tmp);
+        }
+    }
+
+    /// Whitespace-only resume_command → falls back to default "sk tentacle goal resume".
+    /// Regression for issue #185 review: a resume_command that is all whitespace must be
+    /// treated as absent and the default command shown, matching Python's .strip() or "".
+    #[test]
+    fn auto_briefing_resume_hint_whitespace_resume_command_falls_back_to_default() {
+        use std::fs;
+        for (tag, rc_val) in &[
+            ("spaces", "\"   \""),
+            ("tab", "\"\\t\""),
+            ("newline", "\"\\n\""),
+        ] {
+            let tmp = resume_test_dir(&format!("resume_cmd_ws_{}", tag));
+            let octogent = tmp.join(".octogent");
+            let _ = fs::create_dir_all(&octogent);
+            fs::write(
+                octogent.join("goal.json"),
+                r#"{"status": "paused", "goal_id": "gws"}"#,
+            )
+            .unwrap();
+            let bc_json = format!(
+                r#"{{"goal_id":"gws","goal_title":"WS RC Test","goal_path":"{goal_path}","pause_reason":"session_end","resume_command":{rc},"paused_at":"2026-01-01T00:00:00Z","previous_status":"active"}}"#,
+                goal_path = octogent
+                    .join("goal.json")
+                    .to_string_lossy()
+                    .replace('\\', "\\\\"),
+                rc = rc_val,
+            );
+            fs::write(octogent.join(BREADCRUMB_FILENAME), &bc_json).unwrap();
+            let result = load_goal_resume_hint(Some(&tmp));
+            assert!(
+                result.is_some(),
+                "whitespace resume_command ({tag:?}) must still show banner; got: {result:?}"
+            );
+            let combined = result.unwrap().join("\n");
+            assert!(
+                combined.contains("sk tentacle goal resume"),
+                "whitespace resume_command ({tag:?}) must fall back to default; got: {combined:?}"
             );
             let _ = fs::remove_dir_all(&tmp);
         }

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -6231,7 +6231,10 @@ mod tests {
         .unwrap();
 
         let result = load_goal_resume_hint(Some(&tmp));
-        assert!(result.is_some(), "expected banner for paused goal with whitespace title");
+        assert!(
+            result.is_some(),
+            "expected banner for paused goal with whitespace title"
+        );
         let combined = result.unwrap().join("\n");
         assert!(
             combined.contains("ws-goal-id"),
@@ -6274,7 +6277,11 @@ mod tests {
     #[test]
     fn auto_briefing_resume_hint_fail_open_for_non_object_goal_json() {
         use std::fs;
-        for (tag, payload) in &[("array", "[]"), ("number", "42"), ("string", r#""running""#)] {
+        for (tag, payload) in &[
+            ("array", "[]"),
+            ("number", "42"),
+            ("string", r#""running""#),
+        ] {
             let tmp = resume_test_dir(&format!("goal_nonobj_{}", tag));
             let octogent = tmp.join(".octogent");
             let _ = fs::create_dir_all(&octogent);
@@ -6328,7 +6335,10 @@ mod tests {
             // Build breadcrumb JSON with a non-string pause_reason
             let bc_json = format!(
                 r#"{{"goal_id":"gpr","goal_title":"Reason Test Goal","goal_path":"{goal_path}","pause_reason":{pr},"resume_command":"sk tentacle goal resume","paused_at":"2026-01-01T00:00:00Z","previous_status":"active"}}"#,
-                goal_path = octogent.join("goal.json").to_string_lossy().replace('\\', "\\\\"),
+                goal_path = octogent
+                    .join("goal.json")
+                    .to_string_lossy()
+                    .replace('\\', "\\\\"),
                 pr = pr_val,
             );
             fs::write(octogent.join(BREADCRUMB_FILENAME), &bc_json).unwrap();
@@ -6353,7 +6363,10 @@ mod tests {
         assert_eq!(format_pause_reason("session_end:normal"), "session end");
         assert_eq!(format_pause_reason("session_end:"), "session end");
         assert_eq!(format_pause_reason("session_end"), "session end");
-        assert_eq!(format_pause_reason("compaction:quota_triggered"), "context compaction");
+        assert_eq!(
+            format_pause_reason("compaction:quota_triggered"),
+            "context compaction"
+        );
         assert_eq!(format_pause_reason("quota:low_context"), "quota limit");
         assert_eq!(format_pause_reason("unknown_reason"), "paused");
         assert_eq!(format_pause_reason(""), "paused");

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -353,15 +353,137 @@ fn load_memory_md(cwd: Option<&Path>) -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
+// Goal resume breadcrumb helpers (issue #185)
+// ---------------------------------------------------------------------------
+
+const BREADCRUMB_FILENAME: &str = "goal-resume-breadcrumb.json";
+
+/// Map a raw ``pause_reason`` string to a short human-readable label.
+///
+/// The prefix before `:` is extracted and matched so that "session_end:normal"
+/// yields "session end".  Unknown prefixes fall back to "paused".
+///
+/// Future-compatible: "compaction" and "quota" prefixes are recognised even
+/// though those pause paths are not yet implemented (issues #182 / #187).
+fn format_pause_reason(raw: &str) -> &'static str {
+    let prefix = raw.split(':').next().unwrap_or("").trim();
+    match prefix {
+        "session_end" => "session end",
+        "compaction" => "context compaction",
+        "quota" => "quota limit",
+        _ => "paused",
+    }
+}
+
+/// Read `.octogent/goal-resume-breadcrumb.json` relative to `project_root`
+/// and return a short banner if the goal is still paused.
+///
+/// Returns `None` (fail-open) when the breadcrumb is absent, the goal is
+/// already resumed / in a terminal state, or any error occurs.
+///
+/// Mirrors `hooks/rules/briefing.py::_load_goal_resume_hint()`.
+fn load_goal_resume_hint(project_root: Option<&Path>) -> Option<Vec<String>> {
+    let root = match project_root {
+        Some(p) => p.to_path_buf(),
+        None => std::env::current_dir().ok()?,
+    };
+
+    let bc_path = root.join(".octogent").join(BREADCRUMB_FILENAME);
+    if !bc_path.is_file() {
+        return None;
+    }
+
+    let bc_text = fs::read_to_string(&bc_path).ok()?;
+    let bc: Value = serde_json::from_str(&bc_text).ok()?;
+
+    // Guard: valid but non-object JSON (e.g. [], 42, "x") must not produce a
+    // spurious banner.  Mirrors Python's AttributeError path where bc.get()
+    // raises on a non-dict and the outer except swallows it.
+    if !bc.is_object() {
+        return None;
+    }
+
+    // Trim each field independently so a whitespace-only goal_title falls
+    // back to goal_id before the final "(untitled goal)" sentinel, mirroring
+    // hooks/rules/briefing.py::_load_goal_resume_hint().
+    let goal_title = {
+        let trimmed_title = bc
+            .get("goal_title")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty());
+        let trimmed_id = bc
+            .get("goal_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty());
+        trimmed_title.or(trimmed_id).unwrap_or("(untitled goal)")
+    };
+
+    let resume_cmd = bc
+        .get("resume_command")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("sk tentacle goal resume");
+
+    // Staleness check: if goal.json status is no longer "paused", suppress.
+    let goal_json_path = bc
+        .get("goal_path")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| root.join(".octogent").join("goal.json"));
+
+    if goal_json_path.is_file() {
+        if let Ok(goal_text) = fs::read_to_string(&goal_json_path) {
+            if let Ok(goal_state) = serde_json::from_str::<Value>(&goal_text) {
+                // Only suppress when goal.json parses as a JSON *object* and
+                // its "status" is not "paused".  Non-object JSON ([], 42, "x")
+                // must not trigger suppression — fall through and show the banner,
+                // matching Python's AttributeError fail-open path where
+                // state.get("status") raises on a non-dict and the except swallows it.
+                if goal_state.is_object()
+                    && goal_state
+                        .get("status")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        != "paused"
+                {
+                    return None; // goal resumed or in terminal state — suppress
+                }
+            }
+        }
+        // can't read goal.json → fail-open (show banner)
+    }
+
+    let pause_reason = bc
+        .get("pause_reason")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let reason_label = format_pause_reason(pause_reason);
+    let sep = format!("  {}", "\u{2500}".repeat(33));
+
+    Some(vec![
+        format!("\n  \u{23f8}  Paused goal: {goal_title}  ({reason_label})"),
+        format!("  \u{25b6}  Run: {resume_cmd}"),
+        sep,
+    ])
+}
+
+// ---------------------------------------------------------------------------
 // AutoBriefingRule
 // ---------------------------------------------------------------------------
 
 /// Run `briefing.py` at session start, prepend `MEMORY.md`, and sign HMAC
-/// markers (wave9, extended in wave10 with issue #161 MEMORY.md injection).
+/// markers (wave9, extended in wave10 with issue #161 MEMORY.md injection,
+/// wave16 with issue #185 paused-goal resume banner).
 ///
 /// Ports `hooks/rules/briefing.py::AutoBriefingRule`.
 ///
 /// What this rule does:
+///   0. If `.octogent/goal-resume-breadcrumb.json` is present and the goal
+///      is still paused, emits a concise resume-hint banner BEFORE all other
+///      output (issue #185).
 ///   1. Reads `COPILOT_AGENT_SESSION_ID` to identify the current session.
 ///   2. Cleans up stale session-specific markers (own session: deleted and
 ///      re-signed below; orphaned `briefing-done*` markers older than 2h:
@@ -381,6 +503,7 @@ fn load_memory_md(cwd: Option<&Path>) -> Option<String> {
 ///   - Marker signing error → silently skipped.
 ///   - Filesystem errors during cleanup → silently swallowed.
 ///   - MEMORY.md absent, stale, or disabled → silently skipped (no-op).
+///   - Breadcrumb absent, stale, or unreadable → silently skipped (no-op).
 ///
 /// Informational only; never produces `permissionDecision`.
 pub struct AutoBriefingRule;
@@ -452,8 +575,8 @@ impl HookRule for AutoBriefingRule {
             return None; // fail-open: briefing.py absent
         }
 
-        // --- Determine project name (mirrors Python _get_project()) ---
-        let project = Command::new("git")
+        // --- Determine project root and name (mirrors Python _get_project()) ---
+        let git_root_opt: Option<PathBuf> = Command::new("git")
             .args(["rev-parse", "--show-toplevel"])
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -461,15 +584,20 @@ impl HookRule for AutoBriefingRule {
             .ok()
             .and_then(|o| {
                 if o.status.success() {
-                    String::from_utf8(o.stdout).ok().and_then(|s| {
-                        PathBuf::from(s.trim())
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .map(|n| n.to_string())
-                    })
+                    String::from_utf8(o.stdout)
+                        .ok()
+                        .map(|s| PathBuf::from(s.trim()))
                 } else {
                     None
                 }
+            });
+
+        let project = git_root_opt
+            .as_ref()
+            .and_then(|root| {
+                root.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.to_string())
             })
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| {
@@ -483,10 +611,15 @@ impl HookRule for AutoBriefingRule {
                     .unwrap_or_default()
             });
 
-        let mut lines = vec![
-            format!("\n  \u{1f4cb} Session briefing for: {project}"),
-            "  \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}".to_string(),
-        ];
+        let mut lines: Vec<String> = Vec::new();
+
+        // --- Goal resume banner (issue #185): prepend BEFORE briefing header ---
+        if let Some(hint) = load_goal_resume_hint(git_root_opt.as_deref()) {
+            lines.extend(hint);
+        }
+
+        lines.push(format!("\n  \u{1f4cb} Session briefing for: {project}"));
+        lines.push("  \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}".to_string());
 
         // --- MEMORY.md injection (issue #161): prepend promoted knowledge ---
         if let Some(mem) = load_memory_md(None) {
@@ -5862,6 +5995,369 @@ mod tests {
     }
 
     // --- IntegrityRule ---
+
+    // --- load_goal_resume_hint helper tests (issue #185 native parity) ---
+    //
+    // Each test creates a *unique* temp directory using the process ID and an
+    // atomic counter to avoid races when the test binary runs concurrently with
+    // itself (e.g. parallel CI shards) and to stay clean even if a test panics
+    // before reaching its cleanup call.
+
+    /// Returns a unique temp dir path: `<temp>/<prefix>_<pid>_<n>`.
+    /// The directory is NOT created here; callers use create_dir_all.
+    fn resume_test_dir(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static CTR: AtomicU64 = AtomicU64::new(0);
+        let n = CTR.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("sk_resume_{}_{}_{}", tag, std::process::id(), n))
+    }
+
+    /// Graceful no-op: breadcrumb absent → returns None.
+    #[test]
+    fn auto_briefing_resume_hint_none_when_breadcrumb_absent() {
+        let tmp = resume_test_dir("absent");
+        let _ = std::fs::create_dir_all(&tmp);
+        // No breadcrumb written — just ensure the dir exists with no .octogent child.
+        let result = load_goal_resume_hint(Some(&tmp));
+        assert!(
+            result.is_none(),
+            "load_goal_resume_hint must return None when breadcrumb is absent"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Paused goal + valid breadcrumb → banner lines with goal title and resume command.
+    #[test]
+    fn auto_briefing_resume_hint_shows_banner_when_paused() {
+        use std::fs;
+        let tmp = resume_test_dir("paused");
+        let octogent = tmp.join(".octogent");
+        let _ = fs::create_dir_all(&octogent);
+
+        // Write a paused goal.json
+        fs::write(
+            octogent.join("goal.json"),
+            r#"{"status": "paused", "title": "My Test Goal", "goal_id": "g1"}"#,
+        )
+        .unwrap();
+
+        // Write a breadcrumb
+        let bc_path = octogent.join(BREADCRUMB_FILENAME);
+        fs::write(
+            &bc_path,
+            serde_json::json!({
+                "goal_id": "g1",
+                "goal_title": "My Test Goal",
+                "goal_path": octogent.join("goal.json").to_string_lossy().to_string(),
+                "pause_reason": "session_end:normal",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let result = load_goal_resume_hint(Some(&tmp));
+        assert!(result.is_some(), "expected banner lines for paused goal");
+        let lines = result.unwrap();
+        let combined = lines.join("\n");
+        assert!(
+            combined.contains("My Test Goal"),
+            "banner must include goal title; got: {combined:?}"
+        );
+        assert!(
+            combined.contains("sk tentacle goal resume"),
+            "banner must include exact resume command; got: {combined:?}"
+        );
+        assert!(
+            combined.contains("session end"),
+            "banner must map session_end reason; got: {combined:?}"
+        );
+        assert!(
+            lines[0].contains("Paused goal"),
+            "first line must lead with 'Paused goal'; got: {:?}",
+            lines[0]
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Stale breadcrumb (goal already resumed) → None (suppressed).
+    #[test]
+    fn auto_briefing_resume_hint_suppressed_when_goal_resumed() {
+        use std::fs;
+        let tmp = resume_test_dir("stale");
+        let octogent = tmp.join(".octogent");
+        let _ = fs::create_dir_all(&octogent);
+
+        // goal.json status is now "active" (already resumed)
+        fs::write(
+            octogent.join("goal.json"),
+            r#"{"status": "active", "title": "Resumed Goal", "goal_id": "g2"}"#,
+        )
+        .unwrap();
+
+        // Write a breadcrumb that refers to this goal
+        let bc_path = octogent.join(BREADCRUMB_FILENAME);
+        fs::write(
+            &bc_path,
+            serde_json::json!({
+                "goal_id": "g2",
+                "goal_title": "Resumed Goal",
+                "goal_path": octogent.join("goal.json").to_string_lossy().to_string(),
+                "pause_reason": "session_end:normal",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let result = load_goal_resume_hint(Some(&tmp));
+        assert!(
+            result.is_none(),
+            "load_goal_resume_hint must suppress banner when goal is no longer paused"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Stale breadcrumb (goal completed) → None (suppressed).
+    #[test]
+    fn auto_briefing_resume_hint_suppressed_when_goal_completed() {
+        use std::fs;
+        let tmp = resume_test_dir("completed");
+        let octogent = tmp.join(".octogent");
+        let _ = fs::create_dir_all(&octogent);
+
+        fs::write(
+            octogent.join("goal.json"),
+            r#"{"status": "completed", "title": "Done Goal", "goal_id": "g3"}"#,
+        )
+        .unwrap();
+
+        let bc_path = octogent.join(BREADCRUMB_FILENAME);
+        fs::write(
+            &bc_path,
+            serde_json::json!({
+                "goal_id": "g3",
+                "goal_title": "Done Goal",
+                "goal_path": octogent.join("goal.json").to_string_lossy().to_string(),
+                "pause_reason": "session_end:normal",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let result = load_goal_resume_hint(Some(&tmp));
+        assert!(
+            result.is_none(),
+            "load_goal_resume_hint must suppress banner when goal is completed"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Breadcrumb present but goal.json absent → fail-open (banner still shown).
+    #[test]
+    fn auto_briefing_resume_hint_fail_open_when_goal_json_absent() {
+        use std::fs;
+        let tmp = resume_test_dir("no_goal_json");
+        let octogent = tmp.join(".octogent");
+        let _ = fs::create_dir_all(&octogent);
+
+        // No goal.json — breadcrumb points to a non-existent path
+        let goal_json_path = octogent.join("goal.json");
+        // Ensure it does not exist (it won't in a fresh unique dir)
+        let _ = fs::remove_file(&goal_json_path);
+
+        let bc_path = octogent.join(BREADCRUMB_FILENAME);
+        fs::write(
+            &bc_path,
+            serde_json::json!({
+                "goal_id": "g4",
+                "goal_title": "Orphaned Goal",
+                "goal_path": goal_json_path.to_string_lossy().to_string(),
+                "pause_reason": "session_end:crash",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        // Must fail-open: if goal.json is absent we cannot confirm resumption,
+        // so the banner should still appear.
+        let result = load_goal_resume_hint(Some(&tmp));
+        assert!(
+            result.is_some(),
+            "load_goal_resume_hint must show banner when goal.json is absent (fail-open)"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Whitespace-only goal_title must fall back to trimmed goal_id, not "(untitled goal)".
+    /// This is the regression case for the parity fix: Python and Rust must agree.
+    #[test]
+    fn auto_briefing_resume_hint_whitespace_title_falls_back_to_goal_id() {
+        use std::fs;
+        let tmp = resume_test_dir("ws_title");
+        let octogent = tmp.join(".octogent");
+        let _ = fs::create_dir_all(&octogent);
+
+        fs::write(
+            octogent.join("goal.json"),
+            r#"{"status": "paused", "goal_id": "ws-goal-id"}"#,
+        )
+        .unwrap();
+
+        let bc_path = octogent.join(BREADCRUMB_FILENAME);
+        fs::write(
+            &bc_path,
+            serde_json::json!({
+                "goal_id": "ws-goal-id",
+                "goal_title": "   ",   // whitespace-only — should be treated as absent
+                "goal_path": octogent.join("goal.json").to_string_lossy().to_string(),
+                "pause_reason": "session_end:normal",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let result = load_goal_resume_hint(Some(&tmp));
+        assert!(result.is_some(), "expected banner for paused goal with whitespace title");
+        let combined = result.unwrap().join("\n");
+        assert!(
+            combined.contains("ws-goal-id"),
+            "banner must fall back to goal_id when goal_title is whitespace-only; got: {combined:?}"
+        );
+        assert!(
+            !combined.contains("(untitled goal)"),
+            "banner must NOT show '(untitled goal)' when goal_id is available; got: {combined:?}"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Valid non-object breadcrumb JSON (array, number, string) must return None.
+    /// Regression for review finding: serde_json::from_str succeeds for any valid
+    /// JSON value, not just objects; the loader must guard with is_object() so
+    /// native behaviour matches Python's AttributeError fail-open path.
+    #[test]
+    fn auto_briefing_resume_hint_none_for_non_object_breadcrumb() {
+        use std::fs;
+        for (tag, payload) in &[("array", "[]"), ("number", "42"), ("string", r#""x""#)] {
+            let tmp = resume_test_dir(&format!("non_obj_{}", tag));
+            let octogent = tmp.join(".octogent");
+            let _ = fs::create_dir_all(&octogent);
+            let bc_path = octogent.join(BREADCRUMB_FILENAME);
+            fs::write(&bc_path, payload).unwrap();
+            let result = load_goal_resume_hint(Some(&tmp));
+            assert!(
+                result.is_none(),
+                "non-object breadcrumb JSON ({tag:?}) must return None; got: {result:?}"
+            );
+            let _ = fs::remove_dir_all(&tmp);
+        }
+    }
+
+    /// Non-object goal.json ([], 42, "running") → fail-open: banner still shown.
+    /// Regression for issue #185 staleness-check parity gap: when goal.json exists
+    /// but contains valid non-object JSON, the native loader must NOT suppress the
+    /// banner (previously unwrap_or("") != "paused" triggered suppression).
+    /// Must match Python's fail-open path where state.get() raises on non-dict.
+    #[test]
+    fn auto_briefing_resume_hint_fail_open_for_non_object_goal_json() {
+        use std::fs;
+        for (tag, payload) in &[("array", "[]"), ("number", "42"), ("string", r#""running""#)] {
+            let tmp = resume_test_dir(&format!("goal_nonobj_{}", tag));
+            let octogent = tmp.join(".octogent");
+            let _ = fs::create_dir_all(&octogent);
+
+            // Write non-object goal.json
+            fs::write(octogent.join("goal.json"), payload).unwrap();
+
+            let bc_path = octogent.join(BREADCRUMB_FILENAME);
+            fs::write(
+                &bc_path,
+                serde_json::json!({
+                    "goal_id": "g-nonobj",
+                    "goal_title": "Goal With Non-Object Status File",
+                    "goal_path": octogent.join("goal.json").to_string_lossy().to_string(),
+                    "pause_reason": "session_end:normal",
+                    "resume_command": "sk tentacle goal resume",
+                    "paused_at": "2026-01-01T00:00:00Z",
+                    "previous_status": "active"
+                })
+                .to_string(),
+            )
+            .unwrap();
+
+            let result = load_goal_resume_hint(Some(&tmp));
+            assert!(
+                result.is_some(),
+                "non-object goal.json ({tag:?}) must show banner (fail-open); got: {result:?}"
+            );
+            let _ = fs::remove_dir_all(&tmp);
+        }
+    }
+
+    /// Non-string pause_reason in breadcrumb → banner shown with generic "paused" label.
+    /// Regression for issue #185 parity: Rust's .as_str().unwrap_or("") already
+    /// coerces non-string values to ""; this test documents and locks that behaviour.
+    #[test]
+    fn auto_briefing_resume_hint_non_string_pause_reason_falls_back_to_paused() {
+        use std::fs;
+        // pause_reason values that are valid JSON but not strings
+        for (tag, pr_val) in &[("number", "42"), ("array", r#"["x"]"#), ("null", "null")] {
+            let tmp = resume_test_dir(&format!("pause_reason_nonstr_{}", tag));
+            let octogent = tmp.join(".octogent");
+            let _ = fs::create_dir_all(&octogent);
+
+            fs::write(
+                octogent.join("goal.json"),
+                r#"{"status": "paused", "goal_id": "gpr"}"#,
+            )
+            .unwrap();
+
+            // Build breadcrumb JSON with a non-string pause_reason
+            let bc_json = format!(
+                r#"{{"goal_id":"gpr","goal_title":"Reason Test Goal","goal_path":"{goal_path}","pause_reason":{pr},"resume_command":"sk tentacle goal resume","paused_at":"2026-01-01T00:00:00Z","previous_status":"active"}}"#,
+                goal_path = octogent.join("goal.json").to_string_lossy().replace('\\', "\\\\"),
+                pr = pr_val,
+            );
+            fs::write(octogent.join(BREADCRUMB_FILENAME), &bc_json).unwrap();
+
+            let result = load_goal_resume_hint(Some(&tmp));
+            assert!(
+                result.is_some(),
+                "non-string pause_reason ({tag:?}) must show banner; got: {result:?}"
+            );
+            let combined = result.unwrap().join("\n");
+            assert!(
+                combined.contains("paused"),
+                "non-string pause_reason ({tag:?}) must fall back to 'paused' label; got: {combined:?}"
+            );
+            let _ = fs::remove_dir_all(&tmp);
+        }
+    }
+
+    /// format_pause_reason maps known and unknown prefixes correctly.
+    #[test]
+    fn auto_briefing_format_pause_reason_known_and_unknown() {
+        assert_eq!(format_pause_reason("session_end:normal"), "session end");
+        assert_eq!(format_pause_reason("session_end:"), "session end");
+        assert_eq!(format_pause_reason("session_end"), "session end");
+        assert_eq!(format_pause_reason("compaction:quota_triggered"), "context compaction");
+        assert_eq!(format_pause_reason("quota:low_context"), "quota limit");
+        assert_eq!(format_pause_reason("unknown_reason"), "paused");
+        assert_eq!(format_pause_reason(""), "paused");
+    }
 
     #[test]
     fn integrity_rule_fires_only_on_session_start() {

--- a/tests/test_hook_compat.py
+++ b/tests/test_hook_compat.py
@@ -88,7 +88,8 @@ def test_watch_sessions_syntax():
     """watch-sessions.py must be syntactically valid Python."""
     result = subprocess.run(
         [sys.executable, "-m", "py_compile", str(WATCH_SESSIONS)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     test(
         "watch-sessions.py compiles without syntax error",
@@ -101,7 +102,8 @@ def test_auto_update_syntax():
     """auto-update-tools.py must be syntactically valid Python."""
     result = subprocess.run(
         [sys.executable, "-m", "py_compile", str(AUTO_UPDATE)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     test(
         "auto-update-tools.py compiles without syntax error",
@@ -114,7 +116,8 @@ def test_check_syntax_covers_watch():
     """check_syntax.py must report exit 0 when run against watch-sessions.py."""
     result = subprocess.run(
         [sys.executable, str(CHECK_SYNTAX), str(WATCH_SESSIONS)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     test(
         "check_syntax.py exits 0 for watch-sessions.py",
@@ -127,7 +130,8 @@ def test_check_syntax_covers_auto_update():
     """check_syntax.py must report exit 0 when run against auto-update-tools.py."""
     result = subprocess.run(
         [sys.executable, str(CHECK_SYNTAX), str(AUTO_UPDATE)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     test(
         "check_syntax.py exits 0 for auto-update-tools.py",
@@ -264,7 +268,8 @@ def test_pre_commit_syntax_gate_wont_fire_on_valid_file():
     """Simulate what the pre-commit gate does: check_syntax on a valid file exits 0."""
     r = subprocess.run(
         [sys.executable, str(CHECK_SYNTAX), str(WATCH_SESSIONS)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     test(
         "pre-commit syntax gate passes watch-sessions.py (exit 0)",
@@ -273,7 +278,8 @@ def test_pre_commit_syntax_gate_wont_fire_on_valid_file():
     )
     r2 = subprocess.run(
         [sys.executable, str(CHECK_SYNTAX), str(AUTO_UPDATE)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     test(
         "pre-commit syntax gate passes auto-update-tools.py (exit 0)",
@@ -331,12 +337,12 @@ def test_pre_commit_ruff_surface_covers_all_browse_depths():
     content = PRE_COMMIT.read_text(encoding="utf-8")
     test(
         "pre-commit _py_in_surface uses browse/* (all depths, consistent with CI)",
-        "path.startswith((\"browse/\", \"hooks/\", \"scripts/\"))" in content or "browse/*)" in content,
+        'path.startswith(("browse/", "hooks/", "scripts/"))' in content or "browse/*)" in content,
         "pre-commit _py_in_surface should use browse/* to match all depths under browse/",
     )
     test(
         "pre-commit _py_in_surface uses hooks/* (all depths, consistent with CI)",
-        "path.startswith((\"browse/\", \"hooks/\", \"scripts/\"))" in content or "hooks/*)" in content,
+        'path.startswith(("browse/", "hooks/", "scripts/"))' in content or "hooks/*)" in content,
         "pre-commit _py_in_surface should use hooks/* to match all depths under hooks/",
     )
     # Depth-limited patterns that would miss browse/static/vendor/ should not be present
@@ -594,7 +600,10 @@ def test_hooks_json_uses_sk_hooks_run():
         )
         test(
             f"{label} powershell fallback uses python hook_runner.py",
-            all('python "$env:USERPROFILE\\.copilot\\tools\\hooks\\hook_runner.py"' in powershell for _, powershell in commands),
+            all(
+                'python "$env:USERPROFILE\\.copilot\\tools\\hooks\\hook_runner.py"' in powershell
+                for _, powershell in commands
+            ),
             f"{label} powershell fallback must use python hook_runner.py for standard Windows installs",
         )
 
@@ -623,6 +632,7 @@ def test_hooks_json_copies_in_sync():
         test("both hooks.json copies exist for sync check", False)
         return
     import json as _json
+
     src = _json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
     github = _json.loads(GITHUB_HOOKS_JSON.read_text(encoding="utf-8"))
     src_events = set(src.get("hooks", {}).keys())
@@ -675,7 +685,7 @@ def test_restart_manual_uses_sk_watch():
     )
     test(
         "_restart_manual wraps sk.cmd via cmd.exe on Windows",
-        '"cmd.exe"' in content and '"/c"' in content and 'sk_bin.suffix.lower()' in content,
+        '"cmd.exe"' in content and '"/c"' in content and "sk_bin.suffix.lower()" in content,
         "_restart_manual must route sk.cmd / sk.bat through cmd.exe /c on Windows",
     )
 
@@ -684,7 +694,8 @@ def test_auto_update_syntax_still_valid():
     """auto-update-tools.py must still compile after native sk routing changes."""
     result = subprocess.run(
         [sys.executable, "-m", "py_compile", str(AUTO_UPDATE)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     test(
         "auto-update-tools.py compiles after _sk_binary_path addition",
@@ -787,6 +798,7 @@ def test_required_hook_events_present_in_hooks_json():
         test("hooks/hooks.json exists for hook events check", False, str(hooks_json))
         return
     import json as _json
+
     payload = _json.loads(hooks_json.read_text(encoding="utf-8"))
     events = set(payload.get("hooks", {}).keys())
     test(
@@ -869,6 +881,7 @@ def test_managed_posttooluse_stays_python_backed():
     hooks_json = REPO / "hooks" / "hooks.json"
     if hooks_json.exists():
         import json as _json
+
         payload = _json.loads(hooks_json.read_text(encoding="utf-8"))
         events = set(payload.get("hooks", {}).keys())
         test(
@@ -931,7 +944,10 @@ def test_hmac_foundation_module_exists():
         content = marker_auth_rs.read_text(encoding="utf-8")
         test(
             "marker_auth.rs exports counter/list-marker helpers used by native rules",
-            "sign_counter" in content and "verify_counter" in content and "sign_list_marker" in content and "verify_list_marker" in content,
+            "sign_counter" in content
+            and "verify_counter" in content
+            and "sign_list_marker" in content
+            and "verify_list_marker" in content,
             "marker_auth.rs must define counter/list-marker helpers for native parity",
         )
     rules_rs = SK_RUST_HOOKS / "rules.rs"
@@ -1195,6 +1211,7 @@ def test_managed_posttooluse_still_python_backed_after_native_rule_growth():
     hooks_json = REPO / "hooks" / "hooks.json"
     if hooks_json.exists():
         import json as _json
+
         payload = _json.loads(hooks_json.read_text(encoding="utf-8"))
         events = set(payload.get("hooks", {}).keys())
         test(
@@ -1222,6 +1239,7 @@ test_managed_posttooluse_still_python_backed_after_native_rule_growth()
 # ---------------------------------------------------------------------------
 # Wave 8 — VerificationGatePreRule + TentacleSuggestRule native ports
 # ---------------------------------------------------------------------------
+
 
 def test_verification_gate_pre_rule_native():
     """VerificationGatePreRule must be defined in rules.rs.
@@ -1295,9 +1313,7 @@ def test_tentacle_suggest_rule_native():
     )
     test(
         "TentacleSuggestRule handles both tentacle-edits marker formats",
-        "read_tentacle_edits_paths" in content or (
-            "starts_with" in content and "tentacle-edits" in content
-        ),
+        "read_tentacle_edits_paths" in content or ("starts_with" in content and "tentacle-edits" in content),
         "rules.rs must handle both legacy flat and new JSON-dict tentacle-edits formats",
     )
     test(
@@ -1321,6 +1337,7 @@ def test_managed_routing_unchanged_for_new_suggestion_rules():
     """
     if HOOKS_JSON.exists():
         import json as _json
+
         payload = _json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
         events = set(payload.get("hooks", {}).keys())
         test(
@@ -1393,7 +1410,8 @@ def test_auto_briefing_rule_native():
     test(
         "AutoBriefingRule is fail-open — never denies (wave9)",
         "permissionDecision" not in content.split("AutoBriefingRule")[1].split("struct ")[0]
-        if "AutoBriefingRule" in content else False,
+        if "AutoBriefingRule" in content
+        else False,
         "AutoBriefingRule must never produce a permissionDecision",
     )
 
@@ -1525,6 +1543,7 @@ def test_managed_pre_post_routing_unchanged():
     )
     if HOOKS_JSON.exists():
         import json as _json
+
         payload = _json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
         events = set(payload.get("hooks", {}).keys())
         test(
@@ -2266,6 +2285,7 @@ def test_goal_pause_preserves_terminal_states():
     sys.path.insert(0, str(REPO / "hooks"))
     try:
         from rules.session_lifecycle import _PAUSE_STATES
+
         terminal = {"completed", "abandoned", "paused", "needs-human"}
         overlap = _PAUSE_STATES & terminal
         test(
@@ -2291,6 +2311,225 @@ test_session_lifecycle_has_goal_pause()
 test_session_end_py_has_goal_pause()
 test_rules_rs_documents_goal_pause_boundary()
 test_goal_pause_preserves_terminal_states()
+
+
+# ── Wave 16 — sessionStart paused-goal resume banner (issue #185) ────────────
+
+print("\n── wave16: sessionStart paused-goal resume banner — Python/native parity (#185) ──")
+
+BRIEFING_PY = REPO / "hooks" / "rules" / "briefing.py"
+AUTO_BRIEFING_PY = REPO / "hooks" / "auto-briefing.py"
+RULES_RS_185 = REPO / "sk-rust" / "src" / "hooks" / "rules.rs"
+
+
+def test_briefing_py_has_resume_hint():
+    """hooks/rules/briefing.py must implement the paused-goal resume-hint helpers (issue #185)."""
+    if not BRIEFING_PY.exists():
+        test("hooks/rules/briefing.py exists for wave16 check", False, str(BRIEFING_PY))
+        return
+    content = BRIEFING_PY.read_text(encoding="utf-8")
+    test(
+        "briefing.py defines _load_goal_resume_hint (wave16)",
+        "_load_goal_resume_hint" in content,
+        "briefing.py must define _load_goal_resume_hint for issue #185",
+    )
+    test(
+        "briefing.py defines _BREADCRUMB_FILENAME (wave16)",
+        "_BREADCRUMB_FILENAME" in content,
+        "briefing.py must define _BREADCRUMB_FILENAME constant",
+    )
+    test(
+        "briefing.py defines _PAUSE_REASON_LABELS mapping (wave16)",
+        "_PAUSE_REASON_LABELS" in content,
+        "briefing.py must define _PAUSE_REASON_LABELS dict",
+    )
+    test(
+        "briefing.py defines _format_pause_reason helper (wave16)",
+        "_format_pause_reason" in content,
+        "briefing.py must define _format_pause_reason helper",
+    )
+    # Ordering contract: resume hint prepended BEFORE Session briefing header
+    resume_call_idx = content.find("_load_goal_resume_hint")
+    briefing_header_idx = content.find("Session briefing")
+    test(
+        "briefing.py calls _load_goal_resume_hint before Session briefing header (wave16)",
+        0 <= resume_call_idx < briefing_header_idx,
+        f"resume_call_idx={resume_call_idx} briefing_header_idx={briefing_header_idx}",
+    )
+    # Suppression contract: staleness check present
+    test(
+        "briefing.py suppresses banner when goal not paused (staleness check)",
+        'status" != "paused"' in content or '!= "paused"' in content or "!= 'paused'" in content,
+        "briefing.py must suppress banner when goal.json status is not 'paused'",
+    )
+    # Fail-open: breadcrumb read errors must not raise
+    test(
+        "briefing.py _load_goal_resume_hint is fail-open (outer try/except)",
+        "except Exception" in content,
+        "_load_goal_resume_hint must be wrapped in try/except for fail-open behaviour",
+    )
+
+
+def test_auto_briefing_py_has_resume_hint():
+    """hooks/auto-briefing.py (direct legacy path) must also implement resume-hint (issue #185)."""
+    if not AUTO_BRIEFING_PY.exists():
+        test("hooks/auto-briefing.py exists for wave16 check", False, str(AUTO_BRIEFING_PY))
+        return
+    content = AUTO_BRIEFING_PY.read_text(encoding="utf-8")
+    test(
+        "auto-briefing.py defines _load_goal_resume_hint (wave16)",
+        "_load_goal_resume_hint" in content,
+        "auto-briefing.py must define _load_goal_resume_hint for issue #185",
+    )
+    test(
+        "auto-briefing.py defines _BREADCRUMB_FILENAME (wave16)",
+        "_BREADCRUMB_FILENAME" in content,
+        "auto-briefing.py must define _BREADCRUMB_FILENAME constant",
+    )
+    test(
+        "auto-briefing.py prepends resume hint before Session briefing header (wave16)",
+        "_load_goal_resume_hint" in content and "Session briefing" in content,
+        "auto-briefing.py must call _load_goal_resume_hint before printing briefing header",
+    )
+    # Ordering: the resume_hint call must come before the briefing header print
+    resume_call_idx = content.find("_load_goal_resume_hint")
+    briefing_header_idx = content.find("Session briefing")
+    test(
+        "auto-briefing.py resume hint call precedes briefing header (wave16)",
+        0 <= resume_call_idx < briefing_header_idx,
+        f"resume_call_idx={resume_call_idx} briefing_header_idx={briefing_header_idx}",
+    )
+
+
+def test_rules_rs_has_native_resume_hint():
+    """sk-rust/src/hooks/rules.rs must implement native parity for resume hint (issue #185)."""
+    if not RULES_RS_185.exists():
+        test("sk-rust/src/hooks/rules.rs exists for wave16 check", False, str(RULES_RS_185))
+        return
+    content = RULES_RS_185.read_text(encoding="utf-8")
+    test(
+        "rules.rs defines load_goal_resume_hint native function (wave16)",
+        "load_goal_resume_hint" in content,
+        "rules.rs must define a load_goal_resume_hint fn for native parity",
+    )
+    test(
+        "rules.rs defines BREADCRUMB_FILENAME constant (wave16)",
+        "BREADCRUMB_FILENAME" in content,
+        "rules.rs must define BREADCRUMB_FILENAME constant",
+    )
+    test(
+        "rules.rs defines format_pause_reason helper (wave16)",
+        "format_pause_reason" in content,
+        "rules.rs must define format_pause_reason fn mirroring Python",
+    )
+    test(
+        "rules.rs references issue #185 in comments (wave16)",
+        "185" in content,
+        "rules.rs must reference issue #185 in AutoBriefingRule comment",
+    )
+    # Ordering contract: load_goal_resume_hint called before session briefing header emission
+    hint_call_idx = content.find("load_goal_resume_hint")
+    briefing_header_idx = content.find("Session briefing")
+    test(
+        "rules.rs calls load_goal_resume_hint before Session briefing header (wave16)",
+        0 <= hint_call_idx < briefing_header_idx,
+        f"hint_call_idx={hint_call_idx} briefing_header_idx={briefing_header_idx}",
+    )
+    # Suppression contract
+    test(
+        "rules.rs suppresses banner when goal not paused (staleness check)",
+        '"paused"' in content and "suppress" in content.lower(),
+        "rules.rs must suppress banner when goal.json status is not 'paused'",
+    )
+    # Fail-open: banner shown when goal.json is absent
+    test(
+        "rules.rs load_goal_resume_hint is fail-open for goal.json absence",
+        "None" in content or "Ok(" in content,
+        "rules.rs load_goal_resume_hint must return banner when goal.json is absent (fail-open)",
+    )
+
+
+def test_wave16_python_native_naming_parity():
+    """Python and Rust must use matching breadcrumb filename and pause-reason labels (issue #185)."""
+    if not BRIEFING_PY.exists() or not RULES_RS_185.exists():
+        test("wave16 parity check skipped (files absent)", True)
+        return
+    py_content = BRIEFING_PY.read_text(encoding="utf-8")
+    rs_content = RULES_RS_185.read_text(encoding="utf-8")
+    # Both must reference the same breadcrumb filename
+    test(
+        "Python and Rust both use breadcrumb filename 'goal-resume-breadcrumb.json'",
+        "goal-resume-breadcrumb.json" in py_content and "goal-resume-breadcrumb.json" in rs_content,
+        "breadcrumb filename must match across Python/Rust boundaries",
+    )
+    # Both must map 'session_end' → 'session end'
+    test(
+        "Python and Rust both map 'session_end' pause_reason (wave16 parity)",
+        "session_end" in py_content and "session_end" in rs_content,
+        "pause_reason key 'session_end' must be recognised by both Python and Rust",
+    )
+    # Both must reference the resume command
+    test(
+        "Python and Rust both reference 'sk tentacle goal resume' command (wave16)",
+        "sk tentacle goal resume" in py_content and "sk tentacle goal resume" in rs_content,
+        "resume_command fallback must be 'sk tentacle goal resume' in both paths",
+    )
+
+
+def _extract_function_body(
+    content: str, start_marker: str, end_markers: "tuple[str, ...]" = ("\ndef ", "\nclass ")
+) -> str:
+    """Return the text of a function/method from content, stopping at the first end_marker."""
+    start = content.find(start_marker)
+    if start == -1:
+        return ""
+    best_end = len(content)
+    for em in end_markers:
+        idx = content.find(em, start + 1)
+        if idx != -1 and idx < best_end:
+            best_end = idx
+    return content[start:best_end]
+
+
+def test_wave16_breadcrumb_consumption_contract():
+    """Structural contract: breadcrumb must be consumed (not deleted) on sessionStart.
+
+    The banner is informational only — the breadcrumb file is NOT removed by
+    sessionStart so that the operator can start multiple sessions and still see
+    the hint.  Only ``sk tentacle goal resume`` removes the breadcrumb.
+    """
+    if not BRIEFING_PY.exists():
+        test("wave16 breadcrumb consumption check skipped (briefing.py absent)", True)
+        return
+    content = BRIEFING_PY.read_text(encoding="utf-8")
+    hint_body = _extract_function_body(content, "def _load_goal_resume_hint")
+    if not hint_body:
+        test("wave16 breadcrumb consumption: _load_goal_resume_hint found", False, "function not found")
+        return
+    test(
+        "_load_goal_resume_hint does NOT delete the breadcrumb (read-only consumption)",
+        ".unlink(" not in hint_body and "os.remove(" not in hint_body,
+        "breadcrumb must not be removed by _load_goal_resume_hint — it is read-only",
+    )
+    if not RULES_RS_185.exists():
+        return
+    rs_content = RULES_RS_185.read_text(encoding="utf-8")
+    rs_hint_body = _extract_function_body(rs_content, "fn load_goal_resume_hint", ("\nfn ", "\npub ", "\nimpl "))
+    if not rs_hint_body:
+        test("wave16 breadcrumb consumption: Rust load_goal_resume_hint found", False, "fn not found")
+        return
+    test(
+        "Rust load_goal_resume_hint does NOT delete the breadcrumb (read-only consumption)",
+        "remove(" not in rs_hint_body and "unlink(" not in rs_hint_body,
+        "Rust breadcrumb must not be removed by load_goal_resume_hint",
+    )
+
+
+test_briefing_py_has_resume_hint()
+test_auto_briefing_py_has_resume_hint()
+test_rules_rs_has_native_resume_hint()
+test_wave16_python_native_naming_parity()
+test_wave16_breadcrumb_consumption_contract()
 
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/tests/test_hook_rules_more.py
+++ b/tests/test_hook_rules_more.py
@@ -335,7 +335,7 @@ test("SessionEndRule events", "sessionEnd" in rule.events)
 print("\n🔚 Section 3b: SessionEndRule — goal pause + breadcrumb")
 
 import rules.session_lifecycle as _sl_mod2
-from rules.session_lifecycle import _pause_active_goal, _PAUSE_STATES, _BREADCRUMB_FILENAME
+from rules.session_lifecycle import _BREADCRUMB_FILENAME, _PAUSE_STATES, _pause_active_goal
 
 _rule_se = SessionEndRule()
 
@@ -375,6 +375,7 @@ def _make_fake_tentacle(tmp_dir: Path, initial_status: str, title: str = "Test G
         @staticmethod
         def _goal_write(td, state):
             import os as _os
+
             tmp_p = goal_path.with_suffix(".json.tmp")
             tmp_p.write_text(json.dumps(state, indent=2), encoding="utf-8")
             _os.replace(tmp_p, goal_path)
@@ -686,8 +687,8 @@ test(
 print("\n🐙 Section 5: Tentacle rule helpers")
 
 import rules.tentacle as _rt_mod
-from rules.tentacle import _prune_ttl, _get_entries_for_repo
 from rules.subagent_guard import _roots_match
+from rules.tentacle import _get_entries_for_repo, _prune_ttl
 
 # 5a. _prune_ttl keeps recent entries
 now = time.time()
@@ -745,7 +746,7 @@ test("tentacle-suggest in postToolUse rules", "tentacle-suggest" in post_names)
 
 print("\n🛠️  Section 6: common.py helpers")
 
-from rules.common import is_session_path, get_module, is_source_path, CODE_EXTENSIONS
+from rules.common import CODE_EXTENSIONS, get_module, is_session_path, is_source_path
 
 # 6a. is_session_path recognises session-state paths
 _sess_root = str(Path.home() / ".copilot" / "session-state")
@@ -783,19 +784,19 @@ print("\n🔬 Section 7: VerificationGateRule")
 
 import rules.verification_gate as _vg_mod
 from rules.verification_gate import (
-    VerificationGateRule,
-    SURFACE_PY,
-    SURFACE_UI,
     EV_PY_TESTS,
+    EV_UI_BUILD,
     EV_UI_FORMAT,
     EV_UI_LINT,
     EV_UI_TYPECHECK,
-    EV_UI_BUILD,
-    _surfaces_from_path,
+    SURFACE_PY,
+    SURFACE_UI,
+    VerificationGateRule,
     _evidence_from_command,
-    _looks_successful,
     _is_closeout,
+    _looks_successful,
     _read_ledger,
+    _surfaces_from_path,
     _write_ledger,
 )
 
@@ -1060,7 +1061,282 @@ try:
 finally:
     pass
 
-# ── 7i. postToolUse bash writes mark surfaces dirty ───────────────────
+# ══════════════════════════════════════════════════════════════════════
+#  Section 8: AutoBriefingRule — goal resume banner (_load_goal_resume_hint)
+#  Tests for issue #185: paused-goal resume hint injected at sessionStart
+# ══════════════════════════════════════════════════════════════════════
+
+print("\n⏸  Section 8: AutoBriefingRule — goal resume banner")
+
+from rules.briefing import _format_pause_reason, _load_goal_resume_hint  # type: ignore[import]
+
+# ── 8a. _format_pause_reason ──────────────────────────────────────────
+
+test("session_end prefix → 'session end'", _format_pause_reason("session_end:normal") == "session end")
+test("bare session_end → 'session end'", _format_pause_reason("session_end") == "session end")
+test("compaction prefix → 'context compaction'", _format_pause_reason("compaction:ctx") == "context compaction")
+test("quota prefix → 'quota limit'", _format_pause_reason("quota:low") == "quota limit")
+test("unknown reason → 'paused'", _format_pause_reason("something_weird") == "paused")
+test("empty string → 'paused'", _format_pause_reason("") == "paused")
+
+# ── 8b. breadcrumb absent → None ──────────────────────────────────────
+
+_tmp_bc = Path(tempfile.mkdtemp(prefix="sk_test_bc_"))
+try:
+    result = _load_goal_resume_hint(_tmp_bc)
+    test("breadcrumb absent → None", result is None)
+finally:
+    shutil.rmtree(_tmp_bc, ignore_errors=True)
+
+# ── 8c. paused goal + fresh breadcrumb → banner lines ─────────────────
+
+_tmp_bc2 = Path(tempfile.mkdtemp(prefix="sk_test_bc2_"))
+try:
+    _octogent2 = _tmp_bc2 / ".octogent"
+    _octogent2.mkdir()
+    _goal_json2 = _octogent2 / "goal.json"
+    _goal_json2.write_text(json.dumps({"status": "paused", "title": "My Goal", "goal_id": "g1"}), encoding="utf-8")
+    _bc_file2 = _octogent2 / "goal-resume-breadcrumb.json"
+    _bc_file2.write_text(
+        json.dumps(
+            {
+                "goal_id": "g1",
+                "goal_title": "My Goal",
+                "goal_path": str(_goal_json2),
+                "pause_reason": "session_end:normal",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _load_goal_resume_hint(_tmp_bc2)
+    test("paused goal → returns list", isinstance(result, list))
+    if isinstance(result, list):
+        combined = "\n".join(result)
+        test("paused goal → banner has goal title", "My Goal" in combined)
+        test("paused goal → banner has resume command", "sk tentacle goal resume" in combined)
+        test("paused goal → banner has reason label", "session end" in combined)
+        test("paused goal → first line has 'Paused goal'", "Paused goal" in result[0])
+finally:
+    shutil.rmtree(_tmp_bc2, ignore_errors=True)
+
+# ── 8d. goal already resumed (status != paused) → None (suppressed) ───
+
+_tmp_bc3 = Path(tempfile.mkdtemp(prefix="sk_test_bc3_"))
+try:
+    _octogent3 = _tmp_bc3 / ".octogent"
+    _octogent3.mkdir()
+    _goal_json3 = _octogent3 / "goal.json"
+    _goal_json3.write_text(json.dumps({"status": "active", "title": "Resumed Goal", "goal_id": "g2"}), encoding="utf-8")
+    _bc_file3 = _octogent3 / "goal-resume-breadcrumb.json"
+    _bc_file3.write_text(
+        json.dumps(
+            {
+                "goal_id": "g2",
+                "goal_title": "Resumed Goal",
+                "goal_path": str(_goal_json3),
+                "pause_reason": "session_end:normal",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _load_goal_resume_hint(_tmp_bc3)
+    test("already-resumed goal → suppressed (None)", result is None)
+finally:
+    shutil.rmtree(_tmp_bc3, ignore_errors=True)
+
+# ── 8e. goal.json absent → fail-open (banner still shown) ─────────────
+
+_tmp_bc4 = Path(tempfile.mkdtemp(prefix="sk_test_bc4_"))
+try:
+    _octogent4 = _tmp_bc4 / ".octogent"
+    _octogent4.mkdir()
+    _ghost_goal = _octogent4 / "ghost-goal.json"  # does NOT exist
+    _bc_file4 = _octogent4 / "goal-resume-breadcrumb.json"
+    _bc_file4.write_text(
+        json.dumps(
+            {
+                "goal_id": "g3",
+                "goal_title": "Ghost Goal",
+                "goal_path": str(_ghost_goal),
+                "pause_reason": "session_end:crash",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _load_goal_resume_hint(_tmp_bc4)
+    test("goal.json absent → fail-open shows banner", isinstance(result, list) and len(result) > 0)
+finally:
+    shutil.rmtree(_tmp_bc4, ignore_errors=True)
+
+# ── 8f. completed goal → suppressed ───────────────────────────────────
+
+_tmp_bc5 = Path(tempfile.mkdtemp(prefix="sk_test_bc5_"))
+try:
+    _octogent5 = _tmp_bc5 / ".octogent"
+    _octogent5.mkdir()
+    _goal_json5 = _octogent5 / "goal.json"
+    _goal_json5.write_text(json.dumps({"status": "completed", "title": "Done Goal", "goal_id": "g4"}), encoding="utf-8")
+    _bc_file5 = _octogent5 / "goal-resume-breadcrumb.json"
+    _bc_file5.write_text(
+        json.dumps(
+            {
+                "goal_id": "g4",
+                "goal_title": "Done Goal",
+                "goal_path": str(_goal_json5),
+                "pause_reason": "session_end:normal",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _load_goal_resume_hint(_tmp_bc5)
+    test("completed goal → suppressed (None)", result is None)
+finally:
+    shutil.rmtree(_tmp_bc5, ignore_errors=True)
+
+# ── 8g. whitespace-only goal_title → falls back to goal_id ────────────
+# Regression for parity fix: whitespace-only title must yield goal_id,
+# not "(untitled goal)", keeping Python and Rust semantics aligned.
+
+_tmp_bc6 = Path(tempfile.mkdtemp(prefix="sk_test_bc6_"))
+try:
+    _octogent6 = _tmp_bc6 / ".octogent"
+    _octogent6.mkdir()
+    _goal_json6 = _octogent6 / "goal.json"
+    _goal_json6.write_text(json.dumps({"status": "paused", "goal_id": "ws-fallback-id"}), encoding="utf-8")
+    _bc_file6 = _octogent6 / "goal-resume-breadcrumb.json"
+    _bc_file6.write_text(
+        json.dumps(
+            {
+                "goal_id": "ws-fallback-id",
+                "goal_title": "   ",  # whitespace-only — must be treated as absent
+                "goal_path": str(_goal_json6),
+                "pause_reason": "session_end:normal",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _load_goal_resume_hint(_tmp_bc6)
+    test("whitespace-only title → returns list (goal still shown)", isinstance(result, list))
+    if isinstance(result, list):
+        combined = "\n".join(result)
+        test(
+            "whitespace-only title → falls back to goal_id in banner",
+            "ws-fallback-id" in combined,
+        )
+        test(
+            "whitespace-only title → does NOT show '(untitled goal)'",
+            "(untitled goal)" not in combined,
+        )
+finally:
+    shutil.rmtree(_tmp_bc6, ignore_errors=True)
+
+# ── 8h. valid non-object breadcrumb JSON → None (Rust/Python parity guard) ──
+# Regression for review finding: valid non-object JSON such as [], 42, or "x"
+# must not produce a spurious banner; Python already fail-opens here because
+# bc.get() raises AttributeError on non-dict and the outer except swallows it.
+
+for _non_obj_tag, _non_obj_payload in [("array", "[]"), ("number", "42"), ("string", '"x"')]:
+    _tmp_non_obj = Path(tempfile.mkdtemp(prefix=f"sk_test_nonobj_{_non_obj_tag}_"))
+    try:
+        _octogent_non_obj = _tmp_non_obj / ".octogent"
+        _octogent_non_obj.mkdir()
+        (_octogent_non_obj / "goal-resume-breadcrumb.json").write_text(_non_obj_payload, encoding="utf-8")
+        result = _load_goal_resume_hint(_tmp_non_obj)
+        test(f"non-object breadcrumb ({_non_obj_tag}) → None", result is None)
+    finally:
+        shutil.rmtree(_tmp_non_obj, ignore_errors=True)
+
+# ── 8i. non-object goal.json → fail-open (banner still shown) ────────────
+# Regression: when goal.json exists but contains valid non-object JSON
+# ([], 42, "running"), the staleness check must not suppress the banner.
+# Python already fail-opens here (state.get() raises on non-dict → outer
+# except swallows it); this confirms that parity holds after the Rust fix.
+
+for _goal_tag, _goal_payload in [("array", "[]"), ("number", "42"), ("string", '"running"')]:
+    _tmp_go = Path(tempfile.mkdtemp(prefix=f"sk_test_goalobj_{_goal_tag}_"))
+    try:
+        _octogent_go = _tmp_go / ".octogent"
+        _octogent_go.mkdir()
+        _goal_json_go = _octogent_go / "goal.json"
+        _goal_json_go.write_text(_goal_payload, encoding="utf-8")
+        _bc_go = _octogent_go / "goal-resume-breadcrumb.json"
+        _bc_go.write_text(
+            json.dumps(
+                {
+                    "goal_id": "g-go",
+                    "goal_title": "Goal With Bad Status File",
+                    "goal_path": str(_goal_json_go),
+                    "pause_reason": "session_end:normal",
+                    "resume_command": "sk tentacle goal resume",
+                    "paused_at": "2026-01-01T00:00:00Z",
+                    "previous_status": "active",
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = _load_goal_resume_hint(_tmp_go)
+        test(
+            f"non-object goal.json ({_goal_tag}) → fail-open shows banner",
+            isinstance(result, list) and len(result) > 0,
+        )
+    finally:
+        shutil.rmtree(_tmp_go, ignore_errors=True)
+
+# ── 8j. non-string pause_reason → falls back to generic 'paused' label ───
+# Regression: malformed pause_reason (int, list, None) must not drop the
+# banner; Python must normalize to "" before formatting, matching Rust's
+# .as_str().unwrap_or("") which also coerces non-string JSON values.
+
+_tmp_bcj = Path(tempfile.mkdtemp(prefix="sk_test_bcj_"))
+try:
+    _octogentj = _tmp_bcj / ".octogent"
+    _octogentj.mkdir()
+    _goal_jsonj = _octogentj / "goal.json"
+    _goal_jsonj.write_text(json.dumps({"status": "paused", "goal_id": "gj"}), encoding="utf-8")
+    _bc_filej = _octogentj / "goal-resume-breadcrumb.json"
+    for _pr_val, _pr_label in [(42, "int"), (["x"], "list"), (None, "null")]:
+        _bc_filej.write_text(
+            json.dumps(
+                {
+                    "goal_id": "gj",
+                    "goal_title": "Goal With Bad Reason",
+                    "goal_path": str(_goal_jsonj),
+                    "pause_reason": _pr_val,
+                    "resume_command": "sk tentacle goal resume",
+                    "paused_at": "2026-01-01T00:00:00Z",
+                    "previous_status": "active",
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = _load_goal_resume_hint(_tmp_bcj)
+        test(
+            f"non-string pause_reason ({_pr_label}) → banner still shown",
+            isinstance(result, list) and len(result) > 0,
+        )
+        if isinstance(result, list):
+            combined = "\n".join(result)
+            test(
+                f"non-string pause_reason ({_pr_label}) → falls back to 'paused' label",
+                "paused" in combined,
+            )
+finally:
+    shutil.rmtree(_tmp_bcj, ignore_errors=True)
 
 try:
     _fake_ledger.unlink(missing_ok=True)

--- a/tests/test_hook_rules_more.py
+++ b/tests/test_hook_rules_more.py
@@ -1338,6 +1338,197 @@ try:
 finally:
     shutil.rmtree(_tmp_bcj, ignore_errors=True)
 
+# ── 8k. non-string resume_command → falls back to default ─────────────
+# Regression for issue #185 review: non-string JSON values for resume_command
+# (int, list, null, object) must not produce a spurious or empty run command;
+# the default "sk tentacle goal resume" must appear in the banner.
+
+_tmp_bck = Path(tempfile.mkdtemp(prefix="sk_test_bck_"))
+try:
+    _octogentk = _tmp_bck / ".octogent"
+    _octogentk.mkdir()
+    _goal_jsonk = _octogentk / "goal.json"
+    _goal_jsonk.write_text(json.dumps({"status": "paused", "goal_id": "gk"}), encoding="utf-8")
+    _bc_filek = _octogentk / "goal-resume-breadcrumb.json"
+    for _rc_val, _rc_label in [
+        (42, "int"),
+        (["sk", "tentacle"], "list"),
+        (None, "null"),
+        ({"cmd": "x"}, "object"),
+    ]:
+        _bc_filek.write_text(
+            json.dumps(
+                {
+                    "goal_id": "gk",
+                    "goal_title": "Goal With Bad RC",
+                    "goal_path": str(_goal_jsonk),
+                    "pause_reason": "session_end",
+                    "resume_command": _rc_val,
+                    "paused_at": "2026-01-01T00:00:00Z",
+                    "previous_status": "active",
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = _load_goal_resume_hint(_tmp_bck)
+        test(
+            f"non-string resume_command ({_rc_label}) → banner still shown",
+            isinstance(result, list) and len(result) > 0,
+        )
+        if isinstance(result, list):
+            combined = "\n".join(result)
+            test(
+                f"non-string resume_command ({_rc_label}) → falls back to default",
+                "sk tentacle goal resume" in combined,
+            )
+finally:
+    shutil.rmtree(_tmp_bck, ignore_errors=True)
+
+# ── 8l. whitespace-only resume_command → falls back to default ─────────
+# Regression: a resume_command string that is entirely whitespace must be
+# treated as blank and fall back to "sk tentacle goal resume", matching
+# Rust's .map(str::trim).filter(|s| !s.is_empty()).unwrap_or(default).
+
+_tmp_bcl = Path(tempfile.mkdtemp(prefix="sk_test_bcl_"))
+try:
+    _octogentl = _tmp_bcl / ".octogent"
+    _octogentl.mkdir()
+    _goal_jsonl = _octogentl / "goal.json"
+    _goal_jsonl.write_text(json.dumps({"status": "paused", "goal_id": "gl"}), encoding="utf-8")
+    _bc_filel = _octogentl / "goal-resume-breadcrumb.json"
+    for _ws_val, _ws_label in [("   ", "spaces"), ("\t", "tab"), ("\n", "newline"), ("  \t  ", "mixed")]:
+        _bc_filel.write_text(
+            json.dumps(
+                {
+                    "goal_id": "gl",
+                    "goal_title": "Goal With WS RC",
+                    "goal_path": str(_goal_jsonl),
+                    "pause_reason": "session_end",
+                    "resume_command": _ws_val,
+                    "paused_at": "2026-01-01T00:00:00Z",
+                    "previous_status": "active",
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = _load_goal_resume_hint(_tmp_bcl)
+        test(
+            f"whitespace resume_command ({_ws_label!r}) → banner still shown",
+            isinstance(result, list) and len(result) > 0,
+        )
+        if isinstance(result, list):
+            combined = "\n".join(result)
+            test(
+                f"whitespace resume_command ({_ws_label!r}) → falls back to default",
+                "sk tentacle goal resume" in combined,
+            )
+finally:
+    shutil.rmtree(_tmp_bcl, ignore_errors=True)
+
+# ── 8m. non-string goal_title / goal_id → banner not suppressed ──────────
+# Regression for issue #185 review: non-string JSON values for goal_title and
+# goal_id (int, list, dict) must not raise AttributeError and suppress the
+# banner.  Python now guards with isinstance(v, str) before .strip(), matching
+# Rust's .and_then(|v| v.as_str()) which silently skips non-string JSON values.
+
+_tmp_bcm = Path(tempfile.mkdtemp(prefix="sk_test_bcm_"))
+try:
+    _octogentm = _tmp_bcm / ".octogent"
+    _octogentm.mkdir()
+    _goal_jsonm = _octogentm / "goal.json"
+    _goal_jsonm.write_text(json.dumps({"status": "paused"}), encoding="utf-8")
+    _bc_filem = _octogentm / "goal-resume-breadcrumb.json"
+
+    # Case 1: non-string goal_title with valid string goal_id → banner shows goal_id
+    _bc_filem.write_text(
+        json.dumps(
+            {
+                "goal_id": "fallback-id",
+                "goal_title": 42,
+                "goal_path": str(_goal_jsonm),
+                "pause_reason": "session_end",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _load_goal_resume_hint(_tmp_bcm)
+    test("non-string goal_title (int) → banner still shown", isinstance(result, list) and len(result) > 0)
+    if isinstance(result, list):
+        combined = "\n".join(result)
+        test("non-string goal_title (int) → falls back to goal_id", "fallback-id" in combined)
+        test("non-string goal_title (int) → does not show '(untitled goal)'", "(untitled goal)" not in combined)
+
+    # Case 2: non-string goal_title AND non-string goal_id → banner shows "(untitled goal)"
+    _bc_filem.write_text(
+        json.dumps(
+            {
+                "goal_id": {"bad": True},
+                "goal_title": ["not", "a", "string"],
+                "goal_path": str(_goal_jsonm),
+                "pause_reason": "session_end",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _load_goal_resume_hint(_tmp_bcm)
+    test(
+        "non-string goal_title + non-string goal_id → banner still shown",
+        isinstance(result, list) and len(result) > 0,
+    )
+    if isinstance(result, list):
+        combined = "\n".join(result)
+        test(
+            "non-string goal_title + non-string goal_id → falls back to '(untitled goal)'",
+            "(untitled goal)" in combined,
+        )
+finally:
+    shutil.rmtree(_tmp_bcm, ignore_errors=True)
+
+# ── 8n. non-string goal_path → falls back to default goal.json ───────────
+# Regression for issue #185 review: a non-string goal_path (list, int, dict)
+# must not raise TypeError inside Path() and suppress the banner.  Python now
+# guards with isinstance(v, str), falling back to the default .octogent/goal.json
+# path, matching Rust's .and_then(|v| v.as_str()).unwrap_or_else(|| default).
+
+_tmp_bcn = Path(tempfile.mkdtemp(prefix="sk_test_bcn_"))
+try:
+    _octogentn = _tmp_bcn / ".octogent"
+    _octogentn.mkdir()
+    # Provide a paused goal.json at the default fallback path so the staleness
+    # check passes and the banner is shown (not suppressed).
+    _default_goal_jsonn = _octogentn / "goal.json"
+    _default_goal_jsonn.write_text(json.dumps({"status": "paused"}), encoding="utf-8")
+    _bc_filen = _octogentn / "goal-resume-breadcrumb.json"
+
+    for _gp_val, _gp_label in [(["not-a-string"], "list"), (42, "int"), ({"p": "x"}, "object")]:
+        _bc_filen.write_text(
+            json.dumps(
+                {
+                    "goal_id": "gn",
+                    "goal_title": "Goal With Bad Path",
+                    "goal_path": _gp_val,
+                    "pause_reason": "session_end",
+                    "resume_command": "sk tentacle goal resume",
+                    "paused_at": "2026-01-01T00:00:00Z",
+                    "previous_status": "active",
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = _load_goal_resume_hint(_tmp_bcn)
+        test(
+            f"non-string goal_path ({_gp_label}) → banner shown via default goal.json fallback",
+            isinstance(result, list) and len(result) > 0,
+        )
+finally:
+    shutil.rmtree(_tmp_bcn, ignore_errors=True)
+
 try:
     _fake_ledger.unlink(missing_ok=True)
     with patch.object(_vg_mod, "LEDGER_FILE", _fake_ledger), patch.object(_vg_mod, "MARKERS_DIR", _tmp_vg):

--- a/tests/test_hook_runner_entrypoints.py
+++ b/tests/test_hook_runner_entrypoints.py
@@ -71,32 +71,40 @@ def _run(event: str, payload: dict, env: dict | None = None, timeout: int = 15):
 print("\n🚫 Section 1: block-edit-dist via hook_runner subprocess")
 
 # 1a. Edit targeting browse-ui/dist/ → deny output
-r = _run("preToolUse", {
-    "toolName": "edit",
-    "toolArgs": {"path": "browse-ui/dist/bundle.js", "old_str": "a", "new_str": "b"},
-})
-test("edit browse-ui/dist/ → non-zero exit (denied)", r.returncode != 0 or "permissionDecision" in r.stdout,
-     f"rc={r.returncode}, stdout={r.stdout[:200]}")
-test("edit browse-ui/dist/ → deny JSON present", '"deny"' in r.stdout,
-     f"stdout={r.stdout[:200]}")
-test("edit browse-ui/dist/ → pnpm build in reason", "pnpm build" in r.stdout,
-     f"stdout={r.stdout[:200]}")
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "edit",
+        "toolArgs": {"path": "browse-ui/dist/bundle.js", "old_str": "a", "new_str": "b"},
+    },
+)
+test(
+    "edit browse-ui/dist/ → non-zero exit (denied)",
+    r.returncode != 0 or "permissionDecision" in r.stdout,
+    f"rc={r.returncode}, stdout={r.stdout[:200]}",
+)
+test("edit browse-ui/dist/ → deny JSON present", '"deny"' in r.stdout, f"stdout={r.stdout[:200]}")
+test("edit browse-ui/dist/ → pnpm build in reason", "pnpm build" in r.stdout, f"stdout={r.stdout[:200]}")
 
 # 1b. Edit targeting browse-ui/src/ → allowed (exit 0, no deny)
-r = _run("preToolUse", {
-    "toolName": "edit",
-    "toolArgs": {"path": "browse-ui/src/components/Header.tsx", "old_str": "a", "new_str": "b"},
-})
-test("edit browse-ui/src/ → allowed (no deny JSON)", '"deny"' not in r.stdout,
-     f"stdout={r.stdout[:200]}")
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "edit",
+        "toolArgs": {"path": "browse-ui/src/components/Header.tsx", "old_str": "a", "new_str": "b"},
+    },
+)
+test("edit browse-ui/src/ → allowed (no deny JSON)", '"deny"' not in r.stdout, f"stdout={r.stdout[:200]}")
 
 # 1c. Create targeting browse-ui/dist/ → deny
-r = _run("preToolUse", {
-    "toolName": "create",
-    "toolArgs": {"path": "browse-ui/dist/chunk.js", "file_text": "// generated"},
-})
-test("create browse-ui/dist/ → deny JSON present", '"deny"' in r.stdout,
-     f"stdout={r.stdout[:200]}")
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "create",
+        "toolArgs": {"path": "browse-ui/dist/chunk.js", "file_text": "// generated"},
+    },
+)
+test("create browse-ui/dist/ → deny JSON present", '"deny"' in r.stdout, f"stdout={r.stdout[:200]}")
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -106,42 +114,50 @@ test("create browse-ui/dist/ → deny JSON present", '"deny"' in r.stdout,
 print("\n🛡️  Section 2: block-unsafe-html via hook_runner subprocess")
 
 # 2a. dangerouslySetInnerHTML without sanitize in .tsx → deny
-r = _run("preToolUse", {
-    "toolName": "edit",
-    "toolArgs": {
-        "path": "browse-ui/src/Widget.tsx",
-        "old_str": "return null;",
-        "new_str": "return <div dangerouslySetInnerHTML={{ __html: content }} />;",
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "edit",
+        "toolArgs": {
+            "path": "browse-ui/src/Widget.tsx",
+            "old_str": "return null;",
+            "new_str": "return <div dangerouslySetInnerHTML={{ __html: content }} />;",
+        },
     },
-})
-test("dangerouslySetInnerHTML without sanitize → deny JSON", '"deny"' in r.stdout,
-     f"stdout={r.stdout[:300]}")
-test("XSS denial mentions sanitize/XSS",
-     "sanitize" in r.stdout.lower() or "xss" in r.stdout.lower() or "DOMPurify" in r.stdout,
-     f"stdout={r.stdout[:300]}")
+)
+test("dangerouslySetInnerHTML without sanitize → deny JSON", '"deny"' in r.stdout, f"stdout={r.stdout[:300]}")
+test(
+    "XSS denial mentions sanitize/XSS",
+    "sanitize" in r.stdout.lower() or "xss" in r.stdout.lower() or "DOMPurify" in r.stdout,
+    f"stdout={r.stdout[:300]}",
+)
 
 # 2b. dangerouslySetInnerHTML WITH DOMPurify.sanitize → allowed
-r = _run("preToolUse", {
-    "toolName": "edit",
-    "toolArgs": {
-        "path": "browse-ui/src/Safe.tsx",
-        "old_str": "return null;",
-        "new_str": "const html = DOMPurify.sanitize(raw); return <div dangerouslySetInnerHTML={{ __html: html }} />;",
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "edit",
+        "toolArgs": {
+            "path": "browse-ui/src/Safe.tsx",
+            "old_str": "return null;",
+            "new_str": "const html = DOMPurify.sanitize(raw); return <div dangerouslySetInnerHTML={{ __html: html }} />;",
+        },
     },
-})
-test("dangerouslySetInnerHTML + DOMPurify → allowed (no deny)", '"deny"' not in r.stdout,
-     f"stdout={r.stdout[:300]}")
+)
+test("dangerouslySetInnerHTML + DOMPurify → allowed (no deny)", '"deny"' not in r.stdout, f"stdout={r.stdout[:300]}")
 
 # 2c. Non-TS/JS file with dangerouslySetInnerHTML → allowed
-r = _run("preToolUse", {
-    "toolName": "create",
-    "toolArgs": {
-        "path": "docs/notes.md",
-        "file_text": "<!-- dangerouslySetInnerHTML is dangerous -->",
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "create",
+        "toolArgs": {
+            "path": "docs/notes.md",
+            "file_text": "<!-- dangerouslySetInnerHTML is dangerous -->",
+        },
     },
-})
-test("dangerouslySetInnerHTML in .md → allowed (non-JS)", '"deny"' not in r.stdout,
-     f"stdout={r.stdout[:200]}")
+)
+test("dangerouslySetInnerHTML in .md → allowed (non-JS)", '"deny"' not in r.stdout, f"stdout={r.stdout[:200]}")
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -151,40 +167,44 @@ test("dangerouslySetInnerHTML in .md → allowed (non-JS)", '"deny"' not in r.st
 print("\n🔧 Section 3: syntax-gate via hook_runner subprocess")
 
 # 3a. create with invalid Python → deny
-r = _run("preToolUse", {
-    "toolName": "create",
-    "toolArgs": {
-        "path": "broken.py",
-        "file_text": "def foo(\n    syntactically broken !!!",
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "create",
+        "toolArgs": {
+            "path": "broken.py",
+            "file_text": "def foo(\n    syntactically broken !!!",
+        },
     },
-})
-test("create invalid Python → deny JSON", '"deny"' in r.stdout,
-     f"stdout={r.stdout[:300]}")
-test("Syntax denial mentions SyntaxError or syntax",
-     "yntax" in r.stdout,
-     f"stdout={r.stdout[:300]}")
+)
+test("create invalid Python → deny JSON", '"deny"' in r.stdout, f"stdout={r.stdout[:300]}")
+test("Syntax denial mentions SyntaxError or syntax", "yntax" in r.stdout, f"stdout={r.stdout[:300]}")
 
 # 3b. create with valid Python → allowed
-r = _run("preToolUse", {
-    "toolName": "create",
-    "toolArgs": {
-        "path": "valid.py",
-        "file_text": "def greet(name: str) -> str:\n    return f'Hello, {name}'\n",
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "create",
+        "toolArgs": {
+            "path": "valid.py",
+            "file_text": "def greet(name: str) -> str:\n    return f'Hello, {name}'\n",
+        },
     },
-})
-test("create valid Python → allowed (no deny)", '"deny"' not in r.stdout,
-     f"stdout={r.stdout[:200]}")
+)
+test("create valid Python → allowed (no deny)", '"deny"' not in r.stdout, f"stdout={r.stdout[:200]}")
 
 # 3c. create non-Python file (even with bad syntax) → allowed
-r = _run("preToolUse", {
-    "toolName": "create",
-    "toolArgs": {
-        "path": "data.json",
-        "file_text": "{this is not valid json!!!}",
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "create",
+        "toolArgs": {
+            "path": "data.json",
+            "file_text": "{this is not valid json!!!}",
+        },
     },
-})
-test("create invalid JSON (non-Python) → allowed", '"deny"' not in r.stdout,
-     f"stdout={r.stdout[:200]}")
+)
+test("create invalid JSON (non-Python) → allowed", '"deny"' not in r.stdout, f"stdout={r.stdout[:200]}")
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -194,30 +214,45 @@ test("create invalid JSON (non-Python) → allowed", '"deny"' not in r.stdout,
 print("\n📦 Section 4: pnpm-lockfile-guard via hook_runner subprocess")
 
 # 4a. git status command (not commit) → allowed
-r = _run("preToolUse", {
-    "toolName": "bash",
-    "toolArgs": {"command": "git status"},
-})
-test("git status → pnpm guard doesn't trigger", '"permissionDecision"' not in r.stdout or '"deny"' not in r.stdout,
-     f"stdout={r.stdout[:200]}")
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "bash",
+        "toolArgs": {"command": "git status"},
+    },
+)
+test(
+    "git status → pnpm guard doesn't trigger",
+    '"permissionDecision"' not in r.stdout or '"deny"' not in r.stdout,
+    f"stdout={r.stdout[:200]}",
+)
 
 # 4b. Non-bash tool → allowed (guard only on bash)
-r = _run("preToolUse", {
-    "toolName": "view",
-    "toolArgs": {"path": "browse-ui/package.json"},
-})
-test("view tool → no lockfile guard (not bash)", '"deny"' not in r.stdout,
-     f"stdout={r.stdout[:200]}")
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "view",
+        "toolArgs": {"path": "browse-ui/package.json"},
+    },
+)
+test("view tool → no lockfile guard (not bash)", '"deny"' not in r.stdout, f"stdout={r.stdout[:200]}")
 
 # 4c. git commit command — without real git state, subprocess call returns safely
 # (no staged files in isolated env → allow is expected)
-r = _run("preToolUse", {
-    "toolName": "bash",
-    "toolArgs": {"command": "git commit -m 'test'"},
-}, env={**_ISOLATED_ENV})
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "bash",
+        "toolArgs": {"command": "git commit -m 'test'"},
+    },
+    env={**_ISOLATED_ENV},
+)
 # In the isolated home there are no staged files, so the guard should allow.
-test("git commit with no staged files in isolated env → no lockfile deny", '"deny"' not in r.stdout or "pnpm" not in r.stdout,
-     f"stdout={r.stdout[:300]}")
+test(
+    "git commit with no staged files in isolated env → no lockfile deny",
+    '"deny"' not in r.stdout or "pnpm" not in r.stdout,
+    f"stdout={r.stdout[:300]}",
+)
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -237,20 +272,30 @@ _nj_env = {**os.environ, "HOME": str(_nj_isolated), "USERPROFILE": str(_nj_isola
 
 try:
     # 5a. 6th browse-ui .ts edit → should fire reminder
-    r = _run("postToolUse", {
-        "toolName": "edit",
-        "toolArgs": {"path": "browse-ui/src/api/types.ts"},
-    }, env=_nj_env)
-    test("6th browse-ui .ts edit → typecheck reminder output", "typecheck" in r.stdout or "pnpm" in r.stdout,
-         f"stdout={r.stdout[:300]}")
+    r = _run(
+        "postToolUse",
+        {
+            "toolName": "edit",
+            "toolArgs": {"path": "browse-ui/src/api/types.ts"},
+        },
+        env=_nj_env,
+    )
+    test(
+        "6th browse-ui .ts edit → typecheck reminder output",
+        "typecheck" in r.stdout or "pnpm" in r.stdout,
+        f"stdout={r.stdout[:300]}",
+    )
 
     # 5b. Non-browse-ui .ts file → no reminder
-    r = _run("postToolUse", {
-        "toolName": "edit",
-        "toolArgs": {"path": "src/utils.ts"},
-    }, env=_nj_env)
-    test("Non-browse-ui .ts file → no typecheck reminder", "typecheck" not in r.stdout,
-         f"stdout={r.stdout[:300]}")
+    r = _run(
+        "postToolUse",
+        {
+            "toolName": "edit",
+            "toolArgs": {"path": "src/utils.ts"},
+        },
+        env=_nj_env,
+    )
+    test("Non-browse-ui .ts file → no typecheck reminder", "typecheck" not in r.stdout, f"stdout={r.stdout[:300]}")
 finally:
     shutil.rmtree(_nj_isolated, ignore_errors=True)
 
@@ -262,25 +307,32 @@ finally:
 print("\n🔍 Section 6: error-kb via hook_runner subprocess")
 
 # 6a. errorOccurred with no query_script → no crash, exit 0
-r = _run("errorOccurred", {
-    "error": "ModuleNotFoundError: No module named 'nonexistent'",
-    "toolName": "bash",
-})
-test("errorOccurred with error message → no crash (exit 0)", r.returncode == 0,
-     f"rc={r.returncode} stderr={r.stderr[:200]}")
+r = _run(
+    "errorOccurred",
+    {
+        "error": "ModuleNotFoundError: No module named 'nonexistent'",
+        "toolName": "bash",
+    },
+)
+test(
+    "errorOccurred with error message → no crash (exit 0)",
+    r.returncode == 0,
+    f"rc={r.returncode} stderr={r.stderr[:200]}",
+)
 
 # 6b. errorOccurred with dict error → no crash
-r = _run("errorOccurred", {
-    "error": {"message": "AttributeError: 'NoneType' object has no attribute 'strip'"},
-    "toolName": "bash",
-})
-test("errorOccurred with dict error → no crash", r.returncode == 0,
-     f"rc={r.returncode} stderr={r.stderr[:200]}")
+r = _run(
+    "errorOccurred",
+    {
+        "error": {"message": "AttributeError: 'NoneType' object has no attribute 'strip'"},
+        "toolName": "bash",
+    },
+)
+test("errorOccurred with dict error → no crash", r.returncode == 0, f"rc={r.returncode} stderr={r.stderr[:200]}")
 
 # 6c. errorOccurred with empty error → no crash
 r = _run("errorOccurred", {"error": "", "toolName": "bash"})
-test("errorOccurred with empty error → no crash", r.returncode == 0,
-     f"rc={r.returncode} stderr={r.stderr[:200]}")
+test("errorOccurred with empty error → no crash", r.returncode == 0, f"rc={r.returncode} stderr={r.stderr[:200]}")
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -296,54 +348,82 @@ _sa_markers.mkdir(parents=True, exist_ok=True)
 # Pre-create briefing marker so enforce-briefing doesn't block the bash tests
 (_sa_markers / "briefing-done").write_text("test-briefing-done", encoding="utf-8")
 _sa_marker_file = _sa_markers / "dispatched-subagent-active"
-_sa_marker_payload = json.dumps({
-    "ts": int(time.time()),
-    "active_tentacles": ["hook-entrypoints-tentacle"],
-})
+_sa_marker_payload = json.dumps(
+    {
+        "ts": int(time.time()),
+        "active_tentacles": ["hook-entrypoints-tentacle"],
+    }
+)
 _sa_marker_file.write_text(_sa_marker_payload, encoding="utf-8")
 _sa_env = {**os.environ, "HOME": str(_sa_isolated), "USERPROFILE": str(_sa_isolated)}
 
 try:
     # 7a. git commit with marker present (no HMAC secret → fall back to existence check)
-    r = _run("preToolUse", {
-        "toolName": "bash",
-        "toolArgs": {"command": "git commit -m 'blocked by guard'"},
-    }, env=_sa_env)
+    r = _run(
+        "preToolUse",
+        {
+            "toolName": "bash",
+            "toolArgs": {"command": "git commit -m 'blocked by guard'"},
+        },
+        env=_sa_env,
+    )
     # verify_marker falls back to existence-only when no secret configured
     # so the marker IS recognised → guard should block
-    test("git commit with subagent marker → deny or exit non-zero",
-         '"deny"' in r.stdout or r.returncode != 0,
-         f"rc={r.returncode}, stdout={r.stdout[:300]}")
+    test(
+        "git commit with subagent marker → deny or exit non-zero",
+        '"deny"' in r.stdout or r.returncode != 0,
+        f"rc={r.returncode}, stdout={r.stdout[:300]}",
+    )
 
     # 7b. git push with marker present → also blocked
-    r = _run("preToolUse", {
-        "toolName": "bash",
-        "toolArgs": {"command": "git push origin feature"},
-    }, env=_sa_env)
-    test("git push with subagent marker → deny or exit non-zero",
-         '"deny"' in r.stdout or r.returncode != 0,
-         f"rc={r.returncode}, stdout={r.stdout[:300]}")
+    r = _run(
+        "preToolUse",
+        {
+            "toolName": "bash",
+            "toolArgs": {"command": "git push origin feature"},
+        },
+        env=_sa_env,
+    )
+    test(
+        "git push with subagent marker → deny or exit non-zero",
+        '"deny"' in r.stdout or r.returncode != 0,
+        f"rc={r.returncode}, stdout={r.stdout[:300]}",
+    )
 
     # 7c. Non-git command with marker present → allowed
-    r = _run("preToolUse", {
-        "toolName": "bash",
-        "toolArgs": {"command": "python3 test_fixes.py"},
-    }, env=_sa_env)
-    test("Non-git command with marker → allowed (no deny)", '"deny"' not in r.stdout,
-         f"stdout={r.stdout[:200]}")
+    r = _run(
+        "preToolUse",
+        {
+            "toolName": "bash",
+            "toolArgs": {"command": "python3 test_fixes.py"},
+        },
+        env=_sa_env,
+    )
+    test("Non-git command with marker → allowed (no deny)", '"deny"' not in r.stdout, f"stdout={r.stdout[:200]}")
 
     # 7d. Stale marker file (no active_tentacles) → allowed (zombie)
-    _sa_marker_file.write_text(json.dumps({
-        "ts": int(time.time()),
-        "active_tentacles": [],
-    }), encoding="utf-8")
-    r = _run("preToolUse", {
-        "toolName": "bash",
-        "toolArgs": {"command": "git commit -m 'zombie check'"},
-    }, env=_sa_env)
-    test("Zombie marker (empty active_tentacles) → allowed",
-         '"deny"' not in r.stdout or "SUBAGENT" not in r.stdout,
-         f"stdout={r.stdout[:300]}")
+    _sa_marker_file.write_text(
+        json.dumps(
+            {
+                "ts": int(time.time()),
+                "active_tentacles": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    r = _run(
+        "preToolUse",
+        {
+            "toolName": "bash",
+            "toolArgs": {"command": "git commit -m 'zombie check'"},
+        },
+        env=_sa_env,
+    )
+    test(
+        "Zombie marker (empty active_tentacles) → allowed",
+        '"deny"' not in r.stdout or "SUBAGENT" not in r.stdout,
+        f"stdout={r.stdout[:300]}",
+    )
 
 finally:
     shutil.rmtree(_sa_isolated, ignore_errors=True)
@@ -357,19 +437,22 @@ print("\n🔚 Section 8: session-end via hook_runner subprocess")
 
 # 8a. sessionEnd event → no crash, exit 0
 r = _run("sessionEnd", {"reason": "normal_exit"})
-test("sessionEnd event → no crash (exit 0)", r.returncode == 0,
-     f"rc={r.returncode} stderr={r.stderr[:200]}")
+test("sessionEnd event → no crash (exit 0)", r.returncode == 0, f"rc={r.returncode} stderr={r.stderr[:200]}")
 
 # 8b. sessionEnd event with unknown reason → no crash
 r = _run("sessionEnd", {"reason": "unexpected_disconnect"})
-test("sessionEnd with unexpected_disconnect → no crash", r.returncode == 0,
-     f"rc={r.returncode} stderr={r.stderr[:200]}")
+test(
+    "sessionEnd with unexpected_disconnect → no crash", r.returncode == 0, f"rc={r.returncode} stderr={r.stderr[:200]}"
+)
 
 # 8c. sessionEnd with no goal.json present → no crash (fail-open path)
 #     Even though there is no active goal, the hook must exit 0.
 r = _run("sessionEnd", {"reason": "no_active_goal"})
-test("sessionEnd with no active goal → no crash (exit 0)", r.returncode == 0,
-     f"rc={r.returncode} stderr={r.stderr[:200]}")
+test(
+    "sessionEnd with no active goal → no crash (exit 0)",
+    r.returncode == 0,
+    f"rc={r.returncode} stderr={r.stderr[:200]}",
+)
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -379,10 +462,13 @@ test("sessionEnd with no active goal → no crash (exit 0)", r.returncode == 0,
 print("\n🔗 Section 9: Multiple rules — no cross-contamination")
 
 # 9a. preToolUse payload that triggers block-edit-dist should NOT also mention syntax errors
-r = _run("preToolUse", {
-    "toolName": "edit",
-    "toolArgs": {"path": "browse-ui/dist/app.js", "old_str": "x", "new_str": "y"},
-})
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "edit",
+        "toolArgs": {"path": "browse-ui/dist/app.js", "old_str": "x", "new_str": "y"},
+    },
+)
 deny_reason = ""
 if r.stdout:
     try:
@@ -390,17 +476,19 @@ if r.stdout:
         deny_reason = out.get("permissionDecisionReason", "")
     except Exception:
         deny_reason = r.stdout
-test("block-edit-dist deny does not mention SyntaxError",
-     "SyntaxError" not in deny_reason,
-     f"reason={deny_reason[:200]}")
+test(
+    "block-edit-dist deny does not mention SyntaxError", "SyntaxError" not in deny_reason, f"reason={deny_reason[:200]}"
+)
 
 # 9b. Valid edit targeting a src/ file should not trigger any deny
-r = _run("preToolUse", {
-    "toolName": "edit",
-    "toolArgs": {"path": "src/utils.py", "old_str": "x = 1", "new_str": "x = 2"},
-})
-test("Edit src/utils.py → no deny from any rule", '"deny"' not in r.stdout,
-     f"stdout={r.stdout[:200]}")
+r = _run(
+    "preToolUse",
+    {
+        "toolName": "edit",
+        "toolArgs": {"path": "src/utils.py", "old_str": "x = 1", "new_str": "x = 2"},
+    },
+)
+test("Edit src/utils.py → no deny from any rule", '"deny"' not in r.stdout, f"stdout={r.stdout[:200]}")
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -438,12 +526,17 @@ try:
         cwd=str(_mi_cwd),
         timeout=15,
     )
-    test("10a: sessionStart with fresh MEMORY.md → exit 0", r.returncode == 0,
-         f"rc={r.returncode} stderr={r.stderr[:200]}")
+    test(
+        "10a: sessionStart with fresh MEMORY.md → exit 0",
+        r.returncode == 0,
+        f"rc={r.returncode} stderr={r.stderr[:200]}",
+    )
     _combined_output10a = r.stdout + r.stderr
-    test("10a: sessionStart output contains 'MEMORY'",
-         "MEMORY" in _combined_output10a or "parameterised SQL" in _combined_output10a,
-         f"stdout={r.stdout[:400]}")
+    test(
+        "10a: sessionStart output contains 'MEMORY'",
+        "MEMORY" in _combined_output10a or "parameterised SQL" in _combined_output10a,
+        f"stdout={r.stdout[:400]}",
+    )
 finally:
     shutil.rmtree(str(_mi_isolated), ignore_errors=True)
     shutil.rmtree(str(_mi_cwd), ignore_errors=True)
@@ -453,6 +546,7 @@ _mi2_isolated = Path(tempfile.mkdtemp(prefix="test-mi2-ep-home-"))
 (_mi2_isolated / ".copilot" / "markers").mkdir(parents=True, exist_ok=True)
 # Write hooks-config.json with injection disabled
 import json as _json10b
+
 (_mi2_isolated / ".copilot" / "hooks-config.json").write_text(
     _json10b.dumps({"memory_inject_enabled": False}), encoding="utf-8"
 )
@@ -472,11 +566,12 @@ try:
         cwd=str(_mi2_cwd),
         timeout=15,
     )
-    test("10b: sessionStart memory_inject_enabled=false → exit 0", r.returncode == 0,
-         f"rc={r.returncode}")
-    test("10b: disabled injection → memory text not in output",
-         "This must NOT appear." not in r.stdout,
-         f"stdout={r.stdout[:400]}")
+    test("10b: sessionStart memory_inject_enabled=false → exit 0", r.returncode == 0, f"rc={r.returncode}")
+    test(
+        "10b: disabled injection → memory text not in output",
+        "This must NOT appear." not in r.stdout,
+        f"stdout={r.stdout[:400]}",
+    )
 finally:
     shutil.rmtree(str(_mi2_isolated), ignore_errors=True)
     shutil.rmtree(str(_mi2_cwd), ignore_errors=True)
@@ -499,8 +594,11 @@ try:
         cwd=str(_mi3_cwd),
         timeout=15,
     )
-    test("10c: sessionStart without MEMORY.md → no crash (exit 0)", r.returncode == 0,
-         f"rc={r.returncode} stderr={r.stderr[:200]}")
+    test(
+        "10c: sessionStart without MEMORY.md → no crash (exit 0)",
+        r.returncode == 0,
+        f"rc={r.returncode} stderr={r.stderr[:200]}",
+    )
 finally:
     shutil.rmtree(str(_mi3_isolated), ignore_errors=True)
     shutil.rmtree(str(_mi3_cwd), ignore_errors=True)
@@ -509,8 +607,7 @@ finally:
 _mi4_isolated = Path(tempfile.mkdtemp(prefix="test-mi4-ep-home-"))
 (_mi4_isolated / ".copilot" / "markers").mkdir(parents=True, exist_ok=True)
 (_mi4_isolated / ".copilot" / "hooks-config.json").write_text(
-    _json10b.dumps({"memory_inject_enabled": True, "memory_inject_max_tokens": 5}),
-    encoding="utf-8"
+    _json10b.dumps({"memory_inject_enabled": True, "memory_inject_max_tokens": 5}), encoding="utf-8"
 )
 _mi4_cwd = Path(tempfile.mkdtemp(prefix="test-mi4-cwd-"))
 (_mi4_cwd / "MEMORY.md").write_text("A" * 200, encoding="utf-8")
@@ -528,16 +625,16 @@ try:
         cwd=str(_mi4_cwd),
         timeout=15,
     )
-    test("10d: sessionStart memory_inject_max_tokens=5 → exit 0", r.returncode == 0,
-         f"rc={r.returncode}")
+    test("10d: sessionStart memory_inject_max_tokens=5 → exit 0", r.returncode == 0, f"rc={r.returncode}")
     _out10d = r.stdout + r.stderr
-    test("10d: output does not contain 200 'A's (content was truncated)",
-         "A" * 200 not in _out10d,
-         f"stdout={r.stdout[:400]}")
+    test(
+        "10d: output does not contain 200 'A's (content was truncated)",
+        "A" * 200 not in _out10d,
+        f"stdout={r.stdout[:400]}",
+    )
 finally:
     shutil.rmtree(str(_mi4_isolated), ignore_errors=True)
     shutil.rmtree(str(_mi4_cwd), ignore_errors=True)
-
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -557,13 +654,13 @@ _rt_env = {**os.environ, "HOME": str(_rt_isolated), "USERPROFILE": str(_rt_isola
 # Pre-populate session state so ReadTrackerRule will emit an info message on second read
 _rt_session_state = _rt_markers / "session-state-test-info-deny-sess"
 _rt_session_state.write_text(
-    json.dumps({
-        "files_read": {
-            "/repo/hooks/hook_runner.py": {"count": 1, "tokens": 50, "first_read": 1000000}
-        },
-        "total_tokens": 50,
-        "thresholds_warned": [],
-    }),
+    json.dumps(
+        {
+            "files_read": {"/repo/hooks/hook_runner.py": {"count": 1, "tokens": 50, "first_read": 1000000}},
+            "total_tokens": 50,
+            "thresholds_warned": [],
+        }
+    ),
     encoding="utf-8",
 )
 _rt_env2 = {**_rt_env, "COPILOT_AGENT_SESSION_ID": "test-info-deny-sess"}
@@ -571,18 +668,23 @@ _rt_env2 = {**_rt_env, "COPILOT_AGENT_SESSION_ID": "test-info-deny-sess"}
 try:
     # 11a. A preToolUse that yields only an info/warn (e.g. repeat read of a .py file)
     #      must NOT place that message on stdout — only stderr.
-    r11a = _run("preToolUse", {
-        "sessionId": "test-info-deny-sess",
-        "toolName": "view",
-        "toolArgs": {"path": "/repo/hooks/hook_runner.py"},
-    }, env=_rt_env2)
+    r11a = _run(
+        "preToolUse",
+        {
+            "sessionId": "test-info-deny-sess",
+            "toolName": "view",
+            "toolArgs": {"path": "/repo/hooks/hook_runner.py"},
+        },
+        env=_rt_env2,
+    )
     test(
         "11a: preToolUse info message → stdout is empty or pure JSON (no plain text)",
         r11a.stdout == "" or r11a.stdout.strip().startswith("{"),
         f"stdout={r11a.stdout[:300]!r}",
     )
     test(
-        "11a: preToolUse info message exit code 0 (no deny)", r11a.returncode == 0,
+        "11a: preToolUse info message exit code 0 (no deny)",
+        r11a.returncode == 0,
         f"rc={r11a.returncode}",
     )
 
@@ -591,15 +693,19 @@ try:
     #      Note: ReadTrackerRule only fires on `view`, not `edit`, so no info message
     #      is emitted here — this test verifies the stdout JSON channel is clean for
     #      deny-only scenarios (no plain text mixed into stdout before the deny JSON).
-    r11b = _run("preToolUse", {
-        "sessionId": "test-info-deny-sess",
-        "toolName": "edit",
-        "toolArgs": {
-            "path": "browse-ui/dist/bundle.js",
-            "old_str": "a",
-            "new_str": "b",
+    r11b = _run(
+        "preToolUse",
+        {
+            "sessionId": "test-info-deny-sess",
+            "toolName": "edit",
+            "toolArgs": {
+                "path": "browse-ui/dist/bundle.js",
+                "old_str": "a",
+                "new_str": "b",
+            },
         },
-    }, env=_rt_env2)
+        env=_rt_env2,
+    )
     # stdout must contain exactly one parseable JSON object
     stdout_lines = [ln for ln in r11b.stdout.splitlines() if ln.strip()]
     parseable = False
@@ -637,6 +743,201 @@ except Exception as e:
     test("Section 11 ran without exception", False, str(e))
 finally:
     shutil.rmtree(_rt_isolated, ignore_errors=True)
+
+
+# ══════════════════════════════════════════════════════════════════════
+#  Section 12: sessionStart paused-goal resume banner (issue #185)
+# ══════════════════════════════════════════════════════════════════════
+
+print("\n⏸️  Section 12: sessionStart paused-goal resume banner via hook_runner (issue #185)")
+
+import json as _json12  # noqa: E402 (already imported, re-alias for clarity below)
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _make_12_home(prefix: str) -> "tuple[Path, dict]":
+    """Create an isolated HOME with a dummy briefing.py and markers dir."""
+    home = Path(tempfile.mkdtemp(prefix=prefix))
+    markers = home / ".copilot" / "markers"
+    markers.mkdir(parents=True, exist_ok=True)
+    # Pre-sign briefing-done so EnforceBriefingRule never blocks
+    (markers / "briefing-done").write_text("test-briefing-done", encoding="utf-8")
+    tools = home / ".copilot" / "tools"
+    tools.mkdir(parents=True, exist_ok=True)
+    # Minimal dummy so AutoBriefingRule.evaluate() doesn't early-exit
+    (tools / "briefing.py").write_text(
+        "# dummy briefing\nimport sys\nprint('dummy-briefing-output')\n",
+        encoding="utf-8",
+    )
+    env = {**os.environ, "HOME": str(home), "USERPROFILE": str(home)}
+    return home, env
+
+
+def _make_12_cwd(
+    home: Path,
+    goal_status: "str | None" = "paused",
+    goal_title: str = "Test Paused Goal",
+    pause_reason: str = "session_end:normal",
+    include_breadcrumb: bool = True,
+) -> Path:
+    """Create a temp cwd with .octogent/breadcrumb and goal.json.
+
+    goal_status=None skips goal.json creation (breadcrumb points at non-existent file).
+    include_breadcrumb=False skips breadcrumb creation entirely.
+    """
+    cwd = Path(tempfile.mkdtemp(prefix="test12-cwd-"))
+    octogent = cwd / ".octogent"
+    octogent.mkdir(parents=True, exist_ok=True)
+    if include_breadcrumb:
+        goal_json_path = str(octogent / "goal.json")
+        bc = {
+            "goal_title": goal_title,
+            "goal_id": "g12",
+            "pause_reason": pause_reason,
+            "resume_command": "sk tentacle goal resume",
+            "paused_at": "2026-01-01T00:00:00Z",
+            "goal_path": goal_json_path,
+        }
+        (octogent / "goal-resume-breadcrumb.json").write_text(_json12.dumps(bc), encoding="utf-8")
+    if goal_status is not None:
+        goal_state = {"status": goal_status, "title": goal_title, "goal_id": "g12"}
+        (octogent / "goal.json").write_text(_json12.dumps(goal_state), encoding="utf-8")
+    return cwd
+
+
+# ── 12a: paused breadcrumb + paused goal → banner before briefing header ──
+
+_h12a, _e12a = _make_12_home("test12a-home-")
+_cwd12a = _make_12_cwd(_h12a, goal_status="paused", goal_title="My Wave16 Goal")
+try:
+    r12a = subprocess.run(
+        [sys.executable, str(RUNNER), "sessionStart"],
+        input=json.dumps({"sessionId": "test-resume-sess-12a"}),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=_e12a,
+        cwd=str(_cwd12a),
+        timeout=15,
+    )
+    test(
+        "12a: sessionStart with paused breadcrumb → exit 0",
+        r12a.returncode == 0,
+        f"rc={r12a.returncode} stderr={r12a.stderr[:200]}",
+    )
+    _out12a = r12a.stdout + r12a.stderr
+    test(
+        "12a: resume banner present (Paused goal)",
+        "Paused goal" in _out12a or "My Wave16 Goal" in _out12a,
+        f"combined={_out12a[:500]!r}",
+    )
+    test("12a: Session briefing header present", "Session briefing" in _out12a, f"combined={_out12a[:500]!r}")
+    # Order check: "Paused goal" must appear BEFORE "Session briefing"
+    _idx_banner = _out12a.find("Paused goal")
+    if _idx_banner == -1:
+        _idx_banner = _out12a.find("My Wave16 Goal")
+    _idx_header = _out12a.find("Session briefing")
+    test(
+        "12a: resume banner appears BEFORE Session briefing header",
+        0 <= _idx_banner < _idx_header,
+        f"banner_pos={_idx_banner} header_pos={_idx_header} out={_out12a[:500]!r}",
+    )
+    test("12a: resume command present in banner", "sk tentacle goal resume" in _out12a, f"combined={_out12a[:500]!r}")
+finally:
+    shutil.rmtree(str(_h12a), ignore_errors=True)
+    shutil.rmtree(str(_cwd12a), ignore_errors=True)
+
+# ── 12b: breadcrumb present but goal is active (already resumed) → banner suppressed ──
+
+_h12b, _e12b = _make_12_home("test12b-home-")
+_cwd12b = _make_12_cwd(_h12b, goal_status="active", goal_title="Resumed Goal")
+try:
+    r12b = subprocess.run(
+        [sys.executable, str(RUNNER), "sessionStart"],
+        input=json.dumps({"sessionId": "test-resume-sess-12b"}),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=_e12b,
+        cwd=str(_cwd12b),
+        timeout=15,
+    )
+    test(
+        "12b: sessionStart with stale breadcrumb → exit 0",
+        r12b.returncode == 0,
+        f"rc={r12b.returncode} stderr={r12b.stderr[:200]}",
+    )
+    _out12b = r12b.stdout + r12b.stderr
+    test(
+        "12b: banner suppressed when goal already resumed (active)",
+        "Paused goal" not in _out12b,
+        f"unexpected banner in combined={_out12b[:500]!r}",
+    )
+    test("12b: Session briefing header still present", "Session briefing" in _out12b, f"combined={_out12b[:500]!r}")
+finally:
+    shutil.rmtree(str(_h12b), ignore_errors=True)
+    shutil.rmtree(str(_cwd12b), ignore_errors=True)
+
+# ── 12c: breadcrumb absent → no banner, normal exit 0 ────────────────
+
+_h12c, _e12c = _make_12_home("test12c-home-")
+_cwd12c = _make_12_cwd(_h12c, include_breadcrumb=False)
+try:
+    r12c = subprocess.run(
+        [sys.executable, str(RUNNER), "sessionStart"],
+        input=json.dumps({"sessionId": "test-resume-sess-12c"}),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=_e12c,
+        cwd=str(_cwd12c),
+        timeout=15,
+    )
+    test(
+        "12c: sessionStart without breadcrumb → exit 0",
+        r12c.returncode == 0,
+        f"rc={r12c.returncode} stderr={r12c.stderr[:200]}",
+    )
+    _out12c = r12c.stdout + r12c.stderr
+    test("12c: no resume banner when breadcrumb absent", "Paused goal" not in _out12c, f"combined={_out12c[:400]!r}")
+finally:
+    shutil.rmtree(str(_h12c), ignore_errors=True)
+    shutil.rmtree(str(_cwd12c), ignore_errors=True)
+
+# ── 12d: breadcrumb present, goal.json absent → fail-open (banner shown) ──
+
+_h12d, _e12d = _make_12_home("test12d-home-")
+_cwd12d = _make_12_cwd(_h12d, goal_status=None, goal_title="Fail-Open Goal")
+try:
+    r12d = subprocess.run(
+        [sys.executable, str(RUNNER), "sessionStart"],
+        input=json.dumps({"sessionId": "test-resume-sess-12d"}),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=_e12d,
+        cwd=str(_cwd12d),
+        timeout=15,
+    )
+    test(
+        "12d: sessionStart with breadcrumb but no goal.json → exit 0",
+        r12d.returncode == 0,
+        f"rc={r12d.returncode} stderr={r12d.stderr[:200]}",
+    )
+    _out12d = r12d.stdout + r12d.stderr
+    test(
+        "12d: banner shown fail-open when goal.json absent",
+        "Paused goal" in _out12d or "Fail-Open Goal" in _out12d,
+        f"combined={_out12d[:500]!r}",
+    )
+finally:
+    shutil.rmtree(str(_h12d), ignore_errors=True)
+    shutil.rmtree(str(_cwd12d), ignore_errors=True)
 
 
 # ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add paused-goal resume hints on sessionStart in Python and native Rust paths
- keep Python/native parity for stale and malformed breadcrumb or goal state inputs
- extend regression coverage and operator docs for the new sessionStart behavior

Closes #185