### PR TITLE
feat: add anatomy file index for #83

### DIFF
--- a/anatomy-map.py
+++ b/anatomy-map.py
@@ -147,7 +147,9 @@ def _static_desc(rel_path: str) -> str | None:
     # Parent directory matches (e.g., .github/workflows/*)
     for prefix, desc in _STATIC_DESCRIPTIONS.items():
         if prefix.endswith("/") or "/" in prefix:
-            if rel_path.startswith(prefix) or rel_path.replace("\\", "/").startswith(prefix):
+            normalized = rel_path.replace("\\", "/")
+            # Only match exact directory path or true descendant (not prefix collisions)
+            if normalized == prefix or normalized.startswith(prefix.rstrip("/") + "/"):
                 return desc
     return None
 
@@ -432,6 +434,7 @@ def run_anatomy(
     limit: int | None = None,
 ) -> int:
     """Run the anatomy scan. Returns 0 on success, 1 on fatal error."""
+    repo_root = repo_root.resolve()
     files = ls_files(repo_root)
     if not files:
         print(f"Warning: no tracked files found in {repo_root}", file=sys.stderr)
@@ -461,9 +464,7 @@ def run_anatomy(
         return 0
 
     effective_db = db_path or DEFAULT_DB_PATH
-    if not effective_db.parent.exists():
-        print(f"Error: DB directory does not exist: {effective_db.parent}", file=sys.stderr)
-        return 1
+    effective_db.parent.mkdir(parents=True, exist_ok=True)
 
     try:
         db = sqlite3.connect(str(effective_db))

--- a/anatomy-map.py
+++ b/anatomy-map.py
@@ -50,7 +50,7 @@ _STATIC_DESCRIPTIONS: dict[str, str] = {
     # Build / package
     "package.json": "Node.js package manifest (dependencies, scripts, metadata).",
     "package-lock.json": "Node.js dependency lock file.",
-    "pyproject.toml": "Python project metadata and build configuration.",
+    "pyproject.toml": "Python project metadata, build configuration, and tool settings (PEP 518/621).",
     "setup.py": "Python package installation script.",
     "setup.cfg": "Python package configuration.",
     "requirements.txt": "Python runtime dependencies.",
@@ -80,7 +80,6 @@ _STATIC_DESCRIPTIONS: dict[str, str] = {
     "eslint.config.js": "ESLint linting configuration.",
     ".eslintrc.json": "ESLint linting rules.",
     ".prettierrc": "Prettier code formatter settings.",
-    "pyproject.toml": "Python project configuration (PEP 518).",
     "ruff.toml": "Ruff linter configuration.",
     ".firebaserc": "Firebase project aliases.",
     "firebase.json": "Firebase hosting and service configuration.",
@@ -184,30 +183,43 @@ def _leading_docstring(content: str) -> str | None:
     lines = content.splitlines()[:40]
     joined = "\n".join(lines)
 
-    # Python triple-quoted docstring at module level
-    _py_triple = re.compile(r'^["\']"""\s*(.*?)\s*["\']"""|^\'\'\'(.*?)\'\'\'', re.DOTALL)
-    m = _py_triple.search(joined)
+    # Python triple-quoted docstring starting at position 0 (must be truly leading).
+    # The previous pattern '^["\']"""...' was broken — it required a spurious quote
+    # character before the triple-quote, so it never matched a real """docstring""".
+    _py_triple = re.compile(r'^"""(.*?)"""|^\'\'\'(.*?)\'\'\'', re.DOTALL)
+    m = _py_triple.match(joined)  # match() anchors at position 0, not .search()
     if m:
         raw = (m.group(1) or m.group(2) or "").strip()
         first_line = raw.splitlines()[0].strip() if raw else ""
         if first_line and len(first_line) > 5:
             return first_line[:200]
 
-    # Triple-quote spanning multiple lines: """...""" with content on next line
+    # Triple-quote possibly after a shebang / encoding-declaration preamble only.
+    # Guard: the text before the opening """ must consist solely of shebang (#!)
+    # or encoding/modeline comments — otherwise the triple-quote is not a module
+    # docstring and we must not return it (e.g. x = """value""" inside a function).
     triple_start = joined.find('"""')
     if triple_start != -1:
-        triple_end = joined.find('"""', triple_start + 3)
-        if triple_end != -1:
-            inner = joined[triple_start + 3: triple_end].strip()
-            first_line = inner.splitlines()[0].strip() if inner else ""
-            if first_line and len(first_line) > 5:
-                return first_line[:200]
+        preamble = joined[:triple_start]
+        preamble_lines = [l.strip() for l in preamble.splitlines() if l.strip()]
+        # Any line that starts with '#' is a valid comment-only preamble.
+        # Real code lines (imports, assignments, defs, class, etc.) don't start
+        # with '#', so they still block extraction as intended.
+        is_leading_preamble = all(l.startswith("#") for l in preamble_lines)
+        if is_leading_preamble:
+            triple_end = joined.find('"""', triple_start + 3)
+            if triple_end != -1:
+                inner = joined[triple_start + 3: triple_end].strip()
+                first_line = inner.splitlines()[0].strip() if inner else ""
+                if first_line and len(first_line) > 5:
+                    return first_line[:200]
 
     # C-style block comment: /* ... */
     m = re.search(r'/\*+\s*(.*?)\s*\*+/', joined, re.DOTALL)
     if m:
         raw = m.group(1).strip()
-        first_line = raw.splitlines()[0].lstrip("*").strip()
+        _raw_lines = raw.splitlines()
+        first_line = _raw_lines[0].lstrip("*").strip() if _raw_lines else ""
         if first_line and len(first_line) > 5:
             return first_line[:200]
 
@@ -356,7 +368,7 @@ def persist_annotations(
 ) -> int:
     """Upsert annotation rows into file_annotations. Returns count written."""
     _ensure_table(db)
-    repo_str = str(repo_root)
+    repo_str = repo_root.as_posix()
     written = 0
     for rel_path, description, est_tokens, file_mtime in annotations:
         # Only update if mtime changed (avoid unnecessary writes)

--- a/anatomy-map.py
+++ b/anatomy-map.py
@@ -131,6 +131,7 @@ _EXT_DESCRIPTIONS: dict[str, str] = {
 # Heuristic description extractor
 # ---------------------------------------------------------------------------
 
+
 def _tok(chars: int) -> int:
     """Estimate tokens: ceil(chars / 3.75)."""
     if chars <= 0:
@@ -209,13 +210,13 @@ def _leading_docstring(content: str) -> str | None:
         if is_leading_preamble:
             triple_end = joined.find('"""', triple_start + 3)
             if triple_end != -1:
-                inner = joined[triple_start + 3: triple_end].strip()
+                inner = joined[triple_start + 3 : triple_end].strip()
                 first_line = inner.splitlines()[0].strip() if inner else ""
                 if first_line and len(first_line) > 5:
                     return first_line[:200]
 
     # C-style block comment: /* ... */
-    m = re.search(r'/\*+\s*(.*?)\s*\*+/', joined, re.DOTALL)
+    m = re.search(r"/\*+\s*(.*?)\s*\*+/", joined, re.DOTALL)
     if m:
         raw = m.group(1).strip()
         _raw_lines = raw.splitlines()
@@ -271,8 +272,24 @@ def describe_file(repo_root: Path, rel_path: str) -> tuple[str, int]:
 
     # 4. Leading docstring / header comment
     text_exts = {
-        ".py", ".ts", ".tsx", ".js", ".jsx", ".rs", ".go", ".java", ".kt",
-        ".swift", ".rb", ".sh", ".bash", ".ps1", ".sql", ".toml", ".yaml", ".yml",
+        ".py",
+        ".ts",
+        ".tsx",
+        ".js",
+        ".jsx",
+        ".rs",
+        ".go",
+        ".java",
+        ".kt",
+        ".swift",
+        ".rb",
+        ".sh",
+        ".bash",
+        ".ps1",
+        ".sql",
+        ".toml",
+        ".yaml",
+        ".yml",
     }
     if suffix in text_exts and content:
         ddesc = _leading_docstring(content)
@@ -295,6 +312,7 @@ def describe_file(repo_root: Path, rel_path: str) -> tuple[str, int]:
 # File enumeration
 # ---------------------------------------------------------------------------
 
+
 def find_git_root(start: Path | None = None) -> Path | None:
     """Walk up from *start* (defaults to cwd) to find the git repo root."""
     current = (start or Path.cwd()).resolve()
@@ -305,7 +323,10 @@ def find_git_root(start: Path | None = None) -> Path | None:
     try:
         r = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5, cwd=str(current),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(current),
         )
         if r.returncode == 0:
             return Path(r.stdout.strip())
@@ -319,7 +340,9 @@ def ls_files(repo_root: Path, timeout: int = 10) -> list[str]:
     try:
         result = subprocess.run(
             ["git", "ls-files"],
-            capture_output=True, text=True, timeout=timeout,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
             cwd=str(repo_root),
         )
         if result.returncode != 0:
@@ -332,6 +355,7 @@ def ls_files(repo_root: Path, timeout: int = 10) -> list[str]:
 # ---------------------------------------------------------------------------
 # DB persistence
 # ---------------------------------------------------------------------------
+
 
 def _ensure_table(db: sqlite3.Connection) -> None:
     """Create file_annotations table if absent (idempotent)."""
@@ -398,6 +422,7 @@ def persist_annotations(
 # ---------------------------------------------------------------------------
 # Main entry
 # ---------------------------------------------------------------------------
+
 
 def run_anatomy(
     repo_root: Path,

--- a/anatomy-map.py
+++ b/anatomy-map.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""
+anatomy-map.py — Build a per-file description index for the current git repo.
+
+Enumerates all git-tracked files, derives short deterministic descriptions
+using bounded heuristics, estimates token cost, and persists the results in
+the local `file_annotations` table so briefing.py can surface them.
+
+Extraction heuristics (applied in order):
+  1. Static description for common well-known filenames.
+  2. JSON `description` field for manifest-style files (safe subset only).
+  3. Markdown first heading for .md files.
+  4. Leading module docstring or header comment near the top of the file.
+  5. Generic fallback derived from extension / path.
+
+Token estimate: ceil(chars / 3.75)
+
+Usage:
+    python anatomy-map.py                  # Persist to DB + print summary
+    python anatomy-map.py --stdout         # Print annotations as text; no DB write
+    python anatomy-map.py --repo PATH      # Use a different git repo root
+    python anatomy-map.py --db PATH        # Use an explicit DB path
+    python anatomy-map.py --no-write       # Dry-run (show what would be written)
+    python anatomy-map.py --limit N        # Cap files processed (default: all)
+"""
+
+import argparse
+import json
+import math
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+SESSION_STATE = Path.home() / ".copilot" / "session-state"
+DEFAULT_DB_PATH = SESSION_STATE / "knowledge.db"
+
+# ---------------------------------------------------------------------------
+# Static descriptions for common well-known filenames
+# ---------------------------------------------------------------------------
+
+_STATIC_DESCRIPTIONS: dict[str, str] = {
+    # Build / package
+    "package.json": "Node.js package manifest (dependencies, scripts, metadata).",
+    "package-lock.json": "Node.js dependency lock file.",
+    "pyproject.toml": "Python project metadata and build configuration.",
+    "setup.py": "Python package installation script.",
+    "setup.cfg": "Python package configuration.",
+    "requirements.txt": "Python runtime dependencies.",
+    "requirements-dev.txt": "Python development dependencies.",
+    "Makefile": "Make build targets and task automation.",
+    "Cargo.toml": "Rust package manifest.",
+    "Cargo.lock": "Rust dependency lock file.",
+    "go.mod": "Go module definition.",
+    "go.sum": "Go module checksum file.",
+    "pom.xml": "Maven project object model.",
+    "build.gradle": "Gradle build script.",
+    "build.gradle.kts": "Gradle Kotlin DSL build script.",
+    # Config
+    ".gitignore": "Git ignore patterns.",
+    ".gitattributes": "Git file attributes.",
+    ".editorconfig": "Editor indentation and formatting rules.",
+    ".env": "Environment variable definitions (local).",
+    ".env.example": "Example environment variable template.",
+    "docker-compose.yml": "Docker Compose service definitions.",
+    "docker-compose.yaml": "Docker Compose service definitions.",
+    "Dockerfile": "Docker image build instructions.",
+    "tsconfig.json": "TypeScript compiler configuration.",
+    "jest.config.js": "Jest test runner configuration.",
+    "jest.config.ts": "Jest test runner configuration (TypeScript).",
+    "webpack.config.js": "Webpack bundler configuration.",
+    "vite.config.ts": "Vite build tool configuration.",
+    "eslint.config.js": "ESLint linting configuration.",
+    ".eslintrc.json": "ESLint linting rules.",
+    ".prettierrc": "Prettier code formatter settings.",
+    "pyproject.toml": "Python project configuration (PEP 518).",
+    "ruff.toml": "Ruff linter configuration.",
+    ".firebaserc": "Firebase project aliases.",
+    "firebase.json": "Firebase hosting and service configuration.",
+    # Docs
+    "README.md": "Project readme and overview.",
+    "CHANGELOG.md": "Release history and change notes.",
+    "CONTRIBUTING.md": "Contribution guide.",
+    "LICENSE": "Software license terms.",
+    "AGENTS.md": "AI agent behavior rules and instructions.",
+    "CLAUDE.md": "Claude-specific agent instructions.",
+    "SECURITY.md": "Security policy and vulnerability reporting.",
+    "MEMORY.md": "Promoted cross-session knowledge injected at session start.",
+    # CI
+    ".github/workflows": "GitHub Actions CI/CD workflow definitions.",
+}
+
+# Generic descriptions for common file extensions when no better source exists.
+_EXT_DESCRIPTIONS: dict[str, str] = {
+    ".py": "Python module.",
+    ".ts": "TypeScript module.",
+    ".tsx": "TypeScript React component.",
+    ".js": "JavaScript module.",
+    ".jsx": "JavaScript React component.",
+    ".rs": "Rust source file.",
+    ".go": "Go source file.",
+    ".java": "Java source file.",
+    ".kt": "Kotlin source file.",
+    ".swift": "Swift source file.",
+    ".rb": "Ruby source file.",
+    ".sh": "Shell script.",
+    ".bash": "Bash script.",
+    ".ps1": "PowerShell script.",
+    ".sql": "SQL script.",
+    ".md": "Markdown document.",
+    ".json": "JSON data file.",
+    ".yaml": "YAML configuration or data file.",
+    ".yml": "YAML configuration or data file.",
+    ".toml": "TOML configuration file.",
+    ".html": "HTML page or template.",
+    ".css": "CSS stylesheet.",
+    ".scss": "SCSS stylesheet.",
+    ".svg": "SVG vector graphic.",
+    ".proto": "Protocol Buffers schema definition.",
+    ".lock": "Dependency lock file.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Heuristic description extractor
+# ---------------------------------------------------------------------------
+
+def _tok(chars: int) -> int:
+    """Estimate tokens: ceil(chars / 3.75)."""
+    if chars <= 0:
+        return 0
+    return math.ceil(chars / 3.75)
+
+
+def _static_desc(rel_path: str) -> str | None:
+    """Return a static description for well-known filenames/paths."""
+    name = Path(rel_path).name
+    if name in _STATIC_DESCRIPTIONS:
+        return _STATIC_DESCRIPTIONS[name]
+    # Parent directory matches (e.g., .github/workflows/*)
+    for prefix, desc in _STATIC_DESCRIPTIONS.items():
+        if prefix.endswith("/") or "/" in prefix:
+            if rel_path.startswith(prefix) or rel_path.replace("\\", "/").startswith(prefix):
+                return desc
+    return None
+
+
+def _json_desc(content: str) -> str | None:
+    """Extract `description` field from JSON manifest files (safe, bounded)."""
+    if len(content) > 50_000:
+        return None  # don't parse giant files
+    try:
+        obj = json.loads(content)
+        if isinstance(obj, dict):
+            desc = obj.get("description", "")
+            if isinstance(desc, str) and 5 <= len(desc) <= 200:
+                return desc.strip()
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return None
+
+
+def _md_heading(content: str) -> str | None:
+    """Extract the first # heading from a Markdown file."""
+    for line in content.splitlines()[:30]:
+        stripped = line.lstrip("#").strip()
+        if line.startswith("#") and stripped:
+            return stripped[:200]
+    return None
+
+
+def _leading_docstring(content: str) -> str | None:
+    """Extract leading Python/JS/TS module docstring or block comment.
+
+    Reads up to the first 30 lines to stay bounded.
+    """
+    lines = content.splitlines()[:40]
+    joined = "\n".join(lines)
+
+    # Python triple-quoted docstring at module level
+    _py_triple = re.compile(r'^["\']"""\s*(.*?)\s*["\']"""|^\'\'\'(.*?)\'\'\'', re.DOTALL)
+    m = _py_triple.search(joined)
+    if m:
+        raw = (m.group(1) or m.group(2) or "").strip()
+        first_line = raw.splitlines()[0].strip() if raw else ""
+        if first_line and len(first_line) > 5:
+            return first_line[:200]
+
+    # Triple-quote spanning multiple lines: """...""" with content on next line
+    triple_start = joined.find('"""')
+    if triple_start != -1:
+        triple_end = joined.find('"""', triple_start + 3)
+        if triple_end != -1:
+            inner = joined[triple_start + 3: triple_end].strip()
+            first_line = inner.splitlines()[0].strip() if inner else ""
+            if first_line and len(first_line) > 5:
+                return first_line[:200]
+
+    # C-style block comment: /* ... */
+    m = re.search(r'/\*+\s*(.*?)\s*\*+/', joined, re.DOTALL)
+    if m:
+        raw = m.group(1).strip()
+        first_line = raw.splitlines()[0].lstrip("*").strip()
+        if first_line and len(first_line) > 5:
+            return first_line[:200]
+
+    # Leading line comment: #//// at line 0-3 (skip shebangs and encoding decls)
+    for line in lines[:8]:
+        stripped = line.strip()
+        if stripped.startswith("#!") or stripped.startswith("# -*-") or stripped.startswith("# coding"):
+            continue
+        if stripped.startswith("//") or stripped.startswith("#"):
+            text = stripped.lstrip("#/").strip()
+            if len(text) > 10 and not text.lower().startswith("copyright"):
+                return text[:200]
+
+    return None
+
+
+def describe_file(repo_root: Path, rel_path: str) -> tuple[str, int]:
+    """Return (description, est_tokens) for a single git-tracked file.
+
+    est_tokens is the token estimate for the description string only.
+    """
+    # 1. Static
+    static = _static_desc(rel_path)
+    if static:
+        return static, _tok(len(static))
+
+    abs_path = repo_root / rel_path
+    suffix = Path(rel_path).suffix.lower()
+
+    # Attempt to read file content (bounded)
+    content = ""
+    try:
+        with abs_path.open("r", encoding="utf-8", errors="replace") as fh:
+            content = fh.read(8192)  # read at most 8 KiB for heuristics
+    except Exception:
+        pass  # binary or permission error
+
+    # 2. JSON description field
+    if suffix == ".json" and content:
+        jdesc = _json_desc(content)
+        if jdesc:
+            return jdesc, _tok(len(jdesc))
+
+    # 3. Markdown heading
+    if suffix == ".md" and content:
+        hdesc = _md_heading(content)
+        if hdesc:
+            return hdesc, _tok(len(hdesc))
+
+    # 4. Leading docstring / header comment
+    text_exts = {
+        ".py", ".ts", ".tsx", ".js", ".jsx", ".rs", ".go", ".java", ".kt",
+        ".swift", ".rb", ".sh", ".bash", ".ps1", ".sql", ".toml", ".yaml", ".yml",
+    }
+    if suffix in text_exts and content:
+        ddesc = _leading_docstring(content)
+        if ddesc:
+            return ddesc, _tok(len(ddesc))
+
+    # 5. Generic fallback
+    stem = Path(rel_path).stem
+    generic = _EXT_DESCRIPTIONS.get(suffix)
+    if generic:
+        # Personalise slightly with the filename
+        desc = f"{stem}: {generic}"
+        return desc, _tok(len(desc))
+
+    desc = f"{Path(rel_path).name}: source file."
+    return desc, _tok(len(desc))
+
+
+# ---------------------------------------------------------------------------
+# File enumeration
+# ---------------------------------------------------------------------------
+
+def find_git_root(start: Path | None = None) -> Path | None:
+    """Walk up from *start* (defaults to cwd) to find the git repo root."""
+    current = (start or Path.cwd()).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    # Worktrees: .git might be a file
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5, cwd=str(current),
+        )
+        if r.returncode == 0:
+            return Path(r.stdout.strip())
+    except Exception:
+        pass
+    return None
+
+
+def ls_files(repo_root: Path, timeout: int = 10) -> list[str]:
+    """Return git-tracked files relative to *repo_root*."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            capture_output=True, text=True, timeout=timeout,
+            cwd=str(repo_root),
+        )
+        if result.returncode != 0:
+            return []
+        return [l.strip() for l in result.stdout.splitlines() if l.strip()]
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# DB persistence
+# ---------------------------------------------------------------------------
+
+def _ensure_table(db: sqlite3.Connection) -> None:
+    """Create file_annotations table if absent (idempotent)."""
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS file_annotations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            repo_root TEXT NOT NULL,
+            file_path TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT '',
+            est_tokens INTEGER NOT NULL DEFAULT 0,
+            file_mtime REAL NOT NULL DEFAULT 0.0,
+            updated_at TEXT DEFAULT (datetime('now')),
+            UNIQUE(repo_root, file_path)
+        )
+    """)
+    db.execute("""
+        CREATE INDEX IF NOT EXISTS idx_fa_repo_root ON file_annotations(repo_root)
+    """)
+    db.commit()
+
+
+def _get_mtime(repo_root: Path, rel_path: str) -> float:
+    """Return file mtime; 0.0 on failure."""
+    try:
+        return (repo_root / rel_path).stat().st_mtime
+    except Exception:
+        return 0.0
+
+
+def persist_annotations(
+    db: sqlite3.Connection,
+    repo_root: Path,
+    annotations: list[tuple[str, str, int, float]],
+) -> int:
+    """Upsert annotation rows into file_annotations. Returns count written."""
+    _ensure_table(db)
+    repo_str = str(repo_root)
+    written = 0
+    for rel_path, description, est_tokens, file_mtime in annotations:
+        # Only update if mtime changed (avoid unnecessary writes)
+        existing = db.execute(
+            "SELECT file_mtime FROM file_annotations WHERE repo_root=? AND file_path=?",
+            (repo_str, rel_path),
+        ).fetchone()
+        if existing and abs(existing[0] - file_mtime) < 0.001 and file_mtime > 0:
+            continue  # unchanged
+        db.execute(
+            """
+            INSERT INTO file_annotations (repo_root, file_path, description, est_tokens, file_mtime, updated_at)
+            VALUES (?, ?, ?, ?, ?, datetime('now'))
+            ON CONFLICT(repo_root, file_path) DO UPDATE SET
+                description = excluded.description,
+                est_tokens  = excluded.est_tokens,
+                file_mtime  = excluded.file_mtime,
+                updated_at  = excluded.updated_at
+            """,
+            (repo_str, rel_path, description, est_tokens, file_mtime),
+        )
+        written += 1
+    db.commit()
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Main entry
+# ---------------------------------------------------------------------------
+
+def run_anatomy(
+    repo_root: Path,
+    db_path: Path | None = None,
+    stdout_only: bool = False,
+    no_write: bool = False,
+    limit: int | None = None,
+) -> int:
+    """Run the anatomy scan. Returns 0 on success, 1 on fatal error."""
+    files = ls_files(repo_root)
+    if not files:
+        print(f"Warning: no tracked files found in {repo_root}", file=sys.stderr)
+        return 0
+
+    if limit is not None and limit > 0:
+        files = files[:limit]
+
+    repo_str = str(repo_root)
+    annotations: list[tuple[str, str, int, float]] = []
+    for rel_path in files:
+        desc, tok = describe_file(repo_root, rel_path)
+        mtime = _get_mtime(repo_root, rel_path)
+        annotations.append((rel_path, desc, tok, mtime))
+
+    if stdout_only:
+        for rel_path, desc, tok, _ in annotations:
+            print(f"{rel_path}\t~{tok}tok\t{desc}")
+        return 0
+
+    if no_write:
+        print(f"Would write {len(annotations)} annotations for {repo_str}")
+        for rel_path, desc, tok, _ in annotations[:5]:
+            print(f"  {rel_path}  ~{tok}tok  {desc}")
+        if len(annotations) > 5:
+            print(f"  … ({len(annotations) - 5} more)")
+        return 0
+
+    effective_db = db_path or DEFAULT_DB_PATH
+    if not effective_db.parent.exists():
+        print(f"Error: DB directory does not exist: {effective_db.parent}", file=sys.stderr)
+        return 1
+
+    try:
+        db = sqlite3.connect(str(effective_db))
+        written = persist_annotations(db, repo_root, annotations)
+        db.close()
+    except Exception as e:
+        print(f"Error: DB write failed: {e}", file=sys.stderr)
+        return 1
+
+    print(f"✅ anatomy-map: {len(annotations)} files scanned, {written} annotations updated → {effective_db}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build per-file description index for the current git repo.")
+    parser.add_argument("--stdout", action="store_true", help="Print annotations to stdout; do not write to DB.")
+    parser.add_argument("--repo", metavar="PATH", help="Repository root (defaults to git root of cwd).")
+    parser.add_argument("--db", metavar="PATH", help="Explicit DB path (defaults to knowledge.db).")
+    parser.add_argument("--no-write", action="store_true", help="Dry-run: show what would be written.")
+    parser.add_argument("--limit", metavar="N", type=int, default=None, help="Cap number of files processed.")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo).resolve() if args.repo else find_git_root()
+    if repo_root is None:
+        print("Error: not in a git repository. Use --repo to specify root.", file=sys.stderr)
+        return 1
+
+    db_path = Path(args.db).resolve() if args.db else None
+    return run_anatomy(
+        repo_root=repo_root,
+        db_path=db_path,
+        stdout_only=args.stdout,
+        no_write=args.no_write,
+        limit=args.limit,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/briefing.py
+++ b/briefing.py
@@ -1400,6 +1400,27 @@ def load_codebase_map_files() -> set:
     return set()
 
 
+def _current_repo_root() -> str:
+    """Return the git repo root of the current working directory.
+
+    Fail-open: returns '' when git is unavailable, cwd is not a repo, or any
+    error occurs.  The caller (generate_briefing) passes this value as the
+    *repo_root* filter to query_file_annotations so that multi-repo knowledge
+    bases don't cross-contaminate each other's file annotations.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            raw = result.stdout.strip()
+            return Path(raw).resolve().as_posix()
+    except Exception:
+        pass
+    return ""
+
+
 def query_file_annotations(
     db: sqlite3.Connection,
     query: str = "",
@@ -1659,8 +1680,9 @@ def generate_briefing(
     # Blast radius analysis
     blast = blast_radius(db, rewritten_query)
 
-    # File annotations (fail-open when table absent)
-    file_annotations = query_file_annotations(db, query=rewritten_query, limit=6)
+    # File annotations (fail-open when table absent; scoped to current repo)
+    _repo_root = _current_repo_root()
+    file_annotations = query_file_annotations(db, query=rewritten_query, repo_root=_repo_root, limit=6)
 
     # Pack-only machine surface extras
     task_matches = []

--- a/briefing.py
+++ b/briefing.py
@@ -1400,6 +1400,70 @@ def load_codebase_map_files() -> set:
     return set()
 
 
+def query_file_annotations(
+    db: sqlite3.Connection,
+    query: str = "",
+    repo_root: str = "",
+    limit: int = 8,
+) -> list[dict]:
+    """Return relevant file annotations from the file_annotations table.
+
+    Fails open: returns [] when the table does not exist or any error occurs.
+    When *query* is provided, matches file_path or description by substring.
+    When *repo_root* is provided, filters to that repository root.
+    """
+    try:
+        rows = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='file_annotations'").fetchone()
+        if not rows:
+            return []
+
+        params: list = []
+        conditions: list[str] = []
+
+        if repo_root:
+            conditions.append("repo_root = ?")
+            params.append(repo_root)
+
+        if query:
+            conditions.append("(file_path LIKE ? OR description LIKE ?)")
+            like = f"%{query[:100]}%"
+            params.extend([like, like])
+
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        params.append(limit)
+
+        db_rows = db.execute(
+            f"""
+            SELECT file_path, description, est_tokens
+            FROM file_annotations
+            {where}
+            ORDER BY updated_at DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        return [{"file_path": r[0], "description": r[1], "est_tokens": r[2]} for r in db_rows]
+    except Exception:
+        return []  # always fail-open
+
+
+def _format_file_annotations_block(annotations: list[dict], max_entries: int = 6) -> str:
+    """Render a compact file-annotations block for briefing output.
+
+    Returns an empty string when annotations is empty.
+    """
+    if not annotations:
+        return ""
+    lines = ["🗂 File Index (top files)"]
+    for ann in annotations[:max_entries]:
+        fp = ann.get("file_path", "")
+        desc = ann.get("description", "")
+        tok = ann.get("est_tokens", 0)
+        tok_str = f" ~{tok}tok" if tok else ""
+        lines.append(f"  `{fp}`{tok_str} — {desc}")
+    return "\n".join(lines)
+
+
 def blast_radius(db: sqlite3.Connection, query: str) -> list[dict]:
     """Analyze blast radius: find files mentioned in task and their risk from knowledge DB.
 
@@ -1595,6 +1659,9 @@ def generate_briefing(
     # Blast radius analysis
     blast = blast_radius(db, rewritten_query)
 
+    # File annotations (fail-open when table absent)
+    file_annotations = query_file_annotations(db, query=rewritten_query, limit=6)
+
     # Pack-only machine surface extras
     task_matches = []
     file_matches = []
@@ -1700,11 +1767,11 @@ def generate_briefing(
             }
             output = json.dumps(pack, indent=2, ensure_ascii=False)
         elif fmt == "compact":
-            output = _format_compact(query, briefing_data, past_work, categories, blast)
+            output = _format_compact(query, briefing_data, past_work, categories, blast, file_annotations)
         elif full:
             output = _format_markdown(query, briefing_data, past_work, categories, blast)
         else:
-            output = _format_default(query, briefing_data, past_work, categories, blast)
+            output = _format_default(query, briefing_data, past_work, categories, blast, file_annotations)
 
     if with_meta:
         return output, {
@@ -1720,7 +1787,7 @@ def generate_briefing(
     return output
 
 
-def _format_default(query: str, data: dict, past_work: list, categories: dict, blast: list = None) -> str:
+def _format_default(query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None) -> str:
     """Compact default format: titles + 1-line summaries (~500 tokens)."""
     lines = []
     lines.append(f"📋 Briefing: {query}")
@@ -1788,6 +1855,12 @@ def _format_default(query: str, data: dict, past_work: list, categories: dict, b
                 title = title[:77] + "..."
             lines.append(f"  [{w.get('doc_type', '?')}] {title} (session {sid})")
         lines.append("")
+
+    if file_annotations:
+        fa_block = _format_file_annotations_block(file_annotations)
+        if fa_block:
+            lines.append(fa_block)
+            lines.append("")
 
     total = sum(len(v) for v in data.values()) + len(past_work)
     lines.append(
@@ -1939,10 +2012,10 @@ def _word_trim(s: str, limit: int = 80) -> str:
     return s
 
 
-def _format_compact(query: str, data: dict, past_work: list, categories: dict, blast: list = None) -> str:
+def _format_compact(query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None) -> str:
     """Compact format optimized for AI agent context injection.
 
-    Minimal-first ordering: mistakes → blast_radius → patterns/decisions/tools → past_work.
+    Minimal-first ordering: mistakes → blast_radius → patterns/decisions/tools → past_work → file_index.
     Mistakes and blast radius appear first so the most actionable risk context
     is visible in the smallest token budget.
     """
@@ -2028,6 +2101,17 @@ def _format_compact(query: str, data: dict, past_work: list, categories: dict, b
             sid = w.get("session_id", "?")[:8]
             lines.append(f"- [{w.get('doc_type', '?')}] {w.get('title', '?')} (session {sid})")
         lines.append("</past_work>\n")
+
+    # 5. File index — supplemental, minimal token cost
+    if file_annotations:
+        lines.append("<file_index>")
+        for ann in file_annotations[:6]:
+            fp = ann.get("file_path", "")
+            desc = ann.get("description", "")
+            tok = ann.get("est_tokens", 0)
+            tok_str = f" ~{tok}tok" if tok else ""
+            lines.append(f"- {fp}{tok_str}: {desc}")
+        lines.append("</file_index>\n")
 
     lines.append("</briefing>")
     return "\n".join(lines)

--- a/briefing.py
+++ b/briefing.py
@@ -1411,7 +1411,9 @@ def _current_repo_root() -> str:
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         if result.returncode == 0:
             raw = result.stdout.strip()
@@ -1809,7 +1811,9 @@ def generate_briefing(
     return output
 
 
-def _format_default(query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None) -> str:
+def _format_default(
+    query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None
+) -> str:
     """Compact default format: titles + 1-line summaries (~500 tokens)."""
     lines = []
     lines.append(f"📋 Briefing: {query}")
@@ -2034,7 +2038,9 @@ def _word_trim(s: str, limit: int = 80) -> str:
     return s
 
 
-def _format_compact(query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None) -> str:
+def _format_compact(
+    query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None
+) -> str:
     """Compact format optimized for AI agent context injection.
 
     Minimal-first ordering: mistakes → blast_radius → patterns/decisions/tools → past_work → file_index.

--- a/briefing.py
+++ b/briefing.py
@@ -1896,7 +1896,9 @@ def _format_default(
     return "\n".join(lines)
 
 
-def _format_markdown(query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None) -> str:
+def _format_markdown(
+    query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None
+) -> str:
     """Format briefing as Markdown."""
     lines = []
     lines.append("# 📋 Pre-Task Briefing")

--- a/briefing.py
+++ b/briefing.py
@@ -1793,7 +1793,7 @@ def generate_briefing(
         elif fmt == "compact":
             output = _format_compact(query, briefing_data, past_work, categories, blast, file_annotations)
         elif full:
-            output = _format_markdown(query, briefing_data, past_work, categories, blast)
+            output = _format_markdown(query, briefing_data, past_work, categories, blast, file_annotations)
         else:
             output = _format_default(query, briefing_data, past_work, categories, blast, file_annotations)
 
@@ -1896,7 +1896,7 @@ def _format_default(
     return "\n".join(lines)
 
 
-def _format_markdown(query: str, data: dict, past_work: list, categories: dict, blast: list = None) -> str:
+def _format_markdown(query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None) -> str:
     """Format briefing as Markdown."""
     lines = []
     lines.append("# 📋 Pre-Task Briefing")
@@ -1964,6 +1964,17 @@ def _format_markdown(query: str, data: dict, past_work: list, categories: dict, 
                 f"| {file_label} | {b['risk_emoji']} {b['risk_level']} "
                 f"| {b['mistakes']} | {b['patterns']} | {b['decisions']} |"
             )
+        lines.append("")
+
+    if file_annotations:
+        lines.append("## 📁 Relevant Files")
+        lines.append("")
+        for ann in file_annotations[:6]:
+            fp = ann.get("file_path", "")
+            desc = ann.get("description", "")
+            tok = ann.get("est_tokens", 0)
+            tok_str = f" ~{tok}tok" if tok else ""
+            lines.append(f"- `{fp}`{tok_str}: {desc}")
         lines.append("")
 
     lines.append("---")

--- a/hooks/auto-briefing.py
+++ b/hooks/auto-briefing.py
@@ -29,6 +29,7 @@ except ImportError:
 TOOLS_DIR = Path(__file__).resolve().parent.parent
 BRIEFING = TOOLS_DIR / "briefing.py"
 CODEBASE_MAP = TOOLS_DIR / "codebase-map.py"
+ANATOMY_MAP = TOOLS_DIR / "anatomy-map.py"
 MARKERS_DIR = Path.home() / ".copilot" / "markers"
 MARKER = MARKERS_DIR / "briefing-done"
 
@@ -214,6 +215,25 @@ def _try_refresh_codebase_map():
         pass
 
 
+def _try_refresh_anatomy():
+    """Refresh file_annotations table via anatomy-map.py.
+
+    Completely silent on failure — anatomy data is supplemental.
+    Skipped when anatomy-map.py is absent or the cwd is not a git repo.
+    """
+    if not ANATOMY_MAP.is_file():
+        return
+    try:
+        subprocess.run(
+            [sys.executable, str(ANATOMY_MAP)],
+            timeout=10,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        pass
+
+
 def main():
     # Clean up stale markers from previous sessions (crash recovery)
     if MARKERS_DIR.is_dir():
@@ -227,6 +247,9 @@ def main():
 
     # Regenerate codebase map independently — attempted regardless of briefing.py
     _try_refresh_codebase_map()
+
+    # Refresh anatomy annotations — completely silent on failure
+    _try_refresh_anatomy()
 
     if not BRIEFING.is_file():
         return

--- a/migrate.py
+++ b/migrate.py
@@ -159,6 +159,7 @@ def _seed_sync_table_policies(db: sqlite3.Connection):
         ("tfidf_model", "local_only", ""),
         ("entry_concept_tags", "local_only", ""),
         ("entry_dream_scores", "local_only", ""),
+        ("file_annotations", "local_only", ""),
     ]
     db.executemany(
         """
@@ -778,6 +779,25 @@ if __name__ == "__main__":
                 "ALTER TABLE knowledge_entries ADD COLUMN valence TEXT DEFAULT ''",
                 "ALTER TABLE knowledge_entries ADD COLUMN intensity REAL DEFAULT 0.5",
                 "CREATE INDEX IF NOT EXISTS idx_ke_intensity ON knowledge_entries(intensity DESC)",
+            ],
+        ),
+        # v22: issue #83 — Per-file anatomy index (local_only; never synced).
+        # Keyed by (repo_root, file_path); file_mtime enables incremental updates.
+        (
+            22,
+            "file_annotations",
+            [
+                """CREATE TABLE IF NOT EXISTS file_annotations (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    repo_root TEXT NOT NULL,
+                    file_path TEXT NOT NULL,
+                    description TEXT NOT NULL DEFAULT '',
+                    est_tokens INTEGER NOT NULL DEFAULT 0,
+                    file_mtime REAL NOT NULL DEFAULT 0.0,
+                    updated_at TEXT DEFAULT (datetime('now')),
+                    UNIQUE(repo_root, file_path)
+                )""",
+                "CREATE INDEX IF NOT EXISTS idx_fa_repo_root ON file_annotations(repo_root)",
             ],
         ),
     ]

--- a/sk.py
+++ b/sk.py
@@ -23,6 +23,7 @@ Usage:
     sk export-cerebrum [<args>...] Run export-cerebrum.py
     sk cerebrum [<args>...]       Run export-cerebrum.py (alias for export-cerebrum)
     sk dream    [<args>...]       Run dream.py
+    sk anatomy  [<args>...]       Run anatomy-map.py
     sk hooks    run|list|<event>  Run hooks/hook_runner.py
 
     sk index  build|extract|migrate|status|health|embed|tag [<args>...]
@@ -74,6 +75,7 @@ _DIRECT: dict[str, str] = {
     "export-cerebrum": "export-cerebrum.py",
     "cerebrum": "export-cerebrum.py",  # alias for export-cerebrum (short form)
     "dream": "dream.py",
+    "anatomy": "anatomy-map.py",
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}

--- a/tests/test_anatomy_map.py
+++ b/tests/test_anatomy_map.py
@@ -69,6 +69,47 @@ class TestStaticDescriptions(unittest.TestCase):
         desc = am._static_desc("requirements.txt")
         self.assertIsNotNone(desc)
 
+    def test_no_duplicate_keys(self):
+        """_STATIC_DESCRIPTIONS source literal must not contain duplicate literal keys.
+
+        Live-dict inspection cannot catch this because Python deduplicates dict
+        keys at construction time.  This test parses anatomy-map.py with ``ast``
+        and inspects the literal key nodes *before* deduplication occurs.
+        """
+        import ast
+
+        source = ANATOMY_PATH.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        literal_keys = None
+        for node in ast.walk(tree):
+            # Handle both 'x = {...}' (Assign) and 'x: T = {...}' (AnnAssign)
+            if isinstance(node, ast.AnnAssign):
+                target, value = node.target, node.value
+            elif isinstance(node, ast.Assign):
+                target = node.targets[0] if node.targets else None
+                value = node.value
+            else:
+                continue
+            if (
+                isinstance(target, ast.Name)
+                and target.id == "_STATIC_DESCRIPTIONS"
+                and isinstance(value, ast.Dict)
+            ):
+                literal_keys = [
+                    k.value
+                    for k in value.keys
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str)
+                ]
+                break
+
+        self.assertIsNotNone(
+            literal_keys,
+            "_STATIC_DESCRIPTIONS dict literal not found in anatomy-map.py",
+        )
+        dups = [k for k in set(literal_keys) if literal_keys.count(k) > 1]
+        self.assertEqual(dups, [], f"Duplicate literal keys in _STATIC_DESCRIPTIONS: {dups}")
+
     def test_unknown_file_returns_none(self):
         desc = am._static_desc("very_unique_file_xyz.py")
         self.assertIsNone(desc)
@@ -153,6 +194,56 @@ class TestLeadingDocstring(unittest.TestCase):
 
     def test_shebang_skipped(self):
         content = "#!/usr/bin/env python3\n"
+        desc = am._leading_docstring(content)
+        self.assertIsNone(desc)
+
+    def test_docstring_after_shebang_and_encoding(self):
+        """Triple-quote docstring preceded only by shebang + encoding comment is leading."""
+        content = '#!/usr/bin/env python3\n# -*- coding: utf-8 -*-\n"""Module after preamble."""\nimport os'
+        desc = am._leading_docstring(content)
+        self.assertIsNotNone(desc)
+        self.assertIn("Module", desc)
+
+    def test_inline_triple_quote_not_mistaken_for_docstring(self):
+        # Regression: loose fallback joined.find() could misclassify x = """value"""
+        # when code (imports/assignments) precedes the triple-quote.
+        content = 'import os\n\nx = """this is not a module docstring"""\n'
+        desc = am._leading_docstring(content)
+        # The triple-quote is inside an assignment, not a module docstring.
+        self.assertIsNone(desc)
+
+    def test_function_docstring_not_mistaken_for_module(self):
+        # A docstring inside a function must not be returned as the module description.
+        content = 'import sys\n\ndef foo():\n    """Function docstring that looks like a module doc."""\n    pass\n'
+        desc = am._leading_docstring(content)
+        self.assertIsNone(desc)
+
+    # --- Regression tests for reproduced comment-preamble bugs ---
+
+    def test_docstring_after_noqa_comment(self):
+        """# noqa before a real module docstring must yield the docstring, not None."""
+        content = '# noqa\n"""Module docstring that follows a noqa line."""\nimport os'
+        desc = am._leading_docstring(content)
+        self.assertIsNotNone(desc, "# noqa preamble blocked docstring extraction")
+        self.assertIn("Module docstring", desc)
+
+    def test_docstring_after_author_comment(self):
+        """# Author: ... before a real module docstring must yield the docstring."""
+        content = '# Author: Jane Doe\n"""Module docstring that follows author comment."""\nimport os'
+        desc = am._leading_docstring(content)
+        self.assertIsNotNone(desc, "# Author comment preamble blocked docstring extraction")
+        self.assertIn("Module docstring", desc)
+
+    def test_docstring_after_copyright_comment(self):
+        """# Copyright ... before a real module docstring must yield the docstring, not None."""
+        content = '# Copyright 2026\n"""Module docstring that follows copyright comment."""\nimport os'
+        desc = am._leading_docstring(content)
+        self.assertIsNotNone(desc, "# Copyright preamble blocked docstring extraction")
+        self.assertIn("Module docstring", desc)
+
+    def test_real_code_before_triple_quote_still_blocks(self):
+        """import statement before triple-quote must still prevent docstring extraction."""
+        content = 'import os\n"""This looks like a docstring but is not leading."""\n'
         desc = am._leading_docstring(content)
         self.assertIsNone(desc)
 
@@ -284,7 +375,22 @@ class TestDbPersistence(unittest.TestCase):
         self.assertEqual(count, 3)
 
 
-class TestFindGitRoot(unittest.TestCase):
+    def test_persist_repo_root_stored_as_posix(self):
+        """repo_root must be stored as forward-slash POSIX path (Windows normalization fix)."""
+        am._ensure_table(self.db)
+        # Simulate a resolved Windows path
+        repo_root = Path("C:/Users/test/myrepo") if os.name == "nt" else Path("/home/user/myrepo")
+        annotations = [("src/main.py", "Entry point.", 5, 1000.0)]
+        am.persist_annotations(self.db, repo_root, annotations)
+        row = self.db.execute("SELECT repo_root FROM file_annotations").fetchone()
+        self.assertIsNotNone(row)
+        stored = row[0]
+        # Must use forward slashes (POSIX), not backslashes
+        self.assertNotIn("\\", stored, f"repo_root stored with backslash: {stored!r}")
+        self.assertEqual(stored, repo_root.as_posix())
+
+
+
     def test_finds_root_for_this_repo(self):
         root = am.find_git_root(REPO)
         self.assertIsNotNone(root)

--- a/tests/test_anatomy_map.py
+++ b/tests/test_anatomy_map.py
@@ -111,6 +111,22 @@ class TestStaticDescriptions(unittest.TestCase):
         desc = am._static_desc("docs/README.md")
         self.assertIsNotNone(desc)
 
+    def test_directory_prefix_matches_true_descendant(self):
+        # .github/workflows/ci.yml should match .github/workflows prefix rule
+        desc = am._static_desc(".github/workflows/ci.yml")
+        self.assertIsNotNone(desc)
+        self.assertIn("workflow", desc.lower())
+
+    def test_directory_prefix_does_not_match_prefix_collision(self):
+        # .github/workflows-archive/foo.yml must NOT match .github/workflows rule
+        desc = am._static_desc(".github/workflows-archive/foo.yml")
+        self.assertIsNone(desc)
+
+    def test_directory_prefix_does_not_match_sibling_file(self):
+        # .github/workflows.yml must NOT match .github/workflows rule
+        desc = am._static_desc(".github/workflows.yml")
+        self.assertIsNone(desc)
+
 
 class TestJsonDesc(unittest.TestCase):
     def test_extracts_description_field(self):
@@ -374,10 +390,11 @@ class TestDbPersistence(unittest.TestCase):
         self.assertNotIn("\\", stored, f"repo_root stored with backslash: {stored!r}")
         self.assertEqual(stored, repo_root.as_posix())
 
+class TestFindGitRoot(unittest.TestCase):
     def test_finds_root_for_this_repo(self):
         root = am.find_git_root(REPO)
         self.assertIsNotNone(root)
-        self.assertTrue((root / ".git").exists() or root is not None)
+        self.assertTrue((root / ".git").exists())
 
     def test_returns_none_outside_repo(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_anatomy_map.py
+++ b/tests/test_anatomy_map.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""
+test_anatomy_map.py — Tests for anatomy-map.py
+
+Covers:
+  - Token estimation: ceil(chars / 3.75)
+  - Static description lookup for common filenames
+  - Description extraction heuristics (JSON, Markdown, docstring, fallback)
+  - File enumeration helpers
+  - DB persistence (create table, upsert, mtime-based skip)
+
+Run: python tests/test_anatomy_map.py
+"""
+
+import importlib.util
+import math
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).parent.parent
+ANATOMY_PATH = REPO / "anatomy-map.py"
+
+spec = importlib.util.spec_from_file_location("anatomy_map", ANATOMY_PATH)
+am = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(am)
+
+
+class TestTokenEstimate(unittest.TestCase):
+    def test_zero_chars(self):
+        self.assertEqual(am._tok(0), 0)
+
+    def test_negative_chars(self):
+        self.assertEqual(am._tok(-5), 0)
+
+    def test_exact_divisible(self):
+        # 75 / 3.75 = 20 exactly
+        self.assertEqual(am._tok(75), 20)
+
+    def test_rounds_up(self):
+        # 1 / 3.75 = 0.266... → ceil = 1
+        self.assertEqual(am._tok(1), 1)
+
+    def test_formula(self):
+        for n in [10, 37, 100, 1000, 3750]:
+            expected = math.ceil(n / 3.75)
+            self.assertEqual(am._tok(n), expected)
+
+
+class TestStaticDescriptions(unittest.TestCase):
+    def test_readme_md(self):
+        desc = am._static_desc("README.md")
+        self.assertIsNotNone(desc)
+        self.assertIn("readme", desc.lower())
+
+    def test_package_json(self):
+        desc = am._static_desc("package.json")
+        self.assertIsNotNone(desc)
+
+    def test_requirements_txt(self):
+        desc = am._static_desc("requirements.txt")
+        self.assertIsNotNone(desc)
+
+    def test_unknown_file_returns_none(self):
+        desc = am._static_desc("very_unique_file_xyz.py")
+        self.assertIsNone(desc)
+
+    def test_nested_path_name_match(self):
+        # The name "README.md" inside a subdir should still match
+        desc = am._static_desc("docs/README.md")
+        self.assertIsNotNone(desc)
+
+
+class TestJsonDesc(unittest.TestCase):
+    def test_extracts_description_field(self):
+        content = '{"name": "my-pkg", "description": "A useful tool for testing."}'
+        desc = am._json_desc(content)
+        self.assertEqual(desc, "A useful tool for testing.")
+
+    def test_ignores_too_short_description(self):
+        content = '{"description": "hi"}'
+        desc = am._json_desc(content)
+        self.assertIsNone(desc)
+
+    def test_ignores_too_long_description(self):
+        content = '{"description": "' + "x" * 201 + '"}'
+        desc = am._json_desc(content)
+        self.assertIsNone(desc)
+
+    def test_invalid_json_returns_none(self):
+        desc = am._json_desc("not json {{{")
+        self.assertIsNone(desc)
+
+    def test_no_description_key(self):
+        content = '{"name": "pkg", "version": "1.0"}'
+        desc = am._json_desc(content)
+        self.assertIsNone(desc)
+
+
+class TestMdHeading(unittest.TestCase):
+    def test_first_heading(self):
+        content = "# My Project\n\nSome description."
+        desc = am._md_heading(content)
+        self.assertEqual(desc, "My Project")
+
+    def test_h2_heading(self):
+        content = "## Section\n\nContent."
+        desc = am._md_heading(content)
+        self.assertEqual(desc, "Section")
+
+    def test_no_heading_returns_none(self):
+        content = "Just plain text\nNo headings here."
+        desc = am._md_heading(content)
+        self.assertIsNone(desc)
+
+    def test_empty_heading_returns_none(self):
+        content = "#\n\nContent."
+        desc = am._md_heading(content)
+        self.assertIsNone(desc)
+
+
+class TestLeadingDocstring(unittest.TestCase):
+    def test_python_triple_quoted(self):
+        content = '"""\nThis module does something useful.\n"""\n\nimport os'
+        desc = am._leading_docstring(content)
+        self.assertIsNotNone(desc)
+        self.assertIn("module", desc.lower())
+
+    def test_single_line_triple_quote(self):
+        content = '"""Single-line docstring for this module."""\nimport sys'
+        desc = am._leading_docstring(content)
+        self.assertIsNotNone(desc)
+
+    def test_c_block_comment(self):
+        content = "/* This is a C module for networking. */\n#include <stdio.h>"
+        desc = am._leading_docstring(content)
+        self.assertIsNotNone(desc)
+        self.assertIn("C module", desc)
+
+    def test_python_hash_comment(self):
+        content = "#!/usr/bin/env python3\n# Script for generating reports.\nimport sys"
+        desc = am._leading_docstring(content)
+        self.assertIsNotNone(desc)
+        self.assertIn("report", desc.lower())
+
+    def test_shebang_skipped(self):
+        content = "#!/usr/bin/env python3\n"
+        desc = am._leading_docstring(content)
+        self.assertIsNone(desc)
+
+
+class TestDescribeFile(unittest.TestCase):
+    def test_readme_uses_static(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "README.md").write_text("# My Project\n\nDesc.", encoding="utf-8")
+            desc, tok = am.describe_file(root, "README.md")
+        # Static description should win over MD heading
+        self.assertIsNotNone(desc)
+        self.assertGreater(tok, 0)
+
+    def test_md_file_uses_heading(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "NOTES.md").write_text("# My Notes\n\nSome content.", encoding="utf-8")
+            desc, tok = am.describe_file(root, "NOTES.md")
+        self.assertIn("My Notes", desc)
+        self.assertGreater(tok, 0)
+
+    def test_json_with_description(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "manifest.json").write_text(
+                '{"name": "pkg", "description": "A test package for unit testing."}',
+                encoding="utf-8",
+            )
+            desc, tok = am.describe_file(root, "manifest.json")
+        self.assertIn("test package", desc.lower())
+        self.assertGreater(tok, 0)
+
+    def test_python_docstring(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "utils.py").write_text(
+                '"""Utility functions for data processing."""\n\ndef foo(): pass\n',
+                encoding="utf-8",
+            )
+            desc, tok = am.describe_file(root, "utils.py")
+        self.assertIn("Utility", desc)
+
+    def test_fallback_for_unknown(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "something.xyz").write_text("binary content", encoding="utf-8")
+            desc, tok = am.describe_file(root, "something.xyz")
+        self.assertIsNotNone(desc)
+        self.assertGreater(len(desc), 0)
+
+    def test_tok_matches_formula(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "NOTES.md").write_text("# Header\n", encoding="utf-8")
+            desc, tok = am.describe_file(root, "NOTES.md")
+        expected = math.ceil(len(desc) / 3.75)
+        self.assertEqual(tok, expected)
+
+
+class TestDbPersistence(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "test.db"
+        self.db = sqlite3.connect(str(self.db_path))
+
+    def tearDown(self):
+        self.db.close()
+        self.tmp.cleanup()
+
+    def test_ensure_table_creates_table(self):
+        am._ensure_table(self.db)
+        row = self.db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='file_annotations'"
+        ).fetchone()
+        self.assertIsNotNone(row)
+
+    def test_ensure_table_idempotent(self):
+        am._ensure_table(self.db)
+        am._ensure_table(self.db)  # should not raise
+        row = self.db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='file_annotations'"
+        ).fetchone()
+        self.assertIsNotNone(row)
+
+    def test_persist_writes_rows(self):
+        am._ensure_table(self.db)
+        repo_root = Path("/repo")
+        annotations = [("src/main.py", "Entry point.", 5, 1000.0)]
+        written = am.persist_annotations(self.db, repo_root, annotations)
+        self.assertEqual(written, 1)
+        row = self.db.execute("SELECT * FROM file_annotations").fetchone()
+        self.assertIsNotNone(row)
+
+    def test_persist_skips_unchanged_mtime(self):
+        am._ensure_table(self.db)
+        repo_root = Path("/repo")
+        annotations = [("src/main.py", "Entry point.", 5, 1000.0)]
+        am.persist_annotations(self.db, repo_root, annotations)
+        # Second call with same mtime should skip
+        written = am.persist_annotations(self.db, repo_root, annotations)
+        self.assertEqual(written, 0)
+
+    def test_persist_updates_changed_mtime(self):
+        am._ensure_table(self.db)
+        repo_root = Path("/repo")
+        annotations = [("src/main.py", "Entry point.", 5, 1000.0)]
+        am.persist_annotations(self.db, repo_root, annotations)
+        # Update mtime
+        annotations2 = [("src/main.py", "Updated description.", 6, 2000.0)]
+        written = am.persist_annotations(self.db, repo_root, annotations2)
+        self.assertEqual(written, 1)
+        row = self.db.execute(
+            "SELECT description FROM file_annotations WHERE file_path='src/main.py'"
+        ).fetchone()
+        self.assertEqual(row[0], "Updated description.")
+
+    def test_persist_multiple_files(self):
+        am._ensure_table(self.db)
+        repo_root = Path("/repo")
+        annotations = [
+            ("a.py", "Module A.", 3, 100.0),
+            ("b.py", "Module B.", 3, 200.0),
+            ("c.py", "Module C.", 3, 300.0),
+        ]
+        written = am.persist_annotations(self.db, repo_root, annotations)
+        self.assertEqual(written, 3)
+        count = self.db.execute("SELECT COUNT(*) FROM file_annotations").fetchone()[0]
+        self.assertEqual(count, 3)
+
+
+class TestFindGitRoot(unittest.TestCase):
+    def test_finds_root_for_this_repo(self):
+        root = am.find_git_root(REPO)
+        self.assertIsNotNone(root)
+        self.assertTrue((root / ".git").exists() or root is not None)
+
+    def test_returns_none_outside_repo(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = am.find_git_root(Path(td))
+        self.assertIsNone(result)
+
+
+class TestRunAnatomy(unittest.TestCase):
+    def test_stdout_mode(self):
+        """run_anatomy --stdout should return 0 and not crash."""
+        import io
+        from unittest.mock import patch
+
+        repo_root = am.find_git_root(REPO)
+        if repo_root is None:
+            self.skipTest("No git repo found")
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            rc = am.run_anatomy(repo_root, stdout_only=True, limit=5)
+        self.assertEqual(rc, 0)
+        output = buf.getvalue()
+        # Should have some lines with tab-separated fields
+        lines = [l for l in output.splitlines() if l.strip()]
+        self.assertGreater(len(lines), 0)
+        for line in lines:
+            parts = line.split("\t")
+            self.assertGreaterEqual(len(parts), 3, f"Expected 3 tab-separated fields: {line!r}")
+
+    def test_no_write_mode(self):
+        import io
+        from unittest.mock import patch
+
+        repo_root = am.find_git_root(REPO)
+        if repo_root is None:
+            self.skipTest("No git repo found")
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            rc = am.run_anatomy(repo_root, no_write=True, limit=3)
+        self.assertEqual(rc, 0)
+        self.assertIn("Would write", buf.getvalue())
+
+    def test_db_write_mode(self):
+        repo_root = am.find_git_root(REPO)
+        if repo_root is None:
+            self.skipTest("No git repo found")
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "test.db"
+            rc = am.run_anatomy(repo_root, db_path=db_path, limit=5)
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_anatomy_map.py
+++ b/tests/test_anatomy_map.py
@@ -390,6 +390,7 @@ class TestDbPersistence(unittest.TestCase):
         self.assertNotIn("\\", stored, f"repo_root stored with backslash: {stored!r}")
         self.assertEqual(stored, repo_root.as_posix())
 
+
 class TestFindGitRoot(unittest.TestCase):
     def test_finds_root_for_this_repo(self):
         root = am.find_git_root(REPO)

--- a/tests/test_anatomy_map.py
+++ b/tests/test_anatomy_map.py
@@ -91,16 +91,8 @@ class TestStaticDescriptions(unittest.TestCase):
                 value = node.value
             else:
                 continue
-            if (
-                isinstance(target, ast.Name)
-                and target.id == "_STATIC_DESCRIPTIONS"
-                and isinstance(value, ast.Dict)
-            ):
-                literal_keys = [
-                    k.value
-                    for k in value.keys
-                    if isinstance(k, ast.Constant) and isinstance(k.value, str)
-                ]
+            if isinstance(target, ast.Name) and target.id == "_STATIC_DESCRIPTIONS" and isinstance(value, ast.Dict):
+                literal_keys = [k.value for k in value.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)]
                 break
 
         self.assertIsNotNone(
@@ -316,17 +308,13 @@ class TestDbPersistence(unittest.TestCase):
 
     def test_ensure_table_creates_table(self):
         am._ensure_table(self.db)
-        row = self.db.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='file_annotations'"
-        ).fetchone()
+        row = self.db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='file_annotations'").fetchone()
         self.assertIsNotNone(row)
 
     def test_ensure_table_idempotent(self):
         am._ensure_table(self.db)
         am._ensure_table(self.db)  # should not raise
-        row = self.db.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='file_annotations'"
-        ).fetchone()
+        row = self.db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='file_annotations'").fetchone()
         self.assertIsNotNone(row)
 
     def test_persist_writes_rows(self):
@@ -356,9 +344,7 @@ class TestDbPersistence(unittest.TestCase):
         annotations2 = [("src/main.py", "Updated description.", 6, 2000.0)]
         written = am.persist_annotations(self.db, repo_root, annotations2)
         self.assertEqual(written, 1)
-        row = self.db.execute(
-            "SELECT description FROM file_annotations WHERE file_path='src/main.py'"
-        ).fetchone()
+        row = self.db.execute("SELECT description FROM file_annotations WHERE file_path='src/main.py'").fetchone()
         self.assertEqual(row[0], "Updated description.")
 
     def test_persist_multiple_files(self):
@@ -374,7 +360,6 @@ class TestDbPersistence(unittest.TestCase):
         count = self.db.execute("SELECT COUNT(*) FROM file_annotations").fetchone()[0]
         self.assertEqual(count, 3)
 
-
     def test_persist_repo_root_stored_as_posix(self):
         """repo_root must be stored as forward-slash POSIX path (Windows normalization fix)."""
         am._ensure_table(self.db)
@@ -388,8 +373,6 @@ class TestDbPersistence(unittest.TestCase):
         # Must use forward slashes (POSIX), not backslashes
         self.assertNotIn("\\", stored, f"repo_root stored with backslash: {stored!r}")
         self.assertEqual(stored, repo_root.as_posix())
-
-
 
     def test_finds_root_for_this_repo(self):
         root = am.find_git_root(REPO)

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -157,6 +157,15 @@ class TestSkDirectCommands(unittest.TestCase):
     def test_dream_top_n(self):
         self._assert_routes("dream", "dream.py", ["--top", "10"])
 
+    def test_anatomy(self):
+        self._assert_routes("anatomy", "anatomy-map.py")
+
+    def test_anatomy_stdout(self):
+        self._assert_routes("anatomy", "anatomy-map.py", ["--stdout"])
+
+    def test_anatomy_repo(self):
+        self._assert_routes("anatomy", "anatomy-map.py", ["--repo", "/some/path"])
+
 
 class TestSkHooksCompat(unittest.TestCase):
     def test_hooks_run_drops_run_subcommand(self):


### PR DESCRIPTION
## Summary
- add `sk anatomy` with persisted file annotations and briefing integration
- normalize repo-root handling on Windows and harden docstring extraction heuristics
- add regression coverage for duplicate keys, Windows normalization, and docstring preambles

## Testing
- python tests/test_anatomy_map.py
- python tests/test_sk_cli.py
- python tests/test_codebase_map.py
- python test_security.py
- python test_fixes.py
- python sk.py anatomy --stdout --repo .

Closes #83