### PR TITLE
feat(browse-ui): warm design system (#82)

### DIFF
--- a/browse-ui/src/app/globals.css
+++ b/browse-ui/src/app/globals.css
@@ -33,88 +33,122 @@
   --radius-sm: 0.25rem;
   --radius-md: 0.375rem;
   --radius-lg: 0.5rem;
+  /* Spring easing — use with transition-timing-[var(--ease-spring)] or ease-[var(--ease-spring)] */
+  --ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  /* Shimmer animation for primary CTA */
+  --animate-btn-shimmer: btn-shimmer 2.5s ease-in-out infinite;
 }
 
 /* HSL design tokens — canonical values from 03-visual-design.md §1 */
-/* Contrast tuning: off-white background/surfaces reduce glare vs pure #fff per APCA guidance */
+/* Warm-neutral default palette (issue #82): warm off-white bg, coral brand accent, readable contrast */
 @layer base {
   :root {
+    --background: 38 52% 97%; /* warm off-white ≈ #FDFAF6 */
+    --foreground: 20 14% 16%; /* warm dark text */
+    --card: 38 40% 98%;
+    --card-foreground: 20 14% 16%;
+    --popover: 38 40% 98%;
+    --popover-foreground: 20 14% 16%;
+    --primary: 12 75% 44%; /* coral brand — darkened for WCAG AA ≥4.5:1 white text */
+    --primary-foreground: 0 0% 100%;
+    --secondary: 38 30% 92%;
+    --secondary-foreground: 20 14% 16%;
+    --muted: 38 25% 90%;
+    --muted-foreground: 20 10% 45%;
+    --accent: 12 75% 44%;
+    --accent-foreground: 0 0% 100%;
+    --destructive: 358 75% 47%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 38 25% 87%;
+    --input: 38 25% 87%;
+    --ring: 12 75% 18%; /* dark coral ring — decoupled from primary (44%) for WCAG 1.4.11 ≥3:1 focus-border contrast on primary buttons */
+    --radius: 0.375rem;
+    --chart-1: 12 75% 59%;
+    --chart-2: 152 56% 48%;
+    --chart-3: 33 90% 58%;
+    --chart-4: 280 60% 60%;
+    --chart-5: 38 85% 55%;
+  }
+
+  /* Dark theme (.dark class on <html>, set by next-themes attribute="class") */
+  /* Warm dark: slightly warm neutrals, lighter coral for dark-mode contrast */
+  .dark {
+    --background: 30 5% 10%; /* warm dark ≈ #1a1917 */
+    --foreground: 30 15% 88%;
+    --card: 30 6% 15%;
+    --card-foreground: 30 15% 88%;
+    --popover: 30 6% 16%;
+    --popover-foreground: 30 15% 88%;
+    --primary: 12 80% 45%; /* coral brand dark-mode — darkened for WCAG AA ≥4.5:1 white text */
+    --primary-foreground: 0 0% 100%;
+    --secondary: 30 6% 18%;
+    --secondary-foreground: 30 15% 88%;
+    --muted: 30 6% 18%;
+    --muted-foreground: 30 8% 62%; /* raised from 50% for WCAG AA on dark card surfaces */
+    --accent: 12 80% 45%;
+    --accent-foreground: 0 0% 100%;
+    --destructive: 358 78% 63%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 30 6% 22%;
+    --input: 30 6% 22%;
+    --ring: 12 80% 78%; /* decoupled from dark primary — brightened for WCAG 1.4.11 ≥3:1 at ring/50 */
+    --radius: 0.375rem;
+    --chart-1: 12 78% 66%;
+    --chart-2: 152 50% 50%;
+    --chart-3: 38 85% 55%;
+    --chart-4: 280 55% 65%;
+    --chart-5: 33 80% 60%;
+  }
+
+  /* Classic palette opt-in — restores the cool/APCA-tuned indigo design language.
+     Activated by .palette-classic on <html> via use-palette hook.
+
+     Specificity discipline — light overrides MUST be scoped with :not(.dark) so
+     they do not bleed into dark mode (where `.dark` sets the canonical dark bg
+     with lower specificity than `:root.palette-classic` would have). */
+  :root:not(.dark).palette-classic {
     --background: 210 20% 97%;
     --foreground: 215 14% 14%;
     --card: 210 16% 99%;
     --card-foreground: 215 14% 14%;
+    --chart-1: 235 56% 60%; /* indigo — replaces warm coral */
+    --chart-2: 152 56% 48%;
+    --chart-3: 202 72% 52%; /* cool cyan-blue — replaces warm orange */
+    --chart-4: 280 60% 60%;
+    --chart-5: 196 80% 48%; /* teal — replaces warm amber */
     --popover: 210 16% 99%;
     --popover-foreground: 215 14% 14%;
-    --primary: 235 56% 60%; /* #5E6AD2 indigo */
-    --primary-foreground: 0 0% 100%;
+    --primary: 235 56% 60%;
     --secondary: 210 16% 96%;
     --secondary-foreground: 215 14% 14%;
     --muted: 212 18% 93%;
     --muted-foreground: 212 7% 43%;
     --accent: 235 56% 60%;
-    --accent-foreground: 0 0% 100%;
-    --destructive: 358 75% 47%;
-    --destructive-foreground: 0 0% 100%;
     --border: 210 16% 87%;
     --input: 210 16% 87%;
-    --ring: 235 56% 60%;
-    --radius: 0.375rem;
-    --chart-1: 235 56% 60%;
-    --chart-2: 152 56% 48%;
-    --chart-3: 33 90% 58%;
-    --chart-4: 280 60% 60%;
-    --chart-5: 12 80% 60%;
+    --ring: 235 56% 25%; /* dark indigo ring — decoupled from primary (60%) for WCAG 1.4.11 ≥3:1 focus-border contrast on primary buttons */
   }
-
-  /* Dark theme (.dark class on <html>, set by next-themes attribute="class") */
-  /* Contrast tuning: foreground 88% vs 93% reduces halation/glare on dark bg per APCA guidance;
-     card/popover surfaces lifted 1-2% for visible elevation without glass effect */
-  .dark {
+  .dark.palette-classic {
     --background: 215 22% 7%;
     --foreground: 210 20% 88%;
     --card: 215 20% 12%;
     --card-foreground: 210 20% 88%;
+    --chart-1: 235 56% 69%; /* indigo — replaces warm coral */
+    --chart-2: 152 50% 50%;
+    --chart-3: 202 72% 60%; /* cool cyan-blue — replaces warm orange */
+    --chart-4: 280 55% 65%;
+    --chart-5: 196 80% 56%; /* teal — replaces warm amber */
     --popover: 215 20% 13%;
     --popover-foreground: 210 20% 88%;
-    --primary: 235 56% 69%; /* #7B86E2 lighter indigo */
-    --primary-foreground: 0 0% 100%;
+    --primary: 235 56% 56%; /* lowered from 69% for WCAG AA ≥4.5:1 white text */
     --secondary: 215 14% 15%;
     --secondary-foreground: 210 20% 88%;
     --muted: 215 14% 15%;
-    --muted-foreground: 212 7% 47%;
-    --accent: 235 56% 69%;
-    --accent-foreground: 0 0% 100%;
-    --destructive: 358 78% 63%;
-    --destructive-foreground: 0 0% 100%;
+    --muted-foreground: 212 7% 60%; /* raised from 47% for WCAG AA on dark card surfaces */
+    --accent: 235 56% 56%; /* matches primary */
     --border: 215 11% 20%;
     --input: 215 11% 20%;
-    --ring: 235 56% 69%;
-    --radius: 0.375rem;
-    --chart-1: 235 56% 69%;
-    --chart-2: 152 50% 50%;
-    --chart-3: 38 85% 55%;
-    --chart-4: 280 55% 65%;
-    --chart-5: 12 75% 65%;
-  }
-
-  /* Classic palette opt-in (pre-APCA tuning, restored from before commit 2b54b65).
-     Activated by .palette-classic on <html> via use-palette hook.
-
-     Specificity discipline — light overrides MUST be scoped with :not(.dark) so
-     they do not bleed into dark mode (where `.dark` sets the canonical dark bg
-     with lower specificity than the previous `:root.palette-classic`). */
-  :root:not(.dark).palette-classic {
-    --background: 210 20% 99%;
-    --card: 0 0% 100%;
-    --popover: 0 0% 100%;
-  }
-  .dark.palette-classic {
-    --foreground: 210 25% 93%;
-    --card: 215 20% 11%;
-    --card-foreground: 210 25% 93%;
-    --popover: 215 20% 11%;
-    --popover-foreground: 210 25% 93%;
-    --secondary-foreground: 210 25% 93%;
+    --ring: 235 56% 80%; /* decoupled from dark primary — brightened for WCAG 1.4.11 ≥3:1 at ring/50 */
   }
 }
 
@@ -146,5 +180,39 @@
   }
   html {
     @apply font-sans;
+  }
+}
+
+/* Shimmer keyframe for primary CTA (btn-shimmer animation) */
+@keyframes btn-shimmer {
+  0% {
+    transform: translateX(-150%);
+  }
+  100% {
+    transform: translateX(150%);
+  }
+}
+
+/* Text selection uses brand tint for warm accent */
+::selection {
+  background: hsl(var(--primary) / 0.2);
+  color: hsl(var(--foreground));
+}
+
+/* Scrollbar tinting — restores brand-tinted thumb on hover */
+@supports selector(::-webkit-scrollbar) {
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: hsl(var(--border));
+    border-radius: 9999px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--primary) / 0.45);
   }
 }

--- a/browse-ui/src/app/settings/page.tsx
+++ b/browse-ui/src/app/settings/page.tsx
@@ -102,8 +102,8 @@ export default function SettingsPage() {
             <p className="text-sm font-medium">Palette</p>
             <PaletteToggle />
             <p className="text-muted-foreground text-xs">
-              Contrast (default) uses APCA-tuned off-white surfaces. Classic restores the
-              pre-May-2026 pure-white palette. Both keep popovers and dropdowns opaque. Stored as{" "}
+              Warm (default) uses warm-neutral surfaces with a coral accent. Classic restores the
+              cool APCA-tuned indigo palette. Both keep popovers and dropdowns opaque. Stored as{" "}
               <code className="bg-muted rounded px-1 py-0.5 font-mono text-[11px]">
                 browse-palette
               </code>

--- a/browse-ui/src/components/layout/palette-toggle.tsx
+++ b/browse-ui/src/components/layout/palette-toggle.tsx
@@ -7,7 +7,7 @@ import { usePalette, type Palette } from "@/hooks/use-palette";
 import { cn } from "@/lib/utils";
 
 const OPTIONS: ReadonlyArray<{ value: Palette; label: string; icon: typeof PaletteIcon }> = [
-  { value: "contrast", label: "Contrast", icon: Sparkles },
+  { value: "contrast", label: "Warm", icon: Sparkles },
   { value: "classic", label: "Classic", icon: PaletteIcon },
 ];
 

--- a/browse-ui/src/components/ui/button.tsx
+++ b/browse-ui/src/components/ui/button.tsx
@@ -8,7 +8,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default:
+          "relative overflow-hidden before:pointer-events-none before:absolute before:inset-0 before:content-[''] motion-safe:before:animate-btn-shimmer motion-reduce:before:hidden before:bg-gradient-to-r before:from-transparent before:via-white/20 before:to-transparent bg-primary text-primary-foreground shadow-[0_1px_4px_hsl(var(--primary)/0.3)] ease-[var(--ease-spring)] hover:shadow-[0_2px_8px_hsl(var(--primary)/0.4)] [a]:hover:bg-primary/80",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/browse-ui/src/components/ui/contrast-system.test.tsx
+++ b/browse-ui/src/components/ui/contrast-system.test.tsx
@@ -17,10 +17,56 @@ import {
   POPUP_SURFACE_BASE,
   POPUP_SURFACE_BG,
 } from "@/components/ui/popup-surface";
+import { buttonVariants } from "@/components/ui/button";
 import { Select, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogOverlay } from "@/components/ui/dialog";
 import { Sheet, SheetContent, SheetOverlay } from "@/components/ui/sheet";
 import { SurfacePanel } from "@/components/ui/surface-panel";
+
+/** WCAG 2.x contrast helpers — no external deps, pure arithmetic */
+function hslToSrgb(h: number, s: number, l: number): [number, number, number] {
+  const sn = s / 100;
+  const ln = l / 100;
+  const c = (1 - Math.abs(2 * ln - 1)) * sn;
+  const hp = h / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r1 = 0,
+    g1 = 0,
+    b1 = 0;
+  if (hp < 1) {
+    r1 = c;
+    g1 = x;
+  } else if (hp < 2) {
+    r1 = x;
+    g1 = c;
+  } else if (hp < 3) {
+    g1 = c;
+    b1 = x;
+  } else if (hp < 4) {
+    g1 = x;
+    b1 = c;
+  } else if (hp < 5) {
+    r1 = x;
+    b1 = c;
+  } else {
+    r1 = c;
+    b1 = x;
+  }
+  const m = ln - c / 2;
+  return [r1 + m, g1 + m, b1 + m];
+}
+
+function toLinearChannel(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance(r: number, g: number, b: number): number {
+  return 0.2126 * toLinearChannel(r) + 0.7152 * toLinearChannel(g) + 0.0722 * toLinearChannel(b);
+}
+
+function wcagContrast(l1: number, l2: number): number {
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+}
 
 function readGlobalsCss() {
   const currentFile = import.meta.url.startsWith("file:")
@@ -165,29 +211,35 @@ describe("Tailwind theme color tokens — valid opaque colors", () => {
     expect(rawTripletMappings.map((match) => match[0])).toEqual([]);
   });
 
-  it("exposes a .palette-classic opt-in that overrides surface tokens to pre-2b54b65 values", () => {
+  it("exposes a .palette-classic opt-in that restores the cool/APCA indigo design language", () => {
     const globalsCss = readGlobalsCss();
 
     // Light-mode classic MUST be scoped with :not(.dark) — without it,
     // :root.palette-classic (0,1,1) outranks .dark (0,1,0) and bleeds light
     // surfaces into dark mode when classic is active.
     expect(globalsCss).toMatch(
-      /:root:not\(\.dark\)\.palette-classic\s*\{[^}]*--background:\s*210 20% 99%;/
+      /:root:not\(\.dark\)\.palette-classic\s*\{[^}]*--background:\s*210 20% 97%;/
     );
     expect(globalsCss).toMatch(
-      /:root:not\(\.dark\)\.palette-classic\s*\{[^}]*--card:\s*0 0% 100%;/
+      /:root:not\(\.dark\)\.palette-classic\s*\{[^}]*--card:\s*210 16% 99%;/
     );
     expect(globalsCss).toMatch(
-      /:root:not\(\.dark\)\.palette-classic\s*\{[^}]*--popover:\s*0 0% 100%;/
+      /:root:not\(\.dark\)\.palette-classic\s*\{[^}]*--popover:\s*210 16% 99%;/
+    );
+    expect(globalsCss).toMatch(
+      /:root:not\(\.dark\)\.palette-classic\s*\{[^}]*--primary:\s*235 56% 60%;/
+    );
+    expect(globalsCss).toMatch(
+      /:root:not\(\.dark\)\.palette-classic\s*\{[^}]*--ring:\s*235 56% 25%;/
     );
 
-    // Dark-mode classic restores the brighter foreground / lower-elevation card.
-    expect(globalsCss).toMatch(/\.dark\.palette-classic\s*\{[^}]*--foreground:\s*210 25% 93%;/);
-    expect(globalsCss).toMatch(/\.dark\.palette-classic\s*\{[^}]*--popover:\s*215 20% 11%;/);
-    expect(globalsCss).toMatch(/\.dark\.palette-classic\s*\{[^}]*--card:\s*215 20% 11%;/);
-    expect(globalsCss).toMatch(
-      /\.dark\.palette-classic\s*\{[^}]*--secondary-foreground:\s*210 25% 93%;/
-    );
+    // Dark-mode classic restores the cool indigo / APCA-tuned dark surfaces.
+    expect(globalsCss).toMatch(/\.dark\.palette-classic\s*\{[^}]*--foreground:\s*210 20% 88%;/);
+    expect(globalsCss).toMatch(/\.dark\.palette-classic\s*\{[^}]*--popover:\s*215 20% 13%;/);
+    expect(globalsCss).toMatch(/\.dark\.palette-classic\s*\{[^}]*--card:\s*215 20% 12%;/);
+    expect(globalsCss).toMatch(/\.dark\.palette-classic\s*\{[^}]*--primary:\s*235 56% 56%;/);
+    // ring is decoupled from primary in dark mode to satisfy WCAG 1.4.11 at ring/50 opacity
+    expect(globalsCss).toMatch(/\.dark\.palette-classic\s*\{[^}]*--ring:\s*235 56% 80%;/);
   });
 
   it("does not use unscoped :root.palette-classic (would leak light vars into dark mode)", () => {
@@ -195,7 +247,32 @@ describe("Tailwind theme color tokens — valid opaque colors", () => {
     expect(globalsCss).not.toMatch(/:root\.palette-classic\s*\{/);
   });
 
-  it("covers exactly the variables that commit 2b54b65 shifted (no missed token, no extra)", () => {
+  it("classic palette chart tokens are cool/indigo (not warm coral or amber)", () => {
+    const globalsCss = readGlobalsCss();
+
+    const lightBlockMatch = globalsCss.match(/:root:not\(\.dark\)\.palette-classic\s*\{([^}]+)\}/);
+    expect(lightBlockMatch).not.toBeNull();
+    const lightBlock = lightBlockMatch![1];
+    // chart-1 must NOT be the warm coral value
+    expect(lightBlock).not.toMatch(/--chart-1:\s*12 75% 59%/);
+    // chart-5 must NOT be the warm amber value
+    expect(lightBlock).not.toMatch(/--chart-5:\s*38 85% 55%/);
+    // chart-1 should use the indigo primary hue (≈235)
+    expect(lightBlock).toMatch(/--chart-1:\s*235/);
+    // chart-5 should use a cool hue (not warm 12–42 range)
+    expect(lightBlock).toMatch(/--chart-5:\s*19[0-9]/);
+
+    const darkBlockMatch = globalsCss.match(/\.dark\.palette-classic\s*\{([^}]+)\}/);
+    expect(darkBlockMatch).not.toBeNull();
+    const darkBlock = darkBlockMatch![1];
+    // chart-1 must NOT be the warm dark-mode coral value
+    expect(darkBlock).not.toMatch(/--chart-1:\s*12 78% 66%/);
+    expect(darkBlock).not.toMatch(/--chart-1:\s*12 80% 45%/);
+    // chart-1 should use the indigo primary hue
+    expect(darkBlock).toMatch(/--chart-1:\s*235/);
+  });
+
+  it("covers all semantic tokens that differ between warm and classic/cool palettes", () => {
     const globalsCss = readGlobalsCss();
 
     const lightBlockMatch = globalsCss.match(/:root:not\(\.dark\)\.palette-classic\s*\{([^}]+)\}/);
@@ -203,21 +280,59 @@ describe("Tailwind theme color tokens — valid opaque colors", () => {
     const lightVars = Array.from(lightBlockMatch![1].matchAll(/--([\w-]+):/g))
       .map((m) => m[1])
       .sort();
-    expect(lightVars).toEqual(["background", "card", "popover"]);
+    // Classic light block must restore all semantic tokens that differ vs the warm default
+    const expectedLightVars = [
+      "accent",
+      "background",
+      "border",
+      "card",
+      "card-foreground",
+      "chart-1",
+      "chart-2",
+      "chart-3",
+      "chart-4",
+      "chart-5",
+      "foreground",
+      "input",
+      "muted",
+      "muted-foreground",
+      "popover",
+      "popover-foreground",
+      "primary",
+      "ring",
+      "secondary",
+      "secondary-foreground",
+    ];
+    expect(lightVars).toEqual(expectedLightVars);
 
     const darkBlockMatch = globalsCss.match(/\.dark\.palette-classic\s*\{([^}]+)\}/);
     expect(darkBlockMatch).not.toBeNull();
     const darkVars = Array.from(darkBlockMatch![1].matchAll(/--([\w-]+):/g))
       .map((m) => m[1])
       .sort();
-    expect(darkVars).toEqual([
+    const expectedDarkVars = [
+      "accent",
+      "background",
+      "border",
       "card",
       "card-foreground",
+      "chart-1",
+      "chart-2",
+      "chart-3",
+      "chart-4",
+      "chart-5",
       "foreground",
+      "input",
+      "muted",
+      "muted-foreground",
       "popover",
       "popover-foreground",
+      "primary",
+      "ring",
+      "secondary",
       "secondary-foreground",
-    ]);
+    ];
+    expect(darkVars).toEqual(expectedDarkVars);
   });
 });
 
@@ -250,5 +365,231 @@ describe("Shared surface — SheetContent background contract", () => {
     expect(cls).not.toMatch(/bg-popover\/\d+/);
     expect(cls).not.toContain("bg-transparent");
     expect(cls).not.toMatch(/bg-background\/\d+/);
+  });
+});
+
+describe("Primary button — accessibility guards", () => {
+  it("primary button shimmer uses motion-safe: guard (reduced-motion users not subjected to infinite animation)", () => {
+    const defaultClass: string = buttonVariants({ variant: "default" });
+    // motion-safe:before:animate-btn-shimmer must be present
+    expect(defaultClass).toContain("motion-safe:before:animate-btn-shimmer");
+    // Plain before:animate-btn-shimmer (without guard) must NOT be present
+    expect(defaultClass).not.toMatch(/(?<!motion-safe:)before:animate-btn-shimmer/);
+  });
+
+  it("primary button hides shimmer overlay element for reduced-motion users (no static gradient highlight)", () => {
+    const defaultClass: string = buttonVariants({ variant: "default" });
+    // The before: pseudo-element must be fully hidden (display:none) for reduced-motion users
+    // so no static white gradient highlight remains visible when animation is suppressed
+    expect(defaultClass).toContain("motion-reduce:before:hidden");
+  });
+});
+
+describe("WCAG AA contrast regression guards", () => {
+  it("classic dark primary lightness is <=58% so white button text achieves WCAG AA >=4.5:1", () => {
+    const globalsCss = readGlobalsCss();
+    const darkBlockMatch = globalsCss.match(/\.dark\.palette-classic\s*\{([^}]+)\}/);
+    expect(darkBlockMatch).not.toBeNull();
+    const darkBlock = darkBlockMatch![1];
+    // Must NOT be at the old failing 69% lightness
+    expect(darkBlock).not.toMatch(/--primary:\s*235 56% 69%/);
+    // Primary hue must be in the indigo range with lightness <=58%
+    const primaryMatch = darkBlock.match(/--primary:\s*235 56% (\d+)%/);
+    expect(primaryMatch).not.toBeNull();
+    const lightness = parseInt(primaryMatch![1], 10);
+    expect(lightness).toBeLessThanOrEqual(58);
+  });
+
+  it("warm dark muted-foreground lightness is >=60% so secondary text on card surfaces clears WCAG AA", () => {
+    const globalsCss = readGlobalsCss();
+    // The .dark block (warm dark, no palette-classic qualifier)
+    // Match only the plain .dark block, stopping before .dark.palette-classic
+    const darkBlockMatch = globalsCss.match(/\.dark\s*\{([^}]+)\}/);
+    expect(darkBlockMatch).not.toBeNull();
+    const darkBlock = darkBlockMatch![1];
+    // Must NOT be at the old failing 50% lightness
+    expect(darkBlock).not.toMatch(/--muted-foreground:\s*30 8% 50%/);
+    const mutedMatch = darkBlock.match(/--muted-foreground:\s*30 \d+% (\d+)%/);
+    expect(mutedMatch).not.toBeNull();
+    const lightness = parseInt(mutedMatch![1], 10);
+    expect(lightness).toBeGreaterThanOrEqual(60);
+  });
+
+  it("classic dark muted-foreground lightness is >=58% so secondary text on card surfaces clears WCAG AA", () => {
+    const globalsCss = readGlobalsCss();
+    const darkBlockMatch = globalsCss.match(/\.dark\.palette-classic\s*\{([^}]+)\}/);
+    expect(darkBlockMatch).not.toBeNull();
+    const darkBlock = darkBlockMatch![1];
+    // Must NOT be at the old failing 47% lightness
+    expect(darkBlock).not.toMatch(/--muted-foreground:\s*212 7% 47%/);
+    const mutedMatch = darkBlock.match(/--muted-foreground:\s*212 \d+% (\d+)%/);
+    expect(mutedMatch).not.toBeNull();
+    const lightness = parseInt(mutedMatch![1], 10);
+    expect(lightness).toBeGreaterThanOrEqual(58);
+  });
+
+  it("warm dark primary achieves WCAG AA ≥4.5:1 with white text (direct contrast computation — drift guard)", () => {
+    const globalsCss = readGlobalsCss();
+    // Match only the plain .dark block (warm dark, no palette-classic qualifier)
+    const darkBlockMatch = globalsCss.match(/\.dark\s*\{([^}]+)\}/);
+    expect(darkBlockMatch).not.toBeNull();
+    const darkBlock = darkBlockMatch![1];
+    const primaryMatch = darkBlock.match(/--primary:\s*(\d+) (\d+)% (\d+)%/);
+    expect(primaryMatch).not.toBeNull();
+    const [pH, pS, pL] = primaryMatch!.slice(1).map(Number);
+    const [r, g, b] = hslToSrgb(pH, pS, pL);
+    const lPrimary = relativeLuminance(r, g, b);
+    // White foreground luminance
+    const ratio = wcagContrast(1.0, lPrimary);
+    // Any upward drift in primary lightness would silently break WCAG AA —
+    // this direct computation catches it without relying on a proxy threshold.
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe("Dark-mode focus-ring WCAG 1.4.11 contrast guards", () => {
+  it("warm dark ring/50 achieves ≥3:1 contrast against dark background (WCAG 1.4.11 direct computation)", () => {
+    const globalsCss = readGlobalsCss();
+    // Plain .dark block (warm dark, no palette-classic qualifier)
+    const darkBlockMatch = globalsCss.match(/\.dark\s*\{([^}]+)\}/);
+    expect(darkBlockMatch).not.toBeNull();
+    const darkBlock = darkBlockMatch![1];
+
+    const ringMatch = darkBlock.match(/--ring:\s*(\d+) (\d+)% (\d+)%/);
+    expect(ringMatch).not.toBeNull();
+    const [ringH, ringS, ringL] = ringMatch!.slice(1).map(Number);
+
+    // ring must be decoupled from primary (which must stay low for button-text contrast)
+    const primaryMatch = darkBlock.match(/--primary:\s*12 \d+% (\d+)%/);
+    expect(primaryMatch).not.toBeNull();
+    const primaryLightness = parseInt(primaryMatch![1], 10);
+    expect(ringL).not.toEqual(primaryLightness);
+
+    // Direct WCAG 1.4.11 check: ring/50 alpha-blended over the warm dark background
+    // must achieve ≥3:1 contrast against the background.
+    // A proxy lightness threshold (e.g. >=70) is too loose — it can pass a value
+    // where ring/50 still fails 3:1 depending on the background hue and saturation.
+    const bgMatch = darkBlock.match(/--background:\s*(\d+) (\d+)% (\d+)%/);
+    expect(bgMatch).not.toBeNull();
+    const [bgH, bgS, bgL] = bgMatch!.slice(1).map(Number);
+
+    const [rr, rg, rb] = hslToSrgb(ringH, ringS, ringL);
+    const [br, bg, bb] = hslToSrgb(bgH, bgS, bgL);
+    // CSS alpha compositing at 50% opacity (sRGB space, as browsers render it)
+    const blendR = rr * 0.5 + br * 0.5;
+    const blendG = rg * 0.5 + bg * 0.5;
+    const blendB = rb * 0.5 + bb * 0.5;
+    const lBlended = relativeLuminance(blendR, blendG, blendB);
+    const lBg = relativeLuminance(br, bg, bb);
+    const ratio = wcagContrast(lBlended, lBg);
+    expect(ratio).toBeGreaterThanOrEqual(3.0);
+  });
+
+  it("classic dark ring/50 achieves ≥3:1 contrast against dark background (WCAG 1.4.11 direct computation)", () => {
+    const globalsCss = readGlobalsCss();
+    const darkBlockMatch = globalsCss.match(/\.dark\.palette-classic\s*\{([^}]+)\}/);
+    expect(darkBlockMatch).not.toBeNull();
+    const darkBlock = darkBlockMatch![1];
+
+    const ringMatch = darkBlock.match(/--ring:\s*(\d+) (\d+)% (\d+)%/);
+    expect(ringMatch).not.toBeNull();
+    const [ringH, ringS, ringL] = ringMatch!.slice(1).map(Number);
+
+    // ring must be decoupled from primary (which must stay low for button-text contrast)
+    const primaryMatch = darkBlock.match(/--primary:\s*235 56% (\d+)%/);
+    expect(primaryMatch).not.toBeNull();
+    const primaryLightness = parseInt(primaryMatch![1], 10);
+    expect(ringL).not.toEqual(primaryLightness);
+
+    // Direct WCAG 1.4.11 check: ring/50 alpha-blended over the classic dark background
+    // must achieve ≥3:1 contrast against the background.
+    // A proxy lightness threshold (e.g. >=75) is too loose — it cannot account for
+    // the specific background hue/saturation of the classic dark palette.
+    const bgMatch = darkBlock.match(/--background:\s*(\d+) (\d+)% (\d+)%/);
+    expect(bgMatch).not.toBeNull();
+    const [bgH, bgS, bgL] = bgMatch!.slice(1).map(Number);
+
+    const [rr, rg, rb] = hslToSrgb(ringH, ringS, ringL);
+    const [br, bgR, bb] = hslToSrgb(bgH, bgS, bgL);
+    // CSS alpha compositing at 50% opacity (sRGB space, as browsers render it)
+    const blendR = rr * 0.5 + br * 0.5;
+    const blendG = rg * 0.5 + bgR * 0.5;
+    const blendB = rb * 0.5 + bb * 0.5;
+    const lBlended = relativeLuminance(blendR, blendG, blendB);
+    const lBg = relativeLuminance(br, bgR, bb);
+    const ratio = wcagContrast(lBlended, lBg);
+    expect(ratio).toBeGreaterThanOrEqual(3.0);
+  });
+});
+
+describe("Light-mode focus-ring WCAG 1.4.11 contrast guards", () => {
+  it("warm light ring is decoupled from primary and ring/50 achieves ≥3:1 contrast against page background (WCAG 1.4.11)", () => {
+    const globalsCss = readGlobalsCss();
+    // The :root block contains warm light tokens
+    const rootBlockMatch = globalsCss.match(/:root\s*\{([^}]+)\}/);
+    expect(rootBlockMatch).not.toBeNull();
+    const rootBlock = rootBlockMatch![1];
+
+    const ringMatch = rootBlock.match(/--ring:\s*(\d+) (\d+)% (\d+)%/);
+    expect(ringMatch).not.toBeNull();
+    const [ringH, ringS, ringL] = ringMatch!.slice(1).map(Number);
+
+    // ring must be decoupled from primary (not the same lightness)
+    const primaryMatch = rootBlock.match(/--primary:\s*(\d+) (\d+)% (\d+)%/);
+    expect(primaryMatch).not.toBeNull();
+    const primaryL = Number(primaryMatch![3]);
+    expect(ringL).not.toEqual(primaryL);
+
+    // Direct WCAG 1.4.11 check: ring/50 alpha-blended over page background must
+    // achieve ≥3:1 contrast against the page background.
+    // A proxy lightness bound (e.g. <=30) can falsely pass values where ring/50
+    // still fails 3:1 — this direct computation closes that loophole.
+    const bgMatch = rootBlock.match(/--background:\s*(\d+) (\d+)% (\d+)%/);
+    expect(bgMatch).not.toBeNull();
+    const [bgH, bgS, bgL] = bgMatch!.slice(1).map(Number);
+
+    const [rr, rg, rb] = hslToSrgb(ringH, ringS, ringL);
+    const [br, bg, bb] = hslToSrgb(bgH, bgS, bgL);
+    // CSS alpha compositing at 50% opacity (sRGB space, as browsers render it)
+    const blendR = rr * 0.5 + br * 0.5;
+    const blendG = rg * 0.5 + bg * 0.5;
+    const blendB = rb * 0.5 + bb * 0.5;
+    const lBlended = relativeLuminance(blendR, blendG, blendB);
+    const lBg = relativeLuminance(br, bg, bb);
+    const ratio = wcagContrast(lBlended, lBg);
+    expect(ratio).toBeGreaterThanOrEqual(3.0);
+  });
+
+  it("classic light ring is decoupled from primary and ring/50 achieves ≥3:1 contrast against page background (WCAG 1.4.11)", () => {
+    const globalsCss = readGlobalsCss();
+    const lightBlockMatch = globalsCss.match(/:root:not\(\.dark\)\.palette-classic\s*\{([^}]+)\}/);
+    expect(lightBlockMatch).not.toBeNull();
+    const lightBlock = lightBlockMatch![1];
+
+    const ringMatch = lightBlock.match(/--ring:\s*(\d+) (\d+)% (\d+)%/);
+    expect(ringMatch).not.toBeNull();
+    const [ringH, ringS, ringL] = ringMatch!.slice(1).map(Number);
+
+    // ring must be decoupled from primary (not the same lightness)
+    const primaryMatch = lightBlock.match(/--primary:\s*(\d+) (\d+)% (\d+)%/);
+    expect(primaryMatch).not.toBeNull();
+    const primaryL = Number(primaryMatch![3]);
+    expect(ringL).not.toEqual(primaryL);
+
+    // Direct WCAG 1.4.11 check: ring/50 alpha-blended over page background must
+    // achieve ≥3:1 contrast against the page background.
+    const bgMatch = lightBlock.match(/--background:\s*(\d+) (\d+)% (\d+)%/);
+    expect(bgMatch).not.toBeNull();
+    const [bgH, bgS, bgL] = bgMatch!.slice(1).map(Number);
+
+    const [rr, rg, rb] = hslToSrgb(ringH, ringS, ringL);
+    const [br, bgR, bb] = hslToSrgb(bgH, bgS, bgL);
+    const blendR = rr * 0.5 + br * 0.5;
+    const blendG = rg * 0.5 + bgR * 0.5;
+    const blendB = rb * 0.5 + bb * 0.5;
+    const lBlended = relativeLuminance(blendR, blendG, blendB);
+    const lBg = relativeLuminance(br, bgR, bb);
+    const ratio = wcagContrast(lBlended, lBg);
+    expect(ratio).toBeGreaterThanOrEqual(3.0);
   });
 });

--- a/docs/design/browse-ui/03-visual-design.md
+++ b/docs/design/browse-ui/03-visual-design.md
@@ -1,52 +1,53 @@
 # 03 — Visual Design System & Data Visualization Spec
 
-> **Project:** Hindsight Browse UI (Next.js 15 + shadcn/ui + Tailwind v4)
+> **Project:** Hindsight Browse UI (Next.js 16 + shadcn/ui + Tailwind v4)
 > **Design references:** Linear, Vercel Dashboard, GitHub Primer, Datasette
-> **Status:** Design spec — no code
+> **Status:** Living spec — kept in sync with `browse-ui/src/app/globals.css`
 
 ---
 
 ## 1. Color System
 
+> **Default palette (issue #82):** Warm coral (`#E56A4A` brand, `#FDFAF6` light bg, `#1a1917` dark bg).
+> **Legacy / classic palette:** Cool indigo (`#5E6AD2` brand) — opt-in via `.palette-classic` on `<html>`, persisted as `browse-palette=classic` in `localStorage`.
+> The shadcn/ui CSS variable mapping below describes the **warm default**. Classic overrides follow in §1.9.
+
 ### 1.1 Brand Primary
 
-**Choice: `#5E6AD2` (Linear Indigo)**
+**Default (warm): `#E56A4A` (Warm Coral)**
 
-| Criterion | `#5E6AD2` Linear Indigo | `#0969DA` GitHub Blue |
-|-----------|------------------------|----------------------|
-| Distinctiveness | Immediately separable from source-brand colors (Copilot blue, Claude orange) | Collides with Copilot's blue badge — creates identity confusion |
-| Semantic load | Neutral — not associated with success/info semantics | Blue = "info" in most systems; double duty weakens signaling |
-| Dark-mode luminance | Perceptually brighter at low lightness without neon blowout | Needs significant hue-shift in dark to stay readable |
-| Personality | Signals "analytical tool" — aligns with a knowledge-mining product | Signals "social platform" |
-
-**Verdict:** `#5E6AD2` avoids collision with per-source brand colors *and* with semantic `--info` blue. It reads as "product chrome" rather than data.
+Warm coral separates cleanly from Copilot blue, Claude orange (different hue family), and Gemini teal. At lightness 44% (light) / 45% (dark) it delivers WCAG AA ≥4.5:1 with white text.
 
 ```
---primary:            hsl(235, 56%, 60%)   /* #5E6AD2 */
---primary-hover:      hsl(235, 56%, 52%)   /* #4F5ABF */
---primary-foreground: hsl(0, 0%, 100%)     /* #FFFFFF */
+--primary (light): hsl(12, 75%, 44%)   /* warm coral, WCAG AA ≥4.5:1 with white */
+--primary (dark):  hsl(12, 80%, 45%)   /* adjusted for dark bg, WCAG AA ≥4.5:1 with white */
+--primary-foreground: hsl(0, 0%, 100%) /* #FFFFFF */
+```
+
+**Classic opt-in: `#5E6AD2` (Linear Indigo)**
+
+Restored when `.palette-classic` is active. Historically chosen for its neutral analytical personality and separation from per-source brand colors.
+
+```
+--primary (classic light): hsl(235, 56%, 60%)  /* #5E6AD2 */
+--primary (classic dark):  hsl(235, 56%, 56%)  /* darkened for WCAG AA */
 ```
 
 ### 1.2 Neutral Scale
 
-All neutrals are desaturated cool-gray (2% saturation toward blue) to complement the indigo primary. Values tuned so adjacent stops differ by ≥ 1.5:1 APCA contrast (useful for layered surfaces).
+**Default (warm):** Neutrals carry a slight warm tint (hue ≈ 20–38°) to complement the coral primary.
 
-| Stop | Light mode (HEX) | HSL | Dark mode (HEX) | HSL |
-|------|-------------------|-----|------------------|-----|
-| 50 | `#FAFBFC` | 210 20% 99% | `#0D1117` | 215 22% 7% |
-| 100 | `#F3F5F7` | 210 16% 96% | `#151B23` | 215 20% 11% |
-| 150 | `#EAEEF2` | 212 18% 93% | `#1C2128` | 215 18% 13% |
-| 200 | `#D8DEE4` | 212 16% 87% | `#21262D` | 215 14% 15% |
-| 300 | `#C1C8CF` | 210 11% 78% | `#2D333B` | 215 11% 20% |
-| 400 | `#A0A8B0` | 210 8% 66% | `#3D444D` | 215 8% 27% |
-| 500 | `#7D8590` | 212 7% 53% | `#545D68` | 212 9% 37% |
-| 600 | `#656D76` | 212 7% 43% | `#6E7681` | 212 7% 47% |
-| 700 | `#4E5761` | 212 10% 34% | `#8B949E` | 210 7% 58% |
-| 800 | `#343B44` | 213 12% 24% | `#B1BAC4` | 210 12% 73% |
-| 900 | `#1F2328` | 215 14% 14% | `#D0D7DE` | 210 16% 85% |
-| 950 | `#0D1117` | 215 22% 7% | `#F0F3F6` | 210 25% 95% |
+| Stop | Light (HEX approx) | HSL | Dark (HEX approx) | HSL |
+|------|--------------------|----|-------------------|----|
+| bg | `#FDFAF6` | 38 52% 97% | `#1a1917` | 30 5% 10% |
+| card | — | 38 40% 98% | — | 30 6% 15% |
+| secondary | — | 38 30% 92% | — | 30 6% 18% |
+| muted | — | 38 25% 90% | — | 30 6% 18% |
+| border | — | 38 25% 87% | — | 30 6% 22% |
+| foreground | `#28201A` | 20 14% 16% | — | 30 15% 88% |
+| muted-fg | — | 20 10% 45% | — | 30 8% 62% |
 
-> **Note:** Dark mode neutrals are *not* simply inverted. The 50→200 range in dark stays tighter (7%→15% lightness) to create subtle surface layering without blowing out the background.
+> **Classic neutrals** are cool-gray (hue ≈ 210–215°). See §1.9.
 
 ### 1.3 Semantic Colors
 
@@ -68,110 +69,130 @@ WCAG AA proofs (fg on bg):
 | Danger fg on bg | 5.5:1 | 5.0:1 | ✅ AA |
 | Info fg on bg | 5.4:1 | 5.8:1 | ✅ AA |
 
-### 1.4 Surface Tokens
+### 1.4 Surface Tokens (warm default)
 
 | Token | Light | Dark | Usage |
 |-------|-------|------|-------|
-| `--bg` | `#FFFFFF` | `#0D1117` | Page background |
-| `--bg-subtle` | `#FAFBFC` | `#0D1117` | Alternate row, secondary surface |
-| `--bg-muted` | `#EAEEF2` | `#21262D` | Code blocks, disabled inputs |
-| `--bg-elevated` | `#FFFFFF` | `#161B22` | Cards, popovers (layered above bg) |
-| `--bg-hover` | `#E6EBF1` | `#2A3038` | Interactive row/item hover |
-| `--bg-active` | `#DDE3EA` | `#313840` | Pressed / active state |
+| `--background` | warm off-white `38 52% 97%` | warm dark `30 5% 10%` | Page background |
+| `--card` | `38 40% 98%` | `30 6% 15%` | Card surfaces |
+| `--secondary` | `38 30% 92%` | `30 6% 18%` | Secondary surfaces, select triggers |
+| `--muted` | `38 25% 90%` | `30 6% 18%` | Muted / disabled surfaces |
+| `--popover` | `38 40% 98%` | `30 6% 16%` | Dropdown / dialog / sheet background |
 
-Contrast notes:
-- `--bg-elevated` on `--bg`: Light 1:1 (same), Dark 1.5:1 — elevation conveyed via shadow, not color alone.
-- `--bg-hover` on `--bg`: Light 1.2:1, Dark 1.4:1 — perceivable shift without color dependency (backed by cursor change).
+### 1.5 Foreground Tokens (warm default)
 
-### 1.5 Foreground Tokens
-
-| Token | Light | Dark | Contrast on --bg | Usage |
-|-------|-------|------|-------------------|-------|
-| `--fg` | `#1F2328` | `#E6EDF3` | 15.4:1 / 14.8:1 | Primary text |
-| `--fg-muted` | `#656D76` | `#9198A1` | 4.8:1 / 5.2:1 | Secondary text, labels |
-| `--fg-subtle` | `#7D8590` | `#7D8590` | 3.7:1 / 3.4:1 | Placeholder, disabled (AA-large only) |
-| `--fg-on-accent` | `#FFFFFF` | `#FFFFFF` | 4.5:1 on #5E6AD2 | Text on primary buttons |
+| Token | Light | Dark | Contrast on bg | Usage |
+|-------|-------|------|----------------|-------|
+| `--foreground` | `20 14% 16%` | `30 15% 88%` | >12:1 | Primary text |
+| `--muted-foreground` | `20 10% 45%` | `30 8% 62%` | ≥4.5:1 | Secondary text, labels |
+| `--primary-foreground` | `0 0% 100%` | `0 0% 100%` | ≥4.5:1 on primary | Text on primary buttons |
 
 ### 1.6 Border Tokens
 
 | Token | Light | Dark | Usage |
 |-------|-------|------|-------|
-| `--border` | `#D0D7DE` | `#30363D` | Default dividers, card borders |
-| `--border-subtle` | `#E8ECF0` | `#21262D` | Inner separators (table cells) |
-| `--border-strong` | `#AFB8C1` | `#484F58` | Emphasized borders (focused inputs, column headers) |
+| `--border` | `38 25% 87%` | `30 6% 22%` | Default dividers, card borders |
+| `--input` | `38 25% 87%` | `30 6% 22%` | Input borders |
 
-### 1.7 Accent Tokens
+### 1.7 Accent / Ring Tokens (warm default)
 
 | Token | Light | Dark | Usage |
 |-------|-------|------|-------|
-| `--accent` | `#5E6AD2` | `#7B86E2` | Links, active tab indicator, focus ring |
-| `--accent-fg` | `#FFFFFF` | `#FFFFFF` | Text on accent bg (buttons) |
-| `--accent-hover` | `#4F5ABF` | `#6B77D9` | Hover state for accent elements |
+| `--accent` | `12 75% 44%` | `12 80% 45%` | Accent surfaces, hover states |
+| `--ring` | `12 75% 18%` | `12 80% 78%` | Focus ring — **decoupled from primary** for WCAG 1.4.11 |
 
-### 1.8 Mapping to shadcn CSS Variables
+> **Ring decoupling:** Ring tokens are intentionally separate from primary. Light ring must be dark enough that `ring/50` over the page background achieves ≥3:1 (WCAG 1.4.11). Dark ring must be bright enough that `ring/50` over the dark background achieves ≥3:1. Both are guarded by direct contrast computation in `contrast-system.test.tsx`.
 
-shadcn/ui expects HSL values without `hsl()` wrapper. Below is the full mapping:
+### 1.8 Mapping to shadcn CSS Variables (warm default)
+
+shadcn/ui expects HSL values without `hsl()` wrapper. Canonical source: `browse-ui/src/app/globals.css`.
 
 ```css
-/* Light theme (:root) */
+/* Default warm palette (:root) */
 :root {
-  --background:           210 20% 99%;        /* --bg-subtle */
-  --foreground:           215 14% 14%;        /* --fg */
-  --card:                 0 0% 100%;          /* --bg-elevated */
-  --card-foreground:      215 14% 14%;
-  --popover:              0 0% 100%;
-  --popover-foreground:   215 14% 14%;
-  --primary:              235 56% 60%;        /* #5E6AD2 */
+  --background:           38 52% 97%;   /* warm off-white ≈ #FDFAF6 */
+  --foreground:           20 14% 16%;
+  --card:                 38 40% 98%;
+  --card-foreground:      20 14% 16%;
+  --popover:              38 40% 98%;
+  --popover-foreground:   20 14% 16%;
+  --primary:              12 75% 44%;   /* coral — WCAG AA ≥4.5:1 with white */
   --primary-foreground:   0 0% 100%;
-  --secondary:            210 16% 96%;        /* neutral-100 */
-  --secondary-foreground: 215 14% 14%;
-  --muted:                212 18% 93%;        /* neutral-150 */
-  --muted-foreground:     212 7% 43%;         /* neutral-600 */
-  --accent:               235 56% 60%;        /* same as primary */
+  --secondary:            38 30% 92%;
+  --secondary-foreground: 20 14% 16%;
+  --muted:                38 25% 90%;
+  --muted-foreground:     20 10% 45%;
+  --accent:               12 75% 44%;
   --accent-foreground:    0 0% 100%;
-  --destructive:          358 75% 47%;        /* danger */
+  --destructive:          358 75% 47%;
   --destructive-foreground: 0 0% 100%;
-  --border:               210 16% 87%;        /* neutral-200 */
-  --input:                210 16% 87%;
-  --ring:                 235 56% 60%;        /* focus ring = primary */
-  --radius:               0.375rem;           /* 6px = md */
-  --chart-1:              235 56% 60%;        /* primary */
-  --chart-2:              152 56% 48%;        /* teal */
-  --chart-3:              33 90% 58%;         /* amber */
-  --chart-4:              280 60% 60%;        /* purple */
-  --chart-5:              12 80% 60%;         /* coral */
+  --border:               38 25% 87%;
+  --input:                38 25% 87%;
+  --ring:                 12 75% 18%;   /* dark coral — decoupled from primary for WCAG 1.4.11 */
+  --radius:               0.375rem;
+  --chart-1:              12 75% 59%;   /* warm coral */
+  --chart-2:              152 56% 48%;  /* teal */
+  --chart-3:              33 90% 58%;   /* amber */
+  --chart-4:              280 60% 60%;  /* purple */
+  --chart-5:              38 85% 55%;   /* warm yellow */
 }
 
-<!-- FIXED in cross-review pass: BLOCKER-2 — changed [data-theme="dark"] → .dark to match next-themes attribute="class" -->
-/* Dark theme (.dark class on <html>, set by next-themes with attribute="class") */
+/* Dark warm palette (.dark class on <html>, set by next-themes attribute="class") */
 .dark {
-  --background:           215 22% 7%;
-  --foreground:           210 25% 93%;
-  --card:                 215 20% 11%;
-  --card-foreground:      210 25% 93%;
-  --popover:              215 20% 11%;
-  --popover-foreground:   210 25% 93%;
-  --primary:              235 56% 69%;        /* #7B86E2 */
+  --background:           30 5% 10%;    /* warm dark ≈ #1a1917 */
+  --foreground:           30 15% 88%;
+  --card:                 30 6% 15%;
+  --card-foreground:      30 15% 88%;
+  --popover:              30 6% 16%;
+  --popover-foreground:   30 15% 88%;
+  --primary:              12 80% 45%;   /* coral dark-mode — WCAG AA ≥4.5:1 with white */
   --primary-foreground:   0 0% 100%;
-  --secondary:            215 14% 15%;
-  --secondary-foreground: 210 25% 93%;
-  --muted:                215 14% 15%;
-  --muted-foreground:     212 7% 47%;
-  --accent:               235 56% 69%;
+  --secondary:            30 6% 18%;
+  --secondary-foreground: 30 15% 88%;
+  --muted:                30 6% 18%;
+  --muted-foreground:     30 8% 62%;    /* raised for WCAG AA on dark card surfaces */
+  --accent:               12 80% 45%;
   --accent-foreground:    0 0% 100%;
   --destructive:          358 78% 63%;
   --destructive-foreground: 0 0% 100%;
-  --border:               215 11% 20%;
-  --input:                215 11% 20%;
-  --ring:                 235 56% 69%;
+  --border:               30 6% 22%;
+  --input:                30 6% 22%;
+  --ring:                 12 80% 78%;   /* decoupled from primary — bright for WCAG 1.4.11 ≥3:1 */
   --radius:               0.375rem;
-  --chart-1:              235 56% 69%;
+  --chart-1:              12 78% 66%;
   --chart-2:              152 50% 50%;
   --chart-3:              38 85% 55%;
   --chart-4:              280 55% 65%;
-  --chart-5:              12 75% 65%;
+  --chart-5:              33 80% 60%;
 }
 ```
+
+### 1.9 Classic Palette Opt-in (`.palette-classic`)
+
+Activated by adding `.palette-classic` to `<html>` via the palette toggle. Persisted as `browse-palette=classic` in `localStorage`. Restores the original cool/APCA-tuned indigo design language.
+
+```css
+/* Classic light — scoped :not(.dark) to prevent bleeding into dark mode */
+:root:not(.dark).palette-classic {
+  --background:           210 20% 97%;
+  --primary:              235 56% 60%;  /* #5E6AD2 Linear Indigo */
+  --ring:                 235 56% 25%;  /* dark indigo — decoupled for WCAG 1.4.11 */
+  --chart-1:              235 56% 60%;  /* indigo replaces warm coral */
+  /* ... full token set in globals.css */
+}
+
+/* Classic dark */
+.dark.palette-classic {
+  --background:           215 22% 7%;
+  --primary:              235 56% 56%;  /* darkened from 69% for WCAG AA */
+  --muted-foreground:     212 7% 60%;   /* raised from 47% for WCAG AA */
+  --ring:                 235 56% 80%;  /* decoupled from primary for WCAG 1.4.11 */
+  --chart-1:              235 56% 69%;  /* indigo replaces warm coral */
+  /* ... full token set in globals.css */
+}
+```
+
+> **Specificity discipline:** Classic light overrides use `:root:not(.dark).palette-classic` (specificity 0,2,0) so they do not outrank `.dark` (0,1,0) when both classes are present, preventing warm light surfaces from bleeding into dark mode.
 
 ---
 


### PR DESCRIPTION
## Summary
- switch browse-ui to a warm-neutral default palette with a classic indigo opt-in
- add WCAG-clean primary, ring, and reduced-motion shimmer behavior
- sync the visual-design spec with the new palette contract

Closes #82