### PR TITLE
feat(skills): require reviewed step plans for tentacles

### DIFF
--- a/skills/task-step-generator/SKILL.md
+++ b/skills/task-step-generator/SKILL.md
@@ -3,8 +3,9 @@ name: task-step-generator
 description: >
   Generate a structured STEPS.md file that breaks a specific task into concrete, ordered
   steps grounded in the project's phased workflow. Use when a task is too complex for a
-  single prompt but too small for full tentacle orchestration — e.g., a single-module
-  feature, a multi-stage bug fix, or a scripted migration. Trigger phrases: "create step
+  single prompt, when tentacle-orchestration needs a reviewed planning scaffold before
+  dispatch, or for single-module features, multi-stage bug fixes, and scripted migrations.
+  Trigger phrases: "create step
   file", "generate steps", "make a task plan", "write out the steps", "break this into
   steps", "step-by-step plan", "task steps", "execution plan".
 ---
@@ -14,17 +15,20 @@ description: >
 Generate a `STEPS.md` file that breaks a specific task into concrete, ordered steps an
 agent can follow without re-reading the full specification. Steps are grounded in the
 project's existing phases (from `WORKFLOW.md` or the standard phased lifecycle) and
-scoped to complete in a single agent session.
+are normally scoped to complete in a single agent session. When invoked by
+`tentacle-orchestration`, the step file is a top-level scaffold that must be reviewed
+and split into scoped tentacles before dispatch.
 
 ## When to Use
 
 - Task is too complex to fit in one prompt response but touches only 1–3 files or modules
+- Tentacle orchestration needs a first-pass step plan to review before creating parallel work units
 - You want a traceable, reviewable execution plan before starting implementation
 - A task has non-obvious ordering constraints (e.g., schema migration before code change)
 - User says "create step file", "break this into steps", "make a task plan"
 
 **Not for:**
-- Tasks spanning 3+ independent modules → use `tentacle-orchestration` to decompose first
+- Tasks spanning 3+ independent modules as the final execution plan → use `tentacle-orchestration` to review this scaffold and split it into tentacles
 - Project-level process templates → use `workflow-creator` to generate `WORKFLOW.md`
 - Pure research or exploration tasks (no implementation deliverable)
 
@@ -128,7 +132,7 @@ See `references/step-file-template.md` for the full annotated template.
 | Mixing phases (build + test in one step) | Gate is ambiguous; errors mix together |
 | Vague actions ("verify it works") | Not actionable; agent guesses |
 | No ordering constraints | Agent skips steps that depend on earlier output |
-| Generating for 3+ independent modules | Step file becomes too large; use tentacle instead |
+| Treating a 3+ module scaffold as final | Step file becomes too large; review it, then split into tentacles |
 
 <example>
 **Task:** Add a `created_at` timestamp column to the `orders` table and expose it in the API response.

--- a/skills/tentacle-creator/SKILL.md
+++ b/skills/tentacle-creator/SKILL.md
@@ -75,6 +75,8 @@ Create `.github/skills/tentacle-orchestration/SKILL.md` customized for the proje
 `~/.copilot/tools/skills/tentacle-orchestration/SKILL.md` and customize it.
 Every section in the reference MUST appear in the output. You are ADDING
 project-specific content, not cherry-picking sections.
+Preserve the canonical task-step-generator-first planning discipline and the
+decomposition review guidance; customize examples and commands, not the control flow.
 
 #### 4a: Required sections (ALL must be present)
 
@@ -85,19 +87,20 @@ example blocks, description trigger words). Use this checklist:
 
 | # | Required Section | Source | Action |
 |---|-----------------|--------|--------|
-| 1 | `## When to use` | Reference | Keep table, add project-specific rows |
-| 2 | `## Anti-patterns` | Reference | Keep all items, add project-specific items |
-| 3 | `## Core concept` | Reference | **Copy verbatim** — file tree diagram, octopus metaphor |
-| 4 | `## Workflow` (or `## Internal Workflow`) | Reference | Keep 5-phase labels: Clarify → Plan → Execute → Verify → Close |
-| 5 | `### Phase 0: Clarify Spec` | Reference | Keep motivation text ("bug found in spec costs 1x..."), Steps 0.0–0.5 |
-| 6 | `### Phase 1: Plan` | Reference | Keep "Impact Analysis / Risk Assessment" mention, customize folder patterns |
-| 7 | `### Phase 2: Execute` | Reference | Keep `--model` param in swarm, customize agent mapping table |
-| 8 | `### Phase 3: Verify` | Reference | Keep 6-gate table, replace commands with project's build/lint/test |
-| 9 | `### Phase 4: Close` | Reference | Keep `complete` before `delete` warning |
-| 10 | `## Verification summary` | Reference | Keep 6-gate table (mirrors Phase 3 gates) |
-| 11 | `## CLI reference` | Reference | Keep all commands, include `--model` in swarm |
-| 12 | `## Tips` | Reference | Keep all tips, add project-specific tips |
-| 13 | `## Reference docs` | New | Link to `~/.copilot/tools/skills/tentacle-orchestration/references/` |
+| 1 | `## Planning Discipline` | Reference | Keep task-step-generator first, reviewed step plan, and accepted/edited/rejected record |
+| 2 | `## When to use` | Reference | Keep table, add project-specific rows |
+| 3 | `## Anti-patterns` | Reference | Keep all items, add project-specific items |
+| 4 | `## Core concept` | Reference | **Copy verbatim** — file tree diagram, octopus metaphor |
+| 5 | `## Workflow` (or `## Internal Workflow`) | Reference | Keep 5-phase labels: Clarify → Plan → Execute → Verify → Close |
+| 6 | `### Phase 0: Clarify Spec` | Reference | Keep motivation text ("bug found in spec costs 1x..."), Steps 0.0–0.5 |
+| 7 | `### Phase 1: Plan` | Reference | Keep task-step-generator, decomposition review, and "Impact Analysis / Risk Assessment" mention; customize folder patterns |
+| 8 | `### Phase 2: Execute` | Reference | Keep `--model` param in swarm, customize agent mapping table |
+| 9 | `### Phase 3: Verify` | Reference | Keep 6-gate table, replace commands with project's build/lint/test |
+| 10 | `### Phase 4: Close` | Reference | Keep `complete` before `delete` warning |
+| 11 | `## Verification summary` | Reference | Keep 6-gate table (mirrors Phase 3 gates) |
+| 12 | `## CLI reference` | Reference | Keep all commands, include `--model` in swarm |
+| 13 | `## Tips` | Reference | Keep all tips, add project-specific tips |
+| 14 | `## Reference docs` | New | Link to `~/.copilot/tools/skills/tentacle-orchestration/references/` |
 
 **If a reference section exists but is not in the checklist above, include it anyway.**
 The checklist is a minimum — not an exclusive list.
@@ -118,6 +121,9 @@ Layer these ON TOP of the canonical structure:
 
 **CONTEXT.md template** — Include project-specific conventions (linting rules, import patterns,
 naming conventions, theme tokens, i18n rules) so agents follow them.
+Keep a "Step-plan review" section with source step file, accepted/edited/rejected steps,
+dependency order, and evidence contract. This prevents generated plans from becoming
+unreviewed instructions.
 
 **Shared workspace warning** — Include the warning about parallel agents sharing filesystem.
 
@@ -198,5 +204,6 @@ Present a summary: project profile, files created, agent mappings detected, veri
 | `briefing.py` | `~/.copilot/tools/` | Skip knowledge integration |
 | `learn.py` | `~/.copilot/tools/` | Skip auto-learn |
 | `agent-creator` | `~/.copilot/tools/skills/` | Fall back to `general-purpose` agents |
+| `task-step-generator` | `~/.copilot/tools/skills/` | Ask the orchestrator to draft and review a step file manually before creating tentacles |
 | Custom agents | AGENTS.md or `.github/agents/` | Generate via agent-creator, or use `general-purpose` |
 | Git repo | `.git/` | Required (tentacles stored in git root) |

--- a/skills/tentacle-orchestration/SKILL.md
+++ b/skills/tentacle-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tentacle-orchestration
-description: Break complex tasks into scoped parallel work units for multi-agent execution. Use when a task spans multiple modules or layers (API + DB + UI). Each tentacle runs strict-tdd-workflow internally. Not for simple single-module tasks — use strict-tdd-workflow directly instead. Trigger words — "orchestrate", "multi-agent", "parallel agents", "tentacle", "swarm", or any task touching 3+ files across different modules.
+description: Break complex tasks into scoped parallel work units for multi-agent execution. Always use task-step-generator first as a reviewed planning scaffold, then adapt the reviewed steps into tentacles. Use when a task spans multiple modules or layers, needs agent delegation, or the user says "orchestrate", "multi-agent", "parallel agents", "tentacle", or "swarm". Each implementation/fix tentacle runs strict-tdd-workflow internally.
 ---
 
 # Tentacle Orchestration
@@ -9,7 +9,20 @@ Break a complex task into scoped work units ("tentacles"), enrich each with cont
 
 Adapted from the [OctoGent](https://github.com/hesamsheikh/octogent) tentacle pattern.
 
-> **Relationship with strict-tdd-workflow**: Tentacle is the **orchestrator** (splits work), strict-tdd is the **executor** (runs inside each tentacle). For single-module tasks, skip tentacle and use strict-tdd directly.
+> **Relationship with strict-tdd-workflow**: Tentacle is the **orchestrator** (splits work), strict-tdd is the **executor** (runs inside each implementation/fix tentacle). For single-module tasks, skip tentacle and use strict-tdd directly.
+>
+> **Relationship with task-step-generator**: `task-step-generator` is the **planning scaffold**. Run it before creating tentacles, then review and edit the generated steps. Do not copy generated steps blindly.
+
+## Planning Discipline
+
+Use this sequence before creating any tentacle:
+
+1. Generate a step file with `task-step-generator` (`.github/steps/<task-slug>.md` when the project uses `.github/`, otherwise `STEPS.md` or the path requested by the user).
+2. Review the generated step file with `references/decomposition-review.md`.
+3. Record what was accepted, edited, and rejected before dispatching agents.
+4. Convert only the reviewed steps into non-overlapping tentacles and atomic todos.
+
+Why: decomposition and checklists reduce avoidable cognitive load, but generated plans can anchor on the first plausible split. Treat the step file as a draft planning artifact, not as authority.
 
 ## When to use
 
@@ -98,6 +111,8 @@ sk install --install-git-hooks
 - ❌ Skipping `--briefing` on create → past mistakes not injected into CONTEXT.md
 - ❌ Skipping `complete` before `delete` → learnings from handoff.md lost permanently
 - ❌ Overlapping tentacle scopes → agents overwrite each other's work
+- ❌ Creating tentacles directly from intuition without a generated-and-reviewed step file
+- ❌ Copying `task-step-generator` output blindly without checking dependencies, ownership, work-in-progress limits, evidence, and agent fit
 - ❌ Skipping the runtime bundle on multi-agent work → agents lose file-backed context and `recall-pack.json`
 - ❌ Using `--briefing --output json --no-bundle` → briefing cannot be represented without the bundle
 - ❌ Sub-agent commits or pushes → blocked by git hooks when installed (and risky regardless: corrupts orchestrator's merge/verify flow)
@@ -159,15 +174,48 @@ For the full process, see `references/spec-clarification.md`.
 
 **Gate**: Planning on an unclear spec produces incorrect decomposition, wasted agent work, and rework. Never proceed to Phase 1 until the spec is CLEAN and reader-tested.
 
-### Phase 1: Plan (Steps 1–4)
+### Phase 1: Plan
 
 Use the CLEAN spec and its Impact Analysis / Risk Assessment to inform decomposition.
 
-#### Step 1: Decompose the task into modules
+#### Plan A: Generate a step file
+
+Use `task-step-generator` before creating tentacles:
+
+```text
+Generate a step file for this task. Include CLARIFY, RED evidence/test strategy for implementation or fixes, BUILD, TEST, REVIEW, LOOP-EVAL when iteration is likely, and COMMIT/CLOSE.
+```
+
+The output may say the task is too large for a single step file. That is acceptable: use the step file as a top-level scaffold, then split reviewed steps into tentacles.
+
+#### Plan B: Review and edit the generated steps
+
+Apply `references/decomposition-review.md`. At minimum, verify:
+
+- acceptance signal is observable,
+- RED evidence/test strategy exists before implementation,
+- dependencies are ordered before parallel work,
+- steps are small enough to review in one context,
+- only independent work is parallelized,
+- each evidence-producing step names logs/screenshots/hashes or equivalent artifacts,
+- each step maps to the correct agent type/model available in the project.
+
+Do not proceed until the reviewed plan clearly states accepted, edited, and rejected steps.
+
+#### Plan C: Decompose the reviewed task into modules
 
 Read the task description and identify independent code regions. Each region becomes one tentacle.
 
-#### Step 2: Create tentacles
+Each code tentacle must declare:
+
+- source step file and accepted/edited/rejected step numbers,
+- dependency order,
+- test/evidence owner,
+- implementation owner,
+- acceptance signal,
+- verification/evidence paths.
+
+#### Plan D: Create tentacles
 
 ```bash
 sk tentacle create <module-name> \
@@ -179,7 +227,7 @@ sk tentacle create <module-name> \
 
 The `--briefing` flag injects past mistakes and patterns from session-knowledge into CONTEXT.md — use it every time.
 
-#### Step 3: Add todos
+#### Plan E: Add todos
 
 ```bash
 sk tentacle todo <name> add "<specific, atomic task>"
@@ -188,9 +236,10 @@ sk tentacle todo <name> add "<specific, atomic task>"
 
 Each todo should be one deliverable — testable, reviewable, and completable in isolation.
 
-#### Step 4: Enrich CONTEXT.md
+#### Plan F: Enrich CONTEXT.md
 
 Read reference files with `view`, then edit CONTEXT.md to add:
+- **Step-plan review**: source step file, accepted/edited/rejected steps, dependency order, and evidence contract
 - **What exists**: describe the current code in the scope area
 - **Key files**: full paths to reference files the agent needs
 - **Constraints**: rules specific to this code region
@@ -221,6 +270,8 @@ you combine `--output json --briefing`, keep the default bundle enabled so JSON 
 surface `bundle_path`.
 
 Use the output as the prompt for `task()`. Launch independent tentacles in parallel.
+
+Every implementation or bug-fix tentacle must execute the strict-TDD loop internally: define or reproduce the failing evidence first, make the smallest change, then prove the same criterion turns green. Research-only, documentation-only, and review-only tentacles still need explicit evidence gates, but they do not fabricate code tests just to satisfy the pattern.
 
 #### Step 6: Monitor progress
 

--- a/skills/tentacle-orchestration/references/cli-reference.md
+++ b/skills/tentacle-orchestration/references/cli-reference.md
@@ -4,6 +4,13 @@ All commands use `sk tentacle` (fallback: `python3 ~/.copilot/tools/tentacle.py`
 
 ## Lifecycle Commands
 
+Before lifecycle commands, generate and review a task step file with `task-step-generator`:
+
+```text
+Use task-step-generator to write a project-local step file, then review it with `references/decomposition-review.md`.
+Do not create tentacles until accepted/edited/rejected steps, dependencies, and evidence gates are explicit.
+```
+
 ```bash
 # Create a tentacle (--briefing injects past knowledge into CONTEXT.md)
 sk tentacle create <name> --scope "<paths>" --desc "<desc>" --briefing
@@ -135,6 +142,12 @@ sk tentacle handoff my-feature "Updated config docs" --learn
 ## Scope
 - `<file-pattern-1>`
 - `<file-pattern-2>`
+
+## Step-plan review
+- Source step file: `<path>`
+- Accepted/edited/rejected steps: <summary>
+- Dependency order: <what this tentacle waits for>
+- Evidence contract: <logs/screenshots/traces/hashes or equivalent artifacts>
 
 ## What exists
 <!-- Read existing code and summarize -->

--- a/skills/tentacle-orchestration/references/decomposition-review.md
+++ b/skills/tentacle-orchestration/references/decomposition-review.md
@@ -1,0 +1,80 @@
+# Decomposition Review Guide
+
+Use this guide after `task-step-generator` creates a step file and before creating tentacles. The goal is to turn a plausible generated plan into an auditable, low-conflict execution plan.
+
+## Why this review exists
+
+Generated plans are useful scaffolds, but they can anchor on an early decomposition and hide missing evidence, unclear dependencies, or overlapping ownership. Research-informed workflow practices point in the same direction:
+
+- Cognitive-load management: smaller, named work units reduce working-memory pressure and make handoffs more reliable.
+- Checklist discipline: short explicit checks catch omissions better than memory, especially under time pressure.
+- Code-review efficiency: small, focused changes are easier to review and less likely to hide defects.
+- Perspective-based reading: plans improve when reviewed from several viewpoints, such as user behavior, data flow, operations, and rollback.
+
+Use the generated step file as a draft. Keep what is useful, edit what is vague, and reject steps that do not map to a clear owner or evidence gate.
+
+## Review pass
+
+For each generated step, fill this table before dispatch:
+
+| Check | Question | Required outcome |
+|-------|----------|------------------|
+| Acceptance signal | What observable behavior proves the step is done? | A command, assertion, screenshot, log, trace, artifact, or documented non-code output |
+| RED before GREEN | For implementation/fix work, what fails before the change? | A failing test, reproduction, screenshot, log, or deterministic assertion captured before implementation |
+| Dependency order | What must finish before this starts? | Sequential dependencies named; only independent work may run in parallel |
+| Scope boundary | Which files or systems may this step modify? | A narrow, non-overlapping scope suitable for one tentacle |
+| Agent fit | Which agent type/model should own it? | Specialist agent when available; adequate model tier for code generation/review |
+| Evidence owner | Who captures proof and where is it stored? | Evidence path or handoff field named before dispatch |
+| Risk | What can silently regress? | Targeted review/test point added |
+
+## Accept, edit, reject
+
+Record the result in the orchestrator notes and in each tentacle's `CONTEXT.md`.
+
+```markdown
+## Step-plan review
+- Source step file: `.github/steps/<task>.md`
+- Accepted steps: 1, 2, 4
+- Edited steps: 3 (split tests from implementation), 5 (added hash evidence)
+- Rejected steps: 6 (scope overlaps with existing migration tentacle)
+- Dependency order: foundation -> implementation -> tests -> review -> goal-eval
+- Evidence contract: unit test output, integration trace, screenshots with hashes
+```
+
+## Splitting rules
+
+Split a generated step when:
+
+- it mixes test creation, implementation, and review in one owner;
+- it touches multiple independent modules;
+- it cannot be reviewed in one context window;
+- it has multiple unrelated acceptance signals;
+- it would require one agent to edit files also owned by another tentacle.
+
+Keep steps together when:
+
+- separating them would force repeated setup or duplicate context;
+- the change is atomic and one test proves the full behavior;
+- one specialist agent clearly owns the entire concern.
+
+## Evidence rules
+
+Evidence must distinguish the intended behavior from accidental success:
+
+- Prefer stable assertions over screenshots when possible.
+- When screenshots are necessary, include visible unique data and record hashes.
+- Count-only evidence is weak unless the acceptance criterion is explicitly count-based.
+- Logs are useful only when they identify the request, entity, or correlation id being proven.
+- Green evidence must test the same criterion that failed in RED.
+
+## Parallelism rules
+
+Parallelize only when all are true:
+
+1. File scopes do not overlap.
+2. Runtime state does not conflict.
+3. Dependencies are explicit.
+4. Each agent can complete without asking another agent for hidden context.
+5. The orchestrator can verify each result independently.
+
+If any condition is false, run sequentially or create a foundation tentacle first.


### PR DESCRIPTION
## Summary
- Require tentacle orchestration to start from a task-step-generator step plan.
- Add a decomposition review guide so generated plans are edited before dispatch.
- Keep future project-specific tentacle skills aligned with the reviewed-plan workflow.

## Validation
- validate-skill.py passed for tentacle-creator and task-step-generator.
- validate-skill.py passed for tentacle-orchestration with only the existing line-count warning.
- diff whitespace check passed.
- public keyword scan passed.
- independent review returned CLEAN.