### PR TITLE
feat(sk): add skill suggestion CLI

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -21,7 +21,36 @@ sk browse --port 8080 --token TOKEN      # → browse.py
 sk benchmark record                      # → benchmark.py
 sk retro                                 # → retro.py
 sk heal                                  # → copilot-cli-healer.py
+sk skill-suggest                         # → skill-suggest.py
+sk skill-suggest --min-occurrences 3 --format json
 ```
+
+### `sk skill-suggest` — knowledge-to-skill pipeline
+
+Mine the session knowledge DB for repeating patterns and propose new skill candidates.
+**Conservative / suggestion-only surface** — never creates or deploys skills automatically.
+
+```bash
+sk skill-suggest                                  # text output, default threshold (3)
+sk skill-suggest --min-occurrences 3              # minimum occurrence count for a topic
+sk skill-suggest --format json                    # JSON output for scripting
+sk skill-suggest --min-occurrences 3 --format json
+sk skill-suggest --db ~/.copilot/session-state/knowledge.db
+sk skill-suggest --skills-dir ./skills --limit 5  # cap at 5 suggestions
+```
+
+Each suggestion includes:
+- Candidate skill name (slug derived from topic_key or tag cluster)
+- Occurrence score and entry count
+- Overlap check against existing skills in `skills/`
+- A ready-to-use SKILL.md draft that passes `validate-skill.py`
+
+To validate a generated draft:
+```bash
+python validate-skill.py path/to/SKILL.md
+```
+
+> Direct-script form: `python skill-suggest.py [args...]`
 
 ### `sk index` — knowledge index lifecycle
 

--- a/sk-rust/src/main.rs
+++ b/sk-rust/src/main.rs
@@ -136,6 +136,12 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Suggest new skills from knowledge DB patterns (suggestion-only)
+    #[command(name = "skill-suggest")]
+    SkillSuggest {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }
 
 // Map a grouped namespace command (e.g. "index build") to a Python script name.
@@ -265,6 +271,7 @@ fn main() -> ExitCode {
                 }
             }
         }
+        Some(Commands::SkillSuggest { args }) => run_fallback("skill-suggest.py", &args),
     };
 
     if cli.time {

--- a/sk.py
+++ b/sk.py
@@ -23,8 +23,9 @@ Usage:
     sk export-cerebrum [<args>...] Run export-cerebrum.py
     sk cerebrum [<args>...]       Run export-cerebrum.py (alias for export-cerebrum)
     sk dream    [<args>...]       Run dream.py
-    sk anatomy  [<args>...]       Run anatomy-map.py
-    sk hooks    run|list|<event>  Run hooks/hook_runner.py
+    sk anatomy      [<args>...]       Run anatomy-map.py
+    sk skill-suggest [<args>...]      Run skill-suggest.py
+    sk hooks        run|list|<event>  Run hooks/hook_runner.py
 
     sk index  build|extract|migrate|status|health|embed|tag [<args>...]
     sk sync   run|config|status|gateway|merge [<args>...]
@@ -77,6 +78,7 @@ _DIRECT: dict[str, str] = {
     "cerebrum": "export-cerebrum.py",  # alias for export-cerebrum (short form)
     "dream": "dream.py",
     "anatomy": "anatomy-map.py",
+    "skill-suggest": "skill-suggest.py",
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}

--- a/skill-suggest.py
+++ b/skill-suggest.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""skill-suggest.py — Mine the session knowledge DB and propose new skill candidates.
+
+Reads from ~/.copilot/session-state/knowledge.db (read-only).
+Checks existing skills in the repo's skills/ directory to avoid duplicates.
+Outputs SKILL.md draft content that passes validate-skill.py.
+
+CONSERVATIVE: suggestion-only surface — does NOT create or deploy skills.
+
+Usage:
+    python skill-suggest.py
+    python skill-suggest.py --min-occurrences 3
+    python skill-suggest.py --format json
+    python skill-suggest.py --min-occurrences 3 --format json
+    python skill-suggest.py --skills-dir /path/to/skills
+    python skill-suggest.py --db /path/to/knowledge.db
+    python skill-suggest.py --limit 10
+"""
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if os.name == "nt":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+SESSION_STATE = Path.home() / ".copilot" / "session-state"
+DB_PATH = SESSION_STATE / "knowledge.db"
+DEFAULT_SKILLS_DIR = Path(__file__).parent / "skills"
+
+# Category-based score weight: higher = more valuable signal
+_CATEGORY_WEIGHT: dict[str, float] = {
+    "pattern": 2.0,
+    "decision": 1.5,
+    "discovery": 1.2,
+    "tool": 1.0,
+    "mistake": 1.0,
+    "feature": 0.8,
+    "refactor": 0.7,
+}
+
+_STOPWORDS = frozenset(
+    {
+        "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
+        "of", "with", "by", "from", "is", "are", "was", "were", "be", "been",
+        "have", "has", "had", "do", "does", "did", "will", "would", "could",
+        "should", "may", "might", "can", "it", "this", "that", "these",
+        "those", "i", "we", "you", "he", "she", "they", "not", "no", "so",
+        "if", "then", "when", "where", "what", "which", "who", "how", "all",
+        "any", "each", "more", "most", "also", "just", "up", "out", "as",
+        "into", "than", "their", "its", "our", "my", "your", "his", "her",
+        "them", "us", "me", "after", "before", "during", "while", "since",
+        "until", "too", "very", "about", "use", "used", "using", "run",
+        "running", "make", "new", "only", "now", "time", "way", "need",
+        "needs", "see", "get", "set", "add", "put", "let", "say", "one",
+        "two", "per", "via", "etc", "yet", "got",
+    }
+)
+
+
+def _slugify(text: str) -> str:
+    """Convert arbitrary text to a valid Agent Skills name slug.
+
+    Produces lowercase, alphanumeric-plus-hyphens, 1–64 chars,
+    no leading/trailing/consecutive hyphens.
+    """
+    s = (text or "").lower().strip()
+    # Replace non-alphanumeric runs with a single hyphen
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    # Collapse consecutive hyphens
+    s = re.sub(r"-+", "-", s)
+    # Strip leading/trailing hyphens
+    s = s.strip("-")
+    if not s:
+        return "unnamed-skill"
+    # Names must not start with a digit per spec
+    if s[0].isdigit():
+        s = "skill-" + s
+    return s[:64].rstrip("-")
+
+
+def _load_existing_skills(skills_dir: Path) -> list[dict]:
+    """Load existing skill names from a skills directory.
+
+    Returns a list of dicts with keys: name, path.
+    """
+    skills: list[dict] = []
+    if not skills_dir.exists():
+        return skills
+    for skill_md in skills_dir.rglob("SKILL.md"):
+        try:
+            content = skill_md.read_text(encoding="utf-8", errors="replace")
+            name: str = ""
+            if content.startswith("---"):
+                fm_end = content.find("---", 3)
+                if fm_end != -1:
+                    fm = content[3:fm_end]
+                    m = re.search(
+                        r"^name:\s*['\"]?([^\s'\"#\n]+)['\"]?",
+                        fm,
+                        re.MULTILINE,
+                    )
+                    if m:
+                        name = m.group(1).strip()
+            if not name:
+                name = skill_md.parent.name
+            skills.append({"name": name, "path": str(skill_md)})
+        except Exception:
+            skills.append({"name": skill_md.parent.name, "path": str(skill_md)})
+    return skills
+
+
+def _token_overlap(a: str, b: str) -> float:
+    """Compute Jaccard similarity between token sets of two name strings."""
+    ta = set(re.findall(r"[a-z0-9]+", a.lower()))
+    tb = set(re.findall(r"[a-z0-9]+", b.lower()))
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
+
+
+def _find_overlap(candidate_name: str, existing_skills: list[dict]) -> list[str]:
+    """Find existing skills that significantly overlap with candidate_name."""
+    overlaps: list[str] = []
+    for skill in existing_skills:
+        existing = skill["name"]
+        if existing == candidate_name or _token_overlap(candidate_name, existing) >= 0.4:
+            overlaps.append(existing)
+    return overlaps
+
+
+def _make_skill_draft(
+    name: str,
+    title: str,
+    top_tags: list[str],
+    sample_entries: list[dict],
+) -> str:
+    """Generate SKILL.md draft content that passes validate-skill.py.
+
+    Guarantees:
+    - YAML frontmatter with valid name and ≥10-word description containing
+      trigger phrases ("use when", "triggers", "invoke")
+    - A # heading (title)
+    - A "## When to use" section (activates)
+    - A "## Workflow" section
+    - At least one <example>…</example> block
+    - No security-pattern violations
+    - Well under 500 lines
+    """
+    name_human = name.replace("-", " ")
+    tag_str = ", ".join(top_tags[:5]) if top_tags else name_human
+
+    # Description: ≥10 words, trigger phrases required by validator
+    desc = (
+        f"Use when working with {name_human}. "
+        f"Triggers on: {tag_str}. "
+        f"Invoke when you need guidance on {name_human} patterns, "
+        f"workflows, or decisions from session history."
+    )
+    desc = re.sub(r"\s+", " ", desc).strip()[:300]
+
+    # When-to-use bullet list
+    if top_tags:
+        when_bullets = "\n".join(f"- {t}" for t in top_tags[:5])
+    else:
+        when_bullets = f"- {name_human}"
+
+    # Knowledge summary from sample entries
+    content_lines: list[str] = []
+    for entry in sample_entries[:3]:
+        e_title = (entry.get("title") or "").strip()
+        e_content = re.sub(r"\s+", " ", (entry.get("content") or "")[:120]).strip()
+        if e_title:
+            content_lines.append(f"- **{e_title}**: {e_content}")
+    content_block = (
+        "\n".join(content_lines)
+        if content_lines
+        else f"- Apply proven patterns for {name_human}."
+    )
+
+    # Example block from the first sample entry
+    if sample_entries:
+        ex_raw = (sample_entries[0].get("content") or "")[:100]
+        ex_content = re.sub(r"\s+", " ", ex_raw).strip()
+    else:
+        ex_content = f"Apply {name_human} best practices."
+    if not ex_content:
+        ex_content = f"Relevant patterns and decisions surfaced from session history."
+
+    lines = [
+        "---",
+        f"name: {name}",
+        "description: >-",
+        f"  {desc}",
+        "---",
+        "",
+        f"# {title}",
+        "",
+        "## When to use",
+        "",
+        f"Use this skill when working on {name_human} tasks. Activates on:",
+        "",
+        when_bullets,
+        "",
+        "## Knowledge summary",
+        "",
+        "Recurring patterns and decisions from session history:",
+        "",
+        content_block,
+        "",
+        "## Workflow",
+        "",
+        f"1. Review relevant knowledge entries for {name_human} context.",
+        "2. Apply the established patterns from session history.",
+        "3. Validate the approach against known mistakes and decisions.",
+        "4. Record new learnings: `sk learn --pattern` or `sk learn --decision`.",
+        "",
+        "<example>",
+        f"**Scenario**: Working on a task involving {name_human}.",
+        "",
+        f"**Action**: Apply `{name}` skill to surface relevant session knowledge.",
+        "",
+        f"**Result**: {ex_content}",
+        "</example>",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _open_db_readonly(db_path: Path):
+    """Open the knowledge DB in read-only mode. Returns None if unavailable."""
+    if not db_path.exists():
+        return None
+    try:
+        uri = "file:{}?mode=ro".format(db_path.as_posix())
+        db = sqlite3.connect(uri, uri=True)
+        db.row_factory = sqlite3.Row
+        return db
+    except Exception:
+        try:
+            db = sqlite3.connect(str(db_path))
+            db.row_factory = sqlite3.Row
+            return db
+        except Exception:
+            return None
+
+
+def _table_exists(db: sqlite3.Connection, name: str) -> bool:
+    row = db.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def mine_patterns(
+    db_path: Path,
+    min_occurrences: int = 3,
+    limit: int = 20,
+    categories: list[str] | None = None,
+) -> list[dict]:
+    """Mine the knowledge DB for repeating skill-worthy clusters.
+
+    Returns a list of candidate dicts sorted by score descending.
+    Each dict has keys: candidate_name, source_cluster, cluster_type,
+    score, total_occurrences, entry_count, avg_confidence, category,
+    top_tags, representative_title, sample_entries.
+    """
+    if categories is None:
+        categories = ["pattern", "decision", "discovery", "tool", "mistake"]
+
+    db = _open_db_readonly(db_path)
+    if db is None:
+        return []
+
+    candidates: list[dict] = []
+
+    try:
+        if not _table_exists(db, "knowledge_entries"):
+            return []
+
+        placeholders = ",".join("?" * len(categories))
+
+        # ── Strategy 1: cluster by topic_key ──────────────────────────────
+        rows = db.execute(
+            f"""
+            SELECT
+                topic_key,
+                category,
+                GROUP_CONCAT(title, '|||')                  AS all_titles,
+                GROUP_CONCAT(COALESCE(tags, ''), ',')       AS all_tags,
+                GROUP_CONCAT(content, '|||')                AS all_contents,
+                SUM(COALESCE(occurrence_count, 1))          AS total_occurrences,
+                AVG(COALESCE(confidence, 1.0))              AS avg_confidence,
+                COUNT(*)                                    AS entry_count
+            FROM knowledge_entries
+            WHERE topic_key IS NOT NULL AND topic_key != ''
+              AND category IN ({placeholders})
+            GROUP BY topic_key
+            HAVING total_occurrences >= ?
+            ORDER BY total_occurrences DESC, avg_confidence DESC
+            LIMIT ?
+            """,
+            (*categories, min_occurrences, limit),
+        ).fetchall()
+
+        for row in rows:
+            topic_key = row["topic_key"]
+            all_titles = (row["all_titles"] or "").split("|||")
+            raw_tags = (row["all_tags"] or "").split(",")
+            all_tags = [t.strip().lower() for t in raw_tags if t.strip()]
+
+            rep_title = all_titles[0].strip() if all_titles else topic_key
+
+            tag_freq: dict[str, int] = {}
+            for t in all_tags:
+                if t and len(t) >= 3 and t not in _STOPWORDS:
+                    tag_freq[t] = tag_freq.get(t, 0) + 1
+            top_tags = [k for k, _ in sorted(tag_freq.items(), key=lambda x: -x[1])[:8]]
+
+            cat = row["category"] or "pattern"
+            weight = _CATEGORY_WEIGHT.get(cat, 1.0)
+            score = float(row["total_occurrences"]) * weight
+
+            samples_q = db.execute(
+                f"""
+                SELECT title, content, tags
+                FROM knowledge_entries
+                WHERE topic_key = ? AND category IN ({placeholders})
+                ORDER BY COALESCE(occurrence_count, 1) DESC
+                LIMIT 3
+                """,
+                (topic_key, *categories),
+            ).fetchall()
+
+            name = _slugify(topic_key)
+            if not name or name == "unnamed-skill":
+                name = _slugify(rep_title)
+
+            candidates.append(
+                {
+                    "candidate_name": name,
+                    "source_cluster": topic_key,
+                    "cluster_type": "topic_key",
+                    "score": round(score, 2),
+                    "total_occurrences": int(row["total_occurrences"]),
+                    "entry_count": int(row["entry_count"]),
+                    "avg_confidence": round(float(row["avg_confidence"]), 3),
+                    "category": cat,
+                    "top_tags": top_tags,
+                    "representative_title": rep_title,
+                    "sample_entries": [dict(r) for r in samples_q],
+                }
+            )
+
+        # ── Strategy 2: cluster by tag for entries without topic_key ───────
+        tag_rows = db.execute(
+            f"""
+            SELECT tags, category, title, content,
+                   COALESCE(occurrence_count, 1) AS occurrence_count,
+                   COALESCE(confidence, 1.0)     AS confidence
+            FROM knowledge_entries
+            WHERE (topic_key IS NULL OR topic_key = '')
+              AND tags IS NOT NULL AND tags != ''
+              AND category IN ({placeholders})
+            ORDER BY occurrence_count DESC
+            LIMIT 500
+            """,
+            (*categories,),
+        ).fetchall()
+
+        tag_buckets: dict[str, list[dict]] = {}
+        for row in tag_rows:
+            for raw_tag in (row["tags"] or "").split(","):
+                t = raw_tag.strip().lower()
+                if t and len(t) >= 3 and t not in _STOPWORDS:
+                    if t not in tag_buckets:
+                        tag_buckets[t] = []
+                    tag_buckets[t].append(
+                        {
+                            "title": row["title"],
+                            "content": row["content"],
+                            "tags": row["tags"],
+                            "occurrence_count": int(row["occurrence_count"]),
+                            "confidence": float(row["confidence"]),
+                            "category": row["category"],
+                        }
+                    )
+
+        existing_names = {c["candidate_name"] for c in candidates}
+
+        for tag, entries in sorted(
+            tag_buckets.items(),
+            key=lambda kv: -sum(e["occurrence_count"] for e in kv[1]),
+        ):
+            total_occ = sum(e["occurrence_count"] for e in entries)
+            if total_occ < min_occurrences:
+                continue
+
+            name = _slugify(tag)
+            if name in existing_names:
+                continue
+
+            avg_conf = sum(e["confidence"] for e in entries) / len(entries)
+            cat_counts: dict[str, int] = {}
+            for e in entries:
+                c = e.get("category") or "pattern"
+                cat_counts[c] = cat_counts.get(c, 0) + e["occurrence_count"]
+            cat = max(cat_counts, key=lambda k: cat_counts[k])
+
+            weight = _CATEGORY_WEIGHT.get(cat, 1.0)
+            score = total_occ * weight
+
+            rep = max(entries, key=lambda e: e["occurrence_count"])
+            rep_title = rep["title"]
+
+            all_tags_freq: dict[str, int] = {}
+            for e in entries:
+                for t2 in (e.get("tags") or "").split(","):
+                    t2 = t2.strip().lower()
+                    if t2 and len(t2) >= 3 and t2 not in _STOPWORDS:
+                        all_tags_freq[t2] = all_tags_freq.get(t2, 0) + 1
+            top_tags = [k for k, _ in sorted(all_tags_freq.items(), key=lambda x: -x[1])[:8]]
+
+            sample_entries = [
+                {"title": e["title"], "content": e["content"], "tags": e["tags"]}
+                for e in sorted(entries, key=lambda e: -e["occurrence_count"])[:3]
+            ]
+
+            existing_names.add(name)
+            candidates.append(
+                {
+                    "candidate_name": name,
+                    "source_cluster": tag,
+                    "cluster_type": "tag",
+                    "score": round(score, 2),
+                    "total_occurrences": total_occ,
+                    "entry_count": len(entries),
+                    "avg_confidence": round(avg_conf, 3),
+                    "category": cat,
+                    "top_tags": top_tags,
+                    "representative_title": rep_title,
+                    "sample_entries": sample_entries,
+                }
+            )
+
+            if len(candidates) >= limit * 2:
+                break
+
+    except sqlite3.Error:
+        pass
+    finally:
+        try:
+            db.close()
+        except Exception:
+            pass
+
+    candidates.sort(key=lambda c: -c["score"])
+    return candidates[:limit]
+
+
+def suggest(
+    db_path: Path | None = None,
+    skills_dir: Path | None = None,
+    min_occurrences: int = 3,
+    limit: int = 20,
+) -> dict:
+    """Run the full skill suggestion pipeline.
+
+    Returns a result dict suitable for JSON serialisation.
+    Does NOT write any files or modify any state.
+    """
+    if db_path is None:
+        db_path = DB_PATH
+    if skills_dir is None:
+        skills_dir = DEFAULT_SKILLS_DIR
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    existing_skills = _load_existing_skills(skills_dir)
+    existing_skill_names = [s["name"] for s in existing_skills]
+
+    raw_candidates = mine_patterns(db_path, min_occurrences=min_occurrences, limit=limit * 2)
+
+    suggestions: list[dict] = []
+    seen_names: set[str] = set()
+
+    for cand in raw_candidates:
+        name = cand["candidate_name"]
+        if name in seen_names:
+            continue
+        seen_names.add(name)
+
+        overlaps = _find_overlap(name, existing_skills)
+        draft = _make_skill_draft(
+            name=name,
+            title=cand["representative_title"],
+            top_tags=cand["top_tags"],
+            sample_entries=cand["sample_entries"],
+        )
+
+        suggestions.append(
+            {
+                "candidate_name": name,
+                "source_cluster": cand["source_cluster"],
+                "cluster_type": cand["cluster_type"],
+                "score": cand["score"],
+                "total_occurrences": cand["total_occurrences"],
+                "entry_count": cand["entry_count"],
+                "avg_confidence": cand["avg_confidence"],
+                "top_tags": cand["top_tags"],
+                "overlap_with_existing": overlaps,
+                "skill_draft": draft,
+            }
+        )
+
+        if len(suggestions) >= limit:
+            break
+
+    return {
+        "generated_at": now,
+        "min_occurrences": min_occurrences,
+        "db_path": str(db_path),
+        "db_exists": db_path.exists(),
+        "skills_dir": str(skills_dir),
+        "existing_skills_checked": existing_skill_names,
+        "suggestion_count": len(suggestions),
+        "suggestions": suggestions,
+    }
+
+
+def _print_text(result: dict) -> None:
+    """Print human-readable output."""
+    print("\n\U0001f50d Skill Suggestion Report")
+    print(f"   DB: {result['db_path']} (exists: {result['db_exists']})")
+    print(f"   Min occurrences: {result['min_occurrences']}")
+    print(f"   Existing skills checked: {len(result['existing_skills_checked'])}")
+    print(f"   Suggestions found: {result['suggestion_count']}")
+    print()
+
+    if not result["suggestions"]:
+        print("No skill candidates found above the threshold.")
+        if not result["db_exists"]:
+            print(f"  -> Knowledge DB not found at {result['db_path']}")
+            print("  -> Run `sk watch` or `sk index build` to populate the DB first.")
+        return
+
+    for i, sug in enumerate(result["suggestions"], 1):
+        overlaps = sug["overlap_with_existing"]
+        print(f"{'=' * 60}")
+        print(f"  Suggestion #{i}: {sug['candidate_name']}")
+        print(
+            f"  Score: {sug['score']} | Occurrences: {sug['total_occurrences']}"
+            f" | Entries: {sug['entry_count']}"
+        )
+        print(f"  Source: {sug['source_cluster']} ({sug['cluster_type']})")
+        if sug["top_tags"]:
+            print(f"  Tags: {', '.join(sug['top_tags'][:5])}")
+        if overlaps:
+            print(f"  \u26a0\ufe0f  Overlap with existing skills: {', '.join(overlaps)}")
+        else:
+            print("  \u2705 No overlap with existing skills")
+        print()
+        print("--- SKILL.md draft ---")
+        print(sug["skill_draft"])
+        print(f"{'=' * 60}")
+        print()
+
+    print(f"\u2705 {result['suggestion_count']} skill suggestion(s) generated.")
+    print("To validate a draft: python validate-skill.py <path/to/SKILL.md>")
+    print("Note: This tool suggests only -- it does NOT create or deploy skills.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for sk skill-suggest."""
+    parser = argparse.ArgumentParser(
+        description="Mine knowledge DB and propose new skill candidates (suggestion-only).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python skill-suggest.py
+  python skill-suggest.py --min-occurrences 3 --format json
+  python skill-suggest.py --db ~/.copilot/session-state/knowledge.db
+  python skill-suggest.py --skills-dir ./skills --limit 5
+        """,
+    )
+    parser.add_argument(
+        "--min-occurrences",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Minimum occurrence threshold for a topic to become a candidate (default: 3)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        dest="output_format",
+        help="Output format: text (default) or json",
+    )
+    parser.add_argument(
+        "--db",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=f"Path to knowledge.db (default: {DB_PATH})",
+    )
+    parser.add_argument(
+        "--skills-dir",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=f"Skills directory for dedup check (default: {DEFAULT_SKILLS_DIR})",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        metavar="N",
+        help="Maximum number of suggestions to return (default: 20)",
+    )
+
+    args = parser.parse_args(argv)
+
+    db_path = Path(args.db).expanduser() if args.db else DB_PATH
+    skills_dir = (
+        Path(args.skills_dir).expanduser() if args.skills_dir else DEFAULT_SKILLS_DIR
+    )
+
+    result = suggest(
+        db_path=db_path,
+        skills_dir=skills_dir,
+        min_occurrences=args.min_occurrences,
+        limit=args.limit,
+    )
+
+    if args.output_format == "json":
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        _print_text(result)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -166,6 +166,28 @@ class TestSkDirectCommands(unittest.TestCase):
     def test_anatomy_repo(self):
         self._assert_routes("anatomy", "anatomy-map.py", ["--repo", "/some/path"])
 
+    def test_skill_suggest(self):
+        self._assert_routes("skill-suggest", "skill-suggest.py")
+
+    def test_skill_suggest_json(self):
+        self._assert_routes("skill-suggest", "skill-suggest.py", ["--format", "json"])
+
+    def test_skill_suggest_min_occurrences(self):
+        self._assert_routes("skill-suggest", "skill-suggest.py", ["--min-occurrences", "3"])
+
+    def test_skill_suggest_json_with_min_occurrences(self):
+        self._assert_routes(
+            "skill-suggest", "skill-suggest.py",
+            ["--min-occurrences", "3", "--format", "json"],
+        )
+
+    def test_skill_suggest_script_exists(self):
+        """skill-suggest.py must exist in the tools directory."""
+        self.assertTrue(
+            (TOOLS_DIR / "skill-suggest.py").exists(),
+            "skill-suggest.py not found — sk skill-suggest would break",
+        )
+
 
 class TestSkHooksCompat(unittest.TestCase):
     def test_hooks_run_drops_run_subcommand(self):

--- a/tests/test_skill_suggest.py
+++ b/tests/test_skill_suggest.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+"""
+test_skill_suggest.py — Regression tests for skill-suggest.py.
+
+Tests: pattern mining, dedup/overlap, SKILL.md draft generation,
+validate-skill.py compatibility, and CLI argument parsing.
+
+Run:
+    python tests/test_skill_suggest.py
+"""
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+if os.name == "nt":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+REPO = Path(__file__).parent.parent
+ARTIFACT_DIR = REPO / ".skill-suggest-test-artifacts"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_module(mod_name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(mod_name, str(REPO / filename))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _reset_artifacts() -> None:
+    if ARTIFACT_DIR.exists():
+        for p in sorted(ARTIFACT_DIR.rglob("*"), reverse=True):
+            if p.is_file():
+                p.unlink(missing_ok=True)
+            elif p.is_dir():
+                p.rmdir()
+        ARTIFACT_DIR.rmdir()
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _make_knowledge_db(db_path: Path, entries: list[dict]) -> None:
+    """Create a minimal knowledge.db with the given entries."""
+    db = sqlite3.connect(str(db_path))
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS knowledge_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL DEFAULT 'test-session',
+            category TEXT NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            tags TEXT DEFAULT '',
+            confidence REAL DEFAULT 1.0,
+            occurrence_count INTEGER DEFAULT 1,
+            topic_key TEXT DEFAULT NULL,
+            wing TEXT DEFAULT '',
+            room TEXT DEFAULT ''
+        )
+        """
+    )
+    for e in entries:
+        db.execute(
+            """
+            INSERT INTO knowledge_entries
+                (session_id, category, title, content, tags,
+                 confidence, occurrence_count, topic_key)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                e.get("session_id", "sess-1"),
+                e.get("category", "pattern"),
+                e.get("title", "Untitled"),
+                e.get("content", ""),
+                e.get("tags", ""),
+                e.get("confidence", 1.0),
+                e.get("occurrence_count", 1),
+                e.get("topic_key", None),
+            ),
+        )
+    db.commit()
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test suite
+# ---------------------------------------------------------------------------
+
+class TestSlugify(unittest.TestCase):
+    """Unit tests for the _slugify helper."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_module("skill_suggest_slugify", "skill-suggest.py")
+
+    def test_simple_lower(self):
+        self.assertEqual(self.mod._slugify("Docker"), "docker")
+
+    def test_spaces_become_hyphens(self):
+        self.assertEqual(self.mod._slugify("hello world"), "hello-world")
+
+    def test_consecutive_specials_collapse(self):
+        self.assertEqual(self.mod._slugify("foo---bar"), "foo-bar")
+
+    def test_leading_trailing_stripped(self):
+        self.assertEqual(self.mod._slugify("--foo--"), "foo")
+
+    def test_digit_prefix_gets_prefix(self):
+        s = self.mod._slugify("1bad")
+        self.assertTrue(s.startswith("skill-"))
+
+    def test_empty_returns_unnamed(self):
+        self.assertEqual(self.mod._slugify(""), "unnamed-skill")
+
+    def test_max_length_64(self):
+        long = "a" * 100
+        self.assertLessEqual(len(self.mod._slugify(long)), 64)
+
+    def test_unicode_stripped(self):
+        s = self.mod._slugify("résumé builder")
+        self.assertRegex(s, r"^[a-z0-9][a-z0-9\-]*[a-z0-9]$")
+
+
+class TestTokenOverlap(unittest.TestCase):
+    """Unit tests for _token_overlap."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_module("skill_suggest_overlap", "skill-suggest.py")
+
+    def test_identical(self):
+        self.assertAlmostEqual(self.mod._token_overlap("docker", "docker"), 1.0)
+
+    def test_no_overlap(self):
+        self.assertAlmostEqual(self.mod._token_overlap("docker", "python"), 0.0)
+
+    def test_partial(self):
+        score = self.mod._token_overlap("docker-compose", "compose-network")
+        self.assertGreater(score, 0.0)
+        self.assertLess(score, 1.0)
+
+    def test_empty_strings(self):
+        self.assertAlmostEqual(self.mod._token_overlap("", "anything"), 0.0)
+
+
+class TestFindOverlap(unittest.TestCase):
+    """Unit tests for _find_overlap dedup logic."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_module("skill_suggest_dedup", "skill-suggest.py")
+
+    def test_exact_match(self):
+        existing = [{"name": "docker", "path": "/x/SKILL.md"}]
+        result = self.mod._find_overlap("docker", existing)
+        self.assertIn("docker", result)
+
+    def test_high_token_overlap(self):
+        existing = [{"name": "docker-compose", "path": "/x/SKILL.md"}]
+        result = self.mod._find_overlap("docker-compose-tutorial", existing)
+        self.assertIn("docker-compose", result)
+
+    def test_no_overlap(self):
+        existing = [{"name": "react-hooks", "path": "/x/SKILL.md"}]
+        result = self.mod._find_overlap("dynamodb-patterns", existing)
+        self.assertEqual(result, [])
+
+
+class TestMakeSkillDraft(unittest.TestCase):
+    """Unit tests for _make_skill_draft — verifies against validate-skill.py."""
+
+    @classmethod
+    def setUpClass(cls):
+        _reset_artifacts()
+        cls.suggest_mod = _load_module("skill_suggest_draft", "skill-suggest.py")
+        cls.validate_mod = _load_module("validate_skill_draft", "validate-skill.py")
+
+    def _validate_draft(self, draft: str, skill_name: str = "test-skill") -> tuple[list, list]:
+        """Write draft to artifact file and validate with validate-skill.py."""
+        skill_dir = ARTIFACT_DIR / skill_name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(draft, encoding="utf-8")
+        errors, warnings = self.validate_mod.validate(skill_md)
+        return errors, warnings
+
+    def test_basic_draft_no_errors(self):
+        draft = self.suggest_mod._make_skill_draft(
+            name="docker-patterns",
+            title="Docker Patterns",
+            top_tags=["docker", "container", "compose"],
+            sample_entries=[
+                {"title": "Use bind mounts for dev", "content": "Bind mounts sync host and container.", "tags": "docker"},
+            ],
+        )
+        errors, _warnings = self._validate_draft(draft, "docker-patterns")
+        self.assertEqual(errors, [], f"Draft validation errors: {errors}")
+
+    def test_draft_has_required_sections(self):
+        draft = self.suggest_mod._make_skill_draft(
+            name="python-patterns",
+            title="Python Patterns",
+            top_tags=["python", "stdlib", "patterns"],
+            sample_entries=[],
+        )
+        self.assertIn("## When to use", draft)
+        self.assertIn("## Workflow", draft)
+        self.assertIn("<example>", draft)
+        self.assertIn("</example>", draft)
+        self.assertIn("# Python Patterns", draft)
+
+    def test_draft_frontmatter_has_name_and_description(self):
+        draft = self.suggest_mod._make_skill_draft(
+            name="api-design",
+            title="API Design",
+            top_tags=["api", "rest"],
+            sample_entries=[],
+        )
+        self.assertIn("name: api-design", draft)
+        self.assertIn("description:", draft)
+
+    def test_draft_description_has_trigger_phrases(self):
+        draft = self.suggest_mod._make_skill_draft(
+            name="ci-patterns",
+            title="CI Patterns",
+            top_tags=["ci", "pipeline"],
+            sample_entries=[],
+        )
+        desc_lower = draft.lower()
+        has_trigger = any(
+            p in desc_lower
+            for p in ["use when", "trigger", "activat", "invoke", "keyword"]
+        )
+        self.assertTrue(has_trigger, "Description must contain a trigger phrase")
+
+    def test_draft_under_500_lines(self):
+        draft = self.suggest_mod._make_skill_draft(
+            name="test-skill",
+            title="Test Skill",
+            top_tags=["test", "unit", "pytest"],
+            sample_entries=[
+                {"title": f"Pattern {i}", "content": "Some content.", "tags": "test"}
+                for i in range(5)
+            ],
+        )
+        self.assertLessEqual(len(draft.splitlines()), 500)
+
+    def test_draft_name_slug_is_valid(self):
+        """The name in the draft must satisfy the validator's name rules."""
+        draft = self.suggest_mod._make_skill_draft(
+            name="git-workflow",
+            title="Git Workflow",
+            top_tags=["git", "branch"],
+            sample_entries=[],
+        )
+        errors, _ = self._validate_draft(draft, "git-workflow")
+        # Only errors about name validation should be absent
+        name_errors = [e for e in errors if "name" in e.lower()]
+        self.assertEqual(name_errors, [], f"Name validation errors: {name_errors}")
+
+    def test_no_security_violations_in_draft(self):
+        """Generated SKILL.md drafts must not trigger security rules."""
+        draft = self.suggest_mod._make_skill_draft(
+            name="auth-patterns",
+            title="Auth Patterns",
+            top_tags=["auth", "jwt", "token"],
+            sample_entries=[
+                {"title": "JWT expiry", "content": "Set short TTL for access tokens.", "tags": "auth,jwt"}
+            ],
+        )
+        findings = self.validate_mod.validate_security(draft)
+        critical_high = [f for f in findings if f.severity in ("critical", "high")]
+        self.assertEqual(critical_high, [], f"Security violations in draft: {critical_high}")
+
+
+class TestMinePatterns(unittest.TestCase):
+    """Integration tests for mine_patterns against a real SQLite test DB."""
+
+    @classmethod
+    def setUpClass(cls):
+        _reset_artifacts()
+        cls.mod = _load_module("skill_suggest_mine", "skill-suggest.py")
+        cls.db_path = ARTIFACT_DIR / "test-knowledge.db"
+
+        # Create DB with enough entries to pass min_occurrences=3
+        _make_knowledge_db(
+            cls.db_path,
+            [
+                # Topic-key cluster: "docker" with 4 occurrences
+                {
+                    "title": "Docker bind mounts",
+                    "content": "Use bind mounts in dev.",
+                    "tags": "docker,container",
+                    "category": "pattern",
+                    "occurrence_count": 2,
+                    "topic_key": "docker",
+                },
+                {
+                    "title": "Docker volumes for data",
+                    "content": "Named volumes persist data.",
+                    "tags": "docker,volume",
+                    "category": "pattern",
+                    "occurrence_count": 2,
+                    "topic_key": "docker",
+                },
+                # Tag cluster (no topic_key): "python" with 5 occurrences
+                {
+                    "title": "Python type hints",
+                    "content": "Use type hints for clarity.",
+                    "tags": "python,typing",
+                    "category": "pattern",
+                    "occurrence_count": 3,
+                    "topic_key": None,
+                },
+                {
+                    "title": "Python dataclasses",
+                    "content": "Prefer dataclasses over dicts.",
+                    "tags": "python,dataclasses",
+                    "category": "decision",
+                    "occurrence_count": 2,
+                    "topic_key": None,
+                },
+                # Below threshold (occurrence_count=1, topic_key not set)
+                {
+                    "title": "Single occurrence",
+                    "content": "Rare entry.",
+                    "tags": "rare",
+                    "category": "mistake",
+                    "occurrence_count": 1,
+                    "topic_key": None,
+                },
+            ],
+        )
+
+    def test_mine_returns_list(self):
+        result = self.mod.mine_patterns(self.db_path, min_occurrences=3)
+        self.assertIsInstance(result, list)
+
+    def test_docker_topic_key_cluster_found(self):
+        result = self.mod.mine_patterns(self.db_path, min_occurrences=3)
+        names = [c["candidate_name"] for c in result]
+        self.assertIn("docker", names, f"Expected 'docker' cluster in {names}")
+
+    def test_python_tag_cluster_found(self):
+        result = self.mod.mine_patterns(self.db_path, min_occurrences=3)
+        names = [c["candidate_name"] for c in result]
+        self.assertIn("python", names, f"Expected 'python' tag cluster in {names}")
+
+    def test_below_threshold_excluded(self):
+        result = self.mod.mine_patterns(self.db_path, min_occurrences=3)
+        names = [c["candidate_name"] for c in result]
+        self.assertNotIn("rare", names, "Entries below threshold must be excluded")
+
+    def test_missing_db_returns_empty(self):
+        result = self.mod.mine_patterns(ARTIFACT_DIR / "nonexistent.db", min_occurrences=1)
+        self.assertEqual(result, [])
+
+    def test_candidates_have_required_fields(self):
+        result = self.mod.mine_patterns(self.db_path, min_occurrences=3)
+        required = {
+            "candidate_name", "source_cluster", "cluster_type",
+            "score", "total_occurrences", "entry_count",
+            "avg_confidence", "category", "top_tags",
+            "representative_title", "sample_entries",
+        }
+        for c in result:
+            missing = required - set(c.keys())
+            self.assertEqual(missing, set(), f"Candidate missing fields: {missing}")
+
+    def test_results_sorted_by_score_desc(self):
+        result = self.mod.mine_patterns(self.db_path, min_occurrences=1)
+        scores = [c["score"] for c in result]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_limit_respected(self):
+        result = self.mod.mine_patterns(self.db_path, min_occurrences=1, limit=1)
+        self.assertLessEqual(len(result), 1)
+
+
+class TestSuggest(unittest.TestCase):
+    """Tests for the suggest() pipeline function."""
+
+    @classmethod
+    def setUpClass(cls):
+        _reset_artifacts()
+        cls.mod = _load_module("skill_suggest_pipeline", "skill-suggest.py")
+        cls.db_path = ARTIFACT_DIR / "suggest-knowledge.db"
+        cls.skills_dir = ARTIFACT_DIR / "test-skills"
+
+        _make_knowledge_db(
+            cls.db_path,
+            [
+                {
+                    "title": "Git rebase workflow",
+                    "content": "Use interactive rebase to clean commits.",
+                    "tags": "git,rebase,workflow",
+                    "category": "pattern",
+                    "occurrence_count": 4,
+                    "topic_key": "git-workflow",
+                },
+                {
+                    "title": "Git commit hygiene",
+                    "content": "One logical change per commit.",
+                    "tags": "git,commit",
+                    "category": "decision",
+                    "occurrence_count": 2,
+                    "topic_key": "git-workflow",
+                },
+            ],
+        )
+
+        # Create a fake existing skill for dedup testing
+        existing_skill_dir = cls.skills_dir / "git-workflow"
+        existing_skill_dir.mkdir(parents=True, exist_ok=True)
+        (existing_skill_dir / "SKILL.md").write_text(
+            "---\nname: git-workflow\ndescription: Git workflow skill.\n---\n# Git Workflow\n",
+            encoding="utf-8",
+        )
+
+    def test_suggest_returns_dict_with_required_keys(self):
+        result = self.mod.suggest(
+            db_path=self.db_path,
+            skills_dir=ARTIFACT_DIR / "empty-skills",
+            min_occurrences=3,
+        )
+        required = {
+            "generated_at", "min_occurrences", "db_path", "db_exists",
+            "skills_dir", "existing_skills_checked",
+            "suggestion_count", "suggestions",
+        }
+        missing = required - set(result.keys())
+        self.assertEqual(missing, set(), f"Missing keys: {missing}")
+
+    def test_db_exists_true_when_present(self):
+        result = self.mod.suggest(db_path=self.db_path, min_occurrences=1)
+        self.assertTrue(result["db_exists"])
+
+    def test_db_exists_false_when_missing(self):
+        result = self.mod.suggest(db_path=ARTIFACT_DIR / "missing.db", min_occurrences=1)
+        self.assertFalse(result["db_exists"])
+        self.assertEqual(result["suggestions"], [])
+
+    def test_suggestions_have_required_fields(self):
+        result = self.mod.suggest(
+            db_path=self.db_path,
+            skills_dir=ARTIFACT_DIR / "empty-skills",
+            min_occurrences=3,
+        )
+        required = {
+            "candidate_name", "source_cluster", "cluster_type",
+            "score", "total_occurrences", "entry_count", "avg_confidence",
+            "top_tags", "overlap_with_existing", "skill_draft",
+        }
+        for sug in result["suggestions"]:
+            missing = required - set(sug.keys())
+            self.assertEqual(missing, set(), f"Suggestion missing fields: {missing}")
+
+    def test_overlap_detected_against_existing_skill(self):
+        result = self.mod.suggest(
+            db_path=self.db_path,
+            skills_dir=self.skills_dir,
+            min_occurrences=3,
+        )
+        # "git-workflow" topic_key maps to "git-workflow" candidate — exact match with existing
+        overlapping = [
+            s for s in result["suggestions"]
+            if s["candidate_name"] == "git-workflow"
+        ]
+        if overlapping:
+            self.assertIn("git-workflow", overlapping[0]["overlap_with_existing"])
+
+    def test_skill_draft_in_each_suggestion(self):
+        result = self.mod.suggest(
+            db_path=self.db_path,
+            skills_dir=ARTIFACT_DIR / "empty-skills",
+            min_occurrences=3,
+        )
+        for sug in result["suggestions"]:
+            self.assertIn("---", sug["skill_draft"])
+            self.assertIn("name:", sug["skill_draft"])
+            self.assertIn("<example>", sug["skill_draft"])
+
+    def test_json_serializable(self):
+        result = self.mod.suggest(db_path=self.db_path, min_occurrences=1)
+        # Must not raise
+        serialized = json.dumps(result)
+        decoded = json.loads(serialized)
+        self.assertEqual(decoded["suggestion_count"], result["suggestion_count"])
+
+    def test_existing_skills_loaded(self):
+        result = self.mod.suggest(
+            db_path=self.db_path,
+            skills_dir=self.skills_dir,
+            min_occurrences=1,
+        )
+        self.assertIn("git-workflow", result["existing_skills_checked"])
+
+
+class TestValidatorCompatibility(unittest.TestCase):
+    """End-to-end: generate a draft and verify it passes validate-skill.py."""
+
+    @classmethod
+    def setUpClass(cls):
+        _reset_artifacts()
+        cls.suggest_mod = _load_module("skill_suggest_e2e", "skill-suggest.py")
+        cls.validate_mod = _load_module("validate_skill_e2e", "validate-skill.py")
+        cls.db_path = ARTIFACT_DIR / "e2e-knowledge.db"
+
+        _make_knowledge_db(
+            cls.db_path,
+            [
+                {
+                    "title": "Async Python patterns",
+                    "content": "Use asyncio.gather for concurrent IO-bound tasks.",
+                    "tags": "python,asyncio,async,concurrency",
+                    "category": "pattern",
+                    "occurrence_count": 3,
+                    "topic_key": "async-python",
+                },
+                {
+                    "title": "Avoid blocking calls in async",
+                    "content": "Never call time.sleep() inside an async coroutine.",
+                    "tags": "python,asyncio,async",
+                    "category": "mistake",
+                    "occurrence_count": 2,
+                    "topic_key": "async-python",
+                },
+            ],
+        )
+
+    def test_generated_draft_passes_validator(self):
+        result = self.suggest_mod.suggest(
+            db_path=self.db_path,
+            skills_dir=ARTIFACT_DIR / "no-skills",
+            min_occurrences=3,
+        )
+        self.assertGreater(result["suggestion_count"], 0, "Expected at least one suggestion")
+
+        sug = result["suggestions"][0]
+        name = sug["candidate_name"]
+        draft = sug["skill_draft"]
+
+        skill_dir = ARTIFACT_DIR / "e2e-skill" / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(draft, encoding="utf-8")
+
+        errors, _warnings = self.validate_mod.validate(skill_md)
+        self.assertEqual(errors, [], f"Validator errors for '{name}': {errors}")
+
+
+class TestCliMain(unittest.TestCase):
+    """Tests for the CLI main() entry point."""
+
+    @classmethod
+    def setUpClass(cls):
+        _reset_artifacts()
+        cls.mod = _load_module("skill_suggest_cli", "skill-suggest.py")
+        cls.db_path = ARTIFACT_DIR / "cli-knowledge.db"
+
+        _make_knowledge_db(
+            cls.db_path,
+            [
+                {
+                    "title": "CI caching",
+                    "content": "Cache node_modules in CI.",
+                    "tags": "ci,cache,devops",
+                    "category": "pattern",
+                    "occurrence_count": 4,
+                    "topic_key": "ci-caching",
+                },
+            ],
+        )
+
+    def test_main_json_format_exits_0(self):
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = self.mod.main(
+                [
+                    "--db", str(self.db_path),
+                    "--format", "json",
+                    "--min-occurrences", "3",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        output = buf.getvalue()
+        data = json.loads(output)
+        self.assertIn("suggestions", data)
+        self.assertIn("min_occurrences", data)
+
+    def test_main_text_format_exits_0(self):
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = self.mod.main(
+                [
+                    "--db", str(self.db_path),
+                    "--format", "text",
+                    "--min-occurrences", "3",
+                ]
+            )
+        self.assertEqual(rc, 0)
+
+    def test_main_missing_db_exits_0(self):
+        """Missing DB should not crash — just report 0 suggestions."""
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = self.mod.main(
+                [
+                    "--db", str(ARTIFACT_DIR / "does-not-exist.db"),
+                    "--format", "json",
+                    "--min-occurrences", "1",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        data = json.loads(buf.getvalue())
+        self.assertFalse(data["db_exists"])
+
+    def test_main_json_min_occurrences_respected(self):
+        """With min-occurrences=999, no suggestions should be returned."""
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = self.mod.main(
+                [
+                    "--db", str(self.db_path),
+                    "--format", "json",
+                    "--min-occurrences", "999",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        data = json.loads(buf.getvalue())
+        self.assertEqual(data["suggestion_count"], 0)
+
+    def test_main_limit_respected(self):
+        """--limit 1 should cap suggestions at 1."""
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = self.mod.main(
+                [
+                    "--db", str(self.db_path),
+                    "--format", "json",
+                    "--min-occurrences", "1",
+                    "--limit", "1",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        data = json.loads(buf.getvalue())
+        self.assertLessEqual(len(data["suggestions"]), 1)
+
+
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add standalone `skill-suggest.py` to mine repeated patterns from the existing knowledge DB and generate conservative SKILL.md drafts
- wire `sk skill-suggest` through both `sk.py` and the Rust `sk` front door
- add focused tests for mining, dedup, draft validation compatibility, and CLI routing

## Notes
- uses the repo's existing `~/.copilot/session-state/knowledge.db` convention
- suggestion-only surface: no auto-create, no writes into `skills/`

Closes #117