### PR TITLE
feat: add goal resilience-status dashboard

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -838,6 +838,70 @@ are printed: inspect failing criteria (`goal criteria list`), review history (`g
 json`), fix the underlying issues manually or with targeted tentacles, then run `goal resume` to
 re-activate the goal before re-running `goal verify-loop`.
 
+### Resilience status
+
+`goal resilience-status` provides a focused operator dashboard that classifies goal health,
+surfaces budget pressure, blocking gates, and failed criteria at a glance.
+
+Health classifications:
+- **healthy** — goal is active with no budget pressure, blocking gates, or failed criteria.
+- **at-risk** — budget pressure is developing (≤1 iteration remaining, ≥80 % of timeout elapsed,
+  ≤2 tentacles remaining), blocking gates are pending or rejected, criteria have failed, or goal is `paused`
+  for a non-quota reason.
+- **needs-action** — goal is blocked (`needs-human`, `awaiting-gate`, or `abandoned`), has exceeded
+  a budget limit, or is `paused` with quota / rate-limit / blocked-retry signals (including a
+  non-empty `retry_queue`).
+
+```bash
+# Text dashboard (default)
+sk tentacle goal resilience-status
+# fallback: python3 ~/.copilot/tools/tentacle.py goal resilience-status
+
+# Machine-consumable JSON output (stable schema)
+sk tentacle goal resilience-status --format json
+```
+
+Example text output:
+
+```
+✅ Resilience: HEALTHY  |  Goal: My Feature  |  Status: active
+  Budget: iter 2/10, tentacles 3/20
+  Gates: all 2 passed
+  Criteria: 3/5 verified, 0 failed
+```
+
+JSON schema (all top-level keys are always present; future resilience fields default to `null`):
+
+```json
+{
+  "goal_id": "<uuid>",
+  "title": "...",
+  "status": "active",
+  "health": "healthy",
+  "iteration": 2,
+  "budget": {
+    "over_budget": false,
+    "over_iterations": false,
+    "over_tentacles": false,
+    "over_timeout": false,
+    "current_iteration": 2,
+    "max_iterations": 10,
+    "tentacle_count": 3,
+    "max_tentacles": 20,
+    "elapsed_minutes": 45.2,
+    "timeout_minutes": 120
+  },
+  "gates": { "total": 2, "blocking": 0, "blocking_ids": [] },
+  "criteria": { "total": 5, "verified": 3, "failed": 0, "pending": 2 },
+  "needs_human_reason": null,
+  "awaiting_gate_id": null,
+  "awaiting_gate_reason": null,
+  "snapshot_state": null,
+  "pause_metadata": null,
+  "retry_queue": null
+}
+```
+
 ### Typical orchestrator cycle
 
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -848,9 +848,9 @@ Health classifications:
 - **at-risk** — budget pressure is developing (≤1 iteration remaining, ≥80 % of timeout elapsed,
   ≤2 tentacles remaining), blocking gates are pending or rejected, criteria have failed, or goal is `paused`
   for a non-quota reason.
-- **needs-action** — goal is blocked (`needs-human`, `awaiting-gate`, or `abandoned`), has exceeded
+- **needs-action** — goal is blocked (`needs-human`, `awaiting-gate`, `abandoned`, or `budget_limited`), has exceeded
   a budget limit, or is `paused` with quota / rate-limit / blocked-retry signals (including a
-  non-empty `retry_queue`).
+  non-empty `retry_queue` — persisted under `quota_retry_queue` by production writers).
 
 ```bash
 # Text dashboard (default)

--- a/skills/tentacle-orchestration/references/cli-reference.md
+++ b/skills/tentacle-orchestration/references/cli-reference.md
@@ -93,7 +93,7 @@ Operator dashboard that classifies health, surfaces budget pressure, and lists b
 |--------|-----------|
 | `healthy` | Active, no budget pressure, no blocking gates, no failed criteria |
 | `at-risk` | Budget approaching limit (≤1 iter remaining, ≥80 % timeout, ≤2 tentacles left), pending/rejected gates, failed criteria, or `paused` for a non-quota reason |
-| `needs-action` | `needs-human`, `awaiting-gate`, or `abandoned` status; over budget; or `paused` with quota / rate-limit / blocked-retry signals (or non-empty `retry_queue`) |
+| `needs-action` | `needs-human`, `awaiting-gate`, `abandoned`, or `budget_limited` status; over budget; or `paused` with quota / rate-limit / blocked-retry signals (or non-empty `retry_queue` — persisted as `quota_retry_queue` by production writers) |
 
 ```bash
 # Text dashboard (human-readable)

--- a/skills/tentacle-orchestration/references/cli-reference.md
+++ b/skills/tentacle-orchestration/references/cli-reference.md
@@ -37,6 +37,7 @@ sk tentacle goal status [--format text|json]
 sk tentacle goal link <name>
 sk tentacle goal eval [--decision continue|pause|complete|abandon] [--notes "<notes>"]
 sk tentacle goal resume
+sk tentacle goal resilience-status [--format text|json]
 
 # Generate bundle-first dispatch prompt for an agent
 sk tentacle swarm <name> --agent-type <type> --model <model> --briefing
@@ -83,6 +84,27 @@ Lifecycle: `goal init → create/link → todo add → swarm/dispatch (bundle-fi
 | `TOO_BIG` | Scope too large for a single tentacle | ⚠️ Triage signal printed |
 | `AMBIGUOUS` | Spec or requirements unclear | ⚠️ Triage signal printed |
 | `REGRESSED` | Change introduced a regression | ⚠️ Triage signal printed |
+
+### goal resilience-status
+
+Operator dashboard that classifies health, surfaces budget pressure, and lists blocking issues.
+
+| Health | Condition |
+|--------|-----------|
+| `healthy` | Active, no budget pressure, no blocking gates, no failed criteria |
+| `at-risk` | Budget approaching limit (≤1 iter remaining, ≥80 % timeout, ≤2 tentacles left), pending/rejected gates, failed criteria, or `paused` for a non-quota reason |
+| `needs-action` | `needs-human`, `awaiting-gate`, or `abandoned` status; over budget; or `paused` with quota / rate-limit / blocked-retry signals (or non-empty `retry_queue`) |
+
+```bash
+# Text dashboard (human-readable)
+sk tentacle goal resilience-status
+
+# Stable JSON output (machine-consumable; future fields default to null)
+sk tentacle goal resilience-status --format json
+```
+
+JSON top-level keys: `goal_id`, `title`, `status`, `health`, `iteration`, `budget`, `gates`, `criteria`,
+`needs_human_reason`, `awaiting_gate_id`, `awaiting_gate_reason`, `snapshot_state`, `pause_metadata`, `retry_queue`.
 
 ### Handoff examples
 

--- a/tentacle.py
+++ b/tentacle.py
@@ -4884,8 +4884,213 @@ def _cmd_goal_loop(
         print(f"   ▶  Advancing to iteration {current_iter + 1}...")
 
 
+def _goal_resilience_health(state: dict, bs: dict) -> str:
+    """Classify goal resilience health as 'healthy', 'at-risk', or 'needs-action'.
+
+    needs-action: goal is in a blocked/terminal state, over budget, or paused by
+                  quota / rate-limit / blocked-retry signals.
+    at-risk:      budget pressure, pending/rejected gates, failed criteria, or paused
+                  for any other reason.
+    healthy:      active with no pressure signals.
+    """
+    status = state.get("status", "unknown")
+
+    # Completed goals are healthy regardless of budget history — the goal finished.
+    if status == GOAL_STATUS_COMPLETED:
+        return "healthy"
+
+    if status in (GOAL_STATUS_NEEDS_HUMAN, GOAL_STATUS_AWAITING_GATE, GOAL_STATUS_ABANDONED):
+        return "needs-action"
+    if bs.get("over_budget"):
+        return "needs-action"
+
+    # Paused goals are never healthy.  Quota / rate-limit / blocked-retry signals escalate
+    # to needs-action; any other pause reason is at-risk (progress has stopped).
+    # "limit" is intentionally excluded from keywords — it is too generic (e.g. "memory
+    # limit exceeded") and would create false-positive needs-action for non-quota pauses.
+    # The keyword "rate" already covers "rate-limit" and "rate limit exceeded".
+    if status == GOAL_STATUS_PAUSED:
+        _QUOTA_KEYWORDS = {"quota", "rate", "blocked"}
+        pause_metadata = state.get("pause_metadata")
+        retry_queue = state.get("retry_queue")
+        pause_reason = ""
+        if isinstance(pause_metadata, dict):
+            pause_reason = str(pause_metadata.get("reason", "")).lower()
+        has_quota_signal = any(kw in pause_reason for kw in _QUOTA_KEYWORDS)
+        has_retry_queue = bool(retry_queue)
+        if has_quota_signal or has_retry_queue:
+            return "needs-action"
+        return "at-risk"
+
+    blocking_gates = _goal_gates_blocking(state)
+    if blocking_gates:
+        return "at-risk"
+
+    criteria = state.get("success_criteria") or []
+    if any(c.get("status") == "failed" for c in criteria):
+        return "at-risk"
+
+    # Soft budget pressure: ≤1 iteration remaining or ≥80 % of timeout elapsed.
+    if bs.get("max_iterations") is not None:
+        if (bs["max_iterations"] - bs["current_iteration"]) <= 1:
+            return "at-risk"
+    if bs.get("timeout_minutes") and bs.get("elapsed_minutes") is not None:
+        if bs["elapsed_minutes"] / bs["timeout_minutes"] >= 0.8:
+            return "at-risk"
+    if bs.get("max_tentacles") is not None:
+        if (bs["max_tentacles"] - bs["tentacle_count"]) <= 2:
+            return "at-risk"
+
+    return "healthy"
+
+
+def _cmd_goal_resilience_status(args, tentacles: Path) -> None:
+    """Show a focused resilience/health dashboard for the current goal."""
+    state = _goal_load(tentacles)
+    if not state:
+        print("ℹ️  No active goal found. Run `tentacle.py goal init` to create one.")
+        return
+
+    fmt = getattr(args, "format", "text")
+    bs = _goal_budget_status(state)
+    health = _goal_resilience_health(state, bs)
+
+    gates = state.get("gates") or []
+    blocking_gates = _goal_gates_blocking(state)
+    criteria = state.get("success_criteria") or []
+    verified_criteria = [c for c in criteria if c.get("status") == "verified"]
+    failed_criteria = [c for c in criteria if c.get("status") == "failed"]
+
+    # Optional/future resilience fields — degrade gracefully when absent.
+    snapshot_state = state.get("snapshot_state")
+    pause_metadata = state.get("pause_metadata")
+    retry_queue = state.get("retry_queue")
+
+    if fmt == "json":
+        output = {
+            "goal_id": state.get("goal_id"),
+            "title": state.get("title", "(untitled)"),
+            "status": state.get("status", "unknown"),
+            "health": health,
+            "iteration": state.get("iteration", 1),
+            "budget": {
+                "over_budget": bs.get("over_budget", False),
+                "over_iterations": bs.get("over_iterations", False),
+                "over_tentacles": bs.get("over_tentacles", False),
+                "over_timeout": bs.get("over_timeout", False),
+                "current_iteration": bs.get("current_iteration"),
+                "max_iterations": bs.get("max_iterations"),
+                "tentacle_count": bs.get("tentacle_count"),
+                "max_tentacles": bs.get("max_tentacles"),
+                "elapsed_minutes": bs.get("elapsed_minutes"),
+                "timeout_minutes": bs.get("timeout_minutes"),
+            },
+            "gates": {
+                "total": len(gates),
+                "blocking": len(blocking_gates),
+                "blocking_ids": [g.get("id") for g in blocking_gates],
+            },
+            "criteria": {
+                "total": len(criteria),
+                "verified": len(verified_criteria),
+                "failed": len(failed_criteria),
+                "pending": len(criteria) - len(verified_criteria) - len(failed_criteria),
+            },
+            "needs_human_reason": state.get("needs_human_reason"),
+            "awaiting_gate_id": state.get("awaiting_gate_id"),
+            "awaiting_gate_reason": state.get("awaiting_gate_reason"),
+            "snapshot_state": snapshot_state,
+            "pause_metadata": pause_metadata,
+            "retry_queue": retry_queue,
+        }
+        print(json.dumps(output, indent=2))
+        return
+
+    # Text output
+    health_icon = {"healthy": "✅", "at-risk": "⚠️ ", "needs-action": "🚨"}.get(health, "❓")
+    goal_status = state.get("status", "unknown")
+    print(
+        f"{health_icon} Resilience: {health.upper()}"
+        f"  |  Goal: {state.get('title', '(untitled)')}"
+        f"  |  Status: {goal_status}"
+    )
+
+    # Budget pressure
+    if bs.get("over_budget"):
+        flags: list[str] = []
+        if bs.get("over_iterations"):
+            flags.append(f"iterations {bs['current_iteration']}/{bs['max_iterations']}")
+        if bs.get("over_tentacles"):
+            flags.append(f"tentacles {bs['tentacle_count']}/{bs['max_tentacles']}")
+        if bs.get("over_timeout"):
+            flags.append(f"time {bs['elapsed_minutes']}m/{bs['timeout_minutes']}m")
+        print(f"  ⚠️  OVER BUDGET: {', '.join(flags)}")
+    elif any(bs.get(k) is not None for k in ("max_iterations", "max_tentacles", "timeout_minutes")):
+        parts: list[str] = []
+        if bs.get("max_iterations") is not None:
+            parts.append(f"iter {bs['current_iteration']}/{bs['max_iterations']}")
+        if bs.get("max_tentacles") is not None:
+            parts.append(f"tentacles {bs['tentacle_count']}/{bs['max_tentacles']}")
+        if bs.get("timeout_minutes") is not None and bs.get("elapsed_minutes") is not None:
+            parts.append(f"time {bs['elapsed_minutes']}m/{bs['timeout_minutes']}m")
+        if parts:
+            print(f"  Budget: {', '.join(parts)}")
+    else:
+        print("  Budget: no limits set")
+
+    # Gates
+    if blocking_gates:
+        print(f"  Gates: {len(blocking_gates)} blocking (of {len(gates)} total)")
+        for g in blocking_gates[:3]:
+            print(f"    ⛔ [{g.get('id', '?')}] {g.get('description', '')[:60]}")
+        if len(blocking_gates) > 3:
+            print(f"    ... and {len(blocking_gates) - 3} more")
+    elif gates:
+        print(f"  Gates: all {len(gates)} passed")
+    else:
+        print("  Gates: none defined")
+
+    # Criteria
+    if criteria:
+        print(f"  Criteria: {len(verified_criteria)}/{len(criteria)} verified, {len(failed_criteria)} failed")
+    else:
+        print("  Criteria: none defined")
+
+    # Status-specific context
+    if goal_status == GOAL_STATUS_NEEDS_HUMAN:
+        reason = state.get("needs_human_reason", "(no reason recorded)")
+        print(f"  🚨 Needs human: {reason}")
+    if goal_status == GOAL_STATUS_AWAITING_GATE:
+        gate_id = state.get("awaiting_gate_id", "?")
+        gate_reason = state.get("awaiting_gate_reason", "")
+        print(f"  ⛔ Awaiting gate: [{gate_id}]")
+        if gate_reason:
+            print(f"     {gate_reason}")
+    if goal_status == GOAL_STATUS_PAUSED:
+        pm_reason = pause_metadata.get("reason") if isinstance(pause_metadata, dict) else None
+        if pm_reason:
+            print(f"  ⏸ Paused: {pm_reason}")
+        else:
+            print("  ⏸ Paused: (no reason recorded)")
+
+    # Optional future fields — show only when present
+    if snapshot_state is not None:
+        print(f"  Snapshot: {snapshot_state}")
+    if pause_metadata is not None and goal_status != GOAL_STATUS_PAUSED:
+        # For non-paused goals, surface pause_metadata if somehow present
+        pm_reason = pause_metadata.get("reason") if isinstance(pause_metadata, dict) else None
+        if pm_reason:
+            print(f"  Pause reason: {pm_reason}")
+        else:
+            print("  Pause metadata: available")
+    if retry_queue is not None:
+        q_len = len(retry_queue) if isinstance(retry_queue, list) else "?"
+        print(f"  Retry queue: {q_len} item(s)")
+
+
+
 def cmd_goal(args):
-    """Dispatch goal sub-commands: init / create / validate / status / dispatch / link / eval / resume / criteria / gate / budget / next-iter / verify / verify-loop / coverage / loop."""
+    """Dispatch goal sub-commands: init / create / validate / status / dispatch / link / eval / resume / criteria / gate / budget / next-iter / verify / verify-loop / coverage / loop / resilience-status."""
     tentacles = get_tentacles_dir(args.session_dir)
     sub = args.goal_action
 
@@ -4924,6 +5129,8 @@ def cmd_goal(args):
             _cmd_goal_coverage(args, tentacles)
         elif sub == "loop":
             _cmd_goal_loop(args, tentacles)
+        elif sub == "resilience-status":
+            _cmd_goal_resilience_status(args, tentacles)
         else:
             print(f"ERROR: Unknown goal action '{sub}'", file=sys.stderr)
             sys.exit(1)
@@ -7134,6 +7341,13 @@ def main():
             "Marks goal budget_limited if this expires (default: 300)."
         ),
     )
+    # goal resilience-status
+    p_goal_resilience = p_goal_sub.add_parser(
+        "resilience-status",
+        help="Show a focused resilience/health dashboard: health classification, budget pressure, gates, criteria",
+    )
+    p_goal_resilience.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
+
 
     args = parser.parse_args()
 

--- a/tentacle.py
+++ b/tentacle.py
@@ -4899,7 +4899,12 @@ def _goal_resilience_health(state: dict, bs: dict) -> str:
     if status == GOAL_STATUS_COMPLETED:
         return "healthy"
 
-    if status in (GOAL_STATUS_NEEDS_HUMAN, GOAL_STATUS_AWAITING_GATE, GOAL_STATUS_ABANDONED, GOAL_STATUS_BUDGET_LIMITED):
+    if status in (
+        GOAL_STATUS_NEEDS_HUMAN,
+        GOAL_STATUS_AWAITING_GATE,
+        GOAL_STATUS_ABANDONED,
+        GOAL_STATUS_BUDGET_LIMITED,
+    ):
         return "needs-action"
     if bs.get("over_budget"):
         return "needs-action"
@@ -5089,7 +5094,6 @@ def _cmd_goal_resilience_status(args, tentacles: Path) -> None:
     if retry_queue is not None:
         q_len = len(retry_queue) if isinstance(retry_queue, list) else "?"
         print(f"  Retry queue: {q_len} item(s)")
-
 
 
 def cmd_goal(args):
@@ -7350,7 +7354,6 @@ def main():
         help="Show a focused resilience/health dashboard: health classification, budget pressure, gates, criteria",
     )
     p_goal_resilience.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
-
 
     args = parser.parse_args()
 

--- a/tentacle.py
+++ b/tentacle.py
@@ -4899,7 +4899,7 @@ def _goal_resilience_health(state: dict, bs: dict) -> str:
     if status == GOAL_STATUS_COMPLETED:
         return "healthy"
 
-    if status in (GOAL_STATUS_NEEDS_HUMAN, GOAL_STATUS_AWAITING_GATE, GOAL_STATUS_ABANDONED):
+    if status in (GOAL_STATUS_NEEDS_HUMAN, GOAL_STATUS_AWAITING_GATE, GOAL_STATUS_ABANDONED, GOAL_STATUS_BUDGET_LIMITED):
         return "needs-action"
     if bs.get("over_budget"):
         return "needs-action"
@@ -4912,7 +4912,8 @@ def _goal_resilience_health(state: dict, bs: dict) -> str:
     if status == GOAL_STATUS_PAUSED:
         _QUOTA_KEYWORDS = {"quota", "rate", "blocked"}
         pause_metadata = state.get("pause_metadata")
-        retry_queue = state.get("retry_queue")
+        # Prefer quota_retry_queue (production writers) with retry_queue as compat fallback.
+        retry_queue = state.get("quota_retry_queue") or state.get("retry_queue")
         pause_reason = ""
         if isinstance(pause_metadata, dict):
             pause_reason = str(pause_metadata.get("reason", "")).lower()
@@ -4964,7 +4965,9 @@ def _cmd_goal_resilience_status(args, tentacles: Path) -> None:
     # Optional/future resilience fields — degrade gracefully when absent.
     snapshot_state = state.get("snapshot_state")
     pause_metadata = state.get("pause_metadata")
-    retry_queue = state.get("retry_queue")
+    # Prefer quota_retry_queue (production writers) with retry_queue as compat fallback.
+    # The stable JSON output field name remains "retry_queue".
+    retry_queue = state.get("quota_retry_queue") or state.get("retry_queue")
 
     if fmt == "json":
         output = {

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -5643,7 +5643,6 @@ class TestGoalLoop(unittest.TestCase):
 
     def tearDown(self):
         _rmtree(SCRATCH_DIR)
-
     # -- helpers --
 
     def _add_passing_criterion(self, cid: str = "sc-pass") -> None:
@@ -6870,6 +6869,425 @@ class TestNextIterQuotaBlocked(unittest.TestCase):
             T._cmd_goal_next_iter(args, self.tentacles)
         combined = "\n".join(captured)
         self.assertIn("valid-q", combined)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _goal_resilience_health and _cmd_goal_resilience_status
+# ---------------------------------------------------------------------------
+# Tests for _goal_resilience_health and _cmd_goal_resilience_status
+# ---------------------------------------------------------------------------
+
+
+class TestGoalResilienceHealth(unittest.TestCase):
+    """Unit tests for _goal_resilience_health classification logic."""
+
+    def _bs(self, **overrides) -> dict:
+        base = {
+            "over_budget": False,
+            "over_iterations": False,
+            "over_tentacles": False,
+            "over_timeout": False,
+            "current_iteration": 1,
+            "max_iterations": None,
+            "tentacle_count": 0,
+            "max_tentacles": None,
+            "elapsed_minutes": None,
+            "timeout_minutes": None,
+        }
+        base.update(overrides)
+        return base
+
+    def _state(self, status: str = T.GOAL_STATUS_ACTIVE, **extra) -> dict:
+        base: dict = {"status": status, "gates": [], "success_criteria": []}
+        base.update(extra)
+        return base
+
+    def test_active_no_pressure_is_healthy(self):
+        s = self._state()
+        bs = self._bs()
+        self.assertEqual(T._goal_resilience_health(s, bs), "healthy")
+
+    def test_needs_human_is_needs_action(self):
+        s = self._state(status=T.GOAL_STATUS_NEEDS_HUMAN)
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "needs-action")
+
+    def test_awaiting_gate_is_needs_action(self):
+        s = self._state(status=T.GOAL_STATUS_AWAITING_GATE)
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "needs-action")
+
+    def test_abandoned_is_needs_action(self):
+        s = self._state(status=T.GOAL_STATUS_ABANDONED)
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "needs-action")
+
+    def test_over_budget_is_needs_action(self):
+        s = self._state()
+        bs = self._bs(over_budget=True, over_iterations=True, current_iteration=4, max_iterations=3)
+        self.assertEqual(T._goal_resilience_health(s, bs), "needs-action")
+
+    def test_blocking_gate_is_at_risk(self):
+        s = self._state(gates=[{"id": "G1", "status": "pending"}])
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "at-risk")
+
+    def test_rejected_gate_is_at_risk(self):
+        s = self._state(gates=[{"id": "G1", "status": "rejected"}])
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "at-risk")
+
+    def test_all_gates_passed_is_healthy(self):
+        s = self._state(gates=[{"id": "G1", "status": "passed"}, {"id": "G2", "status": "passed"}])
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "healthy")
+
+    def test_failed_criterion_is_at_risk(self):
+        s = self._state(success_criteria=[{"id": 1, "status": "failed"}])
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "at-risk")
+
+    def test_verified_criteria_is_healthy(self):
+        s = self._state(success_criteria=[{"id": 1, "status": "verified"}])
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "healthy")
+
+    def test_soft_pressure_last_iteration_is_at_risk(self):
+        s = self._state()
+        bs = self._bs(current_iteration=2, max_iterations=3)
+        # remaining = 3 - 2 = 1, triggers at-risk
+        self.assertEqual(T._goal_resilience_health(s, bs), "at-risk")
+
+    def test_soft_pressure_exactly_two_remaining_is_healthy(self):
+        s = self._state()
+        bs = self._bs(current_iteration=1, max_iterations=3)
+        # remaining = 3 - 1 = 2, does NOT trigger at-risk
+        self.assertEqual(T._goal_resilience_health(s, bs), "healthy")
+
+    def test_soft_timeout_pressure_at_80pct_is_at_risk(self):
+        s = self._state()
+        bs = self._bs(elapsed_minutes=80.0, timeout_minutes=100)
+        self.assertEqual(T._goal_resilience_health(s, bs), "at-risk")
+
+    def test_soft_timeout_below_80pct_is_healthy(self):
+        s = self._state()
+        bs = self._bs(elapsed_minutes=70.0, timeout_minutes=100)
+        self.assertEqual(T._goal_resilience_health(s, bs), "healthy")
+
+    def test_soft_tentacle_pressure_two_or_fewer_remaining_is_at_risk(self):
+        s = self._state()
+        bs = self._bs(tentacle_count=8, max_tentacles=10)
+        # remaining = 10 - 8 = 2
+        self.assertEqual(T._goal_resilience_health(s, bs), "at-risk")
+
+    def test_soft_tentacle_three_remaining_is_healthy(self):
+        s = self._state()
+        bs = self._bs(tentacle_count=7, max_tentacles=10)
+        # remaining = 10 - 7 = 3
+        self.assertEqual(T._goal_resilience_health(s, bs), "healthy")
+
+    def test_completed_goal_is_healthy(self):
+        # completed is not in the needs-action or at-risk logic
+        s = self._state(status=T.GOAL_STATUS_COMPLETED)
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "healthy")
+
+    def test_completed_over_budget_is_healthy(self):
+        # Reproduced defect: status=completed + over_budget=True must NOT produce needs-action.
+        # A finished goal should not demand operator action just because it ran over budget.
+        s = self._state(status=T.GOAL_STATUS_COMPLETED)
+        bs = self._bs(
+            over_budget=True,
+            over_iterations=True,
+            current_iteration=4,
+            max_iterations=2,
+        )
+        self.assertEqual(T._goal_resilience_health(s, bs), "healthy")
+
+    def test_paused_no_signals_is_at_risk(self):
+        s = self._state(status=T.GOAL_STATUS_PAUSED)
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "at-risk")
+
+    def test_paused_quota_reason_is_needs_action(self):
+        s = self._state(status=T.GOAL_STATUS_PAUSED, pause_metadata={"reason": "quota"})
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "needs-action")
+
+    def test_paused_rate_limit_reason_is_needs_action(self):
+        s = self._state(status=T.GOAL_STATUS_PAUSED, pause_metadata={"reason": "rate-limit"})
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "needs-action")
+
+    def test_paused_blocked_reason_is_needs_action(self):
+        s = self._state(status=T.GOAL_STATUS_PAUSED, pause_metadata={"reason": "blocked"})
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "needs-action")
+
+    def test_paused_with_retry_queue_is_needs_action(self):
+        s = self._state(
+            status=T.GOAL_STATUS_PAUSED,
+            retry_queue=[{"tentacle_name": "t-demo", "reason": "quota"}],
+        )
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "needs-action")
+
+    def test_paused_empty_retry_queue_is_at_risk(self):
+        s = self._state(status=T.GOAL_STATUS_PAUSED, retry_queue=[])
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "at-risk")
+
+    def test_paused_unrelated_reason_is_at_risk(self):
+        s = self._state(status=T.GOAL_STATUS_PAUSED, pause_metadata={"reason": "manual"})
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "at-risk")
+
+    def test_paused_memory_limit_reason_is_at_risk(self):
+        # Reproduced defect: "memory limit exceeded" contains the word "limit" which was
+        # previously in _QUOTA_KEYWORDS, causing a false-positive needs-action.
+        # Non-quota "limit" phrases should classify as at-risk, not needs-action.
+        s = self._state(
+            status=T.GOAL_STATUS_PAUSED,
+            pause_metadata={"reason": "memory limit exceeded", "source": "test-proof"},
+        )
+        self.assertEqual(T._goal_resilience_health(s, self._bs()), "at-risk")
+
+
+class TestCmdGoalResilienceStatus(unittest.TestCase):
+    """Integration-style tests for _cmd_goal_resilience_status text and JSON output."""
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "resilience_status"
+        _, self.tentacles = _make_octogent(self.base)
+        _init_goal(self.tentacles, title="Health Test Goal")
+
+    def tearDown(self):
+        _rmtree(SCRATCH_DIR)
+
+    # --- helpers ---
+
+    def _run_text(self, **state_overrides) -> str:
+        if state_overrides:
+            state = T._goal_load(self.tentacles)
+            state.update(state_overrides)
+            T._goal_write(self.tentacles, state)
+        captured: list[str] = []
+        with patch("builtins.print", side_effect=lambda *a, **k: captured.append(" ".join(str(x) for x in a))):
+            T._cmd_goal_resilience_status(_fake_args(goal_action="resilience-status", format="text"), self.tentacles)
+        return "\n".join(captured)
+
+    def _run_json(self, **state_overrides) -> dict:
+        if state_overrides:
+            state = T._goal_load(self.tentacles)
+            state.update(state_overrides)
+            T._goal_write(self.tentacles, state)
+        captured: list[str] = []
+        with patch("builtins.print", side_effect=lambda *a, **k: captured.append(" ".join(str(x) for x in a))):
+            T._cmd_goal_resilience_status(_fake_args(goal_action="resilience-status", format="json"), self.tentacles)
+        return json.loads("\n".join(captured))
+
+    # --- no goal ---
+
+    def test_no_goal_prints_info_message(self):
+        _, empty_tentacles = _make_octogent(SCRATCH_DIR / "empty_rs")
+        captured: list[str] = []
+        with patch("builtins.print", side_effect=lambda *a, **k: captured.append(str(a[0]))):
+            T._cmd_goal_resilience_status(
+                _fake_args(goal_action="resilience-status", format="text"), empty_tentacles
+            )
+        self.assertTrue(any("No active goal" in line for line in captured))
+
+    # --- text output: healthy state ---
+
+    def test_healthy_state_text_contains_healthy(self):
+        out = self._run_text()
+        self.assertIn("HEALTHY", out.upper())
+
+    def test_healthy_state_text_contains_goal_title(self):
+        out = self._run_text()
+        self.assertIn("Health Test Goal", out)
+
+    def test_healthy_no_limits_shows_no_limits_set(self):
+        out = self._run_text()
+        self.assertIn("no limits set", out)
+
+    def test_healthy_text_shows_no_gates_defined(self):
+        out = self._run_text()
+        self.assertIn("none defined", out)
+
+    # --- text output: at-risk state ---
+
+    def test_at_risk_due_to_blocking_gate(self):
+        out = self._run_text(gates=[{"id": "G1", "description": "merge freeze", "status": "pending"}])
+        self.assertIn("AT-RISK", out.upper())
+        self.assertIn("blocking", out)
+        self.assertIn("G1", out)
+
+    def test_at_risk_due_to_failed_criterion(self):
+        out = self._run_text(success_criteria=[{"id": 1, "description": "tests pass", "status": "failed"}])
+        self.assertIn("AT-RISK", out.upper())
+        self.assertIn("1 failed", out)
+
+    # --- text output: needs-action state ---
+
+    def test_needs_action_needs_human_shows_reason(self):
+        out = self._run_text(
+            status=T.GOAL_STATUS_NEEDS_HUMAN,
+            needs_human_reason="quota exceeded",
+        )
+        self.assertIn("NEEDS-ACTION", out.upper())
+        self.assertIn("quota exceeded", out)
+
+    def test_needs_action_awaiting_gate_shows_gate_id(self):
+        out = self._run_text(
+            status=T.GOAL_STATUS_AWAITING_GATE,
+            awaiting_gate_id="SECURITY",
+            awaiting_gate_reason="Security review required",
+        )
+        self.assertIn("NEEDS-ACTION", out.upper())
+        self.assertIn("SECURITY", out)
+
+    def test_over_budget_shows_over_budget_warning(self):
+        old_created = (datetime.now(timezone.utc) - timedelta(hours=5)).isoformat()
+        out = self._run_text(
+            created_at=old_created,
+            budget={"max_iterations": 2, "max_tentacles": 3, "timeout_minutes": 60, "status": "active"},
+            iteration=4,
+        )
+        self.assertIn("NEEDS-ACTION", out.upper())
+        self.assertIn("OVER BUDGET", out.upper())
+
+    # --- JSON output schema ---
+
+    def test_json_output_has_required_top_level_keys(self):
+        result = self._run_json()
+        for key in ("goal_id", "title", "status", "health", "iteration", "budget", "gates", "criteria"):
+            self.assertIn(key, result, f"Missing key: {key}")
+
+    def test_json_output_budget_has_expected_keys(self):
+        result = self._run_json()
+        for key in (
+            "over_budget",
+            "over_iterations",
+            "over_tentacles",
+            "over_timeout",
+            "current_iteration",
+            "max_iterations",
+            "tentacle_count",
+            "max_tentacles",
+            "elapsed_minutes",
+            "timeout_minutes",
+        ):
+            self.assertIn(key, result["budget"], f"Missing budget key: {key}")
+
+    def test_json_output_gates_has_expected_keys(self):
+        result = self._run_json()
+        for key in ("total", "blocking", "blocking_ids"):
+            self.assertIn(key, result["gates"], f"Missing gates key: {key}")
+
+    def test_json_output_criteria_has_expected_keys(self):
+        result = self._run_json()
+        for key in ("total", "verified", "failed", "pending"):
+            self.assertIn(key, result["criteria"], f"Missing criteria key: {key}")
+
+    def test_json_resilience_fields_null_when_absent(self):
+        result = self._run_json()
+        self.assertIsNone(result.get("snapshot_state"))
+        self.assertIsNone(result.get("pause_metadata"))
+        self.assertIsNone(result.get("retry_queue"))
+        self.assertIsNone(result.get("needs_human_reason"))
+        self.assertIsNone(result.get("awaiting_gate_id"))
+        self.assertIsNone(result.get("awaiting_gate_reason"))
+
+    def test_json_future_fields_surfaced_when_present(self):
+        result = self._run_json(
+            snapshot_state="ready",
+            pause_metadata={"reason": "quota"},
+            retry_queue=[{"id": "t1"}],
+        )
+        self.assertEqual(result["snapshot_state"], "ready")
+        self.assertEqual(result["pause_metadata"], {"reason": "quota"})
+        self.assertEqual(result["retry_queue"], [{"id": "t1"}])
+
+    def test_json_at_risk_blocking_gates_listed(self):
+        result = self._run_json(gates=[{"id": "G1", "description": "review", "status": "pending"}])
+        self.assertEqual(result["health"], "at-risk")
+        self.assertEqual(result["gates"]["blocking"], 1)
+        self.assertIn("G1", result["gates"]["blocking_ids"])
+
+    def test_json_healthy_no_pressure(self):
+        result = self._run_json()
+        self.assertEqual(result["health"], "healthy")
+        self.assertFalse(result["budget"]["over_budget"])
+        self.assertEqual(result["gates"]["blocking"], 0)
+        self.assertEqual(result["criteria"]["total"], 0)
+
+    def test_json_criteria_counts_are_correct(self):
+        result = self._run_json(
+            success_criteria=[
+                {"id": 1, "status": "verified"},
+                {"id": 2, "status": "failed"},
+                {"id": 3, "status": "unverified"},
+            ]
+        )
+        self.assertEqual(result["criteria"]["total"], 3)
+        self.assertEqual(result["criteria"]["verified"], 1)
+        self.assertEqual(result["criteria"]["failed"], 1)
+        self.assertEqual(result["criteria"]["pending"], 1)
+
+    def test_json_needs_human_reason_surfaced(self):
+        result = self._run_json(
+            status=T.GOAL_STATUS_NEEDS_HUMAN,
+            needs_human_reason="stall detected",
+        )
+        self.assertEqual(result["health"], "needs-action")
+        self.assertEqual(result["needs_human_reason"], "stall detected")
+
+    # --- optional future fields in text mode ---
+
+    def test_text_snapshot_state_shown_when_present(self):
+        out = self._run_text(snapshot_state="pending-compact")
+        self.assertIn("pending-compact", out)
+
+    def test_text_retry_queue_shown_when_present(self):
+        out = self._run_text(retry_queue=[{"id": "t1"}, {"id": "t2"}])
+        self.assertIn("Retry queue: 2", out)
+
+    def test_text_pause_metadata_shown_when_present(self):
+        # When pause_metadata is present on a non-paused goal, reason value must be shown.
+        out = self._run_text(pause_metadata={"reason": "rate-limit"})
+        self.assertIn("rate-limit", out)
+
+    # --- paused / quota classification (issue #190 contract) ---
+
+    def test_paused_with_quota_signal_health_is_needs_action(self):
+        out = self._run_text(
+            status=T.GOAL_STATUS_PAUSED,
+            pause_metadata={"reason": "quota", "source": "test-proof"},
+        )
+        self.assertIn("NEEDS-ACTION", out.upper())
+
+    def test_paused_with_retry_queue_health_is_needs_action(self):
+        out = self._run_text(
+            status=T.GOAL_STATUS_PAUSED,
+            retry_queue=[{"tentacle_name": "t-demo", "reason": "quota", "next_retry_after": "2026-05-14T01:00:00Z"}],
+        )
+        self.assertIn("NEEDS-ACTION", out.upper())
+
+    def test_paused_without_quota_signals_health_is_at_risk(self):
+        out = self._run_text(status=T.GOAL_STATUS_PAUSED)
+        self.assertIn("AT-RISK", out.upper())
+        self.assertNotIn("NEEDS-ACTION", out.upper())
+
+    def test_paused_text_surfaces_pause_reason_value(self):
+        out = self._run_text(
+            status=T.GOAL_STATUS_PAUSED,
+            pause_metadata={"reason": "quota", "source": "test-proof"},
+        )
+        self.assertIn("quota", out)
+
+    def test_json_paused_quota_is_needs_action(self):
+        """Orchestrator runtime proof contract: paused + quota → health == needs-action."""
+        result = self._run_json(
+            status=T.GOAL_STATUS_PAUSED,
+            pause_metadata={"reason": "quota", "source": "test-proof"},
+            retry_queue=[{"tentacle_name": "t-demo", "reason": "quota", "next_retry_after": "2026-05-14T01:00:00Z"}],
+            snapshot_state="captured",
+        )
+        self.assertEqual(result["status"], "paused")
+        self.assertEqual(result["health"], "needs-action")
+        self.assertEqual(result["pause_metadata"], {"reason": "quota", "source": "test-proof"})
+        self.assertEqual(len(result["retry_queue"]), 1)
+        self.assertEqual(result["snapshot_state"], "captured")
+
+    def test_json_paused_no_quota_is_at_risk(self):
+        result = self._run_json(status=T.GOAL_STATUS_PAUSED)
+        self.assertEqual(result["status"], "paused")
+        self.assertEqual(result["health"], "at-risk")
 
 
 if __name__ == "__main__":

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -7036,6 +7036,38 @@ class TestGoalResilienceHealth(unittest.TestCase):
         )
         self.assertEqual(T._goal_resilience_health(s, self._bs()), "at-risk")
 
+    # --- reproduced post-rebase bugs (issue #190) ---
+
+    def test_budget_limited_is_needs_action(self):
+        """Reproduced bug: status=budget_limited must classify as needs-action, not healthy."""
+        s = self._state(
+            status=T.GOAL_STATUS_BUDGET_LIMITED,
+            budget_limited_reason="loop max_steps reached",
+        )
+        self.assertEqual(
+            T._goal_resilience_health(s, self._bs()),
+            "needs-action",
+            "budget_limited requires operator action and must not appear healthy",
+        )
+
+    def test_budget_limited_with_no_budget_pressure_is_still_needs_action(self):
+        """budget_limited status must produce needs-action even when no budget fields are set."""
+        s = self._state(status=T.GOAL_STATUS_BUDGET_LIMITED)
+        bs = self._bs()  # no budget limits set, over_budget=False
+        self.assertEqual(T._goal_resilience_health(s, bs), "needs-action")
+
+    def test_paused_quota_retry_queue_key_is_needs_action(self):
+        """Reproduced bug: production writes to quota_retry_queue; health must use that key."""
+        s = self._state(
+            status=T.GOAL_STATUS_PAUSED,
+            quota_retry_queue=[{"tentacle": "t-demo", "reason": "quota"}],
+        )
+        self.assertEqual(
+            T._goal_resilience_health(s, self._bs()),
+            "needs-action",
+            "quota_retry_queue entries must trigger needs-action",
+        )
+
 
 class TestCmdGoalResilienceStatus(unittest.TestCase):
     """Integration-style tests for _cmd_goal_resilience_status text and JSON output."""
@@ -7288,6 +7320,50 @@ class TestCmdGoalResilienceStatus(unittest.TestCase):
         result = self._run_json(status=T.GOAL_STATUS_PAUSED)
         self.assertEqual(result["status"], "paused")
         self.assertEqual(result["health"], "at-risk")
+
+    # --- reproduced post-rebase bugs (issue #190) ---
+
+    def test_json_budget_limited_health_is_needs_action(self):
+        """Reproduced bug: status=budget_limited must produce health=needs-action, not healthy."""
+        result = self._run_json(
+            status=T.GOAL_STATUS_BUDGET_LIMITED,
+            budget_limited_reason="loop max_steps reached",
+        )
+        self.assertEqual(result["status"], T.GOAL_STATUS_BUDGET_LIMITED)
+        self.assertEqual(
+            result["health"],
+            "needs-action",
+            "budget_limited must not appear healthy in JSON output",
+        )
+
+    def test_json_quota_retry_queue_surfaced_as_retry_queue(self):
+        """Reproduced bug: production path stores quota_retry_queue; JSON must surface it as retry_queue."""
+        queue = [{"tentacle": "t-demo", "reason": "quota", "next_retry_after": "2026-05-14T01:00:00Z"}]
+        result = self._run_json(
+            status=T.GOAL_STATUS_PAUSED,
+            pause_metadata={"reason": "quota"},
+            quota_retry_queue=queue,
+        )
+        self.assertEqual(result["health"], "needs-action")
+        self.assertIsNotNone(result.get("retry_queue"), "retry_queue must be surfaced when quota_retry_queue is present")
+        self.assertEqual(len(result["retry_queue"]), 1, "all queue entries must appear under retry_queue")
+
+    def test_text_budget_limited_shows_needs_action(self):
+        """Text output must show NEEDS-ACTION for budget_limited goals."""
+        out = self._run_text(
+            status=T.GOAL_STATUS_BUDGET_LIMITED,
+            budget_limited_reason="loop max_steps reached",
+        )
+        self.assertIn("NEEDS-ACTION", out.upper())
+
+    def test_text_quota_retry_queue_shown(self):
+        """Text output must show retry queue entries stored under quota_retry_queue."""
+        out = self._run_text(
+            status=T.GOAL_STATUS_PAUSED,
+            pause_metadata={"reason": "quota"},
+            quota_retry_queue=[{"tentacle": "t1"}, {"tentacle": "t2"}],
+        )
+        self.assertIn("Retry queue: 2", out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `sk tentacle goal resilience-status` with text and JSON output
- classify healthy / at-risk / needs-action using goal status, budget pressure, gate state, pause state, and retry signals
- add focused tests plus CLI/docs updates for the new dashboard

## Verification
- ran targeted goal command tests and the broader Python regression suite
- reproduced and fixed paused-quota, completed-over-budget, and paused-memory-limit edge cases with isolated runtime proofs

Closes #190