### PR TITLE
feat: track quota-blocked tentacle retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Quota-blocked handoff metadata and retry queue (#187):**
+  - `tentacle.py`: `_classify_quota_signal(text)` — classifies raw dispatch output into a machine-readable `quota_reason` token (`rate_limit`, `quota_exceeded`, `daily_quota`, `monthly_quota`, `token_quota`, `context_limit`). Pattern list is intentionally minimal pending `#183`.
+  - `tentacle.py handoff` gains `--quota-reason <reason>` and `--retry-hint <hint>` optional flags for `BLOCKED` handoffs. These serialize as `QUOTA_REASON:` / `RETRY_HINT:` lines in `handoff.md`.
+  - `tentacle.py`: `_parse_handoff_quota_metadata(content)` extracts `(quota_reason, retry_hint)` from the most recent handoff section. Old `BLOCKED` handoffs without these lines are fully backward compatible.
+  - `tentacle.py complete`: when a tentacle's handoff carries `quota_reason`, `meta.json` gains `quota_reason` and `retry_hint` fields, and an entry is appended to `goal.json["quota_retry_queue"]` for orchestrator tracking.
+  - `tentacle.py goal next-iter`: quota-blocked tentacles (BLOCKED + `quota_reason`) are rendered with a 🚦 icon and quota hint, distinct from generic ⚠️ blocked tentacles. Quota retry queue summary is printed when non-empty. Recommendation advice is quota-aware.
+  - `browse/routes/tentacles.py`: `_parse_handoff_quota_metadata` added; each tentacle entry now includes optional `quota_reason` and `retry_hint` fields from `meta.json` (or live handoff for not-yet-completed tentacles).
+  - Docs updated: `docs/ARCHITECTURE.md` (handoff contract), `docs/USAGE.md` (quota-blocked operator flow), `docs/SYNC-MATRIX.md` (handoff field parity note).
+
 - **Agent Error Prevention System (5-phase implementation):**
   - **Phase 1 — Schema & Learn Enhancement:**
     - `migrate.py` v16: 7 new columns on `knowledge_entries` — `error_type`, `root_cause`, `severity`, `is_resolved`, `fix_steps`, `prevention_hook`, `recurrence_after_briefing`.

--- a/browse/routes/tentacles.py
+++ b/browse/routes/tentacles.py
@@ -46,6 +46,24 @@ def _marker_age_hours(marker_path: Path) -> float | None:
         return None
 
 
+def _find_allowlisted_status_section(sections: list) -> "str | None":
+    """Return the most-recent section whose STATUS: value is in _HANDOFF_STATUS_ALLOWLIST.
+
+    Shared helper used by both ``_parse_handoff_status`` and
+    ``_parse_handoff_quota_metadata`` so the two parsers always anchor to the
+    same section and cannot diverge when a later section carries an invalid
+    STATUS: value.
+
+    Returns None when no allowlisted section exists (backward-compat: legacy
+    free-form handoffs with no STATUS: line at all).
+    """
+    for section in reversed(sections):
+        m = re.search(r"^STATUS:\s*(\S+)", section, flags=re.MULTILINE)
+        if m and m.group(1) in _HANDOFF_STATUS_ALLOWLIST:
+            return section
+    return None
+
+
 def _parse_handoff_status(handoff_path: Path) -> str:
     try:
         if not handoff_path.is_file():
@@ -54,13 +72,46 @@ def _parse_handoff_status(handoff_path: Path) -> str:
     except Exception:
         return ""
     sections = re.split(r"^## \[", handoff_content, flags=re.MULTILINE)
-    for section in reversed(sections):
-        m = re.search(r"^STATUS:\s*(\S+)", section, flags=re.MULTILINE)
-        if m:
-            status = m.group(1)
-            if status in _HANDOFF_STATUS_ALLOWLIST:
-                return status
-    return ""
+    section = _find_allowlisted_status_section(sections)
+    if section is None:
+        return ""
+    m = re.search(r"^STATUS:\s*(\S+)", section, flags=re.MULTILINE)
+    return m.group(1) if m else ""
+
+
+def _parse_handoff_quota_metadata(handoff_path: Path) -> tuple:
+    """Return ``(quota_reason, retry_hint)`` from the same handoff section that wins
+    the status parse (most-recent section with a ``STATUS:`` line).
+
+    Anchoring quota to the status-winning section ensures status and quota metadata
+    always refer to the same handoff entry.  A status-free progress note appended
+    after a BLOCKED+quota section therefore cannot silently clear the quota fields.
+
+    Falls back to the most-recent non-empty section for legacy free-form handoffs.
+    Returns ``("", "")`` when absent (backward compatible).
+    """
+    try:
+        if not handoff_path.is_file():
+            return "", ""
+        content = handoff_path.read_text(encoding="utf-8")
+    except Exception:
+        return "", ""
+    sections = re.split(r"^## \[", content, flags=re.MULTILINE)
+    # Anchor to the same allowlisted section that wins the status parse (bug #187 fix).
+    target = _find_allowlisted_status_section(sections)
+    # Backward-compat fallback: legacy free-form handoffs with no valid STATUS: line.
+    if target is None:
+        target = next((s for s in reversed(sections) if s.strip()), None)
+    if target is None:
+        return "", ""
+    reason_m = re.search(r"^QUOTA_REASON:\s*(.+)", target, flags=re.MULTILINE)
+    hint_m = re.search(r"^RETRY_HINT:\s*(.+)", target, flags=re.MULTILINE)
+    if reason_m or hint_m:
+        return (
+            reason_m.group(1).strip() if reason_m else "",
+            hint_m.group(1).strip() if hint_m else "",
+        )
+    return "", ""
 
 
 def _read_tentacles() -> list[dict]:
@@ -142,6 +193,20 @@ def _read_tentacles() -> list[dict]:
             if not terminal_status and has_handoff:
                 terminal_status = _parse_handoff_status(handoff_path)
 
+            # Quota metadata: prefer meta.json (written by cmd_complete), fall back
+            # to live handoff parse for tentacles not yet completed.
+            # Guard: never surface quota metadata for non-BLOCKED tentacles even if
+            # stale keys exist on disk from an earlier BLOCKED completion.
+            quota_reason = ""
+            retry_hint = ""
+            if terminal_status == "BLOCKED":
+                quota_reason = str(meta.get("quota_reason") or "").strip()
+                retry_hint = str(meta.get("retry_hint") or "").strip()
+                if not quota_reason and has_handoff:
+                    _hq_reason, _hq_hint = _parse_handoff_quota_metadata(handoff_path)
+                    quota_reason = _hq_reason
+                    retry_hint = _hq_hint or retry_hint
+
             tentacle_entry: dict = {
                 "name": str(meta.get("name", "")),
                 "tentacle_id": str(meta.get("tentacle_id", "") or ""),
@@ -155,6 +220,10 @@ def _read_tentacles() -> list[dict]:
                 "has_handoff": has_handoff,
                 "terminal_status": terminal_status,
             }
+            if quota_reason:
+                tentacle_entry["quota_reason"] = quota_reason
+            if retry_hint:
+                tentacle_entry["retry_hint"] = retry_hint
             # Goal-aware optional fields (written by goal-core when tentacle is linked to a goal)
             if meta.get("goal_id"):
                 tentacle_entry["goal_id"] = str(meta["goal_id"])

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -210,6 +210,16 @@ tentacle.py handoff <name> "<summary>" --status DONE --changed-file <path> [--ch
 ```
 `--status` must be one of `DONE`, `BLOCKED`, `TOO_BIG`, `AMBIGUOUS`, or `REGRESSED`. Include one `--changed-file` receipt per modified file so the orchestrator can verify the handoff trail.
 
+**Quota-blocked handoffs** — when a tentacle is `BLOCKED` due to a quota or rate-limit signal, add machine-readable metadata:
+```
+tentacle.py handoff <name> "<summary>" --status BLOCKED \
+  --quota-reason rate_limit \
+  --retry-hint 2026-05-14T00:00:00Z
+```
+`--quota-reason` is a short token (`rate_limit`, `quota_exceeded`, `daily_quota`, `monthly_quota`, `token_quota`, `context_limit`). `--retry-hint` is an optional ISO timestamp or human-readable hint.  `cmd_complete` persists these fields into `meta.json["quota_reason"]` / `meta.json["retry_hint"]` and appends an entry to `goal.json["quota_retry_queue"]` for orchestrator tracking.  Old `BLOCKED` handoffs without quota metadata are fully backward compatible.
+
+`_classify_quota_signal(text)` is available to classify raw dispatch output into a `quota_reason` token. The pattern list is intentionally minimal pending the fuller failure-mode matrix (`#183`).
+
 `tentacle.py marker-cleanup` (dry-run by default, `--apply` to act) inspects and removes stale
 entries from the dispatched-subagent marker without completing a tentacle. Only entries whose
 per-entry timestamp exceeds the declared TTL are eligible; live entries are never touched.

--- a/docs/SYNC-MATRIX.md
+++ b/docs/SYNC-MATRIX.md
@@ -16,8 +16,15 @@
 | Skill or agent change | `docs/SKILLS.md` | — | skill catalog / `lint-skills.py` |
 | Sync config / runtime change | `docs/SKILLS.md` sync section | `learn.py decision` entry | `sync-status.py` output |
 | Tentacle complete | tentacle `handoff.md` | `tentacle.py complete` (auto-learns) | `tentacle.py status` |
+| **Tentacle handoff contract change** | `docs/ARCHITECTURE.md` + `docs/USAGE.md` | `learn.py pattern` entry | `browse/routes/tentacles.py` (mirror new fields) |
 | Test-only change | — | — | — |
 | Doc-only change | — | — | — |
+
+> **Handoff field parity note (#187):** new metadata fields in the `handoff.md` format
+> (`QUOTA_REASON:`, `RETRY_HINT:`) must be mirrored in both `tentacle.py` (parser +
+> `cmd_complete` + `cmd_handoff`) **and** `browse/routes/tentacles.py` (`_parse_handoff_quota_metadata`
+> + `_read_tentacles`).  When adding new structured handoff fields in future, update
+> both surfaces or the browse API will silently miss them.
 
 ---
 
@@ -28,7 +35,7 @@ Run through this before calling `task_complete`:
 ```
 1. Docs         — did behavior change? update docs/ accordingly
 2. Memory       — record mistakes / patterns: sk learn
-3. Handoff      — if inside a tentacle: sk tentacle handoff <name> "<summary>" --status <STATUS> [--changed-file <path>] --learn
+3. Handoff      — if inside a tentacle: sk tentacle handoff <name> "<summary>" --status <STATUS> [--changed-file <path>] [--quota-reason <reason>] [--retry-hint <hint>] --learn
 4. Tests        — run tests for any changed Python files
 5. Sync          — if sync config or runtime changed: sk sync status --health-check
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -476,6 +476,10 @@ python3 ~/.copilot/tools/tentacle.py status                # dashboard: all tent
 python3 ~/.copilot/tools/tentacle.py handoff api-export "Completed API export. OpenAPI schema written." \
   --status DONE --changed-file src/api/schema.py --changed-file src/api/auth.py --learn
 
+# 6b. Sub-agent: quota/rate-limit blocked — write BLOCKED handoff with quota metadata
+python3 ~/.copilot/tools/tentacle.py handoff api-export "Blocked: model rate limit hit." \
+  --status BLOCKED --quota-reason rate_limit --retry-hint 2026-05-14T00:00:00Z
+
 # 7. Orchestrator: verify results and close
 python3 ~/.copilot/tools/tentacle.py complete api-export   # marks done, auto-learns from handoff
 ```
@@ -667,7 +671,35 @@ Both flags can be used together in one command. In all cases:
 - Success-criteria pass/fail state is preserved — `goal resume` does not clear or re-run criteria.
 - Evaluation history is not truncated.
 
-### Success criteria
+### Quota-blocked tentacles
+
+When a dispatched agent hits a quota or rate-limit wall, it should write a `BLOCKED` handoff with machine-readable quota metadata:
+
+```bash
+# Sub-agent: blocked by quota
+sk tentacle handoff <name> "Rate limit hit — daily quota exhausted." \
+  --status BLOCKED --quota-reason rate_limit --retry-hint 2026-05-14T00:00:00Z
+# fallback: python3 ~/.copilot/tools/tentacle.py handoff <name> "..." \
+#   --status BLOCKED --quota-reason rate_limit --retry-hint 2026-05-14T00:00:00Z
+```
+
+`--quota-reason` tokens: `rate_limit`, `quota_exceeded`, `daily_quota`, `monthly_quota`, `token_quota`, `context_limit`.  
+`--retry-hint` is optional (ISO timestamp or human-readable string).
+
+When `cmd_complete` runs on the tentacle:
+- `quota_reason` and `retry_hint` are written into `meta.json` so `tentacle show` and the browse API surface them.
+- An entry is appended to `goal.json["quota_retry_queue"]` for orchestrator tracking.
+- `goal next-iter` shows quota-blocked tentacles with a 🚦 icon and distinct recommendation (vs generic ⚠️ BLOCKED tentacles).
+
+Orchestrator retry flow:
+```bash
+sk tentacle goal next-iter          # Shows 🚦 quota-blocked lane + retry queue
+# Wait for retry_hint window to pass
+sk tentacle goal resume --reset-failed   # Resets BLOCKED tentacles to idle
+sk tentacle dispatch <name>              # Re-dispatch after quota resets
+```
+
+
 
 ```bash
 # Add a verifiable success criterion

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -699,7 +699,7 @@ sk tentacle goal resume --reset-failed   # Resets BLOCKED tentacles to idle
 sk tentacle dispatch <name>              # Re-dispatch after quota resets
 ```
 
-
+### Success criteria
 
 ```bash
 # Add a verifiable success criterion

--- a/tentacle.py
+++ b/tentacle.py
@@ -2137,9 +2137,6 @@ def _remove_quota_retry_entry(tentacle_name: str, tentacles: Path) -> bool:
         return False
 
 
-
-
-
 def _positive_int_arg(value: str) -> int:
     """Argparse type that accepts only positive integers."""
     try:

--- a/tentacle.py
+++ b/tentacle.py
@@ -2098,7 +2098,8 @@ def _append_quota_retry_entry(
         if not isinstance(queue, list):
             queue = []
         # Upsert: remove any stale entry for this tentacle before appending.
-        queue = [e for e in queue if e.get("tentacle") != tentacle_name]
+        # Guard against malformed/non-dict legacy entries.
+        queue = [e for e in queue if isinstance(e, dict) and e.get("tentacle") != tentacle_name]
         queue.append(entry)
         state["quota_retry_queue"] = queue
         state["updated_at"] = datetime.now(timezone.utc).isoformat()
@@ -2116,25 +2117,84 @@ def _remove_quota_retry_entry(tentacle_name: str, tentacles: Path) -> bool:
     Called when a tentacle completes with a non-BLOCKED terminal status so the
     queue reflects only tentacles that are still pending retry.  Fail-open: if
     goal.json is absent or the entry is not present, returns False silently.
+
+    Returns True when an entry was found and removed, False when the entry was
+    absent or goal.json does not exist.
     """
     gp = _goal_path(tentacles)
     if not gp.exists():
         return False
 
+    removed: list[bool] = [False]
+
     def _apply(state: dict) -> None:
         queue: list = state.get("quota_retry_queue") or []
         if not isinstance(queue, list):
             return
-        updated = [e for e in queue if e.get("tentacle") != tentacle_name]
-        if len(updated) != len(queue):
+        # Guard against malformed/non-dict legacy entries.
+        updated = [e for e in queue if not (isinstance(e, dict) and e.get("tentacle") == tentacle_name)]
+        if len(updated) < len(queue):
+            removed[0] = True
             state["quota_retry_queue"] = updated
             state["updated_at"] = datetime.now(timezone.utc).isoformat()
 
     try:
         _goal_transact(tentacles, _apply)
-        return True
+        return removed[0]
     except Exception:
         return False
+
+
+def _write_dispatch_quota_blocked(
+    tentacle_name: str,
+    tentacles: Path,
+    quota_reason: str,
+) -> None:
+    """Write a synthetic BLOCKED handoff when the dispatch launcher exits with a quota signal.
+
+    Called by ``_goal_loop_dispatch_and_wait`` when the dispatch subprocess exits
+    with a non-zero code and its stderr contains a recognised quota/rate-limit
+    pattern.  Writes handoff.md, updates meta.json, and enqueues the tentacle in
+    ``goal.json["quota_retry_queue"]`` so the goal loop treats the tentacle as
+    resolved-error (BLOCKED) immediately rather than waiting for poll_timeout.
+    """
+    tentacle_dir = tentacles / tentacle_name
+    if not tentacle_dir.exists():
+        return
+
+    handoff_path = tentacle_dir / "handoff.md"
+    meta_path = tentacle_dir / "meta.json"
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    handoff_entry = (
+        f"\n## [{timestamp}]\n\n"
+        f"Dispatch launcher exited with quota/rate-limit signal (auto-detected).\n"
+        f"STATUS: BLOCKED\n"
+        f"QUOTA_REASON: {quota_reason}\n"
+    )
+    try:
+        with file_locked(handoff_path):
+            if handoff_path.exists():
+                existing = handoff_path.read_text(encoding="utf-8")
+                handoff_path.write_text(existing + handoff_entry, encoding="utf-8")
+            else:
+                handoff_path.write_text(f"# Handoff Notes\n{handoff_entry}", encoding="utf-8")
+    except OSError:
+        pass
+
+    try:
+        meta: dict = json.loads(meta_path.read_text(encoding="utf-8")) if meta_path.exists() else {}
+        meta["status"] = "completed"
+        meta["terminal_status"] = "BLOCKED"
+        meta["quota_reason"] = quota_reason
+        meta.pop("retry_hint", None)
+        meta["completed_at"] = datetime.now(timezone.utc).isoformat()
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+    _append_quota_retry_entry(tentacle_name, tentacles, quota_reason, None)
+    print(f"   \U0001f6a6 Dispatch quota-blocked: '{tentacle_name}' → BLOCKED ({quota_reason})")
 
 
 def _positive_int_arg(value: str) -> int:
@@ -2511,20 +2571,54 @@ def _goal_loop_dispatch_and_wait(
             dispatched_names.add(entry["name"])
             batch_dispatched.add(entry["name"])
             if _dispatch_fn is not None:
-                _dispatch_fn(cmd_str, entry["name"])
+                # Injection path (tests).  If the callable returns a non-empty
+                # string, treat it as stderr output for quota classification.
+                quota_output = _dispatch_fn(cmd_str, entry["name"])
+                if quota_output:
+                    quota_reason = _classify_quota_signal(str(quota_output))
+                    if quota_reason:
+                        _write_dispatch_quota_blocked(entry["name"], tentacles, quota_reason)
             else:
+                # Real subprocess path: write stderr to a bounded log file in
+                # the tentacle directory so we can classify quota signals without
+                # loading large agent output into memory (no capture_output, no PIPE).
+                returncode = 0
+                stderr_sample = ""
+                stderr_log = tentacles / entry["name"] / "_dispatch_err.log"
                 try:
-                    subprocess.run(
-                        argv,
-                        check=False,
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                        timeout=30,
-                    )
+                    with stderr_log.open("wb") as _flog:
+                        result = subprocess.run(
+                            argv,
+                            check=False,
+                            stdout=subprocess.DEVNULL,
+                            stderr=_flog,
+                            timeout=30,
+                        )
+                    returncode = result.returncode
+                    # Read at most 4 KiB for quota classification, then remove.
+                    try:
+                        stderr_sample = stderr_log.read_bytes()[:4096].decode("utf-8", errors="replace")
+                        stderr_log.unlink()
+                    except OSError:
+                        pass
                 except subprocess.TimeoutExpired:
                     print(f"   \u26a0\ufe0f  Dispatch timed out for '{entry['name']}'")
+                    try:
+                        stderr_log.unlink(missing_ok=True)
+                    except OSError:
+                        pass
                 except Exception as exc:
                     print(f"   \u26a0\ufe0f  Dispatch subprocess failed for '{entry['name']}': {exc}")
+                    returncode = -1
+                    try:
+                        stderr_log.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+                # Classify stderr for quota signal on non-zero exit only.
+                if returncode != 0 and stderr_sample:
+                    quota_reason = _classify_quota_signal(stderr_sample)
+                    if quota_reason:
+                        _write_dispatch_quota_blocked(entry["name"], tentacles, quota_reason)
 
         remaining_ready = plan["ready_total"] - len(plan["selected"])
         if remaining_ready > 0:
@@ -3476,11 +3570,27 @@ def _cmd_goal_resume(args, tentacles: Path) -> None:
                 t_meta["status"] = "idle"
                 t_meta.pop("terminal_status", None)
                 t_meta.pop("completed_at", None)
+                # Clear stale quota metadata when resetting so re-dispatched
+                # tentacles don't carry old quota_reason/retry_hint forward.
+                t_meta.pop("quota_reason", None)
+                t_meta.pop("retry_hint", None)
                 pending_meta_writes.append((meta_path, t_meta))
                 if needs_rewind:
                     rewound_names.add(name)
                 if needs_reset_failed:
                     reset_failed_names.add(name)
+
+        # Remove reset tentacles from quota_retry_queue so next-iter is accurate.
+        # This covers both --reset-failed and --from-iteration rewinds.
+        all_reset_names = rewound_names | reset_failed_names
+        if all_reset_names:
+            existing_queue: list = state.get("quota_retry_queue") or []
+            if isinstance(existing_queue, list) and existing_queue:
+                updated_queue = [
+                    e for e in existing_queue if isinstance(e, dict) and e.get("tentacle") not in all_reset_names
+                ]
+                if len(updated_queue) != len(existing_queue):
+                    state["quota_retry_queue"] = updated_queue
 
         if from_iteration is not None:
             state["iteration"] = from_iteration
@@ -3985,6 +4095,8 @@ def _cmd_goal_next_iter(args, tentacles: Path) -> None:
 
     # Quota retry queue summary.
     quota_queue: list = state.get("quota_retry_queue") or []
+    # Guard against malformed/non-dict legacy entries.
+    quota_queue = [e for e in quota_queue if isinstance(e, dict)]
     if quota_queue:
         print(f"\n🔁 Quota retry queue: {len(quota_queue)} tentacle(s) pending retry")
         for qe in quota_queue[-3:]:

--- a/tentacle.py
+++ b/tentacle.py
@@ -2068,9 +2068,76 @@ def _goal_update(tentacles_dir: Path, **fields) -> dict:
     return _goal_transact(tentacles_dir, _apply)
 
 
-# ---------------------------------------------------------------------------
-# Goal loop helper functions
-# ---------------------------------------------------------------------------
+def _append_quota_retry_entry(
+    tentacle_name: str,
+    tentacles: Path,
+    quota_reason: str,
+    retry_hint: "str | None",
+) -> bool:
+    """Upsert a quota-blocked entry into ``goal.json["quota_retry_queue"]``.
+
+    Replaces any existing entry for the same tentacle name so re-blocking the
+    same tentacle never produces duplicate queue entries.  When no goal.json
+    exists the upsert is a no-op (fail-open) so non-goal workflows are unaffected.
+
+    Returns True when an entry was written, False when goal.json is absent.
+    """
+    gp = _goal_path(tentacles)
+    if not gp.exists():
+        return False
+
+    entry = {
+        "tentacle": tentacle_name,
+        "quota_reason": quota_reason,
+        "retry_hint": retry_hint,
+        "blocked_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    def _apply(state: dict) -> None:
+        queue: list = state.get("quota_retry_queue") or []
+        if not isinstance(queue, list):
+            queue = []
+        # Upsert: remove any stale entry for this tentacle before appending.
+        queue = [e for e in queue if e.get("tentacle") != tentacle_name]
+        queue.append(entry)
+        state["quota_retry_queue"] = queue
+        state["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+    try:
+        _goal_transact(tentacles, _apply)
+        return True
+    except Exception:
+        return False
+
+
+def _remove_quota_retry_entry(tentacle_name: str, tentacles: Path) -> bool:
+    """Remove a tentacle from ``goal.json["quota_retry_queue"]`` on recovery.
+
+    Called when a tentacle completes with a non-BLOCKED terminal status so the
+    queue reflects only tentacles that are still pending retry.  Fail-open: if
+    goal.json is absent or the entry is not present, returns False silently.
+    """
+    gp = _goal_path(tentacles)
+    if not gp.exists():
+        return False
+
+    def _apply(state: dict) -> None:
+        queue: list = state.get("quota_retry_queue") or []
+        if not isinstance(queue, list):
+            return
+        updated = [e for e in queue if e.get("tentacle") != tentacle_name]
+        if len(updated) != len(queue):
+            state["quota_retry_queue"] = updated
+            state["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+    try:
+        _goal_transact(tentacles, _apply)
+        return True
+    except Exception:
+        return False
+
+
+
 
 
 def _positive_int_arg(value: str) -> int:
@@ -3872,9 +3939,10 @@ def _cmd_goal_next_iter(args, tentacles: Path) -> None:
     if bs["over_budget"] and state.get("status") != GOAL_STATUS_BUDGET_LIMITED:
         print("⚠️  WARNING: Goal is over budget.")
 
-    # Categorise tentacles by iteration and status.
+    # Categorise tentacles by iteration and status, with quota-blocked sub-lane.
     done_names: list[str] = []
     blocked_names: list[str] = []
+    quota_blocked_names: list[tuple[str, str]] = []  # (name, quota_reason)
     in_progress_names: list[str] = []
 
     for name in tentacle_names:
@@ -3889,7 +3957,11 @@ def _cmd_goal_next_iter(args, tentacles: Path) -> None:
         terminal = t_meta.get("terminal_status")
         t_status = t_meta.get("status", "idle")
         if terminal in {"BLOCKED", "TOO_BIG", "AMBIGUOUS", "REGRESSED"}:
-            blocked_names.append(name)
+            qr = t_meta.get("quota_reason")
+            if terminal == "BLOCKED" and qr:
+                quota_blocked_names.append((name, str(qr)))
+            else:
+                blocked_names.append(name)
         elif terminal == "DONE" or t_status == "completed":
             done_names.append(name)
         else:
@@ -3898,12 +3970,30 @@ def _cmd_goal_next_iter(args, tentacles: Path) -> None:
     print(f"\nIteration {current_iter} tentacles:")
     for n in done_names:
         print(f"  ✅ {n}")
+    for n, qr in quota_blocked_names:
+        rh = None
+        try:
+            t_meta = json.loads((tentacles / n / "meta.json").read_text(encoding="utf-8"))
+            rh = t_meta.get("retry_hint")
+        except Exception:
+            pass
+        hint_str = f" — retry after: {rh}" if rh else ""
+        print(f"  🚦 {n} (quota-blocked: {qr}{hint_str})")
     for n in blocked_names:
         print(f"  ⚠️  {n} (blocked/ambiguous)")
     for n in in_progress_names:
         print(f"  🔵 {n} (in progress / idle)")
-    if not (done_names or blocked_names or in_progress_names):
+    if not (done_names or quota_blocked_names or blocked_names or in_progress_names):
         print("  (no tentacles assigned to this iteration)")
+
+    # Quota retry queue summary.
+    quota_queue: list = state.get("quota_retry_queue") or []
+    if quota_queue:
+        print(f"\n🔁 Quota retry queue: {len(quota_queue)} tentacle(s) pending retry")
+        for qe in quota_queue[-3:]:
+            rh = qe.get("retry_hint", "")
+            hint = f" — retry after: {rh}" if rh else ""
+            print(f"  • {qe.get('tentacle', '?')} [{qe.get('quota_reason', '?')}]{hint}")
 
     # Gate summary.
     gates = state.get("gates") or []
@@ -3922,6 +4012,7 @@ def _cmd_goal_next_iter(args, tentacles: Path) -> None:
         print(f"\nSuccess criteria: {verified}/{len(criteria)} verified")
 
     # Recommendation.
+    all_blocked_names = [n for n, _ in quota_blocked_names] + blocked_names
     print()
     goal_status = state.get("status")
     if goal_status == GOAL_STATUS_BUDGET_LIMITED:
@@ -3931,7 +4022,12 @@ def _cmd_goal_next_iter(args, tentacles: Path) -> None:
     elif bs["max_iterations"] is not None and current_iter >= bs["max_iterations"]:
         print(f"   This is the final budgeted iteration ({current_iter}/{bs['max_iterations']}).")
         print("   Recommendation: `goal eval --decision complete` or `--decision abandon`")
-    elif blocked_names:
+    elif quota_blocked_names:
+        print("   Some tentacles are quota-blocked. Check retry hints and re-dispatch after the quota resets.")
+        if blocked_names:
+            print("   Other tentacles are blocked/ambiguous — resolve those separately.")
+        print(f"   Then `goal eval --decision continue` to advance to iteration {current_iter + 1}.")
+    elif all_blocked_names:
         print("   Some tentacles are blocked. Resolve or create replacement tentacles.")
         print(f"   Then `goal eval --decision continue` to advance to iteration {current_iter + 1}.")
     else:
@@ -5023,6 +5119,63 @@ def cmd_todo(args):
                 print(f"  [{t['index']}] {mark} {t['text']}")
 
 
+# ---------------------------------------------------------------------------
+# Quota / rate-limit signal classification
+# ---------------------------------------------------------------------------
+
+# Minimal pattern list for classifying quota/rate-limit signals in dispatch output.
+# TODO(#183): Expand this pattern set once the fuller failure-mode matrix (#183) is
+# available.  The current list covers the most common quota/rate-limit signals only.
+_QUOTA_SIGNAL_PATTERNS: list[tuple[str, str]] = [
+    (r"(?i)rate.?limit", "rate_limit"),
+    (r"(?i)too.many.requests", "rate_limit"),
+    (r"(?i)\b429\b", "rate_limit"),
+    (r"(?i)daily.?(limit|quota)", "daily_quota"),
+    (r"(?i)monthly.?(limit|quota)", "monthly_quota"),
+    (r"(?i)token.?(limit|quota).?exceeded", "token_quota"),
+    (r"(?i)context.?window.?exceeded", "context_limit"),
+    (r"(?i)quota.?exceed", "quota_exceeded"),
+    (r"(?i)resource.?exhausted", "quota_exceeded"),
+    (r"(?i)credits?.?exhausted", "quota_exceeded"),
+]
+
+
+def _classify_quota_signal(text: str) -> "str | None":
+    """Classify dispatch output text into a machine-readable quota/rate-limit reason.
+
+    Returns a short reason string (e.g. ``"rate_limit"``, ``"quota_exceeded"``)
+    when the text matches a known quota pattern, or ``None`` when no signal is
+    detected.
+
+    TODO(#183): Pattern list is intentionally minimal pending the fuller
+    failure-mode matrix.
+    """
+    if not text:
+        return None
+    for pattern, reason in _QUOTA_SIGNAL_PATTERNS:
+        if re.search(pattern, text):
+            return reason
+    return None
+
+
+def _find_allowlisted_status_section(sections: "list[str]") -> "str | None":
+    """Return the most-recent section whose STATUS: value is in HANDOFF_STATUS_ALLOWLIST.
+
+    Shared helper used by both ``_parse_handoff_status`` and
+    ``_parse_handoff_quota_metadata`` so the two parsers always anchor to the
+    same section and cannot diverge when a later section carries an invalid
+    STATUS: value.
+
+    Returns None when no allowlisted section exists (backward-compat: legacy
+    free-form handoffs with no STATUS: line at all).
+    """
+    for section in reversed(sections):
+        m = re.search(r"^STATUS:\s*(\S+)", section, flags=re.MULTILINE)
+        if m and m.group(1) in HANDOFF_STATUS_ALLOWLIST:
+            return section
+    return None
+
+
 def _parse_handoff_status(handoff_content: str) -> "str | None":
     """Return the STATUS value from the latest handoff section that contains one.
 
@@ -5030,13 +5183,11 @@ def _parse_handoff_status(handoff_content: str) -> "str | None":
     Returns None when no STATUS: line is found (backward-compat free-form handoffs).
     """
     sections = re.split(r"^## \[", handoff_content, flags=re.MULTILINE)
-    for section in reversed(sections):
-        m = re.search(r"^STATUS:\s*(\S+)", section, flags=re.MULTILINE)
-        if m:
-            status = m.group(1)
-            if status in HANDOFF_STATUS_ALLOWLIST:
-                return status
-    return None
+    section = _find_allowlisted_status_section(sections)
+    if section is None:
+        return None
+    m = re.search(r"^STATUS:\s*(\S+)", section, flags=re.MULTILINE)
+    return m.group(1) if m else None
 
 
 def _parse_handoff_changed_files(handoff_content: str) -> "list[str]":
@@ -5071,6 +5222,39 @@ def _parse_handoff_bridge_links(handoff_content: str) -> "list[str]":
     return bridge_links
 
 
+def _parse_handoff_quota_metadata(handoff_content: str) -> "tuple[str | None, str | None]":
+    """Return ``(quota_reason, retry_hint)`` from the same handoff section that wins
+    the status parse (the most-recent section containing a ``STATUS:`` line).
+
+    Anchoring quota to the status-winning section ensures status and quota metadata
+    always refer to the same handoff entry.  A status-free progress note appended
+    after a BLOCKED+quota section therefore cannot silently clear the quota fields.
+
+    Falls back to the most-recent non-empty section for legacy free-form handoffs
+    that contain no ``STATUS:`` line at all.  Returns ``(None, None)`` when no
+    quota metadata is present (backward compatible — old BLOCKED handoffs without
+    quota lines are unaffected).
+    """
+    if not handoff_content:
+        return None, None
+    sections = re.split(r"^## \[", handoff_content, flags=re.MULTILINE)
+    # Anchor to the same allowlisted section that wins the status parse so status
+    # and quota metadata cannot come from different sections (bug #187 fix).
+    target = _find_allowlisted_status_section(sections)
+    # Backward-compat fallback: legacy free-form handoffs with no valid STATUS: line.
+    if target is None:
+        target = next((s for s in reversed(sections) if s.strip()), None)
+    if target is None:
+        return None, None
+    reason_m = re.search(r"^QUOTA_REASON:\s*(.+)", target, flags=re.MULTILINE)
+    hint_m = re.search(r"^RETRY_HINT:\s*(.+)", target, flags=re.MULTILINE)
+    if reason_m or hint_m:
+        quota_reason = reason_m.group(1).strip() if reason_m else None
+        retry_hint = hint_m.group(1).strip() if hint_m else None
+        return quota_reason, retry_hint
+    return None, None
+
+
 def cmd_handoff(args):
     """Write a handoff message for a tentacle (agent output)."""
     tentacles = get_tentacles_dir(args.session_dir)
@@ -5084,6 +5268,13 @@ def cmd_handoff(args):
     status = getattr(args, "status", None)
     changed_files: list[str] = list(getattr(args, "changed_file", None) or [])
     bridge_links: list[str] = list(getattr(args, "bridge", None) or [])
+    quota_reason: str | None = getattr(args, "quota_reason", None) or None
+    retry_hint: str | None = getattr(args, "retry_hint", None) or None
+
+    # Auto-detect quota signal from message text when BLOCKED with no explicit quota_reason.
+    # Explicit --quota-reason always wins; this only fills in when the caller omits it.
+    if status == "BLOCKED" and not quota_reason:
+        quota_reason = _classify_quota_signal(args.message)
 
     if status is not None and status not in HANDOFF_STATUS_ALLOWLIST:
         allowed = ", ".join(sorted(HANDOFF_STATUS_ALLOWLIST))
@@ -5103,6 +5294,10 @@ def cmd_handoff(args):
         entry += f"Changed: {cf}\n"
     for bl in bridge_links:
         entry += f"Bridge: {bl}\n"
+    if quota_reason:
+        entry += f"QUOTA_REASON: {quota_reason}\n"
+    if retry_hint:
+        entry += f"RETRY_HINT: {retry_hint}\n"
 
     with file_locked(handoff_path):
         if handoff_path.exists():
@@ -5134,6 +5329,8 @@ def cmd_handoff(args):
     # Triage signal for non-DONE statuses
     if status in HANDOFF_TRIAGE_STATUSES:
         print(f"⚠️  TRIAGE: terminal_status={status} — orchestrator review required")
+        if quota_reason:
+            print(f"   quota_reason={quota_reason}" + (f"  retry_hint={retry_hint}" if retry_hint else ""))
 
     # Auto-learn if --learn flag
     if args.learn:
@@ -5212,23 +5409,56 @@ def cmd_complete(args):
     if not (meta.get("verifications") or []):
         print("⚠️  No verification evidence recorded — run 'verify' or use --auto-verify before completing")
 
-    # 2a. Extract structured handoff fields (terminal_status, changed_files, bridge_links)
+    # 2a. Extract structured handoff fields (terminal_status, changed_files, bridge_links, quota metadata)
     terminal_status = None
     changed_files: list[str] = []
     bridge_links: list[str] = []
+    # 2a. Extract structured handoff fields (terminal_status, changed_files, quota metadata)
+    terminal_status = None
+    changed_files: list[str] = []
+    quota_reason: str | None = None
+    retry_hint: str | None = None
     if handoff_path.exists():
         raw_handoff = handoff_path.read_text(encoding="utf-8")
         terminal_status = _parse_handoff_status(raw_handoff)
         changed_files = _parse_handoff_changed_files(raw_handoff)
         bridge_links = _parse_handoff_bridge_links(raw_handoff)
+        quota_reason, retry_hint = _parse_handoff_quota_metadata(raw_handoff)
     if terminal_status:
         meta["terminal_status"] = terminal_status
     if changed_files:
         meta["changed_files"] = changed_files
     if bridge_links:
         meta["bridge_links"] = bridge_links
+    # Only persist quota metadata for BLOCKED terminal status; a newer DONE or
+    # generic BLOCKED section must never carry stale quota fields forward.
+    # Also clear any stale quota keys written by an earlier BLOCKED completion
+    # so re-completing as DONE does not leave stale quota metadata on disk.
+    if terminal_status == "BLOCKED" and quota_reason:
+        meta["quota_reason"] = quota_reason
+        if retry_hint:
+            meta["retry_hint"] = retry_hint
+        else:
+            # Re-blocking without a new hint: clear any stale hint from a prior run.
+            meta.pop("retry_hint", None)
+    else:
+        meta.pop("quota_reason", None)
+        meta.pop("retry_hint", None)
 
     meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+    # 2b. Upsert quota_retry_queue on quota-BLOCKED; remove entry on recovery.
+    if terminal_status == "BLOCKED" and quota_reason:
+        _append_quota_retry_entry(
+            tentacle_name=args.name,
+            tentacles=tentacles,
+            quota_reason=quota_reason,
+            retry_hint=retry_hint,
+        )
+    else:
+        # Non-BLOCKED (DONE, AMBIGUOUS, etc.) means the tentacle recovered;
+        # remove it from the pending-retry queue so next-iter is accurate.
+        _remove_quota_retry_entry(args.name, tentacles)
 
     # 3. Auto-learn from handoff (unless --no-learn)
     learned = 0
@@ -6176,6 +6406,23 @@ def main():
         metavar="SC_ID",
         default=[],
         help="Bridge link to a success criterion ID (repeatable); e.g. --bridge sc-1",
+    )
+    p_handoff.add_argument(
+        "--quota-reason",
+        dest="quota_reason",
+        default=None,
+        metavar="REASON",
+        help=(
+            "Machine-readable quota/rate-limit reason for BLOCKED handoffs "
+            "(e.g. rate_limit, quota_exceeded, daily_quota)"
+        ),
+    )
+    p_handoff.add_argument(
+        "--retry-hint",
+        dest="retry_hint",
+        default=None,
+        metavar="HINT",
+        help="Optional retry-after hint (ISO timestamp or human-readable) for quota-blocked handoffs",
     )
 
     # swarm

--- a/tentacle.py
+++ b/tentacle.py
@@ -2190,7 +2190,7 @@ def _write_dispatch_quota_blocked(
         meta.pop("retry_hint", None)
         meta["completed_at"] = datetime.now(timezone.utc).isoformat()
         meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
-    except OSError:
+    except (OSError, ValueError):
         pass
 
     _append_quota_retry_entry(tentacle_name, tentacles, quota_reason, None)

--- a/tentacle.py
+++ b/tentacle.py
@@ -5413,9 +5413,6 @@ def cmd_complete(args):
     terminal_status = None
     changed_files: list[str] = []
     bridge_links: list[str] = []
-    # 2a. Extract structured handoff fields (terminal_status, changed_files, quota metadata)
-    terminal_status = None
-    changed_files: list[str] = []
     quota_reason: str | None = None
     retry_hint: str | None = None
     if handoff_path.exists():

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -6348,13 +6348,11 @@ class TestQuotaRetryQueue(unittest.TestCase):
         self.assertIn("blocked_at", queue[0])
 
     def test_append_multiple_entries(self):
-        T._append_quota_retry_entry(self.tentacles.parent.parent, self.tentacles, "rate_limit", None)
-        T._append_quota_retry_entry(self.tentacles.parent.parent, self.tentacles, "daily_quota", "tomorrow")
-        # Use direct call instead
         T._append_quota_retry_entry("worker-a", self.tentacles, "rate_limit", None)
         T._append_quota_retry_entry("worker-b", self.tentacles, "daily_quota", "tomorrow")
         state = T._goal_load(self.tentacles)
         queue = state.get("quota_retry_queue", [])
+        self.assertEqual(len(queue), 2)
         names = [e["tentacle"] for e in queue]
         self.assertIn("worker-a", names)
         self.assertIn("worker-b", names)

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -6316,5 +6316,395 @@ class TestGoalLoopAutoDispatch(unittest.TestCase):
                 )
 
 
+# ---------------------------------------------------------------------------
+# Tests for quota retry queue persistence (#187)
+# ---------------------------------------------------------------------------
+
+
+class TestQuotaRetryQueue(unittest.TestCase):
+    """Tests that _append_quota_retry_entry persists entries to goal.json."""
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "quota_retry"
+        _, self.tentacles = _make_octogent(self.base)
+        _init_goal(self.tentacles, title="Quota Goal")
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    def test_append_adds_entry_to_queue(self):
+        result = T._append_quota_retry_entry(
+            tentacle_name="test-worker",
+            tentacles=self.tentacles,
+            quota_reason="rate_limit",
+            retry_hint="2026-05-14T00:00:00Z",
+        )
+        self.assertTrue(result)
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0]["tentacle"], "test-worker")
+        self.assertEqual(queue[0]["quota_reason"], "rate_limit")
+        self.assertEqual(queue[0]["retry_hint"], "2026-05-14T00:00:00Z")
+        self.assertIn("blocked_at", queue[0])
+
+    def test_append_multiple_entries(self):
+        T._append_quota_retry_entry(self.tentacles.parent.parent, self.tentacles, "rate_limit", None)
+        T._append_quota_retry_entry(self.tentacles.parent.parent, self.tentacles, "daily_quota", "tomorrow")
+        # Use direct call instead
+        T._append_quota_retry_entry("worker-a", self.tentacles, "rate_limit", None)
+        T._append_quota_retry_entry("worker-b", self.tentacles, "daily_quota", "tomorrow")
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        names = [e["tentacle"] for e in queue]
+        self.assertIn("worker-a", names)
+        self.assertIn("worker-b", names)
+
+    def test_append_without_retry_hint_stores_none(self):
+        T._append_quota_retry_entry("worker-no-hint", self.tentacles, "quota_exceeded", None)
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        entry = next((e for e in queue if e["tentacle"] == "worker-no-hint"), None)
+        self.assertIsNotNone(entry)
+        self.assertIsNone(entry["retry_hint"])
+
+    def test_append_returns_false_when_no_goal_json(self):
+        _, empty_tentacles = _make_octogent(self.base / "sub")
+        result = T._append_quota_retry_entry("x", empty_tentacles, "rate_limit", None)
+        self.assertFalse(result)
+
+    def test_complete_blocked_with_quota_appends_to_queue(self):
+        """cmd_complete on a BLOCKED+quota_reason tentacle appends to quota_retry_queue."""
+        t_dir = _make_tentacle("quota-blocked-worker", self.tentacles, status="active")
+        handoff_content = (
+            "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\n"
+            "Blocked by rate limit.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: 2026-05-14T00:00:00Z\n"
+        )
+        (t_dir / "handoff.md").write_text(handoff_content, encoding="utf-8")
+
+        args = _fake_args(name="quota-blocked-worker", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.tentacles):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0]["tentacle"], "quota-blocked-worker")
+        self.assertEqual(queue[0]["quota_reason"], "rate_limit")
+        self.assertEqual(queue[0]["retry_hint"], "2026-05-14T00:00:00Z")
+
+    def test_complete_done_does_not_append_to_queue(self):
+        """cmd_complete on a DONE tentacle must not touch quota_retry_queue."""
+        t_dir = _make_tentacle("done-worker", self.tentacles, status="active")
+        handoff_content = "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\nDone.\nSTATUS: DONE\n"
+        (t_dir / "handoff.md").write_text(handoff_content, encoding="utf-8")
+
+        args = _fake_args(name="done-worker", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.tentacles):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state.get("quota_retry_queue", []), [])
+
+    def test_stale_quota_not_appended_when_newer_section_is_done(self):
+        """Multi-section handoff with older BLOCKED+quota and newer DONE must not enqueue quota."""
+        t_dir = _make_tentacle("stale-quota-worker", self.tentacles, status="active")
+        handoff_content = (
+            "# Handoff Notes\n\n"
+            "## [2026-05-01 12:00 UTC]\n\n"
+            "Blocked by rate limit.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: tomorrow\n"
+            "\n## [2026-05-02 09:00 UTC]\n\n"
+            "Completed successfully.\nSTATUS: DONE\n"
+        )
+        (t_dir / "handoff.md").write_text(handoff_content, encoding="utf-8")
+
+        args = _fake_args(name="stale-quota-worker", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.tentacles):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(state.get("quota_retry_queue", []), [])
+        meta = json.loads((t_dir / "meta.json").read_text(encoding="utf-8"))
+        self.assertNotIn("quota_reason", meta)
+        self.assertNotIn("retry_hint", meta)
+        self.assertEqual(meta.get("terminal_status"), "DONE")
+
+    def test_two_step_recompletion_clears_stale_quota_from_meta(self):
+        """Re-completion scenario: first BLOCKED+quota, then DONE — meta.json quota fields cleared."""
+        t_dir = _make_tentacle("recompletion-worker", self.tentacles, status="active")
+
+        # Step 1: complete as BLOCKED with quota metadata
+        handoff_path = t_dir / "handoff.md"
+        handoff_path.write_text(
+            "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\n"
+            "Blocked by rate limit.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: tomorrow\n",
+            encoding="utf-8",
+        )
+        args = _fake_args(name="recompletion-worker", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.tentacles):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+
+        meta = json.loads((t_dir / "meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta.get("quota_reason"), "rate_limit")  # sanity-check
+        self.assertEqual(meta.get("terminal_status"), "BLOCKED")
+
+        # Step 2: agent retries and completes successfully as DONE
+        existing = handoff_path.read_text(encoding="utf-8")
+        handoff_path.write_text(
+            existing + "\n## [2026-05-02 09:00 UTC]\n\nCompleted successfully.\nSTATUS: DONE\n",
+            encoding="utf-8",
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.tentacles):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+
+        meta = json.loads((t_dir / "meta.json").read_text(encoding="utf-8"))
+        self.assertNotIn("quota_reason", meta)
+        self.assertNotIn("retry_hint", meta)
+        self.assertEqual(meta.get("terminal_status"), "DONE")
+
+    def test_reblock_without_hint_upserts_queue_no_duplicate(self):
+        """Re-blocking the same tentacle without a new retry_hint must not duplicate the queue entry.
+
+        Sequence (reproduces after_blocked_with_hint / after_blocked_without_hint bug):
+        1. BLOCKED with hint  → queue has 1 entry, hint = "2026-05-14T00:00:00Z"
+        2. BLOCKED without hint → queue still has 1 entry (upsert), hint = None
+        """
+        t_dir = _make_tentacle("reblock-worker", self.tentacles, status="active")
+
+        # Step 1 — first BLOCKED with a retry_hint
+        (t_dir / "handoff.md").write_text(
+            "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\n"
+            "Blocked.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: 2026-05-14T00:00:00Z\n",
+            encoding="utf-8",
+        )
+        args = _fake_args(name="reblock-worker", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.tentacles):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        # after_blocked_with_hint: 1 entry, hint preserved
+        self.assertEqual(len(queue), 1, "after_blocked_with_hint: expected 1 queue entry")
+        self.assertEqual(queue[0]["retry_hint"], "2026-05-14T00:00:00Z",
+                         "after_blocked_with_hint: hint should be 2026-05-14T00:00:00Z")
+
+        # Step 2 — re-block the same tentacle without a retry_hint
+        (t_dir / "handoff.md").write_text(
+            "# Handoff Notes\n\n## [2026-05-14 08:00 UTC]\n\n"
+            "Still blocked.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\n",
+            encoding="utf-8",
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.tentacles):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        # after_blocked_without_hint: still 1 entry (upsert, not append), hint cleared
+        self.assertEqual(len(queue), 1, "after_blocked_without_hint: expected 1 queue entry (upsert)")
+        self.assertIsNone(queue[0]["retry_hint"],
+                          "after_blocked_without_hint: old hint must be cleared on re-block without hint")
+
+    def test_done_completion_removes_tentacle_from_queue(self):
+        """Completing as DONE removes the tentacle from quota_retry_queue.
+
+        Sequence (reproduces after_done bug):
+        1. BLOCKED with hint  → queue has 1 entry
+        2. DONE               → queue is empty
+        """
+        t_dir = _make_tentacle("recovery-worker", self.tentacles, status="active")
+
+        # Step 1 — BLOCKED with quota
+        (t_dir / "handoff.md").write_text(
+            "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\n"
+            "Blocked.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: 2026-05-14T00:00:00Z\n",
+            encoding="utf-8",
+        )
+        args = _fake_args(name="recovery-worker", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.tentacles):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(len(state.get("quota_retry_queue", [])), 1)
+
+        # Step 2 — agent recovers and completes as DONE
+        existing = (t_dir / "handoff.md").read_text(encoding="utf-8")
+        (t_dir / "handoff.md").write_text(
+            existing + "\n## [2026-05-15 09:00 UTC]\n\nResolved.\nSTATUS: DONE\n",
+            encoding="utf-8",
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.tentacles):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        # after_done: queue must be empty — tentacle recovered
+        self.assertEqual(len(queue), 0, "after_done: DONE completion must remove tentacle from queue")
+        names = [e.get("tentacle") for e in queue]
+        self.assertNotIn("recovery-worker", names)
+
+    def test_blocked_quota_preserved_when_later_status_free_note_appended(self):
+        """Bug #187 status-anchor fix: quota_retry_queue must be populated when the
+        latest handoff section is a status-free progress note and an older section
+        has STATUS: BLOCKED + quota metadata.
+
+        Before the fix: _parse_handoff_quota_metadata read the latest non-empty
+        section (the status-free note) and returned (None, None), so cmd_complete
+        treated the tentacle as generic-BLOCKED and did not enqueue it.
+        """
+        t_dir = _make_tentacle("status-anchor-worker", self.tentacles, status="active")
+        handoff_content = (
+            "# Handoff Notes\n\n"
+            "## [2026-05-01 12:00 UTC]\n\n"
+            "Blocked by rate limit.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: 2026-05-14T00:00:00Z\n"
+            "\n## [2026-05-02 10:00 UTC]\n\n"
+            "Progress update — still waiting for quota reset.\n"
+        )
+        (t_dir / "handoff.md").write_text(handoff_content, encoding="utf-8")
+        args = _fake_args(name="status-anchor-worker", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.tentacles):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        self.assertEqual(len(queue), 1, "status-anchor: BLOCKED+quota must be enqueued even with later status-free note")
+        self.assertEqual(queue[0]["tentacle"], "status-anchor-worker")
+        self.assertEqual(queue[0]["quota_reason"], "rate_limit")
+        self.assertEqual(queue[0]["retry_hint"], "2026-05-14T00:00:00Z")
+        meta = json.loads((t_dir / "meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta.get("quota_reason"), "rate_limit")
+        self.assertEqual(meta.get("terminal_status"), "BLOCKED")
+
+    def test_blocked_quota_preserved_when_later_section_has_invalid_status(self):
+        """Bug #187 allowlist-anchor fix: quota_retry_queue must be populated when a
+        newer handoff section carries an invalid STATUS: value (not in allowlist).
+
+        Scenario (the live repro from issue #187):
+        - older section: STATUS: BLOCKED, QUOTA_REASON: rate_limit, RETRY_HINT: 2026-05-14
+        - newer section: STATUS: STALE_STATUS_NOT_IN_ALLOWLIST
+
+        Before the fix: _parse_handoff_quota_metadata anchored to the newer section
+        (any STATUS: line sufficed) and returned (None, None) because that section
+        has no quota fields; cmd_complete treated the tentacle as generic-BLOCKED.
+        """
+        t_dir = _make_tentacle("allowlist-anchor-worker", self.tentacles, status="active")
+        handoff_content = (
+            "# Handoff Notes\n\n"
+            "## [2026-05-13 10:00 UTC]\n\n"
+            "Blocked by rate limit.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: 2026-05-14T00:00:00Z\n"
+            "\n## [2026-05-13 11:00 UTC]\n\n"
+            "Still waiting.\nSTATUS: STALE_STATUS_NOT_IN_ALLOWLIST\n"
+        )
+        (t_dir / "handoff.md").write_text(handoff_content, encoding="utf-8")
+        args = _fake_args(name="allowlist-anchor-worker", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.tentacles):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        self.assertEqual(len(queue), 1,
+                         "allowlist-anchor: BLOCKED+quota must be enqueued when newer section has invalid status")
+        self.assertEqual(queue[0]["tentacle"], "allowlist-anchor-worker")
+        self.assertEqual(queue[0]["quota_reason"], "rate_limit")
+        self.assertEqual(queue[0]["retry_hint"], "2026-05-14T00:00:00Z")
+        meta = json.loads((t_dir / "meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta.get("quota_reason"), "rate_limit")
+        self.assertEqual(meta.get("terminal_status"), "BLOCKED")
+
+
+class TestNextIterQuotaBlocked(unittest.TestCase):
+    """Tests that _cmd_goal_next_iter distinguishes quota-blocked from generic blocked."""
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "next_iter_quota"
+        _, self.tentacles = _make_octogent(self.base)
+        _init_goal(self.tentacles, title="Quota Next-Iter Goal")
+
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    def _link_tentacle(self, name: str, terminal_status: str = "", quota_reason: str = "", retry_hint: str = "") -> Path:
+        t_dir = _make_tentacle(name, self.tentacles, status="completed")
+        meta = json.loads((t_dir / "meta.json").read_text(encoding="utf-8"))
+        if terminal_status:
+            meta["terminal_status"] = terminal_status
+        if quota_reason:
+            meta["quota_reason"] = quota_reason
+        if retry_hint:
+            meta["retry_hint"] = retry_hint
+        (t_dir / "meta.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        state = T._goal_load(self.tentacles)
+        ikey = str(state.get("iteration", 1))
+        if "iterations" not in state:
+            state["iterations"] = {}
+        if ikey not in state["iterations"]:
+            state["iterations"][ikey] = {"tentacles": []}
+        state["iterations"][ikey]["tentacles"].append(name)
+        if name not in state.get("tentacles", []):
+            state.setdefault("tentacles", []).append(name)
+        T._goal_write(self.tentacles, state)
+        return t_dir
+
+    def test_quota_blocked_renders_with_traffic_light_icon(self):
+        self._link_tentacle("q-worker", terminal_status="BLOCKED", quota_reason="rate_limit")
+        captured = []
+        args = _fake_args(goal_action="next-iter")
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(" ".join(str(x) for x in a))):
+            T._cmd_goal_next_iter(args, self.tentacles)
+        combined = "\n".join(captured)
+        self.assertIn("q-worker", combined)
+        self.assertIn("quota-blocked", combined)
+        self.assertIn("rate_limit", combined)
+
+    def test_generic_blocked_renders_without_quota_fields(self):
+        self._link_tentacle("g-worker", terminal_status="BLOCKED")
+        captured = []
+        args = _fake_args(goal_action="next-iter")
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(" ".join(str(x) for x in a))):
+            T._cmd_goal_next_iter(args, self.tentacles)
+        combined = "\n".join(captured)
+        self.assertIn("g-worker", combined)
+        self.assertIn("blocked/ambiguous", combined)
+        self.assertNotIn("quota-blocked", combined)
+
+    def test_retry_hint_shown_for_quota_blocked(self):
+        self._link_tentacle("h-worker", terminal_status="BLOCKED", quota_reason="daily_quota", retry_hint="2026-06-01")
+        captured = []
+        args = _fake_args(goal_action="next-iter")
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(" ".join(str(x) for x in a))):
+            T._cmd_goal_next_iter(args, self.tentacles)
+        combined = "\n".join(captured)
+        self.assertIn("2026-06-01", combined)
+
+    def test_recommendation_mentions_quota_when_quota_blocked(self):
+        self._link_tentacle("qrec-worker", terminal_status="BLOCKED", quota_reason="quota_exceeded")
+        captured = []
+        args = _fake_args(goal_action="next-iter")
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(" ".join(str(x) for x in a))):
+            T._cmd_goal_next_iter(args, self.tentacles)
+        combined = "\n".join(captured)
+        self.assertIn("quota", combined.lower())
+        self.assertIn("retry", combined.lower())
+
+    def test_quota_retry_queue_shown_in_next_iter(self):
+        """quota_retry_queue entries appear in next-iter output."""
+        T._append_quota_retry_entry("q-queued", self.tentacles, "rate_limit", "tomorrow")
+        captured = []
+        args = _fake_args(goal_action="next-iter")
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(" ".join(str(x) for x in a))):
+            T._cmd_goal_next_iter(args, self.tentacles)
+        combined = "\n".join(captured)
+        self.assertIn("quota retry queue", combined.lower())
+        self.assertIn("q-queued", combined)
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -1165,8 +1165,38 @@ class TestGoalResume(unittest.TestCase):
             "success_criteria status must be preserved by --from-iteration",
         )
 
+    def test_reset_failed_removes_quota_retry_queue_entries(self):
+        """--reset-failed must remove reset tentacles from quota_retry_queue (#187)."""
+        self._link_tentacle_with_meta("q-blocked", terminal_status="BLOCKED")
+        # Manually enqueue a quota entry for that tentacle
+        T._append_quota_retry_entry("q-blocked", self.tentacles, "rate_limit", "tomorrow")
+        state = T._goal_load(self.tentacles)
+        self.assertEqual(len(state.get("quota_retry_queue", [])), 1, "sanity: queue should have 1 entry")
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", reset_failed=True, from_iteration=None)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        names = [e.get("tentacle") for e in queue if isinstance(e, dict)]
+        self.assertNotIn("q-blocked", names, "--reset-failed must remove q-blocked from quota_retry_queue")
+
+    def test_reset_failed_clears_quota_metadata_from_meta(self):
+        """--reset-failed must clear quota_reason/retry_hint from meta.json (#187)."""
+        t_dir = self._link_tentacle_with_meta("q-meta-blocked", terminal_status="BLOCKED")
+        meta = json.loads((t_dir / "meta.json").read_text(encoding="utf-8"))
+        meta["quota_reason"] = "rate_limit"
+        meta["retry_hint"] = "tomorrow"
+        (t_dir / "meta.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        self._pause_goal()
+        args = _fake_args(goal_action="resume", reset_failed=True, from_iteration=None)
+        with patch("builtins.print"):
+            T._cmd_goal_resume(args, self.tentacles)
+        meta_after = json.loads((t_dir / "meta.json").read_text(encoding="utf-8"))
+        self.assertNotIn("quota_reason", meta_after, "--reset-failed must clear quota_reason from meta")
+        self.assertNotIn("retry_hint", meta_after, "--reset-failed must clear retry_hint from meta")
+
     def test_from_iteration_out_of_bounds_low_exits(self):
-        """--from-iteration 0 must exit with code 1 (below valid range)."""
         self._pause_goal()
         args = _fake_args(goal_action="resume", from_iteration=0, reset_failed=False)
         with patch("builtins.print"):
@@ -2764,7 +2794,6 @@ class TestGoalLifecycleEndToEnd(unittest.TestCase):
         self.assertIn("OVER TIME", combined)
 
 
-
 # ---------------------------------------------------------------------------
 # Tests for budget overrun escalation in _cmd_goal_eval (issue #186)
 # ---------------------------------------------------------------------------
@@ -2990,10 +3019,14 @@ class TestGoalEvalBudgetEscalation(unittest.TestCase):
         force_line = next((l for l in captured if "force-over-budget" in l), None)
         complete_line = next((l for l in captured if "--decision complete" in l and "resume" in l), None)
         self.assertIsNotNone(force_line, "Advisory must mention --force-over-budget")
-        self.assertIn("goal resume", force_line,
-                      "Advisory step for force-over-budget must include 'goal resume' before 'goal eval'")
-        self.assertIsNotNone(complete_line,
-                             "Advisory must include a 'goal resume' then 'goal eval --decision complete' step")
+        self.assertIn(
+            "goal resume",
+            force_line,
+            "Advisory step for force-over-budget must include 'goal resume' before 'goal eval'",
+        )
+        self.assertIsNotNone(
+            complete_line, "Advisory must include a 'goal resume' then 'goal eval --decision complete' step"
+        )
 
     def test_budget_escalation_advisory_requires_resume_before_complete(self):
         """Advisory for the 'complete' path must include 'goal resume' before 'goal eval'.
@@ -3011,8 +3044,9 @@ class TestGoalEvalBudgetEscalation(unittest.TestCase):
         # Every advisory line that mentions 'goal eval' must also mention 'goal resume'.
         for line in captured:
             if "goal eval" in line:
-                self.assertIn("goal resume", line,
-                              f"Advisory line mentions 'goal eval' without prior 'goal resume': {line!r}")
+                self.assertIn(
+                    "goal resume", line, f"Advisory line mentions 'goal eval' without prior 'goal resume': {line!r}"
+                )
 
     def test_budget_text_lines_show_remaining_for_timeout(self):
         """_goal_budget_text_lines shows remaining minutes when under timeout budget."""
@@ -6260,11 +6294,9 @@ class TestGoalLoopAutoDispatch(unittest.TestCase):
 
     def test_real_dispatch_subprocess_does_not_capture_output(self):
         """
-        The real dispatch subprocess path must NOT use capture_output=True.
-
-        Capturing large agent stdout/stderr into memory defeats the purpose of
-        fire-and-discard dispatch for large prompts.  The subprocess must redirect
-        stdout/stderr to DEVNULL (or inherit), never to PIPE.
+        The real dispatch subprocess path must NOT use capture_output=True or
+        PIPE for stdout.  stderr may be redirected to a file for bounded quota
+        classification, but must never be subprocess.PIPE (which buffers into memory).
         """
         import subprocess as _sp
 
@@ -6301,19 +6333,71 @@ class TestGoalLoopAutoDispatch(unittest.TestCase):
                 "capture_output must NOT be passed to dispatch subprocess.run — "
                 "it buffers large agent output into memory",
             )
-            # stdout/stderr must be DEVNULL (not PIPE) to avoid memory buffering.
+            # stdout must be DEVNULL to avoid memory buffering of agent output.
             if "stdout" in kwargs:
                 self.assertEqual(
                     kwargs["stdout"],
                     _sp.DEVNULL,
                     "stdout must be subprocess.DEVNULL, not PIPE",
                 )
+            # stderr must not be PIPE — it is allowed to be a file handle for
+            # bounded quota-signal classification (issue #187 fix).
             if "stderr" in kwargs:
-                self.assertEqual(
+                self.assertNotEqual(
                     kwargs["stderr"],
-                    _sp.DEVNULL,
-                    "stderr must be subprocess.DEVNULL, not PIPE",
+                    _sp.PIPE,
+                    "stderr must NOT be subprocess.PIPE — use a file handle or DEVNULL",
                 )
+
+    def test_dispatch_quota_signal_creates_blocked_handoff(self):
+        """Regression for issue #187: when dispatch subprocess exits non-zero with
+        a quota/rate-limit signal in stderr, _goal_loop_dispatch_and_wait must
+        write a synthetic BLOCKED handoff and enqueue the tentacle.
+        """
+        self._link_tentacle("quota-launcher-task")
+        _init_goal_with_queue = T._goal_load(self.tentacles)
+
+        # Simulate a quota-signal dispatch failure via the _dispatch_fn injection.
+        # Returning a non-empty string signals quota output to the caller.
+        def quota_dispatch_fn(cmd, name):
+            return "error: rate limit exceeded (429 Too Many Requests)"
+
+        with patch("builtins.print"):
+            T._goal_loop_dispatch_and_wait(
+                _fake_args(
+                    agent_type="general-purpose",
+                    model="claude-sonnet-4.6",
+                    briefing=False,
+                    bundle=True,
+                    worktree=False,
+                ),
+                T._goal_load(self.tentacles),
+                self.tentacles,
+                poll_timeout=5,
+                _dispatch_fn=quota_dispatch_fn,
+                _sleep_fn=lambda s: None,
+                _monotonic_fn=iter([0.0, 9999.0]).__next__,
+            )
+
+        # handoff.md must have been written with BLOCKED + QUOTA_REASON
+        handoff_path = self.tentacles / "quota-launcher-task" / "handoff.md"
+        self.assertTrue(handoff_path.exists(), "handoff.md must be written for quota-blocked dispatch")
+        handoff_text = handoff_path.read_text(encoding="utf-8")
+        self.assertIn("STATUS: BLOCKED", handoff_text)
+        self.assertIn("QUOTA_REASON: rate_limit", handoff_text)
+
+        # meta.json must reflect completed/BLOCKED
+        import json as _json
+
+        meta = _json.loads((self.tentacles / "quota-launcher-task" / "meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta.get("terminal_status"), "BLOCKED")
+        self.assertEqual(meta.get("quota_reason"), "rate_limit")
+
+        # quota_retry_queue must have an entry
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        names = [e.get("tentacle") for e in queue if isinstance(e, dict)]
+        self.assertIn("quota-launcher-task", names)
 
 
 # ---------------------------------------------------------------------------
@@ -6328,6 +6412,7 @@ class TestQuotaRetryQueue(unittest.TestCase):
         self.base = SCRATCH_DIR / "quota_retry"
         _, self.tentacles = _make_octogent(self.base)
         _init_goal(self.tentacles, title="Quota Goal")
+
     def tearDown(self):
         _rmtree(SCRATCH_DIR)
 
@@ -6488,8 +6573,11 @@ class TestQuotaRetryQueue(unittest.TestCase):
         queue = state.get("quota_retry_queue", [])
         # after_blocked_with_hint: 1 entry, hint preserved
         self.assertEqual(len(queue), 1, "after_blocked_with_hint: expected 1 queue entry")
-        self.assertEqual(queue[0]["retry_hint"], "2026-05-14T00:00:00Z",
-                         "after_blocked_with_hint: hint should be 2026-05-14T00:00:00Z")
+        self.assertEqual(
+            queue[0]["retry_hint"],
+            "2026-05-14T00:00:00Z",
+            "after_blocked_with_hint: hint should be 2026-05-14T00:00:00Z",
+        )
 
         # Step 2 — re-block the same tentacle without a retry_hint
         (t_dir / "handoff.md").write_text(
@@ -6505,8 +6593,9 @@ class TestQuotaRetryQueue(unittest.TestCase):
         queue = state.get("quota_retry_queue", [])
         # after_blocked_without_hint: still 1 entry (upsert, not append), hint cleared
         self.assertEqual(len(queue), 1, "after_blocked_without_hint: expected 1 queue entry (upsert)")
-        self.assertIsNone(queue[0]["retry_hint"],
-                          "after_blocked_without_hint: old hint must be cleared on re-block without hint")
+        self.assertIsNone(
+            queue[0]["retry_hint"], "after_blocked_without_hint: old hint must be cleared on re-block without hint"
+        )
 
     def test_done_completion_removes_tentacle_from_queue(self):
         """Completing as DONE removes the tentacle from quota_retry_queue.
@@ -6572,7 +6661,9 @@ class TestQuotaRetryQueue(unittest.TestCase):
                 T.cmd_complete(args)
         state = T._goal_load(self.tentacles)
         queue = state.get("quota_retry_queue", [])
-        self.assertEqual(len(queue), 1, "status-anchor: BLOCKED+quota must be enqueued even with later status-free note")
+        self.assertEqual(
+            len(queue), 1, "status-anchor: BLOCKED+quota must be enqueued even with later status-free note"
+        )
         self.assertEqual(queue[0]["tentacle"], "status-anchor-worker")
         self.assertEqual(queue[0]["quota_reason"], "rate_limit")
         self.assertEqual(queue[0]["retry_hint"], "2026-05-14T00:00:00Z")
@@ -6607,14 +6698,72 @@ class TestQuotaRetryQueue(unittest.TestCase):
                 T.cmd_complete(args)
         state = T._goal_load(self.tentacles)
         queue = state.get("quota_retry_queue", [])
-        self.assertEqual(len(queue), 1,
-                         "allowlist-anchor: BLOCKED+quota must be enqueued when newer section has invalid status")
+        self.assertEqual(
+            len(queue), 1, "allowlist-anchor: BLOCKED+quota must be enqueued when newer section has invalid status"
+        )
         self.assertEqual(queue[0]["tentacle"], "allowlist-anchor-worker")
         self.assertEqual(queue[0]["quota_reason"], "rate_limit")
         self.assertEqual(queue[0]["retry_hint"], "2026-05-14T00:00:00Z")
         meta = json.loads((t_dir / "meta.json").read_text(encoding="utf-8"))
         self.assertEqual(meta.get("quota_reason"), "rate_limit")
         self.assertEqual(meta.get("terminal_status"), "BLOCKED")
+
+    def test_remove_returns_true_when_entry_exists(self):
+        """_remove_quota_retry_entry must return True when an entry is actually removed (#187)."""
+        T._append_quota_retry_entry("worker-to-remove", self.tentacles, "rate_limit", None)
+        result = T._remove_quota_retry_entry("worker-to-remove", self.tentacles)
+        self.assertTrue(result, "_remove_quota_retry_entry must return True when entry was removed")
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        names = [e.get("tentacle") for e in queue if isinstance(e, dict)]
+        self.assertNotIn("worker-to-remove", names)
+
+    def test_remove_returns_false_when_entry_absent(self):
+        """_remove_quota_retry_entry must return False when entry is not in the queue (#187)."""
+        result = T._remove_quota_retry_entry("not-in-queue", self.tentacles)
+        self.assertFalse(result, "_remove_quota_retry_entry must return False when entry was absent")
+
+    def test_remove_returns_false_when_no_goal_json(self):
+        """_remove_quota_retry_entry must return False when goal.json is absent."""
+        from pathlib import Path as _Path
+
+        _, empty_tentacles = _make_octogent(self.base / "no-goal")
+        result = T._remove_quota_retry_entry("x", empty_tentacles)
+        self.assertFalse(result)
+
+    def test_append_ignores_malformed_queue_entries(self):
+        """_append_quota_retry_entry must be robust against non-dict entries in the queue (#187)."""
+        # Directly inject a malformed entry (plain string) into goal.json
+        with T._goal_lock(self.tentacles):
+            state = T._goal_load(self.tentacles)
+            state["quota_retry_queue"] = ["bad-string-entry", 42, None]
+            T._goal_write(self.tentacles, state)
+        # Should not raise; malformed entries must be discarded
+        result = T._append_quota_retry_entry("clean-worker", self.tentacles, "rate_limit", None)
+        self.assertTrue(result)
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        # Only the clean dict entry should remain
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0]["tentacle"], "clean-worker")
+
+    def test_remove_ignores_malformed_queue_entries(self):
+        """_remove_quota_retry_entry must handle non-dict entries without crashing (#187)."""
+        T._append_quota_retry_entry("real-worker", self.tentacles, "rate_limit", None)
+        with T._goal_lock(self.tentacles):
+            state = T._goal_load(self.tentacles)
+            queue = state.get("quota_retry_queue", [])
+            queue.insert(0, "bad-string")
+            queue.append(99)
+            state["quota_retry_queue"] = queue
+            T._goal_write(self.tentacles, state)
+        # Removing the real worker must not raise even with malformed entries present
+        result = T._remove_quota_retry_entry("real-worker", self.tentacles)
+        self.assertTrue(result, "must return True — real-worker entry was present")
+        state = T._goal_load(self.tentacles)
+        queue = state.get("quota_retry_queue", [])
+        dict_names = [e.get("tentacle") for e in queue if isinstance(e, dict)]
+        self.assertNotIn("real-worker", dict_names)
 
 
 class TestNextIterQuotaBlocked(unittest.TestCase):
@@ -6628,7 +6777,9 @@ class TestNextIterQuotaBlocked(unittest.TestCase):
     def tearDown(self):
         _rmtree(SCRATCH_DIR)
 
-    def _link_tentacle(self, name: str, terminal_status: str = "", quota_reason: str = "", retry_hint: str = "") -> Path:
+    def _link_tentacle(
+        self, name: str, terminal_status: str = "", quota_reason: str = "", retry_hint: str = ""
+    ) -> Path:
         t_dir = _make_tentacle(name, self.tentacles, status="completed")
         meta = json.loads((t_dir / "meta.json").read_text(encoding="utf-8"))
         if terminal_status:
@@ -6702,7 +6853,24 @@ class TestNextIterQuotaBlocked(unittest.TestCase):
         self.assertIn("quota retry queue", combined.lower())
         self.assertIn("q-queued", combined)
 
+    def test_next_iter_handles_malformed_quota_queue_entries(self):
+        """_cmd_goal_next_iter must not crash when quota_retry_queue contains non-dict entries (#187)."""
+        T._append_quota_retry_entry("valid-q", self.tentacles, "rate_limit", "tomorrow")
+        with T._goal_lock(self.tentacles):
+            state = T._goal_load(self.tentacles)
+            queue = state.get("quota_retry_queue", [])
+            queue.insert(0, "bad-string")
+            queue.append(None)
+            state["quota_retry_queue"] = queue
+            T._goal_write(self.tentacles, state)
+        # Must not raise and must still show the valid entry
+        captured = []
+        args = _fake_args(goal_action="next-iter")
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(" ".join(str(x) for x in a))):
+            T._cmd_goal_next_iter(args, self.tentacles)
+        combined = "\n".join(captured)
+        self.assertIn("valid-q", combined)
+
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_tentacle_runtime.py
+++ b/tests/test_tentacle_runtime.py
@@ -7355,6 +7355,39 @@ class TestCmdCompleteQuotaPersistence(unittest.TestCase):
         self.assertEqual(meta.get("quota_reason"), "rate_limit")
 
 
+class TestWriteDispatchQuotaBlockedFailOpen(unittest.TestCase):
+    """Regression: _write_dispatch_quota_blocked must fail-open even on corrupted meta.json."""
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "dispatch_quota_blocked"
+        self.base.mkdir(parents=True, exist_ok=True)
+        make_tentacle("quota-dispatch-worker", self.base)
+
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    def test_corrupted_meta_json_does_not_raise(self):
+        """Corrupted meta.json must not propagate json.JSONDecodeError — helper fails open."""
+        meta_path = self.base / "quota-dispatch-worker" / "meta.json"
+        meta_path.write_text("{not valid json!!!", encoding="utf-8")
+        # Must not raise:
+        with patch("builtins.print"):
+            T._write_dispatch_quota_blocked("quota-dispatch-worker", self.base, "rate_limit")
+        # handoff.md should still be written with the BLOCKED entry
+        handoff = (self.base / "quota-dispatch-worker" / "handoff.md").read_text(encoding="utf-8")
+        self.assertIn("BLOCKED", handoff)
+        self.assertIn("rate_limit", handoff)
+
+    def test_valid_meta_json_is_updated(self):
+        """Valid meta.json must be updated with status=completed and BLOCKED fields."""
+        with patch("builtins.print"):
+            T._write_dispatch_quota_blocked("quota-dispatch-worker", self.base, "daily_quota")
+        meta = json.loads((self.base / "quota-dispatch-worker" / "meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta["status"], "completed")
+        self.assertEqual(meta["terminal_status"], "BLOCKED")
+        self.assertEqual(meta["quota_reason"], "daily_quota")
+
+
 class TestCmdHandoffAutoDetect(unittest.TestCase):
     """Tests that cmd_handoff auto-detects quota signal from message text when BLOCKED."""
 

--- a/tests/test_tentacle_runtime.py
+++ b/tests/test_tentacle_runtime.py
@@ -6973,5 +6973,612 @@ class TestBridgeLinkRuntimeFlow(unittest.TestCase):
         self.assertIn("brt-text-worker", output)
 
 
+
+
+# ---------------------------------------------------------------------------
+# Tests for quota/rate-limit signal classification (#187)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyQuotaSignal(unittest.TestCase):
+    """Unit tests for _classify_quota_signal."""
+
+    def test_returns_none_for_empty_text(self):
+        self.assertIsNone(T._classify_quota_signal(""))
+
+    def test_returns_none_for_normal_output(self):
+        self.assertIsNone(T._classify_quota_signal("Task completed successfully. All tests pass."))
+
+    def test_detects_rate_limit(self):
+        self.assertEqual(T._classify_quota_signal("Error: rate limit exceeded"), "rate_limit")
+
+    def test_detects_429(self):
+        self.assertEqual(T._classify_quota_signal("HTTP 429 Too Many Requests"), "rate_limit")
+
+    def test_detects_quota_exceeded(self):
+        self.assertEqual(T._classify_quota_signal("API quota exceeded for this billing period"), "quota_exceeded")
+
+    def test_detects_resource_exhausted(self):
+        self.assertEqual(T._classify_quota_signal("RESOURCE_EXHAUSTED: quota reached"), "quota_exceeded")
+
+    def test_detects_daily_quota(self):
+        self.assertEqual(T._classify_quota_signal("Daily quota limit reached"), "daily_quota")
+
+    def test_detects_monthly_quota(self):
+        self.assertEqual(T._classify_quota_signal("Monthly quota exceeded"), "monthly_quota")
+
+    def test_detects_token_quota(self):
+        self.assertEqual(T._classify_quota_signal("Token quota exceeded for your plan"), "token_quota")
+
+    def test_case_insensitive(self):
+        self.assertEqual(T._classify_quota_signal("RATE LIMIT HIT"), "rate_limit")
+
+    def test_returns_none_for_none_input(self):
+        self.assertIsNone(T._classify_quota_signal(None))
+
+
+# ---------------------------------------------------------------------------
+# Tests for handoff quota metadata parsing (#187)
+# ---------------------------------------------------------------------------
+
+
+class TestParseHandoffQuotaMetadata(unittest.TestCase):
+    """Unit tests for _parse_handoff_quota_metadata."""
+
+    def test_returns_none_tuple_for_empty_content(self):
+        reason, hint = T._parse_handoff_quota_metadata("")
+        self.assertIsNone(reason)
+        self.assertIsNone(hint)
+
+    def test_returns_none_tuple_for_content_without_quota_lines(self):
+        content = "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\nDone.\nSTATUS: DONE\n"
+        reason, hint = T._parse_handoff_quota_metadata(content)
+        self.assertIsNone(reason)
+        self.assertIsNone(hint)
+
+    def test_parses_quota_reason(self):
+        content = "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\nBlocked.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\n"
+        reason, hint = T._parse_handoff_quota_metadata(content)
+        self.assertEqual(reason, "rate_limit")
+        self.assertIsNone(hint)
+
+    def test_parses_quota_reason_and_retry_hint(self):
+        content = (
+            "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\nBlocked.\n"
+            "STATUS: BLOCKED\nQUOTA_REASON: daily_quota\nRETRY_HINT: 2026-05-02T00:00:00Z\n"
+        )
+        reason, hint = T._parse_handoff_quota_metadata(content)
+        self.assertEqual(reason, "daily_quota")
+        self.assertEqual(hint, "2026-05-02T00:00:00Z")
+
+    def test_latest_section_wins(self):
+        content = (
+            "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\nFirst.\nQUOTA_REASON: quota_exceeded\n"
+            "\n## [2026-05-02 08:00 UTC]\n\nSecond.\nQUOTA_REASON: rate_limit\n"
+        )
+        reason, hint = T._parse_handoff_quota_metadata(content)
+        self.assertEqual(reason, "rate_limit")
+
+    def test_retry_hint_without_reason_is_captured(self):
+        content = "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\nHint only.\nRETRY_HINT: 2026-05-03T00:00:00Z\n"
+        reason, hint = T._parse_handoff_quota_metadata(content)
+        self.assertIsNone(reason)
+        self.assertEqual(hint, "2026-05-03T00:00:00Z")
+
+    def test_stale_quota_does_not_bleed_into_newer_done_section(self):
+        """Older BLOCKED+quota section must not bleed quota into a newer DONE section."""
+        content = (
+            "# Handoff Notes\n\n"
+            "## [2026-05-01 12:00 UTC]\n\n"
+            "Blocked by rate limit.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: tomorrow\n"
+            "\n## [2026-05-02 09:00 UTC]\n\n"
+            "Completed successfully.\nSTATUS: DONE\n"
+        )
+        reason, hint = T._parse_handoff_quota_metadata(content)
+        self.assertIsNone(reason)
+        self.assertIsNone(hint)
+
+    def test_stale_quota_does_not_bleed_into_newer_generic_blocked_section(self):
+        """Older quota-blocked section must not bleed into a newer generic BLOCKED section."""
+        content = (
+            "# Handoff Notes\n\n"
+            "## [2026-05-01 12:00 UTC]\n\n"
+            "Quota hit.\nSTATUS: BLOCKED\nQUOTA_REASON: daily_quota\nRETRY_HINT: 2026-05-03\n"
+            "\n## [2026-05-02 08:00 UTC]\n\n"
+            "Scope ambiguous.\nSTATUS: BLOCKED\n"
+        )
+        reason, hint = T._parse_handoff_quota_metadata(content)
+        self.assertIsNone(reason)
+        self.assertIsNone(hint)
+
+    def test_quota_anchored_to_status_winning_section(self):
+        """Bug #187 status-anchor fix: quota must come from the section that wins the status parse.
+
+        Scenario: older BLOCKED+quota section, newer status-free progress note.
+        _parse_handoff_status returns BLOCKED (from section 1).
+        _parse_handoff_quota_metadata must also use section 1, not section 2.
+        """
+        content = (
+            "# Handoff Notes\n\n"
+            "## [2026-05-01 12:00 UTC]\n\n"
+            "Blocked by rate limit.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: 2026-05-14T00:00:00Z\n"
+            "\n## [2026-05-02 10:00 UTC]\n\n"
+            "Progress update — still waiting for quota reset.\n"
+        )
+        reason, hint = T._parse_handoff_quota_metadata(content)
+        self.assertEqual(reason, "rate_limit")
+        self.assertEqual(hint, "2026-05-14T00:00:00Z")
+
+    def test_invalid_status_in_newer_section_does_not_anchor_quota(self):
+        """Bug #187 allowlist-anchor fix: a newer section with an invalid STATUS:
+        must not displace the quota from an older allowlisted BLOCKED section.
+
+        Scenario: older section has STATUS: BLOCKED + quota metadata;
+        newer section has STATUS: STALE_STATUS_NOT_IN_ALLOWLIST (not allowlisted).
+        _parse_handoff_status must return BLOCKED; quota must come from the BLOCKED section.
+        """
+        content = (
+            "# Handoff Notes\n\n"
+            "## [2026-05-13 10:00 UTC]\n\n"
+            "Blocked by rate limit.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: 2026-05-14\n"
+            "\n## [2026-05-13 11:00 UTC]\n\n"
+            "Still waiting.\nSTATUS: STALE_STATUS_NOT_IN_ALLOWLIST\n"
+        )
+        # _parse_handoff_status must skip the invalid section and return BLOCKED
+        self.assertEqual(T._parse_handoff_status(content), "BLOCKED")
+        # _parse_handoff_quota_metadata must anchor to the same BLOCKED section
+        reason, hint = T._parse_handoff_quota_metadata(content)
+        self.assertEqual(reason, "rate_limit")
+        self.assertEqual(hint, "2026-05-14")
+
+    def test_all_invalid_statuses_fall_back_to_legacy_quota_parsing(self):
+        """When every section has an invalid STATUS:, quota falls back to
+        the most-recent non-empty section (legacy free-form compat).
+        """
+        content = (
+            "# Handoff Notes\n\n"
+            "## [2026-05-13 10:00 UTC]\n\n"
+            "QUOTA_REASON: rate_limit\nRETRY_HINT: 2026-05-14\nSTATUS: NOT_VALID\n"
+            "\n## [2026-05-13 11:00 UTC]\n\n"
+            "Still waiting.\nSTATUS: ALSO_INVALID\n"
+        )
+        # Both statuses invalid → _parse_handoff_status returns None
+        self.assertIsNone(T._parse_handoff_status(content))
+        # Quota falls back to most-recent non-empty section (no quota fields there)
+        reason, hint = T._parse_handoff_quota_metadata(content)
+        self.assertIsNone(reason)
+        self.assertIsNone(hint)
+
+
+    """Tests that cmd_handoff writes QUOTA_REASON and RETRY_HINT into handoff.md."""
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "handoff_quota"
+        self.base.mkdir(parents=True, exist_ok=True)
+        make_tentacle("quota-worker", self.base)
+
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    def test_handoff_writes_quota_reason(self):
+        args = fake_args(
+            name="quota-worker",
+            message="Rate limited by model provider.",
+            status="BLOCKED",
+            changed_file=[],
+            quota_reason="rate_limit",
+            retry_hint=None,
+            learn=False,
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_handoff(args)
+        handoff = (self.base / "quota-worker" / "handoff.md").read_text(encoding="utf-8")
+        self.assertIn("QUOTA_REASON: rate_limit", handoff)
+
+    def test_handoff_writes_retry_hint(self):
+        args = fake_args(
+            name="quota-worker",
+            message="Daily quota reached.",
+            status="BLOCKED",
+            changed_file=[],
+            quota_reason="daily_quota",
+            retry_hint="2026-05-14T00:00:00Z",
+            learn=False,
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_handoff(args)
+        handoff = (self.base / "quota-worker" / "handoff.md").read_text(encoding="utf-8")
+        self.assertIn("QUOTA_REASON: daily_quota", handoff)
+        self.assertIn("RETRY_HINT: 2026-05-14T00:00:00Z", handoff)
+
+    def test_handoff_no_quota_fields_when_not_provided(self):
+        args = fake_args(
+            name="quota-worker",
+            message="Done.",
+            status="DONE",
+            changed_file=["src/foo.py"],
+            quota_reason=None,
+            retry_hint=None,
+            learn=False,
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_handoff(args)
+        handoff = (self.base / "quota-worker" / "handoff.md").read_text(encoding="utf-8")
+        self.assertNotIn("QUOTA_REASON", handoff)
+        self.assertNotIn("RETRY_HINT", handoff)
+
+    def test_triage_output_includes_quota_reason(self):
+        args = fake_args(
+            name="quota-worker",
+            message="Blocked by quota.",
+            status="BLOCKED",
+            changed_file=[],
+            quota_reason="monthly_quota",
+            retry_hint="next month",
+            learn=False,
+        )
+        captured = []
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(" ".join(str(x) for x in a))):
+                T.cmd_handoff(args)
+        combined = "\n".join(captured)
+        self.assertIn("TRIAGE", combined)
+        self.assertIn("monthly_quota", combined)
+
+
+# ---------------------------------------------------------------------------
+# Tests for cmd_complete quota metadata persistence (#187)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdCompleteQuotaPersistence(unittest.TestCase):
+    """Tests that cmd_complete persists quota_reason and retry_hint into meta.json."""
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "complete_quota"
+        self.base.mkdir(parents=True, exist_ok=True)
+        make_tentacle("quota-complete-test", self.base)
+
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    def _write_handoff(self, name: str, status: str, quota_reason: str = "", retry_hint: str = "") -> None:
+        handoff_path = self.base / name / "handoff.md"
+        content = f"# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\nMessage.\nSTATUS: {status}\n"
+        if quota_reason:
+            content += f"QUOTA_REASON: {quota_reason}\n"
+        if retry_hint:
+            content += f"RETRY_HINT: {retry_hint}\n"
+        handoff_path.write_text(content, encoding="utf-8")
+
+    def test_complete_persists_quota_reason_to_meta(self):
+        self._write_handoff("quota-complete-test", "BLOCKED", "rate_limit", "2026-05-14T00:00:00Z")
+        args = fake_args(name="quota-complete-test", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+        meta = json.loads((self.base / "quota-complete-test" / "meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta.get("quota_reason"), "rate_limit")
+        self.assertEqual(meta.get("retry_hint"), "2026-05-14T00:00:00Z")
+
+    def test_complete_no_quota_fields_for_done_handoff(self):
+        self._write_handoff("quota-complete-test", "DONE")
+        args = fake_args(name="quota-complete-test", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+        meta = json.loads((self.base / "quota-complete-test" / "meta.json").read_text(encoding="utf-8"))
+        self.assertNotIn("quota_reason", meta)
+        self.assertNotIn("retry_hint", meta)
+
+    def test_complete_without_handoff_is_backward_compatible(self):
+        """Completing a tentacle with no handoff must not fail or set quota fields."""
+        args = fake_args(name="quota-complete-test", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+        meta = json.loads((self.base / "quota-complete-test" / "meta.json").read_text(encoding="utf-8"))
+        self.assertNotIn("quota_reason", meta)
+        self.assertNotIn("retry_hint", meta)
+        self.assertEqual(meta["status"], "completed")
+
+    def test_complete_stale_quota_not_persisted_when_newer_section_is_done(self):
+        """Multi-section handoff: older BLOCKED+quota, newer DONE → no quota in meta.json."""
+        handoff_path = self.base / "quota-complete-test" / "handoff.md"
+        content = (
+            "# Handoff Notes\n\n"
+            "## [2026-05-01 12:00 UTC]\n\n"
+            "Blocked by rate limit.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: tomorrow\n"
+            "\n## [2026-05-02 09:00 UTC]\n\n"
+            "Completed successfully.\nSTATUS: DONE\n"
+        )
+        handoff_path.write_text(content, encoding="utf-8")
+        args = fake_args(name="quota-complete-test", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+        meta = json.loads((self.base / "quota-complete-test" / "meta.json").read_text(encoding="utf-8"))
+        self.assertNotIn("quota_reason", meta)
+        self.assertNotIn("retry_hint", meta)
+        self.assertEqual(meta.get("terminal_status"), "DONE")
+
+    def test_two_step_recompletion_clears_stale_quota_from_meta(self):
+        """Two-step recompletion: BLOCKED+quota first, then DONE → stale quota must be cleared."""
+        # Step 1: complete as BLOCKED with quota_reason
+        self._write_handoff("quota-complete-test", "BLOCKED", "rate_limit", "2026-05-14T00:00:00Z")
+        args = fake_args(name="quota-complete-test", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+        meta = json.loads((self.base / "quota-complete-test" / "meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta.get("quota_reason"), "rate_limit")  # sanity-check written
+
+        # Step 2: agent retries and completes as DONE — append a new DONE handoff section
+        handoff_path = self.base / "quota-complete-test" / "handoff.md"
+        existing = handoff_path.read_text(encoding="utf-8")
+        handoff_path.write_text(
+            existing + "\n## [2026-05-02 09:00 UTC]\n\nResolved.\nSTATUS: DONE\n",
+            encoding="utf-8",
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+        meta = json.loads((self.base / "quota-complete-test" / "meta.json").read_text(encoding="utf-8"))
+        self.assertNotIn("quota_reason", meta)
+        self.assertNotIn("retry_hint", meta)
+        self.assertEqual(meta.get("terminal_status"), "DONE")
+
+    def test_reblock_without_hint_clears_stale_hint_in_meta(self):
+        """Re-blocking without a new retry_hint must clear the old hint from meta.json.
+
+        Sequence (reproduces after_blocked_without_hint bug):
+        1. BLOCKED with hint      → meta has retry_hint = "2026-05-14T00:00:00Z"
+        2. BLOCKED without hint   → meta retry_hint must be absent (not stale)
+        """
+        # Step 1: complete as BLOCKED with a retry_hint
+        self._write_handoff("quota-complete-test", "BLOCKED", "rate_limit", "2026-05-14T00:00:00Z")
+        args = fake_args(name="quota-complete-test", no_learn=True)
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+        meta = json.loads((self.base / "quota-complete-test" / "meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta.get("retry_hint"), "2026-05-14T00:00:00Z",
+                         "after_blocked_with_hint: sanity-check hint written")
+
+        # Step 2: re-block the same tentacle, no retry_hint this time
+        self._write_handoff("quota-complete-test", "BLOCKED", "rate_limit")  # no retry_hint
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_complete(args)
+        meta = json.loads((self.base / "quota-complete-test" / "meta.json").read_text(encoding="utf-8"))
+        self.assertNotIn("retry_hint", meta,
+                         "after_blocked_without_hint: stale hint must be cleared when re-blocking without hint")
+        self.assertEqual(meta.get("quota_reason"), "rate_limit")
+
+
+class TestCmdHandoffAutoDetect(unittest.TestCase):
+    """Tests that cmd_handoff auto-detects quota signal from message text when BLOCKED."""
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "handoff_autodetect"
+        self.base.mkdir(parents=True, exist_ok=True)
+        make_tentacle("autodetect-worker", self.base)
+
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    def test_auto_detects_rate_limit_from_blocked_message(self):
+        """BLOCKED handoff with quota-like message and no --quota-reason → auto-detected QUOTA_REASON."""
+        args = fake_args(
+            name="autodetect-worker",
+            message="Error: rate limit exceeded. Please retry later.",
+            status="BLOCKED",
+            changed_file=[],
+            quota_reason=None,
+            retry_hint=None,
+            learn=False,
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_handoff(args)
+        handoff = (self.base / "autodetect-worker" / "handoff.md").read_text(encoding="utf-8")
+        self.assertIn("QUOTA_REASON: rate_limit", handoff)
+
+    def test_explicit_quota_reason_wins_over_auto_detect(self):
+        """Explicit --quota-reason must take precedence over auto-detection."""
+        args = fake_args(
+            name="autodetect-worker",
+            message="Daily quota limit reached.",
+            status="BLOCKED",
+            changed_file=[],
+            quota_reason="token_quota",  # explicit overrides auto
+            retry_hint=None,
+            learn=False,
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_handoff(args)
+        handoff = (self.base / "autodetect-worker" / "handoff.md").read_text(encoding="utf-8")
+        self.assertIn("QUOTA_REASON: token_quota", handoff)
+        self.assertNotIn("QUOTA_REASON: daily_quota", handoff)
+
+    def test_no_auto_detect_for_non_blocked_status(self):
+        """Quota signal auto-detection only fires for BLOCKED; DONE with quota-like text must not emit QUOTA_REASON."""
+        args = fake_args(
+            name="autodetect-worker",
+            message="Rate limit exceeded during run, but we handled it and completed.",
+            status="DONE",
+            changed_file=[],
+            quota_reason=None,
+            retry_hint=None,
+            learn=False,
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_handoff(args)
+        handoff = (self.base / "autodetect-worker" / "handoff.md").read_text(encoding="utf-8")
+        self.assertNotIn("QUOTA_REASON", handoff)
+
+    def test_no_auto_detect_for_non_quota_blocked_message(self):
+        """BLOCKED handoff with non-quota message must not emit QUOTA_REASON."""
+        args = fake_args(
+            name="autodetect-worker",
+            message="Blocked waiting for external dependency to respond.",
+            status="BLOCKED",
+            changed_file=[],
+            quota_reason=None,
+            retry_hint=None,
+            learn=False,
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_handoff(args)
+        handoff = (self.base / "autodetect-worker" / "handoff.md").read_text(encoding="utf-8")
+        self.assertNotIn("QUOTA_REASON", handoff)
+
+    def test_auto_detects_quota_exceeded_from_blocked_message(self):
+        """BLOCKED message containing 'quota exceeded' → auto-detected as quota_exceeded."""
+        args = fake_args(
+            name="autodetect-worker",
+            message="API quota exceeded for this billing period.",
+            status="BLOCKED",
+            changed_file=[],
+            quota_reason=None,
+            retry_hint=None,
+            learn=False,
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_handoff(args)
+        handoff = (self.base / "autodetect-worker" / "handoff.md").read_text(encoding="utf-8")
+        self.assertIn("QUOTA_REASON: quota_exceeded", handoff)
+
+
+# ---------------------------------------------------------------------------
+# Tests for browse-route stale quota metadata guard (#187)
+# ---------------------------------------------------------------------------
+
+
+class TestBrowseRouteStaleMeta(unittest.TestCase):
+    """Tests that _read_tentacles in browse/routes/tentacles.py does not expose
+    stale quota fields for non-BLOCKED tentacles."""
+
+    def setUp(self):
+        import importlib
+
+        import browse.routes.tentacles as brt
+        self._brt = brt
+        self.base = SCRATCH_DIR / "browse_route_quota"
+        self.base.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    def _make_tentacle_dir(self, name: str, meta_extra: dict | None = None) -> Path:
+        d = self.base / name
+        d.mkdir(parents=True, exist_ok=True)
+        meta = {
+            "name": name,
+            "status": "completed",
+            "created_at": "2026-05-01T00:00:00+00:00",
+            "description": f"Test {name}",
+            "scope": [],
+        }
+        if meta_extra:
+            meta.update(meta_extra)
+        (d / "meta.json").write_text(
+            __import__("json").dumps(meta, indent=2) + "\n", encoding="utf-8"
+        )
+        return d
+
+    def test_stale_quota_not_exposed_for_done_tentacle(self):
+        """A DONE tentacle with stale quota_reason/retry_hint in meta.json must not expose them."""
+        self._make_tentacle_dir(
+            "stale-done-worker",
+            meta_extra={
+                "terminal_status": "DONE",
+                "quota_reason": "rate_limit",
+                "retry_hint": "tomorrow",
+            },
+        )
+        with patch.object(self._brt, "_OCTOGENT_DIR", self.base):
+            tentacles = self._brt._read_tentacles()
+        entries = [t for t in tentacles if t["name"] == "stale-done-worker"]
+        self.assertEqual(len(entries), 1)
+        entry = entries[0]
+        self.assertNotIn("quota_reason", entry)
+        self.assertNotIn("retry_hint", entry)
+
+    def test_quota_exposed_for_blocked_tentacle(self):
+        """A BLOCKED tentacle with quota_reason in meta.json must have quota fields exposed."""
+        self._make_tentacle_dir(
+            "blocked-quota-worker",
+            meta_extra={
+                "terminal_status": "BLOCKED",
+                "quota_reason": "daily_quota",
+                "retry_hint": "2026-06-01",
+            },
+        )
+        with patch.object(self._brt, "_OCTOGENT_DIR", self.base):
+            tentacles = self._brt._read_tentacles()
+        entries = [t for t in tentacles if t["name"] == "blocked-quota-worker"]
+        self.assertEqual(len(entries), 1)
+        entry = entries[0]
+        self.assertEqual(entry.get("quota_reason"), "daily_quota")
+        self.assertEqual(entry.get("retry_hint"), "2026-06-01")
+
+    def test_non_blocked_with_handoff_quota_not_exposed(self):
+        """A DONE tentacle whose handoff.md has an old QUOTA_REASON must not expose it."""
+        t_dir = self._make_tentacle_dir(
+            "done-with-old-handoff",
+            meta_extra={"terminal_status": "DONE"},
+        )
+        # Handoff has an old BLOCKED+quota section and a newer DONE section
+        handoff_content = (
+            "# Handoff Notes\n\n"
+            "## [2026-05-01 12:00 UTC]\n\nBlocked.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\n"
+            "\n## [2026-05-02 09:00 UTC]\n\nDone.\nSTATUS: DONE\n"
+        )
+        (t_dir / "handoff.md").write_text(handoff_content, encoding="utf-8")
+        with patch.object(self._brt, "_OCTOGENT_DIR", self.base):
+            tentacles = self._brt._read_tentacles()
+        entries = [t for t in tentacles if t["name"] == "done-with-old-handoff"]
+        self.assertEqual(len(entries), 1)
+        self.assertNotIn("quota_reason", entries[0])
+
+    def test_quota_anchored_to_status_winning_section_browse(self):
+        """Bug #187 status-anchor fix for browse route: quota must come from the
+        section that wins the status parse, not the latest non-empty section.
+
+        Scenario: older BLOCKED+quota section, newer status-free progress note.
+        The browse route must still surface quota_reason and retry_hint because
+        the status-winning section is the BLOCKED+quota one.
+        """
+        t_dir = self._make_tentacle_dir(
+            "blocked-with-progress-note",
+            meta_extra={"terminal_status": ""},  # force handoff-parse fallback
+        )
+        handoff_content = (
+            "# Handoff Notes\n\n"
+            "## [2026-05-01 12:00 UTC]\n\n"
+            "Blocked by rate limit.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\nRETRY_HINT: 2026-05-14T00:00:00Z\n"
+            "\n## [2026-05-02 10:00 UTC]\n\n"
+            "Progress update — still waiting for quota reset.\n"
+        )
+        (t_dir / "handoff.md").write_text(handoff_content, encoding="utf-8")
+        with patch.object(self._brt, "_OCTOGENT_DIR", self.base):
+            tentacles = self._brt._read_tentacles()
+        entries = [t for t in tentacles if t["name"] == "blocked-with-progress-note"]
+        self.assertEqual(len(entries), 1)
+        entry = entries[0]
+        self.assertEqual(entry.get("terminal_status"), "BLOCKED")
+        self.assertEqual(entry.get("quota_reason"), "rate_limit")
+        self.assertEqual(entry.get("retry_hint"), "2026-05-14T00:00:00Z")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+

--- a/tests/test_tentacle_runtime.py
+++ b/tests/test_tentacle_runtime.py
@@ -6833,16 +6833,13 @@ class TestBridgeLinkRuntimeFlow(unittest.TestCase):
         """cmd_complete must parse Bridge: lines and store bridge_links in meta.json."""
         self._make_worker("brt-complete")
         (self.tentacles / "brt-complete" / "handoff.md").write_text(
-            "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\nDone.\n"
-            "STATUS: DONE\nBridge: sc-1\nBridge: sc-2\n",
+            "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\nDone.\nSTATUS: DONE\nBridge: sc-1\nBridge: sc-2\n",
             encoding="utf-8",
         )
 
         self._complete("brt-complete")
 
-        meta = json.loads(
-            (self.tentacles / "brt-complete" / "meta.json").read_text(encoding="utf-8")
-        )
+        meta = json.loads((self.tentacles / "brt-complete" / "meta.json").read_text(encoding="utf-8"))
         self.assertIn("bridge_links", meta)
         self.assertIn("sc-1", meta["bridge_links"])
         self.assertIn("sc-2", meta["bridge_links"])
@@ -6857,9 +6854,7 @@ class TestBridgeLinkRuntimeFlow(unittest.TestCase):
 
         self._complete("brt-no-bridge")
 
-        meta = json.loads(
-            (self.tentacles / "brt-no-bridge" / "meta.json").read_text(encoding="utf-8")
-        )
+        meta = json.loads((self.tentacles / "brt-no-bridge" / "meta.json").read_text(encoding="utf-8"))
         self.assertNotIn("bridge_links", meta)
 
     def test_goal_coverage_shows_covered_criterion_after_handoff_and_complete(self):
@@ -6949,9 +6944,7 @@ class TestBridgeLinkRuntimeFlow(unittest.TestCase):
 
         self._complete("brt-dedup")
 
-        meta = json.loads(
-            (self.tentacles / "brt-dedup" / "meta.json").read_text(encoding="utf-8")
-        )
+        meta = json.loads((self.tentacles / "brt-dedup" / "meta.json").read_text(encoding="utf-8"))
         bridge_links = meta.get("bridge_links", [])
         # sc-1 must appear exactly once (deduplicated)
         self.assertEqual(bridge_links.count("sc-1"), 1)
@@ -6971,8 +6964,6 @@ class TestBridgeLinkRuntimeFlow(unittest.TestCase):
         self.assertIn("sc-1", output)
         self.assertIn("sc-2", output)
         self.assertIn("brt-text-worker", output)
-
-
 
 
 # ---------------------------------------------------------------------------
@@ -7037,7 +7028,9 @@ class TestParseHandoffQuotaMetadata(unittest.TestCase):
         self.assertIsNone(hint)
 
     def test_parses_quota_reason(self):
-        content = "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\nBlocked.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\n"
+        content = (
+            "# Handoff Notes\n\n## [2026-05-01 12:00 UTC]\n\nBlocked.\nSTATUS: BLOCKED\nQUOTA_REASON: rate_limit\n"
+        )
         reason, hint = T._parse_handoff_quota_metadata(content)
         self.assertEqual(reason, "rate_limit")
         self.assertIsNone(hint)
@@ -7150,6 +7143,7 @@ class TestParseHandoffQuotaMetadata(unittest.TestCase):
         self.assertIsNone(hint)
 
 
+class TestCmdHandoffQuotaMetadata(unittest.TestCase):
     """Tests that cmd_handoff writes QUOTA_REASON and RETRY_HINT into handoff.md."""
 
     def setUp(self):
@@ -7345,8 +7339,9 @@ class TestCmdCompleteQuotaPersistence(unittest.TestCase):
             with patch("builtins.print"):
                 T.cmd_complete(args)
         meta = json.loads((self.base / "quota-complete-test" / "meta.json").read_text(encoding="utf-8"))
-        self.assertEqual(meta.get("retry_hint"), "2026-05-14T00:00:00Z",
-                         "after_blocked_with_hint: sanity-check hint written")
+        self.assertEqual(
+            meta.get("retry_hint"), "2026-05-14T00:00:00Z", "after_blocked_with_hint: sanity-check hint written"
+        )
 
         # Step 2: re-block the same tentacle, no retry_hint this time
         self._write_handoff("quota-complete-test", "BLOCKED", "rate_limit")  # no retry_hint
@@ -7354,8 +7349,9 @@ class TestCmdCompleteQuotaPersistence(unittest.TestCase):
             with patch("builtins.print"):
                 T.cmd_complete(args)
         meta = json.loads((self.base / "quota-complete-test" / "meta.json").read_text(encoding="utf-8"))
-        self.assertNotIn("retry_hint", meta,
-                         "after_blocked_without_hint: stale hint must be cleared when re-blocking without hint")
+        self.assertNotIn(
+            "retry_hint", meta, "after_blocked_without_hint: stale hint must be cleared when re-blocking without hint"
+        )
         self.assertEqual(meta.get("quota_reason"), "rate_limit")
 
 
@@ -7470,6 +7466,7 @@ class TestBrowseRouteStaleMeta(unittest.TestCase):
         import importlib
 
         import browse.routes.tentacles as brt
+
         self._brt = brt
         self.base = SCRATCH_DIR / "browse_route_quota"
         self.base.mkdir(parents=True, exist_ok=True)
@@ -7489,9 +7486,7 @@ class TestBrowseRouteStaleMeta(unittest.TestCase):
         }
         if meta_extra:
             meta.update(meta_extra)
-        (d / "meta.json").write_text(
-            __import__("json").dumps(meta, indent=2) + "\n", encoding="utf-8"
-        )
+        (d / "meta.json").write_text(__import__("json").dumps(meta, indent=2) + "\n", encoding="utf-8")
         return d
 
     def test_stale_quota_not_exposed_for_done_tentacle(self):
@@ -7581,4 +7576,3 @@ class TestBrowseRouteStaleMeta(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
-


### PR DESCRIPTION
## Summary
- add quota-aware blocked handoff metadata and retry queue persistence for tentacles
- surface quota-blocked state coherently across completion parsing, goal summaries, browse routes, and tests
- preserve newer bridge-link behavior from origin/main while integrating the #187 quota flow

## Verification
- python -m ruff check tentacle.py browse/routes/tentacles.py tests/test_tentacle_goal.py tests/test_tentacle_runtime.py
- python -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(encoding='utf-8')) for p in ['tentacle.py','browse/routes/tentacles.py','tests/test_tentacle_goal.py','tests/test_tentacle_runtime.py']]; print('AST OK')"
- python -m pytest tests/test_tentacle_goal.py tests/test_tentacle_runtime.py -x -v
- python test_fixes.py

Closes #187