### PR TITLE
feat: enrich paused-goal snapshot for #182

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -237,6 +237,11 @@ As of wave9, **`sessionStart`** is also routed natively:
      resume` banner.  Staleness check: if `goal.json` status ≠ `"paused"`, banner is
      suppressed.  Fail-open: goal.json absent or unreadable → banner shown.  Breadcrumb
      absent or unreadable → no banner.
+     **wave20 (#182):** breadcrumb enriched with a structured `budget_snapshot` object
+     (fields: `current_iteration`, `tentacle_count`, and whichever of `max_iterations`,
+     `max_tentacles`, `timeout_minutes` were set on the goal's budget).  Iteration lives
+     inside `budget_snapshot.current_iteration`; there is no separate flat `iteration` field.
+     (Backward-compatible — existing readers that ignore unknown fields are unaffected.)
   3. `IntegrityRule` — reads `~/.copilot/hooks/integrity-manifest.json`; refreshes the
      manifest when hook files have changed since the last check; emits a verified or
      refresh notice.  Informational only — never blocks.  Fail-open on missing manifest

--- a/hooks/auto-briefing.py
+++ b/hooks/auto-briefing.py
@@ -186,11 +186,23 @@ def _load_goal_resume_hint(project_root: "Path | None" = None) -> "list[str] | N
         pause_reason = pause_reason_raw if isinstance(pause_reason_raw, str) else ""
         reason_label = _format_pause_reason(pause_reason)
         sep = "  " + "\u2500" * 33
-        return [
+        lines = [
             f"\n  \u23f8  Paused goal: {goal_title}  ({reason_label})",
             f"  \u25b6  Run: {resume_cmd}",
-            sep,
         ]
+        # Optional one-line budget detail from issue #182 structured snapshot.
+        # Backward-compatible: old breadcrumbs without budget_snapshot skip this.
+        _bs_raw = bc.get("budget_snapshot")
+        if isinstance(_bs_raw, dict):
+            ci = _bs_raw.get("current_iteration")
+            mi = _bs_raw.get("max_iterations")
+            tc = _bs_raw.get("tentacle_count")
+            mt = _bs_raw.get("max_tentacles")
+            iter_str = (f"{ci}/{mi}" if mi is not None else str(ci)) if ci is not None else "?"
+            tent_str = (f"{tc}/{mt}" if mt is not None else str(tc)) if tc is not None else "?"
+            lines.append(f"  \u2139  Budget: iter {iter_str}, tentacles {tent_str}")
+        lines.append(sep)
+        return lines
     except Exception:
         return None  # always fail-open
 

--- a/hooks/rules/briefing.py
+++ b/hooks/rules/briefing.py
@@ -207,11 +207,23 @@ def _load_goal_resume_hint(project_root: "Path | None" = None) -> "list[str] | N
         pause_reason = pause_reason_raw if isinstance(pause_reason_raw, str) else ""
         reason_label = _format_pause_reason(pause_reason)
         sep = "  " + "\u2500" * 33
-        return [
+        lines = [
             f"\n  \u23f8  Paused goal: {goal_title}  ({reason_label})",
             f"  \u25b6  Run: {resume_cmd}",
-            sep,
         ]
+        # Optional one-line budget detail from issue #182 structured snapshot.
+        # Backward-compatible: old breadcrumbs without budget_snapshot skip this.
+        _bs_raw = bc.get("budget_snapshot")
+        if isinstance(_bs_raw, dict):
+            ci = _bs_raw.get("current_iteration")
+            mi = _bs_raw.get("max_iterations")
+            tc = _bs_raw.get("tentacle_count")
+            mt = _bs_raw.get("max_tentacles")
+            iter_str = (f"{ci}/{mi}" if mi is not None else str(ci)) if ci is not None else "?"
+            tent_str = (f"{tc}/{mt}" if mt is not None else str(tc)) if tc is not None else "?"
+            lines.append(f"  \u2139  Budget: iter {iter_str}, tentacles {tent_str}")
+        lines.append(sep)
+        return lines
     except Exception:
         return None  # always fail-open
 

--- a/hooks/rules/session_lifecycle.py
+++ b/hooks/rules/session_lifecycle.py
@@ -44,6 +44,31 @@ _PAUSE_STATES: frozenset[str] = frozenset({"active", "awaiting-gate"})
 _BREADCRUMB_FILENAME = "goal-resume-breadcrumb.json"
 
 
+def _build_budget_snapshot(budget: dict, current_iteration: int, tentacle_count: int) -> dict:
+    """Return a structured budget snapshot dict for the resume breadcrumb.
+
+    Mirrors the fields produced by tentacle.py::_goal_budget_status() but is
+    computed inline so session_lifecycle.py stays a standalone script with no
+    cross-script imports.  Only the numeric fields needed for the resume banner
+    are included; over_budget flags are intentionally omitted (they are
+    point-in-time and stale by the time the operator reads the breadcrumb).
+    """
+    snap: dict = {
+        "current_iteration": current_iteration,
+        "tentacle_count": tentacle_count,
+    }
+    max_iters = budget.get("max_iterations")
+    if max_iters is not None:
+        snap["max_iterations"] = max_iters
+    max_tent = budget.get("max_tentacles")
+    if max_tent is not None:
+        snap["max_tentacles"] = max_tent
+    timeout = budget.get("timeout_minutes")
+    if timeout is not None:
+        snap["timeout_minutes"] = timeout
+    return snap
+
+
 class _GoalAbsent(Exception):
     """Raised inside _mutate to abort _goal_transact when goal is absent or malformed.
 
@@ -131,6 +156,10 @@ def _pause_active_goal(reason: str) -> None:
             captured["prev_status"] = prev
             captured["goal_id"] = state.get("goal_id") or ""
             captured["title"] = state.get("title") or ""
+            # Capture snapshot fields for breadcrumb enrichment (issue #182)
+            captured["iteration"] = state.get("iteration") or 1
+            captured["budget"] = dict(state.get("budget") or {})
+            captured["tentacle_count"] = len(state.get("tentacles") or [])
             if prev in _PAUSE_STATES:
                 state["status"] = "paused"
                 state["paused_at"] = paused_at
@@ -145,6 +174,11 @@ def _pause_active_goal(reason: str) -> None:
         if captured.get("prev_status") not in _PAUSE_STATES:
             return  # terminal or absent goal — no breadcrumb needed
 
+        budget_snapshot = _build_budget_snapshot(
+            captured.get("budget") or {},
+            captured.get("iteration", 1),
+            captured.get("tentacle_count", 0),
+        )
         breadcrumb_path = goal_path.parent / _BREADCRUMB_FILENAME
         breadcrumb = {
             "goal_id": captured.get("goal_id") or "",
@@ -154,6 +188,9 @@ def _pause_active_goal(reason: str) -> None:
             "resume_command": "sk tentacle goal resume",
             "paused_at": paused_at,
             "previous_status": captured["prev_status"],
+            # Structured budget snapshot for resume banner (issue #182).
+            # Iteration is nested inside budget_snapshot.current_iteration.
+            "budget_snapshot": budget_snapshot,
         }
         breadcrumb_path.write_text(_json.dumps(breadcrumb, indent=2) + "\n", encoding="utf-8")
     except Exception:

--- a/hooks/rules/session_lifecycle.py
+++ b/hooks/rules/session_lifecycle.py
@@ -158,8 +158,10 @@ def _pause_active_goal(reason: str) -> None:
             captured["title"] = state.get("title") or ""
             # Capture snapshot fields for breadcrumb enrichment (issue #182)
             captured["iteration"] = state.get("iteration") or 1
-            captured["budget"] = dict(state.get("budget") or {})
-            captured["tentacle_count"] = len(state.get("tentacles") or [])
+            raw_budget = state.get("budget")
+            captured["budget"] = dict(raw_budget) if isinstance(raw_budget, dict) else {}
+            raw_tentacles = state.get("tentacles")
+            captured["tentacle_count"] = len(raw_tentacles) if isinstance(raw_tentacles, list) else 0
             if prev in _PAUSE_STATES:
                 state["status"] = "paused"
                 state["paused_at"] = paused_at

--- a/hooks/session-end.py
+++ b/hooks/session-end.py
@@ -38,6 +38,31 @@ _PAUSE_STATES: frozenset[str] = frozenset({"active", "awaiting-gate"})
 _BREADCRUMB_FILENAME = "goal-resume-breadcrumb.json"
 
 
+def _build_budget_snapshot(budget: dict, current_iteration: int, tentacle_count: int) -> dict:
+    """Return a structured budget snapshot dict for the resume breadcrumb.
+
+    Mirrors the fields produced by tentacle.py::_goal_budget_status() but is
+    computed inline so session-end.py stays a standalone script with no
+    cross-script imports.  Only the numeric fields needed for the resume banner
+    are included; over_budget flags are intentionally omitted (they are
+    point-in-time and stale by the time the operator reads the breadcrumb).
+    """
+    snap: dict = {
+        "current_iteration": current_iteration,
+        "tentacle_count": tentacle_count,
+    }
+    max_iters = budget.get("max_iterations")
+    if max_iters is not None:
+        snap["max_iterations"] = max_iters
+    max_tent = budget.get("max_tentacles")
+    if max_tent is not None:
+        snap["max_tentacles"] = max_tent
+    timeout = budget.get("timeout_minutes")
+    if timeout is not None:
+        snap["timeout_minutes"] = timeout
+    return snap
+
+
 class _GoalAbsent(Exception):
     """Raised inside _mutate to abort _goal_transact when goal is absent or malformed.
 
@@ -78,6 +103,10 @@ def _pause_active_goal(reason: str) -> None:
             captured["prev_status"] = prev
             captured["goal_id"] = state.get("goal_id") or ""
             captured["title"] = state.get("title") or ""
+            # Capture snapshot fields for breadcrumb enrichment (issue #182)
+            captured["iteration"] = state.get("iteration") or 1
+            captured["budget"] = dict(state.get("budget") or {})
+            captured["tentacle_count"] = len(state.get("tentacles") or [])
             if prev in _PAUSE_STATES:
                 state["status"] = "paused"
                 state["paused_at"] = paused_at
@@ -92,6 +121,11 @@ def _pause_active_goal(reason: str) -> None:
         if captured.get("prev_status") not in _PAUSE_STATES:
             return
 
+        budget_snapshot = _build_budget_snapshot(
+            captured.get("budget") or {},
+            captured.get("iteration", 1),
+            captured.get("tentacle_count", 0),
+        )
         breadcrumb_path = goal_path.parent / _BREADCRUMB_FILENAME
         breadcrumb = {
             "goal_id": captured.get("goal_id") or "",
@@ -101,6 +135,9 @@ def _pause_active_goal(reason: str) -> None:
             "resume_command": "sk tentacle goal resume",
             "paused_at": paused_at,
             "previous_status": captured["prev_status"],
+            # Structured budget snapshot for resume banner (issue #182).
+            # Iteration is nested inside budget_snapshot.current_iteration.
+            "budget_snapshot": budget_snapshot,
         }
         breadcrumb_path.write_text(json.dumps(breadcrumb, indent=2) + "\n", encoding="utf-8")
     except Exception:

--- a/hooks/session-end.py
+++ b/hooks/session-end.py
@@ -105,8 +105,10 @@ def _pause_active_goal(reason: str) -> None:
             captured["title"] = state.get("title") or ""
             # Capture snapshot fields for breadcrumb enrichment (issue #182)
             captured["iteration"] = state.get("iteration") or 1
-            captured["budget"] = dict(state.get("budget") or {})
-            captured["tentacle_count"] = len(state.get("tentacles") or [])
+            raw_budget = state.get("budget")
+            captured["budget"] = dict(raw_budget) if isinstance(raw_budget, dict) else {}
+            raw_tentacles = state.get("tentacles")
+            captured["tentacle_count"] = len(raw_tentacles) if isinstance(raw_tentacles, list) else 0
             if prev in _PAUSE_STATES:
                 state["status"] = "paused"
                 state["paused_at"] = paused_at

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -6584,6 +6584,7 @@ mod tests {
             !combined.contains("Budget:"),
             "old breadcrumb must NOT show Budget: line; got: {combined:?}"
         );
+        let _ = fs::remove_dir_all(&tmp);
     }
 
     /// format_pause_reason maps known and unknown prefixes correctly.

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -6518,7 +6518,10 @@ mod tests {
         .unwrap();
 
         let result = load_goal_resume_hint(Some(&tmp));
-        assert!(result.is_some(), "expected banner for paused goal with budget_snapshot");
+        assert!(
+            result.is_some(),
+            "expected banner for paused goal with budget_snapshot"
+        );
         let lines = result.unwrap();
         let combined = lines.join("\n");
         assert!(

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -469,11 +469,42 @@ fn load_goal_resume_hint(project_root: Option<&Path>) -> Option<Vec<String>> {
     let reason_label = format_pause_reason(pause_reason);
     let sep = format!("  {}", "\u{2500}".repeat(33));
 
-    Some(vec![
+    let mut lines = vec![
         format!("\n  \u{23f8}  Paused goal: {goal_title}  ({reason_label})"),
         format!("  \u{25b6}  Run: {resume_cmd}"),
-        sep,
-    ])
+    ];
+
+    // Optional one-line budget detail from issue #182 structured snapshot.
+    // Backward-compatible: old breadcrumbs without budget_snapshot skip this.
+    if let Some(snap) = bc.get("budget_snapshot").and_then(|v| v.as_object()) {
+        let ci = snap
+            .get("current_iteration")
+            .and_then(|v| v.as_i64())
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "?".to_string());
+        let iter_str = if let Some(mi) = snap.get("max_iterations").and_then(|v| v.as_i64()) {
+            format!("{}/{}", ci, mi)
+        } else {
+            ci
+        };
+        let tc = snap
+            .get("tentacle_count")
+            .and_then(|v| v.as_i64())
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "?".to_string());
+        let tent_str = if let Some(mt) = snap.get("max_tentacles").and_then(|v| v.as_i64()) {
+            format!("{}/{}", tc, mt)
+        } else {
+            tc
+        };
+        lines.push(format!(
+            "  \u{2139}  Budget: iter {}, tentacles {}",
+            iter_str, tent_str
+        ));
+    }
+
+    lines.push(sep);
+    Some(lines)
 }
 
 // ---------------------------------------------------------------------------
@@ -6446,6 +6477,110 @@ mod tests {
             );
             let _ = fs::remove_dir_all(&tmp);
         }
+    }
+
+    /// Breadcrumb with budget_snapshot → banner includes a budget detail line
+    /// (issue #182 native parity: mirrors Python _load_goal_resume_hint reader).
+    #[test]
+    fn auto_briefing_resume_hint_shows_budget_snapshot_line() {
+        use std::fs;
+        let tmp = resume_test_dir("budget_snap");
+        let octogent = tmp.join(".octogent");
+        let _ = fs::create_dir_all(&octogent);
+
+        fs::write(
+            octogent.join("goal.json"),
+            r#"{"status": "paused", "goal_id": "bs-goal"}"#,
+        )
+        .unwrap();
+
+        let bc_path = octogent.join(BREADCRUMB_FILENAME);
+        fs::write(
+            &bc_path,
+            serde_json::json!({
+                "goal_id": "bs-goal",
+                "goal_title": "Budget Snapshot Goal",
+                "goal_path": octogent.join("goal.json").to_string_lossy().to_string(),
+                "pause_reason": "session_end:normal",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active",
+                "goal_status_at_pause": "paused",
+                "budget_snapshot": {
+                    "current_iteration": 6,
+                    "max_iterations": 30,
+                    "tentacle_count": 38,
+                    "max_tentacles": 100
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let result = load_goal_resume_hint(Some(&tmp));
+        assert!(result.is_some(), "expected banner for paused goal with budget_snapshot");
+        let lines = result.unwrap();
+        let combined = lines.join("\n");
+        assert!(
+            combined.contains("Budget:"),
+            "banner must include a 'Budget:' detail line; got: {combined:?}"
+        );
+        assert!(
+            combined.contains("6/30"),
+            "banner must show current_iteration/max_iterations; got: {combined:?}"
+        );
+        assert!(
+            combined.contains("38/100"),
+            "banner must show tentacle_count/max_tentacles; got: {combined:?}"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Old breadcrumb without budget_snapshot → banner still shown, no Budget: line
+    /// (issue #182 backward-compat: old breadcrumbs must not crash the reader).
+    #[test]
+    fn auto_briefing_resume_hint_no_budget_line_for_old_breadcrumb() {
+        use std::fs;
+        let tmp = resume_test_dir("no_budget_snap");
+        let octogent = tmp.join(".octogent");
+        let _ = fs::create_dir_all(&octogent);
+
+        fs::write(
+            octogent.join("goal.json"),
+            r#"{"status": "paused", "goal_id": "old-bc"}"#,
+        )
+        .unwrap();
+
+        let bc_path = octogent.join(BREADCRUMB_FILENAME);
+        fs::write(
+            &bc_path,
+            serde_json::json!({
+                "goal_id": "old-bc",
+                "goal_title": "Old Breadcrumb Goal",
+                "goal_path": octogent.join("goal.json").to_string_lossy().to_string(),
+                "pause_reason": "session_end:normal",
+                "resume_command": "sk tentacle goal resume",
+                "paused_at": "2026-01-01T00:00:00Z",
+                "previous_status": "active"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let result = load_goal_resume_hint(Some(&tmp));
+        assert!(
+            result.is_some(),
+            "old breadcrumb must still show banner (backward compat); got: {result:?}"
+        );
+        let combined = result.unwrap().join("\n");
+        assert!(
+            combined.contains("Old Breadcrumb Goal"),
+            "banner must include goal title; got: {combined:?}"
+        );
+        assert!(
+            !combined.contains("Budget:"),
+            "old breadcrumb must NOT show Budget: line; got: {combined:?}"
+        );
     }
 
     /// format_pause_reason maps known and unknown prefixes correctly.

--- a/tests/test_hook_rules_more.py
+++ b/tests/test_hook_rules_more.py
@@ -599,6 +599,188 @@ try:
     test("TOCTOU: no breadcrumb written when goal absent inside transaction", not bc_path9.exists())
 finally:
     shutil.rmtree(_tmp_3b9, ignore_errors=True)
+
+# ══════════════════════════════════════════════════════════════════════
+#  Section 3c: _build_budget_snapshot + enriched breadcrumb fields (#182)
+# ══════════════════════════════════════════════════════════════════════
+
+print("\n📊 Section 3c: enriched breadcrumb snapshot fields (issue #182)")
+
+from rules.session_lifecycle import _build_budget_snapshot
+
+# 3c-1: snapshot with full budget — has all fields
+snap1 = _build_budget_snapshot(
+    {"max_iterations": 30, "max_tentacles": 100, "timeout_minutes": 480},
+    current_iteration=6,
+    tentacle_count=38,
+)
+test("budget_snapshot is a dict", isinstance(snap1, dict))
+test("budget_snapshot has current_iteration=6", snap1.get("current_iteration") == 6)
+test("budget_snapshot has max_iterations=30", snap1.get("max_iterations") == 30)
+test("budget_snapshot has tentacle_count=38", snap1.get("tentacle_count") == 38)
+test("budget_snapshot has max_tentacles=100", snap1.get("max_tentacles") == 100)
+test("budget_snapshot has timeout_minutes=480", snap1.get("timeout_minutes") == 480)
+
+# 3c-2: snapshot with no limits — omits limit keys
+snap2 = _build_budget_snapshot({}, current_iteration=3, tentacle_count=5)
+test("snapshot no-limits has current_iteration=3", snap2.get("current_iteration") == 3)
+test("snapshot no-limits has tentacle_count=5", snap2.get("tentacle_count") == 5)
+test("snapshot no-limits omits max_iterations", "max_iterations" not in snap2)
+test("snapshot no-limits omits max_tentacles", "max_tentacles" not in snap2)
+test("snapshot no-limits omits timeout_minutes", "timeout_minutes" not in snap2)
+
+# 3c-3: enriched breadcrumb fields written for active goal
+_tmp_3c3 = Path(tempfile.mkdtemp(prefix="test-se-enriched-"))
+try:
+    goal_state_rich = {
+        "title": "Enriched Goal",
+        "status": "active",
+        "goal_id": "rich-goal-1",
+        "iteration": 4,
+        "budget": {"max_iterations": 10, "max_tentacles": 50, "timeout_minutes": 120},
+        "tentacles": ["t1", "t2", "t3"],
+    }
+    octogent_rich = _tmp_3c3 / ".octogent"
+    tentacles_rich = octogent_rich / "tentacles"
+    tentacles_rich.mkdir(parents=True, exist_ok=True)
+    goal_path_rich = octogent_rich / "goal.json"
+    goal_path_rich.write_text(json.dumps(goal_state_rich, indent=2), encoding="utf-8")
+
+    class FakeTentacleRich:
+        @staticmethod
+        def get_tentacles_dir(*_, **__):
+            return tentacles_rich
+
+        @staticmethod
+        def _goal_path(td):
+            return goal_path_rich
+
+        @staticmethod
+        def _goal_load(td):
+            try:
+                return json.loads(goal_path_rich.read_text(encoding="utf-8"))
+            except Exception:
+                return {}
+
+        @staticmethod
+        def _goal_write(td, state):
+            import os as _os
+
+            tmp_p = goal_path_rich.with_suffix(".json.tmp")
+            tmp_p.write_text(json.dumps(state, indent=2), encoding="utf-8")
+            _os.replace(tmp_p, goal_path_rich)
+
+        @staticmethod
+        def _goal_transact(td, mutate_fn):
+            state = FakeTentacleRich._goal_load(td)
+            mutate_fn(state)
+            FakeTentacleRich._goal_write(td, state)
+            return state
+
+    with patch.object(_sl_mod2, "_tentacle_mod", FakeTentacleRich()):
+        _pause_active_goal("user_exit")
+
+    bc_rich = octogent_rich / _BREADCRUMB_FILENAME
+    test("enriched: breadcrumb file written", bc_rich.exists())
+    if bc_rich.exists():
+        bc = json.loads(bc_rich.read_text(encoding="utf-8"))
+        # Core fields still present (backward compat)
+        test("enriched: goal_id present", bc.get("goal_id") == "rich-goal-1")
+        test("enriched: goal_title present", bc.get("goal_title") == "Enriched Goal")
+        test("enriched: pause_reason present", "session_end" in bc.get("pause_reason", ""))
+        test("enriched: previous_status present", bc.get("previous_status") == "active")
+        # New structured snapshot (issue #182) — dict, not string
+        test("enriched: budget_snapshot is a dict", isinstance(bc.get("budget_snapshot"), dict))
+        bsnap = bc.get("budget_snapshot", {})
+        test("enriched: budget_snapshot.current_iteration == 4", bsnap.get("current_iteration") == 4)
+        test("enriched: budget_snapshot.max_iterations == 10", bsnap.get("max_iterations") == 10)
+        test("enriched: budget_snapshot.tentacle_count == 3", bsnap.get("tentacle_count") == 3)
+        test("enriched: budget_snapshot.max_tentacles == 50", bsnap.get("max_tentacles") == 50)
+        test("enriched: budget_snapshot.timeout_minutes == 120", bsnap.get("timeout_minutes") == 120)
+        # goal_status_at_pause was removed (dead field — hardcoded to "paused", no reader consumed it)
+        test("enriched: no dead 'goal_status_at_pause' field", "goal_status_at_pause" not in bc)
+        # Confirm old misleading 'status' field is gone
+        test("enriched: no misleading 'status' field", "status" not in bc)
+        # Confirm old lossy string 'budget_summary' field is gone
+        test("enriched: no lossy 'budget_summary' string field", "budget_summary" not in bc)
+finally:
+    shutil.rmtree(_tmp_3c3, ignore_errors=True)
+
+# 3c-4: backward compatibility — old breadcrumb without new fields
+#        _load_goal_resume_hint must still produce a banner (no crash, no suppression)
+print("\n🔄 Section 3c-4: backward compat — old breadcrumb without new fields")
+
+import rules.briefing as _br_mod
+from rules.briefing import _load_goal_resume_hint
+
+_tmp_3c4 = Path(tempfile.mkdtemp(prefix="test-bc-compat-"))
+try:
+    octogent_compat = _tmp_3c4 / ".octogent"
+    octogent_compat.mkdir(parents=True, exist_ok=True)
+    # Old-style breadcrumb — missing budget_snapshot (pre-wave20)
+    old_breadcrumb = {
+        "goal_id": "old-goal",
+        "goal_title": "Old Style Goal",
+        "goal_path": str(octogent_compat / "goal.json"),
+        "pause_reason": "session_end:normal",
+        "resume_command": "sk tentacle goal resume",
+        "paused_at": "2024-01-01T00:00:00+00:00",
+        "previous_status": "active",
+    }
+    (octogent_compat / _BREADCRUMB_FILENAME).write_text(json.dumps(old_breadcrumb), encoding="utf-8")
+    # goal.json in 'paused' state so staleness check passes
+    (octogent_compat / "goal.json").write_text(
+        json.dumps({"status": "paused", "title": "Old Style Goal"}), encoding="utf-8"
+    )
+
+    hint = _load_goal_resume_hint(_tmp_3c4)
+    test("old breadcrumb: banner not suppressed (fail-open compat)", hint is not None)
+    if hint:
+        banner_text = " ".join(hint)
+        test("old breadcrumb: banner mentions goal title", "Old Style Goal" in banner_text)
+        test("old breadcrumb: banner mentions resume command", "sk tentacle goal resume" in banner_text)
+        test("old breadcrumb: no budget line when snapshot absent", not any("Budget:" in l for l in hint))
+finally:
+    shutil.rmtree(_tmp_3c4, ignore_errors=True)
+
+# 3c-5: reader surfaces budget line when budget_snapshot present
+print("\n💡 Section 3c-5: reader surfaces budget detail when budget_snapshot present")
+
+_tmp_3c5 = Path(tempfile.mkdtemp(prefix="test-bc-budget-"))
+try:
+    octogent_3c5 = _tmp_3c5 / ".octogent"
+    octogent_3c5.mkdir(parents=True, exist_ok=True)
+    new_breadcrumb = {
+        "goal_id": "snap-goal",
+        "goal_title": "Snapshot Goal",
+        "goal_path": str(octogent_3c5 / "goal.json"),
+        "pause_reason": "session_end:normal",
+        "resume_command": "sk tentacle goal resume",
+        "paused_at": "2024-01-01T00:00:00+00:00",
+        "previous_status": "active",
+        "goal_status_at_pause": "paused",
+        "budget_snapshot": {
+            "current_iteration": 6,
+            "max_iterations": 30,
+            "tentacle_count": 38,
+            "max_tentacles": 100,
+        },
+    }
+    (octogent_3c5 / _BREADCRUMB_FILENAME).write_text(json.dumps(new_breadcrumb), encoding="utf-8")
+    (octogent_3c5 / "goal.json").write_text(
+        json.dumps({"status": "paused", "title": "Snapshot Goal"}), encoding="utf-8"
+    )
+
+    hint5 = _load_goal_resume_hint(_tmp_3c5)
+    test("snapshot breadcrumb: banner returned", hint5 is not None)
+    if hint5:
+        combined5 = "\n".join(hint5)
+        test("snapshot breadcrumb: budget line present", "Budget:" in combined5)
+        test("snapshot breadcrumb: iter 6/30 in budget line", "6/30" in combined5)
+        test("snapshot breadcrumb: tentacles 38/100 in budget line", "38/100" in combined5)
+finally:
+    shutil.rmtree(_tmp_3c5, ignore_errors=True)
+
 # ══════════════════════════════════════════════════════════════════════
 
 print("\n🛑 Section 4: SubagentStopRule")

--- a/tests/test_hook_rules_more.py
+++ b/tests/test_hook_rules_more.py
@@ -706,6 +706,71 @@ try:
 finally:
     shutil.rmtree(_tmp_3c3, ignore_errors=True)
 
+# 3c-4: malformed budget/tentacles metadata stays fail-open
+_tmp_3c4_bad = Path(tempfile.mkdtemp(prefix="test-se-enriched-malformed-"))
+try:
+    goal_state_bad = {
+        "title": "Malformed Snapshot Goal",
+        "status": "active",
+        "goal_id": "bad-goal-1",
+        "iteration": 2,
+        "budget": ["not", "a", "dict"],
+        "tentacles": 7,
+    }
+    octogent_bad = _tmp_3c4_bad / ".octogent"
+    tentacles_bad = octogent_bad / "tentacles"
+    tentacles_bad.mkdir(parents=True, exist_ok=True)
+    goal_path_bad = octogent_bad / "goal.json"
+    goal_path_bad.write_text(json.dumps(goal_state_bad, indent=2), encoding="utf-8")
+
+    class FakeTentacleBad:
+        @staticmethod
+        def get_tentacles_dir(*_, **__):
+            return tentacles_bad
+
+        @staticmethod
+        def _goal_path(td):
+            return goal_path_bad
+
+        @staticmethod
+        def _goal_load(td):
+            try:
+                return json.loads(goal_path_bad.read_text(encoding="utf-8"))
+            except Exception:
+                return {}
+
+        @staticmethod
+        def _goal_write(td, state):
+            import os as _os
+
+            tmp_p = goal_path_bad.with_suffix(".json.tmp")
+            tmp_p.write_text(json.dumps(state, indent=2), encoding="utf-8")
+            _os.replace(tmp_p, goal_path_bad)
+
+        @staticmethod
+        def _goal_transact(td, mutate_fn):
+            state = FakeTentacleBad._goal_load(td)
+            mutate_fn(state)
+            FakeTentacleBad._goal_write(td, state)
+            return state
+
+    with patch.object(_sl_mod2, "_tentacle_mod", FakeTentacleBad()):
+        _pause_active_goal("user_exit")
+
+    paused_state_bad = json.loads(goal_path_bad.read_text(encoding="utf-8"))
+    test("malformed metadata: goal still pauses", paused_state_bad.get("status") == "paused")
+    bc_bad = octogent_bad / _BREADCRUMB_FILENAME
+    test("malformed metadata: breadcrumb still written", bc_bad.exists())
+    if bc_bad.exists():
+        bc = json.loads(bc_bad.read_text(encoding="utf-8"))
+        bsnap = bc.get("budget_snapshot", {})
+        test("malformed metadata: budget_snapshot still present", isinstance(bsnap, dict))
+        test("malformed metadata: current_iteration preserved", bsnap.get("current_iteration") == 2)
+        test("malformed metadata: non-dict budget falls back to no max_iterations", "max_iterations" not in bsnap)
+        test("malformed metadata: non-list tentacles fall back to count 0", bsnap.get("tentacle_count") == 0)
+finally:
+    shutil.rmtree(_tmp_3c4_bad, ignore_errors=True)
+
 # 3c-4: backward compatibility — old breadcrumb without new fields
 #        _load_goal_resume_hint must still produce a banner (no crash, no suppression)
 print("\n🔄 Section 3c-4: backward compat — old breadcrumb without new fields")


### PR DESCRIPTION
## Summary
- enrich the paused-goal breadcrumb with a structured budget snapshot for the #182 compaction-proxy path
- surface that snapshot in both Python and Rust session-start resume hints
- update hook docs and regression coverage for the final breadcrumb schema

## Verification
- python tests/test_hook_rules_more.py
- python tests/test_hook_runner_entrypoints.py
- python tests/test_hook_compat.py
- cargo test auto_briefing_resume_hint --manifest-path sk-rust\Cargo.toml -j 1

Closes #182