### PR TITLE
feat(sk): add project registry CLI

### DIFF
--- a/auto-update-tools.py
+++ b/auto-update-tools.py
@@ -312,11 +312,22 @@ def _load_project_registry() -> list[Path]:
     Written by setup-project.py on each successful (non-dry-run) deployment so
     that deploy_skills() can propagate vendored-skill updates to every managed
     project even when called from the tools repo or a non-project context.
+
+    Handles both the legacy plain-string format and the richer dict format written
+    by project-registry.py (``{"name": ..., "path": ..., "created_at": ...}``).
     """
     try:
         if REGISTRY_PATH.exists():
             data = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
-            return [Path(p) for p in data.get("projects", []) if isinstance(p, str)]
+            paths: list[Path] = []
+            for entry in data.get("projects", []):
+                if isinstance(entry, str):
+                    paths.append(Path(entry))
+                elif isinstance(entry, dict):
+                    p = entry.get("path", "")
+                    if isinstance(p, str) and p:
+                        paths.append(Path(p))
+            return paths
     except Exception:
         pass
     return []

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,6 +79,7 @@ recovery hints. None of these scripts are candidates for deletion as a consequen
 | `migrate.py` | Versioned schema migrations via `schema_version` table |
 | `install.py` | Deploy skills/hooks; inject global AI instructions |
 | `setup-project.py` | Full project onboarding: skills + hooks + WORKFLOW.md |
+| `project-registry.py` | `sk project add/remove/list` — manage the persistent project registry (`tools-managed-projects.json`) |
 | `host_manifest.py` | Single source of truth for supported hosts + their filesystem paths |
 | `index-status.py` | Row counts, FTS integrity, event-offset coverage |
 | `knowledge-health.py` | Knowledge base health + recall telemetry |
@@ -319,6 +320,33 @@ These conventions apply to all scripts in this repo. Follow them in every change
 - `briefing.py --pack` → `entries.<category>[]`
 - `snippet_freshness` values: `fresh | drifted | missing | unknown`
 - `related_entry_ids` — JSON ints, confidence-ranked, capped to top 3
+
+### Project Registry (`tools-managed-projects.json`)
+
+The file `~/.copilot/session-state/tools-managed-projects.json` is the persistent registry of
+projects managed by session-knowledge tools. It is written by `install.py`, `setup-project.py`,
+and `project-registry.py`.
+
+**Schema — backward-compatible mixed format:**
+
+```json
+{
+  "projects": [
+    "/legacy/string/path",
+    {"name": "myproject", "path": "/richer/dict/path", "created_at": "2025-01-01T00:00:00+00:00"}
+  ]
+}
+```
+
+- **Legacy string entries** (`install.py`, `setup-project.py`): plain path strings. Written by
+  existing scripts; always preserved on any write.
+- **Rich dict entries** (`project-registry.py`): `{name, path, created_at}`. Written by
+  `sk project add`. Both formats co-exist in the same file.
+
+All readers (`_load_project_registry()` in `install.py`, `setup-project.py`, and
+`auto-update-tools.py`) extract the path string from either format.
+
+`project-registry.py` is the CLI owner of this file: `sk project add|remove|list`.
 
 ### DB Migrations
 

--- a/docs/AUTO-UPDATE.md
+++ b/docs/AUTO-UPDATE.md
@@ -117,11 +117,18 @@ After `git pull`, auto-update analyzes `git diff` to run only what changed:
 > **Project discovery (registry-backed):** `deploy_skills()` finds which projects to update via
 > `~/.copilot/session-state/tools-managed-projects.json`. A project is added to this registry
 > whenever `setup-project.py` **or** `install.py --deploy-skill` performs a real deployment in
-> that project. Projects that were set up by other means (manual file copies, etc.) and have never
-> been run through either of those commands are not auto-updated from the tools-repo context; in
-> that case, run `install.py --deploy-skill` once from inside the project to register it.
+> that project. Projects can also be added manually via `sk project add [path]` without requiring
+> a full skill deployment.  Projects that were set up by other means (manual file copies, etc.) and
+> have never been registered are not auto-updated from the tools-repo context; in that case, run
+> `install.py --deploy-skill` or `sk project add` once from inside the project to register it.
 > As a fallback, `deploy_skills()` also checks the current git root (handles ad-hoc installs run
 > directly from the target project).
+>
+> **Registry schema:** the registry file supports a backward-compatible mixed format where
+> plain-string path entries (written by `install.py` / `setup-project.py`) co-exist with richer
+> dict entries (`{"name": ..., "path": ..., "created_at": ...}`) written by `sk project add`.
+> All readers in `auto-update-tools.py`, `install.py`, and `setup-project.py` handle both formats.
+>
 >
 > **Hook templates:** Files in `hooks/references/` are classified under the `hooks` category
 > but auto-update intentionally does **not** deploy them — they are manually copied at project

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -84,6 +84,30 @@ sk scout config                     # scout-config.py
 sk scout status                     # scout-status.py
 ```
 
+### `sk project` — project registry
+
+Manage the persistent registry of projects that have had session-knowledge deployed.
+
+```bash
+sk project add                      # register cwd (auto-detects .copilot/ or git root)
+sk project add /path/to/project     # register explicit path
+sk project remove                   # unregister cwd
+sk project remove /path/to/project  # unregister explicit path
+sk project list                     # show all registered projects
+sk project list --json              # JSON output
+```
+
+**Auto-detect order:** walks up ancestor directories looking for `.copilot/`; falls back to
+`git rev-parse --show-toplevel` when no `.copilot/` directory is found.
+
+**Registry file:** `~/.copilot/session-state/tools-managed-projects.json`
+
+**Schema:** new writes use `{"name": ..., "path": ..., "created_at": ...}` (richer format).
+Existing plain-string entries from `install.py` / `setup-project.py` continue to work
+unchanged alongside richer entries in the same file.
+
+> Direct-script form: `python project-registry.py add|remove|list [args...]`
+
 ### `sk hooks` — hook runner
 
 `sk hooks` is available in both the Rust binary and the Python `sk.py` compatibility shim.

--- a/install.py
+++ b/install.py
@@ -113,26 +113,61 @@ REGISTRY_PATH = SESSION_STATE / "tools-managed-projects.json"
 
 
 def _load_project_registry() -> list[str]:
-    """Return the list of registered project root paths (strings)."""
+    """Return the list of registered project root paths (strings).
+
+    Handles both the legacy plain-string format and the richer dict format
+    written by project-registry.py (``{"name": ..., "path": ..., "created_at": ...}``).
+    Only the path string is extracted; callers receive a flat list of strings.
+    """
     try:
         if REGISTRY_PATH.exists():
             data = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
-            return [p for p in data.get("projects", []) if isinstance(p, str)]
+            paths: list[str] = []
+            for entry in data.get("projects", []):
+                if isinstance(entry, str):
+                    paths.append(entry)
+                elif isinstance(entry, dict):
+                    p = entry.get("path", "")
+                    if isinstance(p, str) and p:
+                        paths.append(p)
+            return paths
     except Exception:
         pass
     return []
 
 
 def _register_project(project_root: Path) -> None:
-    """Add *project_root* to the persistent registry (idempotent, silent on error)."""
+    """Add *project_root* to the persistent registry (idempotent, silent on error).
+
+    Reads the full raw registry (which may contain richer dict entries written by
+    project-registry.py) and appends a plain string entry when the path is new.
+    Existing entries of either format are preserved unchanged.
+    """
     try:
-        projects = _load_project_registry()
         key = str(project_root.resolve())
-        if key not in projects:
-            projects.append(key)
+        try:
+            raw: list = (
+                json.loads(REGISTRY_PATH.read_text(encoding="utf-8")).get("projects", [])
+                if REGISTRY_PATH.exists()
+                else []
+            )
+        except Exception:
+            raw = []
+
+        existing_paths: set[str] = set()
+        for entry in raw:
+            if isinstance(entry, str):
+                existing_paths.add(entry)
+            elif isinstance(entry, dict):
+                p = entry.get("path", "")
+                if p:
+                    existing_paths.add(p)
+
+        if key not in existing_paths:
+            raw.append(key)
             REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
             # P1-7: atomic write prevents registry truncation on concurrent access
-            _atomic_write_text(REGISTRY_PATH, json.dumps({"projects": projects}, indent=2))
+            _atomic_write_text(REGISTRY_PATH, json.dumps({"projects": raw}, indent=2))
     except Exception:
         pass
 

--- a/project-registry.py
+++ b/project-registry.py
@@ -100,16 +100,23 @@ def _detect_project_root(start: Path | None = None) -> Path | None:
     """
     Detect the project root by:
     1. Walking up from *start* (or cwd) looking for a ``.copilot/`` directory.
+       The global ``~/.copilot/`` directory is intentionally excluded so that
+       running from anywhere inside the home directory does not incorrectly
+       register the home directory itself as a project root.
     2. Falling back to ``git rev-parse --show-toplevel``.
 
     Returns an absolute Path, or None if detection fails.
     """
     cwd = (start or Path.cwd()).resolve()
+    # Resolve once so the comparison is always against a canonical absolute path.
+    global_copilot = Path.home().resolve() / ".copilot"
 
     # Walk up looking for .copilot/
     probe = cwd
     for _ in range(32):  # safety cap
-        if (probe / ".copilot").is_dir():
+        candidate = probe / ".copilot"
+        # Skip the global ~/.copilot — it is not a project-local marker.
+        if candidate.is_dir() and candidate.resolve() != global_copilot:
             return probe
         parent = probe.parent
         if parent == probe:

--- a/project-registry.py
+++ b/project-registry.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+project-registry.py — Manage the sk project registry.
+
+Commands:
+    add   [path]       Register a project root (default: auto-detect)
+    remove [path]      Unregister a project root (default: auto-detect)
+    list               List all registered projects
+
+Registry file: ~/.copilot/session-state/tools-managed-projects.json
+
+Schema (backward-compatible):
+  Old entries: "/abs/path"                (plain string, written by install.py / setup-project.py)
+  New entries: {"name": "x", "path": ..., "created_at": "ISO8601"}   (written here)
+
+Both formats co-exist.  All read paths normalize to the path string.
+"""
+
+import argparse
+import datetime
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+REGISTRY_PATH = Path.home() / ".copilot" / "session-state" / "tools-managed-projects.json"
+
+
+# ---------------------------------------------------------------------------
+# Atomic write (self-contained per architecture — no inter-script imports)
+# ---------------------------------------------------------------------------
+
+def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
+    """Write *content* to *path* atomically via a sibling .tmp + os.replace."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_bytes(content.encode(encoding))
+        os.replace(str(tmp), str(path))
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Registry helpers — backward-compatible with string-only registries
+# ---------------------------------------------------------------------------
+
+def _entry_path(entry: object) -> str:
+    """Return the path string from a registry entry (string or dict)."""
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, dict):
+        return entry.get("path", "")
+    return ""
+
+
+def _load_raw_registry() -> list:
+    """Return the raw list of registry entries (strings and/or dicts); never raises."""
+    try:
+        if REGISTRY_PATH.exists():
+            data = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+            return [e for e in data.get("projects", []) if isinstance(e, (str, dict))]
+    except Exception:
+        pass
+    return []
+
+
+def _load_project_paths() -> list[str]:
+    """Return a list of registered path strings in insertion order (de-duplicated)."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for entry in _load_raw_registry():
+        p = _entry_path(entry)
+        if p and p not in seen:
+            seen.add(p)
+            result.append(p)
+    return result
+
+
+def _save_registry(entries: list) -> None:
+    """Persist the entry list atomically."""
+    REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_text(REGISTRY_PATH, json.dumps({"projects": entries}, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection helpers
+# ---------------------------------------------------------------------------
+
+def _detect_project_root(start: Path | None = None) -> Path | None:
+    """
+    Detect the project root by:
+    1. Walking up from *start* (or cwd) looking for a ``.copilot/`` directory.
+    2. Falling back to ``git rev-parse --show-toplevel``.
+
+    Returns an absolute Path, or None if detection fails.
+    """
+    cwd = (start or Path.cwd()).resolve()
+
+    # Walk up looking for .copilot/
+    probe = cwd
+    for _ in range(32):  # safety cap
+        if (probe / ".copilot").is_dir():
+            return probe
+        parent = probe.parent
+        if parent == probe:
+            break
+        probe = parent
+
+    # Git root fallback
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            timeout=5,
+        )
+        if proc.returncode == 0:
+            root = proc.stdout.strip()
+            if root:
+                return Path(root).resolve()
+    except Exception:
+        pass
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
+
+def cmd_add(path_arg: str | None, quiet: bool = False) -> int:
+    """Register a project root in the registry."""
+    if path_arg:
+        root = Path(path_arg).resolve()
+    else:
+        detected = _detect_project_root()
+        if detected is None:
+            print(
+                "sk project add: could not auto-detect a project root.\n"
+                "  Looked for .copilot/ in ancestor directories and tried git rev-parse.\n"
+                "  Supply a path explicitly:  sk project add <path>",
+                file=sys.stderr,
+            )
+            return 1
+        root = detected
+
+    key = str(root)
+    raw = _load_raw_registry()
+    existing_paths = {_entry_path(e) for e in raw}
+
+    if key in existing_paths:
+        if not quiet:
+            print(f"already registered: {key}")
+        return 0
+
+    name = root.name
+    created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    raw.append({"name": name, "path": key, "created_at": created_at})
+
+    try:
+        _save_registry(raw)
+    except Exception as exc:
+        print(f"sk project add: failed to write registry: {exc}", file=sys.stderr)
+        return 1
+
+    if not quiet:
+        print(f"registered: {key}")
+    return 0
+
+
+def cmd_remove(path_arg: str | None, quiet: bool = False) -> int:
+    """Unregister a project root from the registry."""
+    if path_arg:
+        key = str(Path(path_arg).resolve())
+    else:
+        detected = _detect_project_root()
+        if detected is None:
+            print(
+                "sk project remove: could not auto-detect a project root.\n"
+                "  Supply a path explicitly:  sk project remove <path>",
+                file=sys.stderr,
+            )
+            return 1
+        key = str(detected)
+
+    raw = _load_raw_registry()
+    new_raw = [e for e in raw if _entry_path(e) != key]
+
+    if len(new_raw) == len(raw):
+        if not quiet:
+            print(f"not registered: {key}")
+        return 0
+
+    try:
+        _save_registry(new_raw)
+    except Exception as exc:
+        print(f"sk project remove: failed to write registry: {exc}", file=sys.stderr)
+        return 1
+
+    if not quiet:
+        print(f"removed: {key}")
+    return 0
+
+
+def _load_deduped_registry() -> list:
+    """Return raw entries de-duplicated by path (first occurrence wins)."""
+    seen: set[str] = set()
+    result: list = []
+    for entry in _load_raw_registry():
+        p = _entry_path(entry)
+        if p and p not in seen:
+            seen.add(p)
+            result.append(entry)
+    return result
+
+
+def cmd_list(json_output: bool = False) -> int:
+    """List registered projects (de-duplicated by path)."""
+    deduped = _load_deduped_registry()
+
+    if not deduped:
+        if json_output:
+            print("[]")
+        else:
+            print("no projects registered")
+        return 0
+
+    if json_output:
+        normalized = []
+        for entry in deduped:
+            if isinstance(entry, str):
+                normalized.append({"name": Path(entry).name, "path": entry, "created_at": None})
+            elif isinstance(entry, dict):
+                normalized.append(entry)
+        print(json.dumps(normalized, indent=2))
+    else:
+        for entry in deduped:
+            if isinstance(entry, str):
+                print(entry)
+            elif isinstance(entry, dict):
+                path = entry.get("path", "")
+                name = entry.get("name", Path(path).name if path else "")
+                added = entry.get("created_at", "")
+                if added:
+                    print(f"{path}  ({name}, added {added})")
+                else:
+                    print(f"{path}  ({name})")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing and entry point
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sk project",
+        description="Manage the sk project registry.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Registry: ~/.copilot/session-state/tools-managed-projects.json\n"
+            "Auto-detect: walks up from cwd for .copilot/, then falls back to git root."
+        ),
+    )
+    sub = parser.add_subparsers(dest="subcommand", metavar="<subcommand>")
+
+    add_p = sub.add_parser("add", help="Register a project root")
+    add_p.add_argument("path", nargs="?", default=None, help="Absolute or relative path (default: auto-detect)")
+    add_p.add_argument("--quiet", "-q", action="store_true", help="Suppress output")
+
+    rm_p = sub.add_parser("remove", help="Unregister a project root")
+    rm_p.add_argument("path", nargs="?", default=None, help="Absolute or relative path (default: auto-detect)")
+    rm_p.add_argument("--quiet", "-q", action="store_true", help="Suppress output")
+
+    ls_p = sub.add_parser("list", help="List all registered projects")
+    ls_p.add_argument("--json", action="store_true", dest="json_output", help="Output as JSON array")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.subcommand is None:
+        parser.print_help()
+        return 0
+
+    if args.subcommand == "add":
+        return cmd_add(args.path, quiet=args.quiet)
+    if args.subcommand == "remove":
+        return cmd_remove(args.path, quiet=args.quiet)
+    if args.subcommand == "list":
+        return cmd_list(json_output=args.json_output)
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup-project.py
+++ b/setup-project.py
@@ -122,26 +122,61 @@ REGISTRY_PATH = Path.home() / ".copilot" / "session-state" / "tools-managed-proj
 
 
 def _load_project_registry() -> list[str]:
-    """Return the list of registered project root paths (strings)."""
+    """Return the list of registered project root paths (strings).
+
+    Handles both the legacy plain-string format and the richer dict format
+    written by project-registry.py (``{"name": ..., "path": ..., "created_at": ...}``).
+    Only the path string is extracted; callers receive a flat list of strings.
+    """
     try:
         if REGISTRY_PATH.exists():
             data = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
-            return [p for p in data.get("projects", []) if isinstance(p, str)]
+            paths: list[str] = []
+            for entry in data.get("projects", []):
+                if isinstance(entry, str):
+                    paths.append(entry)
+                elif isinstance(entry, dict):
+                    p = entry.get("path", "")
+                    if isinstance(p, str) and p:
+                        paths.append(p)
+            return paths
     except Exception:
         pass
     return []
 
 
 def _register_project(project_root: Path) -> None:
-    """Add *project_root* to the persistent registry (idempotent, silent on error)."""
+    """Add *project_root* to the persistent registry (idempotent, silent on error).
+
+    Reads the full raw registry (which may contain richer dict entries written by
+    project-registry.py) and appends a plain string entry when the path is new.
+    Existing entries of either format are preserved unchanged.
+    """
     try:
-        projects = _load_project_registry()
         key = str(project_root.resolve())
-        if key not in projects:
-            projects.append(key)
+        try:
+            raw: list = (
+                json.loads(REGISTRY_PATH.read_text(encoding="utf-8")).get("projects", [])
+                if REGISTRY_PATH.exists()
+                else []
+            )
+        except Exception:
+            raw = []
+
+        existing_paths: set[str] = set()
+        for entry in raw:
+            if isinstance(entry, str):
+                existing_paths.add(entry)
+            elif isinstance(entry, dict):
+                p = entry.get("path", "")
+                if p:
+                    existing_paths.add(p)
+
+        if key not in existing_paths:
+            raw.append(key)
             REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
             # P1-7: atomic write prevents registry truncation on concurrent access
-            _atomic_write_text(REGISTRY_PATH, json.dumps({"projects": projects}, indent=2))
+            _atomic_write_text(REGISTRY_PATH, json.dumps({"projects": raw}, indent=2))
     except Exception:
         pass
 

--- a/sk-rust/src/main.rs
+++ b/sk-rust/src/main.rs
@@ -254,9 +254,7 @@ fn main() -> ExitCode {
                 None | Some("-h") | Some("--help") => {
                     run_fallback("project-registry.py", &["--help".to_string()])
                 }
-                Some(s) if VALID_SUBS.contains(&s) => {
-                    run_fallback("project-registry.py", &args)
-                }
+                Some(s) if VALID_SUBS.contains(&s) => run_fallback("project-registry.py", &args),
                 Some(bad) => {
                     eprintln!(
                         "sk project: unknown subcommand '{}'. Choose from: {}",

--- a/sk-rust/src/main.rs
+++ b/sk-rust/src/main.rs
@@ -131,6 +131,11 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Manage the project registry (add / remove / list)
+    Project {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }
 
 // Map a grouped namespace command (e.g. "index build") to a Python script name.
@@ -237,6 +242,31 @@ fn main() -> ExitCode {
         }
         Some(Commands::Hooks { args }) => commands::hooks::run_hooks_command(&args),
         Some(Commands::Watch { args }) => commands::watch::run_watch_command(&args),
+        Some(Commands::Project { args }) => {
+            // Validate subcommand before forwarding to project-registry.py so
+            // that bad subcommands fail fast with a consistent message even if
+            // the Python script is missing or not invocable — matching the
+            // behaviour of the Python sk.py _run_project() dispatcher.
+            const VALID_SUBS: &[&str] = &["add", "remove", "list"];
+            let sub = args.first().map(|s| s.as_str());
+            match sub {
+                // No subcommand or explicit help flag → show help
+                None | Some("-h") | Some("--help") => {
+                    run_fallback("project-registry.py", &["--help".to_string()])
+                }
+                Some(s) if VALID_SUBS.contains(&s) => {
+                    run_fallback("project-registry.py", &args)
+                }
+                Some(bad) => {
+                    eprintln!(
+                        "sk project: unknown subcommand '{}'. Choose from: {}",
+                        bad,
+                        VALID_SUBS.join(", ")
+                    );
+                    ExitCode::from(2)
+                }
+            }
+        }
     };
 
     if cli.time {

--- a/sk.py
+++ b/sk.py
@@ -32,6 +32,7 @@ Usage:
     sk profile build|import|export [<args>...]
     sk context project|map [<args>...]
     sk scout  run|config|status [<args>...]
+    sk project add|remove|list [<args>...]
 
     sk --help     Show this help
     sk --version  Show version
@@ -114,6 +115,11 @@ _GROUPS: dict[str, dict[str, str]] = {
         "run": "trend-scout.py",
         "config": "scout-config.py",
         "status": "scout-status.py",
+    },
+    "project": {
+        "add": "project-registry.py",
+        "remove": "project-registry.py",
+        "list": "project-registry.py",
     },
 }
 
@@ -204,6 +210,27 @@ def _run_hooks(extra_args: list[str]) -> int:
     return _run(str(Path("hooks") / "hook_runner.py"), extra_args)
 
 
+def _run_project(extra_args: list[str]) -> int:
+    """Dispatch ``sk project ...`` to project-registry.py.
+
+    Unlike other grouped namespace commands, all ``project`` subcommands
+    (add / remove / list) share a single script that uses argparse internally.
+    The subcommand must therefore be forwarded as the first positional argument.
+    """
+    if not extra_args or extra_args[0] in ("-h", "--help"):
+        return _run("project-registry.py", ["--help"])
+    sub = extra_args[0]
+    if sub not in _GROUPS["project"]:
+        subs = list(_GROUPS["project"].keys())
+        print(
+            f"sk project: unknown subcommand '{sub}'. Choose from: {', '.join(subs)}",
+            file=sys.stderr,
+        )
+        return 2
+    # Forward ALL args including the subcommand to project-registry.py
+    return _run("project-registry.py", extra_args)
+
+
 def _print_help() -> None:
     direct_list = "  " + "\n  ".join(f"sk {cmd:<12} → {script}" for cmd, script in _DIRECT.items())
     print(
@@ -234,6 +261,8 @@ def main(argv: list[str] | None = None) -> int:
     # Direct command?
     if cmd == "hooks":
         return _run_hooks(rest)
+    if cmd == "project":
+        return _run_project(rest)
     if cmd in _DIRECT:
         return _run(_DIRECT[cmd], rest)
 

--- a/tests/test_install_helpers.py
+++ b/tests/test_install_helpers.py
@@ -159,6 +159,59 @@ test("first project still present", resolved_key in registered3)
 _install.REGISTRY_PATH = original_registry
 
 
+# ── 3b. _register_project + _load_project_registry — richer schema compat ────
+
+print("\n📌 _register_project / _load_project_registry — richer schema compat")
+
+_install.REGISTRY_PATH = SCRATCH / "reg-rich-compat.json"
+if _install.REGISTRY_PATH.exists():
+    _install.REGISTRY_PATH.unlink()
+
+import json as _json
+
+# Pre-populate with a dict entry (as written by project-registry.py)
+rich_path = str((SCRATCH / "rich-proj").resolve())
+rich_entry = {"name": "rich-proj", "path": rich_path, "created_at": "2025-01-01T00:00:00+00:00"}
+_install.REGISTRY_PATH.write_text(_json.dumps({"projects": [rich_entry]}), encoding="utf-8")
+
+# _load_project_registry must return the path from the dict entry
+loaded_paths = _install._load_project_registry()
+test("load handles dict entry — path extracted", rich_path in loaded_paths)
+
+# _register_project must not add a duplicate when the path already exists as a dict entry
+_rich_proj = SCRATCH / "rich-proj"
+_rich_proj.mkdir(exist_ok=True)
+_install._register_project(_rich_proj)
+reload_paths = _install._load_project_registry()
+test("register does not duplicate dict-only entry", reload_paths.count(rich_path) == 1)
+
+# _register_project must preserve the original dict entry (not overwrite with string only)
+raw_after = _json.loads(_install.REGISTRY_PATH.read_text(encoding="utf-8"))["projects"]
+test("dict entry preserved after no-op register_project", any(isinstance(e, dict) for e in raw_after))
+
+# Mixed mode: pre-populate with both a string entry and a dict entry
+str_path = "/legacy/string/path"
+_install.REGISTRY_PATH.write_text(
+    _json.dumps({"projects": [str_path, rich_entry]}),
+    encoding="utf-8",
+)
+mixed_paths = _install._load_project_registry()
+test("load mixed registry returns string path", str_path in mixed_paths)
+test("load mixed registry returns dict path", rich_path in mixed_paths)
+
+# Register a new project into a mixed registry — both existing entries preserved
+new_proj = SCRATCH / "new-proj"
+new_proj.mkdir(exist_ok=True)
+_install._register_project(new_proj)
+final_raw = _json.loads(_install.REGISTRY_PATH.read_text(encoding="utf-8"))["projects"]
+final_paths_extracted = [e if isinstance(e, str) else e.get("path", "") for e in final_raw]
+test("mixed: string entry preserved after register new project", str_path in final_paths_extracted)
+test("mixed: dict entry preserved after register new project", rich_path in final_paths_extracted)
+test("mixed: new project added as string", str(new_proj.resolve()) in final_paths_extracted)
+
+_install.REGISTRY_PATH = original_registry
+
+
 # ── 4. _count_scripts ────────────────────────────────────────────────────────
 
 print("\n🔢 _count_scripts")

--- a/tests/test_project_registry.py
+++ b/tests/test_project_registry.py
@@ -389,6 +389,70 @@ class TestDetectProjectRoot(unittest.TestCase):
                     detected = self.mod._detect_project_root(start=isolated)
             self.assertEqual(detected, Path(fake_root).resolve())
 
+    def test_home_copilot_not_treated_as_project_root(self):
+        """
+        Regression: global ~/.copilot must NOT cause the home directory to be
+        detected as a project root when running from a subdirectory of home.
+
+        PR #205 review thread: https://github.com/magicpro97/copilot-session-knowledge/pull/205#discussion_r3243436861
+        """
+        with tempfile.TemporaryDirectory() as td:
+            fake_home = Path(td) / "home"
+            fake_home.mkdir()
+            # Only fake_home/.copilot "exists" (simulates global ~/.copilot)
+            fake_home_copilot = (fake_home / ".copilot").resolve()
+            subdir = fake_home / "work" / "myproject"
+            subdir.mkdir(parents=True)
+
+            orig_is_dir = Path.is_dir
+            def _fake_is_dir(self_path):
+                if self_path.name == ".copilot":
+                    return self_path.resolve() == fake_home_copilot
+                return orig_is_dir(self_path)
+
+            with patch("pathlib.Path.home", return_value=fake_home.resolve()):
+                with patch.object(Path, "is_dir", _fake_is_dir):
+                    with patch.object(self.mod.subprocess, "run") as mock_run:
+                        mock_run.return_value = MagicMock(returncode=1, stdout="")
+                        detected = self.mod._detect_project_root(start=subdir)
+            self.assertIsNone(
+                detected,
+                f"home dir should NOT be detected as project root, got: {detected}",
+            )
+
+    def test_project_copilot_under_home_is_detected(self):
+        """
+        A real project-local .copilot/ that lives *inside* the home directory
+        (e.g. ~/work/myrepo/.copilot/) must still be detected correctly.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            fake_home = Path(td) / "home"
+            fake_home.mkdir()
+            fake_home_copilot = (fake_home / ".copilot").resolve()
+            project = fake_home / "work" / "myrepo"
+            project.mkdir(parents=True)
+            project_copilot = (project / ".copilot").resolve()
+            subdir = project / "src"
+            subdir.mkdir()
+
+            orig_is_dir = Path.is_dir
+            def _fake_is_dir(self_path):
+                if self_path.name == ".copilot":
+                    # Both global and project-local exist; only project-local should win
+                    return self_path.resolve() in (fake_home_copilot, project_copilot)
+                return orig_is_dir(self_path)
+
+            with patch("pathlib.Path.home", return_value=fake_home.resolve()):
+                with patch.object(Path, "is_dir", _fake_is_dir):
+                    with patch.object(self.mod.subprocess, "run") as mock_run:
+                        mock_run.return_value = MagicMock(returncode=1, stdout="")
+                        detected = self.mod._detect_project_root(start=subdir)
+            self.assertEqual(
+                detected,
+                project.resolve(),
+                f"project-local .copilot should be detected, got: {detected}",
+            )
+
 
 class TestMainDispatch(unittest.TestCase):
     """Test main() dispatches add/remove/list correctly."""

--- a/tests/test_project_registry.py
+++ b/tests/test_project_registry.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""
+test_project_registry.py — Tests for project-registry.py
+
+Covers:
+  - _entry_path() handles both string and dict entries
+  - _load_raw_registry() returns empty list on missing/corrupt file
+  - _load_project_paths() de-duplicates and filters
+  - cmd_add() registers a new project (idempotent)
+  - cmd_add() handles richer schema co-existence with legacy strings
+  - cmd_remove() removes a registered project
+  - cmd_remove() is graceful when path is not registered
+  - cmd_list() human-readable output
+  - cmd_list() --json output
+  - _detect_project_root() .copilot/ detection
+  - _detect_project_root() git fallback detection (mocked)
+  - main() dispatch: add / remove / list
+  - backward compatibility: mixed string+dict registry round-trips
+  - _atomic_write_text() no .tmp leak
+
+Run: python tests/test_project_registry.py
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+TOOLS_DIR = Path(__file__).parent.parent
+REG_PATH = TOOLS_DIR / "project-registry.py"
+
+SCRATCH = TOOLS_DIR / ".test-scratch" / "project-registry-tests"
+SCRATCH.mkdir(parents=True, exist_ok=True)
+
+
+def _load_module(registry_path_override: Path | None = None):
+    """Load project-registry as a fresh module, optionally overriding REGISTRY_PATH."""
+    spec = importlib.util.spec_from_file_location("_proj_reg", REG_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    if registry_path_override is not None:
+        mod.REGISTRY_PATH = registry_path_override
+    return mod
+
+
+PASS = 0
+FAIL = 0
+
+
+def _record(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  ✅ {name}")
+    else:
+        FAIL += 1
+        print(f"  ❌ {name}" + (f" — {detail}" if detail else ""))
+
+
+class TestEntryPath(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_module()
+
+    def test_string_entry(self):
+        self.assertEqual(self.mod._entry_path("/some/path"), "/some/path")
+
+    def test_dict_entry(self):
+        self.assertEqual(self.mod._entry_path({"path": "/some/path", "name": "x"}), "/some/path")
+
+    def test_dict_missing_path(self):
+        self.assertEqual(self.mod._entry_path({"name": "x"}), "")
+
+    def test_none(self):
+        self.assertEqual(self.mod._entry_path(None), "")
+
+    def test_integer(self):
+        self.assertEqual(self.mod._entry_path(42), "")
+
+
+class TestLoadRawRegistry(unittest.TestCase):
+    def setUp(self):
+        self.reg = SCRATCH / "test-raw-registry.json"
+        self.mod = _load_module(self.reg)
+        if self.reg.exists():
+            self.reg.unlink()
+
+    def test_missing_file_returns_empty(self):
+        self.assertEqual(self.mod._load_raw_registry(), [])
+
+    def test_empty_projects_key(self):
+        self.reg.write_text(json.dumps({"projects": []}), encoding="utf-8")
+        self.assertEqual(self.mod._load_raw_registry(), [])
+
+    def test_string_entries(self):
+        self.reg.write_text(json.dumps({"projects": ["/a", "/b"]}), encoding="utf-8")
+        self.assertEqual(self.mod._load_raw_registry(), ["/a", "/b"])
+
+    def test_dict_entries(self):
+        entries = [{"name": "x", "path": "/a", "created_at": "2025-01-01T00:00:00+00:00"}]
+        self.reg.write_text(json.dumps({"projects": entries}), encoding="utf-8")
+        self.assertEqual(self.mod._load_raw_registry(), entries)
+
+    def test_mixed_entries(self):
+        entries = ["/a", {"name": "b", "path": "/b", "created_at": "2025-01-01T00:00:00+00:00"}]
+        self.reg.write_text(json.dumps({"projects": entries}), encoding="utf-8")
+        self.assertEqual(self.mod._load_raw_registry(), entries)
+
+    def test_corrupt_json_returns_empty(self):
+        self.reg.write_text("NOT JSON", encoding="utf-8")
+        self.assertEqual(self.mod._load_raw_registry(), [])
+
+    def test_integer_entries_filtered_out(self):
+        self.reg.write_text(json.dumps({"projects": ["/a", 42, None]}), encoding="utf-8")
+        result = self.mod._load_raw_registry()
+        self.assertEqual(result, ["/a"])
+
+
+class TestLoadProjectPaths(unittest.TestCase):
+    def setUp(self):
+        self.reg = SCRATCH / "test-paths-registry.json"
+        self.mod = _load_module(self.reg)
+        if self.reg.exists():
+            self.reg.unlink()
+
+    def test_string_entries(self):
+        self.reg.write_text(json.dumps({"projects": ["/a", "/b"]}), encoding="utf-8")
+        self.assertEqual(self.mod._load_project_paths(), ["/a", "/b"])
+
+    def test_dict_entries_extracted(self):
+        entries = [{"name": "x", "path": "/c"}]
+        self.reg.write_text(json.dumps({"projects": entries}), encoding="utf-8")
+        self.assertEqual(self.mod._load_project_paths(), ["/c"])
+
+    def test_deduplication(self):
+        entries = ["/a", "/a", {"path": "/a"}]
+        self.reg.write_text(json.dumps({"projects": entries}), encoding="utf-8")
+        self.assertEqual(self.mod._load_project_paths(), ["/a"])
+
+
+class TestCmdAdd(unittest.TestCase):
+    def setUp(self):
+        self.reg = SCRATCH / "test-add-registry.json"
+        self.mod = _load_module(self.reg)
+        if self.reg.exists():
+            self.reg.unlink()
+        # Use a real temp directory so paths resolve correctly on all platforms
+        self._td = tempfile.mkdtemp(prefix="sk-add-test-")
+        self.proj = Path(self._td) / "alpha"
+        self.proj.mkdir()
+        self.proj_key = str(self.proj.resolve())
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def test_add_new_path(self):
+        rc = self.mod.cmd_add(self.proj_key, quiet=True)
+        self.assertEqual(rc, 0)
+        data = json.loads(self.reg.read_text(encoding="utf-8"))
+        paths = [self.mod._entry_path(e) for e in data["projects"]]
+        self.assertIn(self.proj_key, paths)
+
+    def test_add_idempotent(self):
+        self.mod.cmd_add(self.proj_key, quiet=True)
+        self.mod.cmd_add(self.proj_key, quiet=True)
+        data = json.loads(self.reg.read_text(encoding="utf-8"))
+        paths = [self.mod._entry_path(e) for e in data["projects"]]
+        self.assertEqual(paths.count(self.proj_key), 1)
+
+    def test_add_creates_rich_entry(self):
+        self.mod.cmd_add(self.proj_key, quiet=True)
+        data = json.loads(self.reg.read_text(encoding="utf-8"))
+        rich = [e for e in data["projects"] if isinstance(e, dict)]
+        self.assertTrue(len(rich) >= 1)
+        entry = rich[0]
+        self.assertIn("name", entry)
+        self.assertIn("path", entry)
+        self.assertIn("created_at", entry)
+
+    def test_add_preserves_existing_string_entries(self):
+        # Pre-populate with a legacy string entry using a real path
+        legacy = str(Path(self._td).resolve())
+        self.reg.write_text(json.dumps({"projects": [legacy]}), encoding="utf-8")
+        self.mod.cmd_add(self.proj_key, quiet=True)
+        data = json.loads(self.reg.read_text(encoding="utf-8"))
+        paths = [self.mod._entry_path(e) for e in data["projects"]]
+        self.assertIn(legacy, paths)
+        self.assertIn(self.proj_key, paths)
+
+    def test_add_detects_existing_dict_entry(self):
+        # If a dict entry already has the path, don't add again
+        entries = [{"name": "x", "path": self.proj_key, "created_at": "2025-01-01T00:00:00+00:00"}]
+        self.reg.write_text(json.dumps({"projects": entries}), encoding="utf-8")
+        rc = self.mod.cmd_add(self.proj_key, quiet=True)
+        self.assertEqual(rc, 0)
+        data = json.loads(self.reg.read_text(encoding="utf-8"))
+        paths = [self.mod._entry_path(e) for e in data["projects"]]
+        self.assertEqual(paths.count(self.proj_key), 1)
+
+
+class TestCmdRemove(unittest.TestCase):
+    def setUp(self):
+        self.reg = SCRATCH / "test-remove-registry.json"
+        self.mod = _load_module(self.reg)
+        # Use real temp dir so path resolution is consistent
+        self._td = tempfile.mkdtemp(prefix="sk-remove-test-")
+        self.keep_path = str((Path(self._td) / "keep").resolve())
+        self.remove_path = str((Path(self._td) / "remove").resolve())
+        Path(self.keep_path).mkdir(exist_ok=True)
+        Path(self.remove_path).mkdir(exist_ok=True)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _populate(self, entries):
+        self.reg.write_text(json.dumps({"projects": entries}), encoding="utf-8")
+
+    def test_remove_string_entry(self):
+        self._populate([self.keep_path, self.remove_path])
+        rc = self.mod.cmd_remove(self.remove_path, quiet=True)
+        self.assertEqual(rc, 0)
+        data = json.loads(self.reg.read_text(encoding="utf-8"))
+        paths = [self.mod._entry_path(e) for e in data["projects"]]
+        self.assertNotIn(self.remove_path, paths)
+        self.assertIn(self.keep_path, paths)
+
+    def test_remove_dict_entry(self):
+        self._populate([
+            {"name": "keep", "path": self.keep_path, "created_at": "2025-01-01T00:00:00+00:00"},
+            {"name": "gone", "path": self.remove_path, "created_at": "2025-01-01T00:00:00+00:00"},
+        ])
+        rc = self.mod.cmd_remove(self.remove_path, quiet=True)
+        self.assertEqual(rc, 0)
+        data = json.loads(self.reg.read_text(encoding="utf-8"))
+        paths = [self.mod._entry_path(e) for e in data["projects"]]
+        self.assertNotIn(self.remove_path, paths)
+        self.assertIn(self.keep_path, paths)
+
+    def test_remove_not_registered_returns_0(self):
+        self._populate([self.keep_path])
+        other = str((Path(self._td) / "other").resolve())
+        rc = self.mod.cmd_remove(other, quiet=True)
+        self.assertEqual(rc, 0)
+
+    def test_remove_empty_registry_returns_0(self):
+        self._populate([])
+        rc = self.mod.cmd_remove(self.remove_path, quiet=True)
+        self.assertEqual(rc, 0)
+
+
+class TestCmdList(unittest.TestCase):
+    def setUp(self):
+        self.reg = SCRATCH / "test-list-registry.json"
+        self.mod = _load_module(self.reg)
+
+    def test_list_empty(self):
+        self.reg.write_text(json.dumps({"projects": []}), encoding="utf-8")
+        with patch("builtins.print") as mock_print:
+            rc = self.mod.cmd_list()
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("no projects", output)
+
+    def test_list_string_entries(self):
+        self.reg.write_text(json.dumps({"projects": ["/path/a", "/path/b"]}), encoding="utf-8")
+        with patch("builtins.print") as mock_print:
+            rc = self.mod.cmd_list()
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("/path/a", output)
+        self.assertIn("/path/b", output)
+
+    def test_list_json_output(self):
+        self.reg.write_text(json.dumps({"projects": ["/path/a"]}), encoding="utf-8")
+        with patch("builtins.print") as mock_print:
+            rc = self.mod.cmd_list(json_output=True)
+        self.assertEqual(rc, 0)
+        output = "".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        parsed = json.loads(output)
+        self.assertIsInstance(parsed, list)
+        self.assertTrue(any(item.get("path") == "/path/a" for item in parsed))
+
+    def test_list_json_empty(self):
+        self.reg.write_text(json.dumps({"projects": []}), encoding="utf-8")
+        with patch("builtins.print") as mock_print:
+            rc = self.mod.cmd_list(json_output=True)
+        self.assertEqual(rc, 0)
+        output = "".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertEqual(output.strip(), "[]")
+
+    def test_list_deduplicates_human_readable(self):
+        """Duplicate paths in the raw registry must appear only once in human output."""
+        self.reg.write_text(
+            json.dumps({"projects": ["/path/dup", "/path/other", "/path/dup"]}),
+            encoding="utf-8",
+        )
+        with patch("builtins.print") as mock_print:
+            rc = self.mod.cmd_list()
+        self.assertEqual(rc, 0)
+        all_lines = [str(c) for call in mock_print.call_args_list for c in call[0]]
+        dup_count = sum(1 for line in all_lines if "/path/dup" in line)
+        self.assertEqual(dup_count, 1, f"Expected 1 occurrence of /path/dup, got {dup_count}")
+        self.assertTrue(any("/path/other" in line for line in all_lines))
+
+    def test_list_json_deduplicates(self):
+        """Duplicate paths in the raw registry must appear only once in --json output."""
+        self.reg.write_text(
+            json.dumps({"projects": ["/path/dup", "/path/other", "/path/dup"]}),
+            encoding="utf-8",
+        )
+        with patch("builtins.print") as mock_print:
+            rc = self.mod.cmd_list(json_output=True)
+        self.assertEqual(rc, 0)
+        raw = "".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        parsed = json.loads(raw)
+        paths = [item["path"] for item in parsed]
+        self.assertEqual(paths.count("/path/dup"), 1, f"Expected 1 /path/dup in JSON, got {paths}")
+        self.assertIn("/path/other", paths)
+
+    def test_list_deduplicates_mixed_entries(self):
+        """Duplicate dict+string entries for same path appear only once in output."""
+        entries = [
+            "/path/x",
+            {"name": "x", "path": "/path/x", "created_at": "2024-01-01T00:00:00"},
+        ]
+        self.reg.write_text(json.dumps({"projects": entries}), encoding="utf-8")
+        with patch("builtins.print") as mock_print:
+            rc = self.mod.cmd_list()
+        self.assertEqual(rc, 0)
+        all_lines = [str(c) for call in mock_print.call_args_list for c in call[0]]
+        dup_count = sum(1 for line in all_lines if "/path/x" in line)
+        self.assertEqual(dup_count, 1, f"Expected 1 occurrence, got {dup_count}: {all_lines}")
+
+
+class TestDetectProjectRoot(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_module()
+
+    def test_detects_copilot_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / ".copilot").mkdir()
+            subdir = root / "sub" / "deeper"
+            subdir.mkdir(parents=True)
+            detected = self.mod._detect_project_root(start=subdir)
+            self.assertEqual(detected, root.resolve())
+
+    def test_returns_none_if_no_copilot_no_git(self):
+        """Mock both the .copilot dir walk and subprocess so neither fires."""
+        with tempfile.TemporaryDirectory() as td:
+            isolated = Path(td) / "iso"
+            isolated.mkdir()
+            # Patch Path.is_dir to return False for any path ending in .copilot
+            orig_is_dir = Path.is_dir
+            def _fake_is_dir(self_path):
+                if self_path.name == ".copilot":
+                    return False
+                return orig_is_dir(self_path)
+            with patch.object(Path, "is_dir", _fake_is_dir):
+                with patch.object(self.mod.subprocess, "run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=1, stdout="")
+                    detected = self.mod._detect_project_root(start=isolated)
+            self.assertIsNone(detected)
+
+    def test_git_fallback(self):
+        """With no .copilot dir, falls back to git rev-parse."""
+        with tempfile.TemporaryDirectory() as td:
+            isolated = Path(td) / "iso"
+            isolated.mkdir()
+            fake_root = str(isolated.resolve())
+            orig_is_dir = Path.is_dir
+            def _fake_is_dir(self_path):
+                if self_path.name == ".copilot":
+                    return False
+                return orig_is_dir(self_path)
+            with patch.object(Path, "is_dir", _fake_is_dir):
+                with patch.object(self.mod.subprocess, "run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0, stdout=fake_root + "\n")
+                    detected = self.mod._detect_project_root(start=isolated)
+            self.assertEqual(detected, Path(fake_root).resolve())
+
+
+class TestMainDispatch(unittest.TestCase):
+    """Test main() dispatches add/remove/list correctly."""
+
+    def setUp(self):
+        self.reg = SCRATCH / "test-main-registry.json"
+        self.mod = _load_module(self.reg)
+        if self.reg.exists():
+            self.reg.unlink()
+        self._td = tempfile.mkdtemp(prefix="sk-main-test-")
+        self.proj_key = str((Path(self._td) / "proj").resolve())
+        Path(self.proj_key).mkdir(exist_ok=True)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def test_add_via_main(self):
+        rc = self.mod.main(["add", self.proj_key])
+        self.assertEqual(rc, 0)
+        data = json.loads(self.reg.read_text(encoding="utf-8"))
+        paths = [self.mod._entry_path(e) for e in data["projects"]]
+        self.assertIn(self.proj_key, paths)
+
+    def test_remove_via_main(self):
+        self.reg.write_text(json.dumps({"projects": [self.proj_key]}), encoding="utf-8")
+        rc = self.mod.main(["remove", self.proj_key])
+        self.assertEqual(rc, 0)
+        data = json.loads(self.reg.read_text(encoding="utf-8"))
+        paths = [self.mod._entry_path(e) for e in data["projects"]]
+        self.assertNotIn(self.proj_key, paths)
+
+    def test_list_via_main(self):
+        self.reg.write_text(json.dumps({"projects": [self.proj_key]}), encoding="utf-8")
+        with patch("builtins.print") as mock_print:
+            rc = self.mod.main(["list"])
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn(self.proj_key, output)
+
+    def test_no_args_returns_0(self):
+        with patch("builtins.print"):
+            rc = self.mod.main([])
+        self.assertEqual(rc, 0)
+
+    def test_unknown_subcommand_exits_nonzero(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.mod.main(["nonexistent"])
+        self.assertNotEqual(cm.exception.code, 0)
+
+
+class TestBackwardCompatibility(unittest.TestCase):
+    """Mixed-mode registry: string and dict entries co-existing."""
+
+    def setUp(self):
+        self.reg = SCRATCH / "test-compat-registry.json"
+        self.mod = _load_module(self.reg)
+        self._td = tempfile.mkdtemp(prefix="sk-compat-test-")
+        self.legacy_path = str((Path(self._td) / "legacy").resolve())
+        self.rich_path = str((Path(self._td) / "rich").resolve())
+        self.new_path = str((Path(self._td) / "new").resolve())
+        Path(self.legacy_path).mkdir(exist_ok=True)
+        Path(self.rich_path).mkdir(exist_ok=True)
+        Path(self.new_path).mkdir(exist_ok=True)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def test_mixed_registry_round_trip(self):
+        # Simulate a registry with one legacy string and one rich dict entry
+        mixed = [
+            self.legacy_path,
+            {"name": "rich", "path": self.rich_path, "created_at": "2025-01-01T00:00:00+00:00"},
+        ]
+        self.reg.write_text(json.dumps({"projects": mixed}), encoding="utf-8")
+
+        # add() should preserve both existing entries and append new one
+        rc = self.mod.cmd_add(self.new_path, quiet=True)
+        self.assertEqual(rc, 0)
+
+        data = json.loads(self.reg.read_text(encoding="utf-8"))
+        paths = [self.mod._entry_path(e) for e in data["projects"]]
+        self.assertIn(self.legacy_path, paths)
+        self.assertIn(self.rich_path, paths)
+        self.assertIn(self.new_path, paths)
+
+    def test_add_does_not_duplicate_legacy_path(self):
+        self.reg.write_text(json.dumps({"projects": [self.legacy_path]}), encoding="utf-8")
+        self.mod.cmd_add(self.legacy_path, quiet=True)
+        data = json.loads(self.reg.read_text(encoding="utf-8"))
+        paths = [self.mod._entry_path(e) for e in data["projects"]]
+        self.assertEqual(paths.count(self.legacy_path), 1)
+
+    def test_list_shows_both_formats(self):
+        mixed = [
+            self.legacy_path,
+            {"name": "dict-proj", "path": self.rich_path, "created_at": "2025-01-01T00:00:00+00:00"},
+        ]
+        self.reg.write_text(json.dumps({"projects": mixed}), encoding="utf-8")
+        with patch("builtins.print") as mock_print:
+            rc = self.mod.cmd_list()
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn(self.legacy_path, output)
+        self.assertIn(self.rich_path, output)
+
+
+class TestAtomicWrite(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_module()
+
+    def test_creates_file(self):
+        target = SCRATCH / "atomic-write-test.json"
+        if target.exists():
+            target.unlink()
+        self.mod._atomic_write_text(target, '{"test": true}')
+        self.assertTrue(target.exists())
+        self.assertEqual(json.loads(target.read_text(encoding="utf-8")), {"test": True})
+
+    def test_no_tmp_file_left(self):
+        target = SCRATCH / "atomic-no-tmp.json"
+        self.mod._atomic_write_text(target, "hello")
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        self.assertFalse(tmp.exists(), "temp file should not be left behind")
+
+    def test_overwrites_existing(self):
+        target = SCRATCH / "atomic-overwrite.json"
+        target.write_text("old", encoding="utf-8")
+        self.mod._atomic_write_text(target, "new")
+        self.assertEqual(target.read_text(encoding="utf-8"), "new")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -275,7 +275,73 @@ class TestSkGroupedCommands(unittest.TestCase):
         self._assert_group_routes("scout", "status", "scout-status.py")
 
 
+class TestSkProjectNamespace(unittest.TestCase):
+    """Verify that sk project add/remove/list route to project-registry.py."""
+
+    def _assert_project_routes(self, sub: str, extra: list[str] | None = None):
+        """sk project <sub> [extra] must call _run('project-registry.py', [sub] + extra)."""
+        extra = extra or []
+        expected_args = [sub] + extra
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main(["project", sub] + extra)
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with("project-registry.py", expected_args)
+
+    def test_project_add(self):
+        self._assert_project_routes("add")
+
+    def test_project_add_with_path(self):
+        self._assert_project_routes("add", ["/some/project/path"])
+
+    def test_project_add_quiet(self):
+        self._assert_project_routes("add", ["/path", "--quiet"])
+
+    def test_project_remove(self):
+        self._assert_project_routes("remove")
+
+    def test_project_remove_with_path(self):
+        self._assert_project_routes("remove", ["/some/path"])
+
+    def test_project_list(self):
+        self._assert_project_routes("list")
+
+    def test_project_list_json(self):
+        self._assert_project_routes("list", ["--json"])
+
+    def test_project_unknown_sub_returns_2(self):
+        with patch("builtins.print"):
+            rc = sk.main(["project", "switch"])
+        self.assertEqual(rc, 2)
+
+    def test_project_help_flag(self):
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main(["project", "--help"])
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with("project-registry.py", ["--help"])
+
+    def test_project_no_args_shows_help(self):
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main(["project"])
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with("project-registry.py", ["--help"])
+
+    def test_project_registry_script_exists(self):
+        """project-registry.py must exist in the tools directory."""
+        self.assertTrue(
+            (TOOLS_DIR / "project-registry.py").exists(),
+            "project-registry.py not found — sk project would break",
+        )
+
+    def test_project_in_help_output(self):
+        with patch("builtins.print") as mock_print:
+            sk.main(["--help"])
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("project", output)
+
+
 class TestSkErrorCases(unittest.TestCase):
+    """Generic CLI error and edge-case routing tests."""
+
     def test_unknown_command_returns_2(self):
         with patch("builtins.print"):
             rc = sk.main(["nonexistent-command"])


### PR DESCRIPTION
## Summary
- add `project-registry.py` with `sk project add/remove/list`
- auto-detect project roots via `.copilot/` with git-root fallback
- keep install/setup/update registry readers backward-compatible with mixed string/dict schemas
- add docs and regression coverage for the safe registry slice

## Scope
Partial implementation of #91.

Delivered here:
- registry file tracks multiple projects
- `sk project add/remove/list`
- auto-detect project root via `.copilot/`

Deferred to a later slice:
- per-project isolated DB
- project switching
- project stats
- watcher / multi-project runtime behavior