### PR TITLE
feat(tentacle): add sk tentacle pr subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ KNOWLEDGE.md
 # Local tentacle / multi-agent orchestration artifacts
 .octogent/
 .*-test-artifacts/
+_test_tentacle_pr_scratch/
 
 # browse-ui Node.js artifacts
 browse-ui/node_modules/

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -960,7 +960,7 @@ JSON schema (all top-level keys are always present; future resilience fields def
 ```
 goal init → (dispatch wave of tentacles) → handoffs collected
   → goal gate pass / goal criteria check → goal eval --decision continue
-  → (new wave if goal unmet) → goal eval --decision complete → git commit + close
+  → (new wave if goal unmet) → goal eval --decision complete → sk tentacle pr
 
 Human gate path:
   goal gate add G1 → (human reviews) → goal gate approve/reject G1
@@ -974,6 +974,67 @@ Record goal-eval evidence with:
 sk tentacle verify <name> "<check-command>" --label "goal-eval"
 # fallback: python3 ~/.copilot/tools/tentacle.py verify <name> "<check-command>" --label "goal-eval"
 ```
+
+---
+
+## Automated PR Creation — `sk tentacle pr`
+
+After `goal eval --decision complete`, run `sk tentacle pr` to automate the full
+git add → commit → push → `gh pr create` pipeline.
+
+**Requires:** goal status must be `completed`. The command exits non-zero if the goal
+is still `active`, `paused`, `abandoned`, or not initialized.
+
+```bash
+# Basic usage (auto-generates commit message, PR title, and PR body)
+sk tentacle pr
+# fallback: python3 ~/.copilot/tools/tentacle.py pr
+
+# Override PR title and base branch
+sk tentacle pr --title "feat: Add export API" --base main
+
+# Close a linked issue automatically (adds "Closes #114" to PR body)
+sk tentacle pr --issue 114
+
+# Dry-run: print commit message and PR body without running git or gh
+sk tentacle pr --dry-run
+
+# Full options
+sk tentacle pr \
+  --title "feat(export): Add billing export" \
+  --base main \
+  --commit-msg "feat(export): Implement billing export endpoint" \
+  --issue 114 \
+  --label "feature" \
+  --reviewer octocat \
+  --repo owner/repo \
+  --dry-run
+```
+
+### What it does
+
+1. **Validates goal state** — exits 1 if goal status is not `completed`.
+2. **Collects tentacle data** — reads `handoff.md` and `meta.json` for every tentacle
+   linked to the goal.
+3. **Generates a conventional commit message** — format: `feat(<scope>): <title>`.
+   Scope is derived from `goal_id` or the first linked tentacle name.
+4. **Generates a structured PR body** with six sections:
+   - **What / Why / How** — goal title, description, and per-tentacle implementation summaries.
+   - **Changes** — table of every file changed (from `Changed:` lines in handoffs).
+   - **Decision Points** — all `eval_history` entries with decision, date, and criteria/gate counts.
+   - **Unresolved Blockers** — tentacles with `BLOCKED`, `AMBIGUOUS`, `TOO_BIG`, or `REGRESSED` status.
+   - **Test Results** — verification records from `meta.json` (pass/fail icon, duration).
+   - **Closing keyword** — `Closes #<issue>` when `--issue` is provided.
+5. **Runs git add -A → git commit → git push** (sets `--set-upstream origin <branch>` when no remote tracking branch is configured).
+6. **Runs `gh pr create`** non-interactively with the generated title, body, and base branch.
+
+### Safety notes
+
+- `--dry-run` prints the commit message and PR body without touching git or gh.
+- The command uses `subprocess.run` with explicit argument lists — no shell injection.
+- Works on Windows and Unix.
+- If `git push` fails (e.g. no remote configured), the command exits with the git exit code.
+- If `gh` is not installed or not authenticated, `gh pr create` will fail with a clear error.
 
 ---
 

--- a/tentacle.py
+++ b/tentacle.py
@@ -41,6 +41,7 @@ Usage:
     python3 ~/.copilot/tools/tentacle.py goal budget [--max-iterations N] [--max-tentacles N] [--timeout MINUTES] [--format text|json]
     python3 ~/.copilot/tools/tentacle.py goal next-iter
     python3 ~/.copilot/tools/tentacle.py goal verify-loop [--id <id>] [--max-retries N] [--retry-delay SECONDS] [--timeout SECONDS] [--escalate]
+    python3 ~/.copilot/tools/tentacle.py pr [--title <title>] [--base <branch>] [--commit-msg <msg>] [--issue <ref>] [--label <label>] [--reviewer <login>] [--repo <owner/repo>] [--dry-run]
 
 Environment:
     TENTACLE_SESSION_DIR — Override session directory (default: auto-detect)
@@ -6628,6 +6629,471 @@ def cmd_marker_cleanup(args):
         print(f"\n✅ Removed {removed}/{len(stale_entries)} stale entries.")
 
 
+# ---------------------------------------------------------------------------
+# PR automation — sk tentacle pr
+# ---------------------------------------------------------------------------
+
+
+def _pr_collect_handoffs(tentacles_dir: Path, tentacle_names: list[str]) -> list[dict]:
+    """Collect parsed handoff data for each named tentacle.
+
+    Returns list of dicts:
+      {"name": str, "text": str, "status": str|None,
+       "changed_files": list[str], "has_blockers": bool}
+    """
+    results: list[dict] = []
+    for name in tentacle_names:
+        hp = tentacles_dir / name / "handoff.md"
+        if not hp.exists():
+            continue
+        try:
+            text = hp.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        # Extract STATUS: lines
+        status_m = re.search(r"^STATUS:\s*(\S+)", text, flags=re.MULTILINE)
+        status = status_m.group(1).strip() if status_m else None
+        # Extract Changed: lines (all occurrences)
+        changed = re.findall(r"^Changed:\s*(.+)", text, flags=re.MULTILINE)
+        changed = [c.strip() for c in changed if c.strip()]
+        has_blockers = status in HANDOFF_TRIAGE_STATUSES
+        results.append(
+            {
+                "name": name,
+                "text": text,
+                "status": status,
+                "changed_files": changed,
+                "has_blockers": has_blockers,
+            }
+        )
+    return results
+
+
+def _pr_collect_verifications(tentacles_dir: Path, tentacle_names: list[str]) -> list[dict]:
+    """Collect verification records from meta.json for each named tentacle.
+
+    Returns list of dicts: {"tentacle": str, "label": str, "exit_code": int,
+                             "command": str, "duration_seconds": float}
+    """
+    results: list[dict] = []
+    for name in tentacle_names:
+        mp = tentacles_dir / name / "meta.json"
+        if not mp.exists():
+            continue
+        try:
+            meta = json.loads(mp.read_text(encoding="utf-8", errors="replace"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        for v in meta.get("verifications") or []:
+            if not isinstance(v, dict):
+                continue
+            results.append(
+                {
+                    "tentacle": name,
+                    "label": v.get("label", v.get("command", "?"))[:60],
+                    "exit_code": v.get("exit_code", -1),
+                    "command": v.get("command", "?")[:80],
+                    "duration_seconds": v.get("duration_seconds", 0.0),
+                }
+            )
+    return results
+
+
+def _pr_generate_commit_message(goal_title: str, goal_id: str | None, tentacle_names: list[str]) -> str:
+    """Generate a conventional commit message from the goal title.
+
+    Format: feat(<scope>): <summary>
+
+    The scope is derived from the goal title or goal_id.
+    The summary is the goal title lowercased and normalized.
+    """
+    # Derive conventional commit scope from goal_id or tentacle name prefix
+    if goal_id:
+        scope = goal_id[:30].lower().replace(" ", "-")
+    elif tentacle_names:
+        # Use a common prefix of the tentacle names as scope
+        first = tentacle_names[0]
+        # Strip wave/iter prefix patterns like "wave27-" or "iter1-"
+        scope_part = re.sub(r"^(wave\d+-|iter\d+-)", "", first)[:30]
+        scope = scope_part if scope_part else first[:30]
+    else:
+        scope = "tentacle"
+
+    # Derive conventional commit subject from goal title
+    subject = goal_title.strip()
+    # Capitalize first letter and truncate to 72 chars (commit subject limit)
+    if subject:
+        subject = subject[0].upper() + subject[1:]
+    # Remove trailing period
+    subject = subject.rstrip(".")
+    # Truncate entire "feat(scope): subject" to 72 chars
+    prefix = f"feat({scope}): "
+    max_subj_len = 72 - len(prefix)
+    if len(subject) > max_subj_len:
+        subject = subject[: max_subj_len - 1] + "…"
+
+    return f"{prefix}{subject}"
+
+
+def _pr_generate_body(
+    goal_state: dict,
+    handoffs: list[dict],
+    verifications: list[dict],
+    tentacle_names: list[str],
+    issue_ref: str | None = None,
+) -> str:
+    """Generate a structured PR body from goal state and tentacle data.
+
+    Sections:
+      ## What / Why / How
+      ## Changes
+      ## Decision Points
+      ## Unresolved Blockers
+      ## Test Results
+    """
+    title = goal_state.get("title", "(untitled)")
+    desc = goal_state.get("description", "")
+    eval_history: list = goal_state.get("eval_history") or []
+    criteria: list = goal_state.get("success_criteria") or []
+
+    lines: list[str] = []
+
+    # ── What / Why / How ─────────────────────────────────────────────────────
+    lines.append("## What / Why / How")
+    lines.append("")
+    lines.append(f"**Goal:** {title}")
+    if desc and desc.strip():
+        lines.append("")
+        for para in desc.strip().splitlines():
+            lines.append(para)
+    lines.append("")
+
+    # Derive What/Why/How from handoff messages (first non-empty handoff text per tentacle)
+    what_lines: list[str] = []
+    for h in handoffs:
+        first_entry_m = re.search(r"## \[.*?\]\n\n(.*?)(?=\n##|\nSTATUS:|\nChanged:|\Z)", h["text"], re.DOTALL)
+        if first_entry_m:
+            entry_text = first_entry_m.group(1).strip()
+            if entry_text:
+                snippet = entry_text[:200].split("\n")[0].strip()
+                if snippet:
+                    what_lines.append(f"- **{h['name']}**: {snippet}")
+
+    if what_lines:
+        lines.append("**Implementation summaries:**")
+        lines.extend(what_lines)
+        lines.append("")
+
+    if criteria:
+        verified = [c for c in criteria if c.get("status") == "verified"]
+        lines.append(f"**Success criteria:** {len(verified)}/{len(criteria)} verified")
+        lines.append("")
+
+    if issue_ref:
+        lines.append(f"Closes {issue_ref}")
+        lines.append("")
+
+    # ── Changes table ─────────────────────────────────────────────────────────
+    lines.append("## Changes")
+    lines.append("")
+
+    # Collect all changed files with the tentacle that changed them
+    file_to_tentacles: dict[str, list[str]] = {}
+    for h in handoffs:
+        for cf in h["changed_files"]:
+            file_to_tentacles.setdefault(cf, []).append(h["name"])
+
+    if file_to_tentacles:
+        lines.append("| File | Changed by |")
+        lines.append("|------|-----------|")
+        for fpath, names in file_to_tentacles.items():
+            names_str = ", ".join(names[:3])
+            lines.append(f"| `{fpath}` | {names_str} |")
+    else:
+        lines.append("_(No file-level change records found in handoffs.)_")
+
+    lines.append("")
+
+    # ── Decision points ───────────────────────────────────────────────────────
+    lines.append("## Decision Points")
+    lines.append("")
+
+    if eval_history:
+        for ev in eval_history:
+            iteration = ev.get("iteration", "?")
+            decision = ev.get("decision", "?")
+            notes = ev.get("notes", "").strip()
+            evaluated_at = ev.get("evaluated_at", "")[:10]  # date only
+            criteria_verified = ev.get("criteria_verified")
+            criteria_total = ev.get("criteria_total")
+            gates_passed = ev.get("gates_passed")
+            gates_total = ev.get("gates_total")
+
+            summary_parts = [f"iter-{iteration}: **{decision}**"]
+            if evaluated_at:
+                summary_parts.append(f"({evaluated_at})")
+            if criteria_verified is not None and criteria_total is not None:
+                summary_parts.append(f"criteria {criteria_verified}/{criteria_total}")
+            if gates_passed is not None and gates_total is not None:
+                summary_parts.append(f"gates {gates_passed}/{gates_total}")
+
+            lines.append(f"- {' '.join(summary_parts)}")
+            if notes:
+                lines.append(f"  > {notes[:120]}")
+    else:
+        lines.append("_(No evaluation history recorded.)_")
+
+    lines.append("")
+
+    # ── Unresolved blockers ───────────────────────────────────────────────────
+    lines.append("## Unresolved Blockers")
+    lines.append("")
+
+    blocker_handoffs = [h for h in handoffs if h["has_blockers"]]
+    if blocker_handoffs:
+        for h in blocker_handoffs:
+            lines.append(f"- **{h['name']}** (STATUS: {h['status']})")
+            # Extract the first meaningful line of the handoff as context
+            first_m = re.search(r"## \[.*?\]\n\n(.+)", h["text"])
+            if first_m:
+                ctx = first_m.group(1).strip()[:120]
+                lines.append(f"  > {ctx}")
+    else:
+        lines.append("_(None — all tentacles completed without blocking status.)_")
+
+    lines.append("")
+
+    # ── Test results summary ──────────────────────────────────────────────────
+    lines.append("## Test Results")
+    lines.append("")
+
+    if verifications:
+        passed = sum(1 for v in verifications if v["exit_code"] == 0)
+        total = len(verifications)
+        lines.append(f"**{passed}/{total} verification(s) passed**")
+        lines.append("")
+        lines.append("| Tentacle | Check | Result | Duration |")
+        lines.append("|----------|-------|--------|----------|")
+        for v in verifications:
+            icon = "✅" if v["exit_code"] == 0 else "❌"
+            dur = f"{v['duration_seconds']:.1f}s" if v["duration_seconds"] else "—"
+            lines.append(f"| {v['tentacle']} | `{v['label']}` | {icon} | {dur} |")
+    else:
+        lines.append("_(No verification records found in tentacle metadata.)_")
+
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _pr_run_subprocess_safe(
+    cmd: list[str],
+    *,
+    cwd: str | None = None,
+    timeout: int = 60,
+    input_text: str | None = None,
+) -> tuple[int, str, str]:
+    """Run a subprocess safely on Windows and Unix.
+
+    Returns (exit_code, stdout, stderr).  Never raises — returns exit_code=-1 on error.
+    """
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=cwd,
+            timeout=timeout,
+            input=input_text,
+        )
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return -1, "", f"TIMEOUT after {timeout}s"
+    except FileNotFoundError as exc:
+        return -1, "", f"Command not found: {exc}"
+    except Exception as exc:
+        return -1, "", f"ERROR: {exc}"
+
+
+def cmd_pr(args) -> None:
+    """Automate git add -A, commit, push, and gh pr create from a completed goal.
+
+    Requires goal-complete state (goal.json status == 'completed').  Generates a
+    conventional commit message and PR body from all linked tentacle handoffs.
+
+    Safety gate: exits non-zero if goal is not yet completed.
+    """
+    tentacles = get_tentacles_dir(args.session_dir)
+    goal_state = _goal_load(tentacles)
+
+    # ── Goal-complete gate (hard requirement) ─────────────────────────────────
+    if not goal_state:
+        print(
+            "ERROR: No goal.json found. Run `tentacle.py goal init` first "
+            "and complete the goal before using `tentacle pr`.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    current_status = goal_state.get("status", "")
+    if current_status != GOAL_STATUS_COMPLETED:
+        print(
+            f"ERROR: Goal is not completed (status: {current_status!r}). "
+            "Run `tentacle.py goal eval --decision complete` first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    goal_title: str = goal_state.get("title", "Implement goal")
+    goal_id: str | None = goal_state.get("goal_id")
+    tentacle_names: list[str] = list(goal_state.get("tentacles") or [])
+
+    # ── Collect data from tentacles ───────────────────────────────────────────
+    handoffs = _pr_collect_handoffs(tentacles, tentacle_names)
+    verifications = _pr_collect_verifications(tentacles, tentacle_names)
+
+    # ── Determine working directory (worktree > git root > cwd) ──────────────
+    git_root = find_git_root()
+    work_dir = str(git_root) if git_root else None
+
+    # ── Generate commit message ───────────────────────────────────────────────
+    commit_msg = getattr(args, "commit_msg", None) or _pr_generate_commit_message(
+        goal_title, goal_id, tentacle_names
+    )
+
+    # ── Generate PR body ──────────────────────────────────────────────────────
+    issue_ref: str | None = getattr(args, "issue", None)
+    # Bare numeric refs (e.g. "114") become "#114".
+    # Existing "#NNN", "owner/repo#NNN", and URL forms must remain unchanged.
+    if (
+        issue_ref
+        and not issue_ref.startswith("#")
+        and not issue_ref.startswith("https://")
+        and "#" not in issue_ref
+    ):
+        issue_ref = f"#{issue_ref}"
+
+    pr_title: str = getattr(args, "title", None) or goal_title
+    pr_base: str = getattr(args, "base", None) or "main"
+    pr_body = _pr_generate_body(goal_state, handoffs, verifications, tentacle_names, issue_ref)
+
+    dry_run: bool = getattr(args, "dry_run", False)
+
+    print(f"🔀 sk tentacle pr — goal: {goal_title!r} (status: completed)")
+    print(f"   Tentacles: {len(tentacle_names)} | Handoffs: {len(handoffs)} | Verifications: {len(verifications)}")
+    print()
+    print(f"📝 Commit message: {commit_msg}")
+    print(f"📋 PR title: {pr_title}")
+    print(f"   Base branch: {pr_base}")
+    if issue_ref:
+        print(f"   Closes: {issue_ref}")
+    print()
+
+    if dry_run:
+        print("🔍 DRY RUN — git/gh commands will NOT be executed.")
+        print()
+        print("── Commit message ──────────────────────────────────────────────────────")
+        print(commit_msg)
+        print()
+        print("── PR body ─────────────────────────────────────────────────────────────")
+        print(pr_body)
+        return
+
+    # ── git add -A ────────────────────────────────────────────────────────────
+    print("▶  git add -A")
+    rc, out, err = _pr_run_subprocess_safe(["git", "add", "-A"], cwd=work_dir, timeout=30)
+    if rc != 0:
+        print(f"ERROR: git add -A failed (exit {rc}):\n{err}", file=sys.stderr)
+        sys.exit(rc if rc > 0 else 1)
+
+    # ── git commit ────────────────────────────────────────────────────────────
+    print(f"▶  git commit -m {commit_msg!r}")
+    rc, out, err = _pr_run_subprocess_safe(
+        ["git", "commit", "-m", commit_msg],
+        cwd=work_dir,
+        timeout=30,
+    )
+    if rc != 0:
+        # Exit 1 with "nothing to commit" is not a failure — warn and continue
+        combined = (out + err).lower()
+        if "nothing to commit" in combined or "nothing added to commit" in combined:
+            print("⚠️  Nothing to commit — working tree is clean. Proceeding to push.")
+        else:
+            print(f"ERROR: git commit failed (exit {rc}):\n{err}", file=sys.stderr)
+            sys.exit(rc if rc > 0 else 1)
+    else:
+        if out:
+            print(f"   {out.splitlines()[0]}")
+
+    # ── git push ──────────────────────────────────────────────────────────────
+    print("▶  git push")
+    push_cmd = ["git", "push"]
+    # Add --set-upstream if no upstream is configured (best-effort check)
+    rc_check, tracking, _ = _pr_run_subprocess_safe(
+        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        cwd=work_dir,
+        timeout=15,
+    )
+    if rc_check != 0:
+        # No upstream: push with --set-upstream to origin HEAD
+        rc_branch, branch_name, _ = _pr_run_subprocess_safe(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=work_dir,
+            timeout=15,
+        )
+        branch = branch_name.strip() if rc_branch == 0 else "HEAD"
+        push_cmd = ["git", "push", "--set-upstream", "origin", branch]
+
+    rc, out, err = _pr_run_subprocess_safe(push_cmd, cwd=work_dir, timeout=60)
+    if rc != 0:
+        print(f"ERROR: git push failed (exit {rc}):\n{err}", file=sys.stderr)
+        sys.exit(rc if rc > 0 else 1)
+    else:
+        push_msg = (out or err).splitlines()[0] if (out or err) else "pushed"
+        print(f"   {push_msg}")
+
+    # ── gh pr create ─────────────────────────────────────────────────────────
+    print("▶  gh pr create")
+    gh_cmd = [
+        "gh",
+        "pr",
+        "create",
+        "--title",
+        pr_title,
+        "--body",
+        pr_body,
+        "--base",
+        pr_base,
+    ]
+
+    # Optional labels
+    labels: list[str] = list(getattr(args, "label", None) or [])
+    for lbl in labels:
+        gh_cmd.extend(["--label", lbl])
+
+    # Optional reviewer
+    reviewer: str | None = getattr(args, "reviewer", None)
+    if reviewer:
+        gh_cmd.extend(["--reviewer", reviewer])
+
+    # Optional repo override
+    repo: str | None = getattr(args, "repo", None)
+    if repo:
+        gh_cmd.extend(["--repo", repo])
+
+    rc, out, err = _pr_run_subprocess_safe(gh_cmd, cwd=work_dir, timeout=60)
+    if rc != 0:
+        print(f"ERROR: gh pr create failed (exit {rc}):\n{err}", file=sys.stderr)
+        sys.exit(rc if rc > 0 else 1)
+
+    pr_url = out.strip()
+    print(f"✅ PR created: {pr_url}")
+    if issue_ref:
+        print(f"   Will close {issue_ref} on merge.")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Tentacle Pattern Manager for Copilot CLI",
@@ -7348,6 +7814,65 @@ def main():
             "Marks goal budget_limited if this expires (default: 300)."
         ),
     )
+    # pr
+    p_pr = sub.add_parser(
+        "pr",
+        help=(
+            "Automate git add -A, commit, push, and gh pr create from a completed goal. "
+            "Requires goal status == 'completed'."
+        ),
+    )
+    p_pr.add_argument(
+        "--title",
+        default=None,
+        help="PR title (default: auto-generated from goal title)",
+    )
+    p_pr.add_argument(
+        "--base",
+        default="main",
+        help="Base branch for the PR (default: main)",
+    )
+    p_pr.add_argument(
+        "--commit-msg",
+        dest="commit_msg",
+        default=None,
+        metavar="MSG",
+        help="Override the conventional commit message (default: auto-generated)",
+    )
+    p_pr.add_argument(
+        "--issue",
+        default=None,
+        metavar="REF",
+        help="Issue reference to close, e.g. '114' or '#114' or 'owner/repo#114'",
+    )
+    p_pr.add_argument(
+        "--label",
+        action="append",
+        dest="label",
+        default=[],
+        metavar="LABEL",
+        help="GitHub label to add to the PR (repeatable)",
+    )
+    p_pr.add_argument(
+        "--reviewer",
+        default=None,
+        metavar="LOGIN",
+        help="GitHub login to request review from",
+    )
+    p_pr.add_argument(
+        "--repo",
+        default=None,
+        metavar="REPO",
+        help="GitHub repository in owner/repo format (default: auto-detected by gh)",
+    )
+    p_pr.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        default=False,
+        help="Print commit message and PR body without running git or gh commands",
+    )
+
     # goal resilience-status
     p_goal_resilience = p_goal_sub.add_parser(
         "resilience-status",
@@ -7390,6 +7915,8 @@ def main():
         cmd_verify(args)
     elif args.command == "marker-cleanup":
         cmd_marker_cleanup(args)
+    elif args.command == "pr":
+        cmd_pr(args)
     elif args.command == "goal":
         cmd_goal(args)
 

--- a/tentacle.py
+++ b/tentacle.py
@@ -6687,13 +6687,16 @@ def _pr_collect_verifications(tentacles_dir: Path, tentacle_names: list[str]) ->
         for v in meta.get("verifications") or []:
             if not isinstance(v, dict):
                 continue
+            label_raw = v.get("label") or v.get("command") or "?"
+            cmd_raw = v.get("command") or "?"
+            dur_raw = v.get("duration_seconds")
             results.append(
                 {
                     "tentacle": name,
-                    "label": v.get("label", v.get("command", "?"))[:60],
-                    "exit_code": v.get("exit_code", -1),
-                    "command": v.get("command", "?")[:80],
-                    "duration_seconds": v.get("duration_seconds", 0.0),
+                    "label": str(label_raw)[:60],
+                    "exit_code": v.get("exit_code") if v.get("exit_code") is not None else -1,
+                    "command": str(cmd_raw)[:80],
+                    "duration_seconds": float(dur_raw) if dur_raw is not None else 0.0,
                 }
             )
     return results
@@ -6706,9 +6709,17 @@ def _pr_generate_commit_message(goal_title: str, goal_id: str | None, tentacle_n
 
     The scope is derived from the goal title or goal_id.
     The summary is the goal title lowercased and normalized.
+    UUID-shaped goal_ids are opaque and unreadable as commit scopes; when
+    goal_id matches the standard 8-4-4-4-12 UUID format the tentacle-name
+    fallback path is used instead.
     """
-    # Derive conventional commit scope from goal_id or tentacle name prefix
-    if goal_id:
+    _UUID_RE = re.compile(
+        r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+        re.IGNORECASE,
+    )
+    # Derive conventional commit scope from goal_id or tentacle name prefix.
+    # Skip UUID-shaped goal_ids — they are opaque identifiers, not human labels.
+    if goal_id and not _UUID_RE.match(goal_id):
         scope = goal_id[:30].lower().replace(" ", "-")
     elif tentacle_names:
         # Use a common prefix of the tentacle names as scope
@@ -6959,9 +6970,7 @@ def cmd_pr(args) -> None:
     work_dir = str(git_root) if git_root else None
 
     # ── Generate commit message ───────────────────────────────────────────────
-    commit_msg = getattr(args, "commit_msg", None) or _pr_generate_commit_message(
-        goal_title, goal_id, tentacle_names
-    )
+    commit_msg = getattr(args, "commit_msg", None) or _pr_generate_commit_message(goal_title, goal_id, tentacle_names)
 
     # ── Generate PR body ──────────────────────────────────────────────────────
     issue_ref: str | None = getattr(args, "issue", None)
@@ -6971,6 +6980,7 @@ def cmd_pr(args) -> None:
         issue_ref
         and not issue_ref.startswith("#")
         and not issue_ref.startswith("https://")
+        and not issue_ref.startswith("http://")
         and "#" not in issue_ref
     ):
         issue_ref = f"#{issue_ref}"
@@ -7029,6 +7039,20 @@ def cmd_pr(args) -> None:
 
     # ── git push ──────────────────────────────────────────────────────────────
     print("▶  git push")
+    # Detect detached HEAD before attempting to push — a detached HEAD has no
+    # branch name and git push would fail with a confusing error.
+    rc_head, head_ref, _ = _pr_run_subprocess_safe(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=work_dir,
+        timeout=15,
+    )
+    if rc_head == 0 and head_ref.strip() == "HEAD":
+        print(
+            "ERROR: repository is in detached HEAD state. Checkout a named branch before running `sk tentacle pr`.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     push_cmd = ["git", "push"]
     # Add --set-upstream if no upstream is configured (best-effort check)
     rc_check, tracking, _ = _pr_run_subprocess_safe(
@@ -7037,13 +7061,8 @@ def cmd_pr(args) -> None:
         timeout=15,
     )
     if rc_check != 0:
-        # No upstream: push with --set-upstream to origin HEAD
-        rc_branch, branch_name, _ = _pr_run_subprocess_safe(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-            cwd=work_dir,
-            timeout=15,
-        )
-        branch = branch_name.strip() if rc_branch == 0 else "HEAD"
+        # No upstream: push with --set-upstream to origin <branch>
+        branch = head_ref.strip() if rc_head == 0 else "HEAD"
         push_cmd = ["git", "push", "--set-upstream", "origin", branch]
 
     rc, out, err = _pr_run_subprocess_safe(push_cmd, cwd=work_dir, timeout=60)

--- a/tests/test_tentacle_pr.py
+++ b/tests/test_tentacle_pr.py
@@ -182,6 +182,30 @@ class TestGenerateCommitMessage(unittest.TestCase):
         msg = T._pr_generate_commit_message("Add feature", "my-scope", [])
         self.assertRegex(msg, r"^feat\([^)]+\): .+")
 
+    def test_uuid_goal_id_falls_back_to_tentacle_name(self):
+        """UUID-shaped goal_ids must NOT become commit scopes; use tentacle name instead.
+
+        Regression for: goal_id="603ba4ad-04fe-400e-88e7-c0f975a399fd" was used
+        verbatim as the conventional commit scope, producing an unreadable message.
+        """
+        uuid_id = "603ba4ad-04fe-400e-88e7-c0f975a399fd"
+        msg = T._pr_generate_commit_message(
+            "Implement feature", uuid_id, ["wave27-some-feature"]
+        )
+        # The scope must NOT contain opaque UUID hex fragments
+        self.assertNotIn("603ba4ad", msg)
+        # Should fall back to tentacle-name-derived scope
+        self.assertIn("some-feature", msg)
+        # Must still be valid conventional commit format
+        self.assertRegex(msg, r"^feat\([^)]+\): .+")
+
+    def test_uuid_goal_id_no_tentacles_uses_default(self):
+        """UUID goal_id with empty tentacle list falls back to 'tentacle' scope."""
+        uuid_id = "603ba4ad-04fe-400e-88e7-c0f975a399fd"
+        msg = T._pr_generate_commit_message("Implement feature", uuid_id, [])
+        self.assertNotIn("603ba4ad", msg)
+        self.assertIn("feat(tentacle):", msg)
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: _pr_collect_handoffs
@@ -298,6 +322,29 @@ class TestCollectVerifications(unittest.TestCase):
         labels = [r["label"] for r in results]
         self.assertIn("check-1", labels)
         self.assertIn("check-2", labels)
+
+    def test_null_label_and_command_fields(self):
+        """Explicit JSON nulls in label/command/duration must not crash.
+
+        Regression for: v.get("label", v.get("command", "?"))[:60] raises
+        TypeError when label is explicitly null (None[:60] fails).
+        """
+        verifs = [{"label": None, "command": None, "exit_code": 0, "duration_seconds": None}]
+        _make_tentacle("t-null", self.tentacles, verifications=verifs)
+        results = T._pr_collect_verifications(self.tentacles, ["t-null"])
+        self.assertEqual(len(results), 1)
+        r = results[0]
+        self.assertIsInstance(r["label"], str)
+        self.assertIsInstance(r["command"], str)
+        self.assertEqual(r["duration_seconds"], 0.0)
+
+    def test_null_label_uses_command_fallback(self):
+        """When label is null but command is present, command is used as the label."""
+        verifs = [{"label": None, "command": "python test.py", "exit_code": 0, "duration_seconds": 1.0}]
+        _make_tentacle("t-null-label", self.tentacles, verifications=verifs)
+        results = T._pr_collect_verifications(self.tentacles, ["t-null-label"])
+        self.assertEqual(len(results), 1)
+        self.assertIn("python test.py", results[0]["label"])
 
 
 # ---------------------------------------------------------------------------
@@ -661,6 +708,75 @@ class TestCmdPrIssueRefNormalization(unittest.TestCase):
         output = self._run_pr_capture(url)
         self.assertIn(f"Closes {url}", output)
         self.assertNotIn(f"Closes #{url}", output)
+
+    def test_http_url_ref_unchanged(self):
+        """Plain http:// issue URLs must not be prefixed with '#'."""
+        url = "http://github.com/owner/repo/issues/114"
+        output = self._run_pr_capture(url)
+        self.assertIn(f"Closes {url}", output)
+        self.assertNotIn(f"Closes #{url}", output)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: detached HEAD push guard
+# ---------------------------------------------------------------------------
+
+
+class TestDetachedHeadGuard(unittest.TestCase):
+    """cmd_pr must fail clearly when the working tree is in detached HEAD state.
+
+    Regression for: git push --set-upstream origin HEAD was attempted silently
+    instead of failing with a clear error.
+    """
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "detached_head"
+        _rmtree(self.base)
+        self.octogent, self.tentacles = _make_env(self.base)
+        _init_goal(self.tentacles, "Detached HEAD test", force=True)
+        _set_goal_completed(self.tentacles)
+
+    def tearDown(self):
+        _rmtree(self.base)
+
+    def test_detached_head_exits_with_error(self):
+        """cmd_pr must sys.exit(1) and print an error when HEAD is detached."""
+        env_patch = patch.dict(os.environ, {"TENTACLE_SESSION_DIR": str(self.tentacles)})
+        args = _fake_args(
+            dry_run=False,
+            title=None,
+            base="main",
+            commit_msg=None,
+            issue=None,
+            label=[],
+            reviewer=None,
+            repo=None,
+        )
+
+        call_count = [0]
+
+        def _fake_subprocess(cmd, cwd=None, timeout=30):
+            call_count[0] += 1
+            cmd_str = " ".join(cmd)
+            if "add" in cmd_str and "-A" in cmd_str:
+                return (0, "", "")
+            if "commit" in cmd_str:
+                return (0, "[branch abc1234] test commit", "")
+            if "--abbrev-ref" in cmd_str and "@{u}" not in cmd_str:
+                # Simulate detached HEAD: rev-parse --abbrev-ref HEAD → "HEAD"
+                return (0, "HEAD\n", "")
+            return (0, "", "")
+
+        stderr_lines: list[str] = []
+
+        with env_patch:
+            with patch.object(T, "_pr_run_subprocess_safe", side_effect=_fake_subprocess):
+                with patch("sys.stderr") as mock_stderr:
+                    mock_stderr.write = lambda s: stderr_lines.append(s)
+                    with self.assertRaises(SystemExit) as ctx:
+                        with patch("builtins.print"):
+                            T.cmd_pr(args)
+        self.assertEqual(ctx.exception.code, 1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tentacle_pr.py
+++ b/tests/test_tentacle_pr.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python3
+"""
+test_tentacle_pr.py — Tests for tentacle.py `pr` subcommand (issue #114).
+
+Tests cover:
+  - _pr_generate_commit_message: scope derivation from goal_id / tentacle names
+  - _pr_collect_handoffs: changed-file extraction, status parsing, blocker detection
+  - _pr_collect_verifications: meta.json verifications aggregation
+  - _pr_generate_body: all six PR body sections
+  - cmd_pr: goal-complete gate (no goal.json / wrong status / correct status)
+  - cmd_pr --dry-run: full dry-run path without subprocess calls
+
+Runs in-process using a temp subdirectory under the tools dir.
+Does NOT write to /tmp.
+"""
+
+import json
+import os
+import sys
+import types
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(TOOLS_DIR))
+
+import tentacle as T
+
+# ---------------------------------------------------------------------------
+# Scratch directory helpers
+# ---------------------------------------------------------------------------
+
+SCRATCH_DIR = TOOLS_DIR / "_test_tentacle_pr_scratch"
+
+
+def _rmtree(path: Path) -> None:
+    import shutil
+    import stat
+
+    if not path.exists():
+        return
+
+    def _handle_readonly(func, fpath, exc):
+        try:
+            os.chmod(fpath, stat.S_IWRITE)
+            func(fpath)
+        except Exception:
+            pass
+
+    shutil.rmtree(path, onerror=_handle_readonly)
+
+
+def _make_env(base: Path) -> tuple[Path, Path]:
+    """Return (octogent_dir, tentacles_dir) inside *base*, creating them."""
+    octogent = base / ".octogent"
+    tentacles = octogent / "tentacles"
+    tentacles.mkdir(parents=True, exist_ok=True)
+    return octogent, tentacles
+
+
+def _make_tentacle(
+    name: str,
+    tentacles: Path,
+    *,
+    status: str = "completed",
+    handoff_text: str | None = None,
+    verifications: list[dict] | None = None,
+    changed_files: list[str] | None = None,
+) -> Path:
+    """Create a minimal tentacle directory for PR tests."""
+    d = tentacles / name
+    d.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "name": name,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "scope": ["src/foo.py"],
+        "description": f"Test tentacle {name}",
+        "status": status,
+    }
+    if verifications is not None:
+        meta["verifications"] = verifications
+    (d / "meta.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    (d / "CONTEXT.md").write_text(f"# {name}\n", encoding="utf-8")
+    (d / "todo.md").write_text("# Todo\n\n- [x] Task A\n", encoding="utf-8")
+
+    if handoff_text is not None:
+        (d / "handoff.md").write_text(handoff_text, encoding="utf-8")
+    elif changed_files is not None:
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+        entry = f"# Handoff Notes\n\n## [{ts}]\n\nImplementation complete.\nSTATUS: DONE\n"
+        for cf in changed_files:
+            entry += f"Changed: {cf}\n"
+        (d / "handoff.md").write_text(entry, encoding="utf-8")
+
+    return d
+
+
+def _fake_args(**kwargs) -> types.SimpleNamespace:
+    return types.SimpleNamespace(session_dir=None, **kwargs)
+
+
+def _init_goal(tentacles: Path, title: str = "Test Goal", **kwargs) -> dict:
+    """Initialize goal.json and return state."""
+    args = _fake_args(
+        title=title,
+        desc=kwargs.get("desc", ""),
+        force=kwargs.get("force", True),
+        max_iterations=kwargs.get("max_iterations", None),
+        max_tentacles=kwargs.get("max_tentacles", None),
+        timeout=kwargs.get("timeout", None),
+        goal_action="init",
+    )
+    with patch("builtins.print"):
+        T._cmd_goal_init(args, tentacles)
+    return T._goal_load(tentacles)
+
+
+def _set_goal_completed(tentacles: Path) -> dict:
+    """Set goal status to completed and return updated state."""
+
+    def _apply(state: dict) -> None:
+        state["status"] = T.GOAL_STATUS_COMPLETED
+        state["completed_at"] = datetime.now(timezone.utc).isoformat()
+        state["eval_history"] = [
+            {
+                "iteration": 1,
+                "decision": "complete",
+                "notes": "All criteria verified.",
+                "evaluated_at": datetime.now(timezone.utc).isoformat(),
+                "criteria_verified": 2,
+                "criteria_total": 2,
+            }
+        ]
+
+    return T._goal_transact(tentacles, _apply)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _pr_generate_commit_message
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateCommitMessage(unittest.TestCase):
+    """Tests for _pr_generate_commit_message."""
+
+    def test_uses_goal_id_as_scope(self):
+        msg = T._pr_generate_commit_message("Implement auth module", "auth-module", ["wave1-auth"])
+        self.assertIn("feat(auth-module):", msg)
+        self.assertIn("Implement auth module", msg)
+
+    def test_uses_tentacle_name_when_no_goal_id(self):
+        msg = T._pr_generate_commit_message("Add export API", None, ["wave2-export-api"])
+        # Should strip wave prefix and derive scope
+        self.assertIn("feat(", msg)
+        self.assertIn("export-api", msg)
+
+    def test_falls_back_to_tentacle_scope(self):
+        msg = T._pr_generate_commit_message("Fix bug", None, ["fix-bug-worker"])
+        self.assertIn("feat(", msg)
+        self.assertIn("Fix bug", msg)
+
+    def test_empty_tentacle_list_uses_default_scope(self):
+        msg = T._pr_generate_commit_message("Update docs", None, [])
+        self.assertIn("feat(tentacle):", msg)
+
+    def test_long_goal_title_is_truncated(self):
+        long_title = "A" * 100
+        msg = T._pr_generate_commit_message(long_title, "scope", [])
+        self.assertLessEqual(len(msg), 72)
+
+    def test_no_trailing_period(self):
+        msg = T._pr_generate_commit_message("Deploy service.", "svc", [])
+        self.assertFalse(msg.rstrip().endswith("."))
+
+    def test_conventional_commit_format(self):
+        msg = T._pr_generate_commit_message("Add feature", "my-scope", [])
+        self.assertRegex(msg, r"^feat\([^)]+\): .+")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _pr_collect_handoffs
+# ---------------------------------------------------------------------------
+
+
+class TestCollectHandoffs(unittest.TestCase):
+    def setUp(self):
+        self.base = SCRATCH_DIR / "collect_handoffs"
+        _rmtree(self.base)
+        _, self.tentacles = _make_env(self.base)
+
+    def tearDown(self):
+        _rmtree(self.base)
+
+    def test_parses_done_handoff(self):
+        ts = "2026-05-01 12:00 UTC"
+        text = (
+            f"# Handoff Notes\n\n## [{ts}]\n\nAll done.\nSTATUS: DONE\n"
+            "Changed: src/foo.py\nChanged: tests/test_foo.py\n"
+        )
+        _make_tentacle("t1", self.tentacles, handoff_text=text)
+        results = T._pr_collect_handoffs(self.tentacles, ["t1"])
+        self.assertEqual(len(results), 1)
+        r = results[0]
+        self.assertEqual(r["name"], "t1")
+        self.assertEqual(r["status"], "DONE")
+        self.assertIn("src/foo.py", r["changed_files"])
+        self.assertIn("tests/test_foo.py", r["changed_files"])
+        self.assertFalse(r["has_blockers"])
+
+    def test_detects_blocked_handoff(self):
+        ts = "2026-05-01 12:00 UTC"
+        text = f"# Handoff Notes\n\n## [{ts}]\n\nBlocked.\nSTATUS: BLOCKED\n"
+        _make_tentacle("t2", self.tentacles, handoff_text=text)
+        results = T._pr_collect_handoffs(self.tentacles, ["t2"])
+        self.assertTrue(results[0]["has_blockers"])
+
+    def test_detects_ambiguous_handoff(self):
+        ts = "2026-05-01 12:00 UTC"
+        text = f"# Handoff Notes\n\n## [{ts}]\n\nUnclear.\nSTATUS: AMBIGUOUS\n"
+        _make_tentacle("t3", self.tentacles, handoff_text=text)
+        results = T._pr_collect_handoffs(self.tentacles, ["t3"])
+        self.assertTrue(results[0]["has_blockers"])
+
+    def test_skips_missing_handoff(self):
+        _make_tentacle("no-handoff", self.tentacles)
+        # no handoff.md created
+        results = T._pr_collect_handoffs(self.tentacles, ["no-handoff"])
+        self.assertEqual(len(results), 0)
+
+    def test_multiple_tentacles(self):
+        for i in range(3):
+            _make_tentacle(f"t{i}", self.tentacles, changed_files=[f"file{i}.py"])
+        results = T._pr_collect_handoffs(self.tentacles, ["t0", "t1", "t2"])
+        self.assertEqual(len(results), 3)
+        all_files = [cf for r in results for cf in r["changed_files"]]
+        self.assertIn("file0.py", all_files)
+        self.assertIn("file2.py", all_files)
+
+    def test_no_changed_files_in_plain_handoff(self):
+        ts = "2026-05-01 12:00 UTC"
+        text = f"# Handoff Notes\n\n## [{ts}]\n\nMinimal done.\nSTATUS: DONE\n"
+        _make_tentacle("t-plain", self.tentacles, handoff_text=text)
+        results = T._pr_collect_handoffs(self.tentacles, ["t-plain"])
+        self.assertEqual(results[0]["changed_files"], [])
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _pr_collect_verifications
+# ---------------------------------------------------------------------------
+
+
+class TestCollectVerifications(unittest.TestCase):
+    def setUp(self):
+        self.base = SCRATCH_DIR / "collect_verif"
+        _rmtree(self.base)
+        _, self.tentacles = _make_env(self.base)
+
+    def tearDown(self):
+        _rmtree(self.base)
+
+    def test_parses_verifications(self):
+        verifs = [
+            {"label": "tests", "command": "python test_fixes.py", "exit_code": 0, "duration_seconds": 3.2},
+            {"label": "lint", "command": "ruff check .", "exit_code": 1, "duration_seconds": 1.1},
+        ]
+        _make_tentacle("t1", self.tentacles, verifications=verifs)
+        results = T._pr_collect_verifications(self.tentacles, ["t1"])
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["exit_code"], 0)
+        self.assertEqual(results[1]["exit_code"], 1)
+        self.assertEqual(results[0]["tentacle"], "t1")
+
+    def test_skips_missing_meta(self):
+        # Tentacle without meta.json
+        d = self.tentacles / "no-meta"
+        d.mkdir(parents=True, exist_ok=True)
+        results = T._pr_collect_verifications(self.tentacles, ["no-meta"])
+        self.assertEqual(results, [])
+
+    def test_empty_verifications_list(self):
+        _make_tentacle("t-empty", self.tentacles, verifications=[])
+        results = T._pr_collect_verifications(self.tentacles, ["t-empty"])
+        self.assertEqual(results, [])
+
+    def test_aggregates_across_tentacles(self):
+        v1 = [{"label": "check-1", "command": "cmd1", "exit_code": 0, "duration_seconds": 1.0}]
+        v2 = [{"label": "check-2", "command": "cmd2", "exit_code": 0, "duration_seconds": 2.0}]
+        _make_tentacle("ta", self.tentacles, verifications=v1)
+        _make_tentacle("tb", self.tentacles, verifications=v2)
+        results = T._pr_collect_verifications(self.tentacles, ["ta", "tb"])
+        self.assertEqual(len(results), 2)
+        labels = [r["label"] for r in results]
+        self.assertIn("check-1", labels)
+        self.assertIn("check-2", labels)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _pr_generate_body
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateBody(unittest.TestCase):
+    def _make_goal_state(self, **overrides) -> dict:
+        base = {
+            "title": "Add export feature",
+            "description": "Implement data export for the billing service.",
+            "status": T.GOAL_STATUS_COMPLETED,
+            "tentacles": [],
+            "eval_history": [
+                {
+                    "iteration": 1,
+                    "decision": "complete",
+                    "notes": "All tests pass.",
+                    "evaluated_at": "2026-05-14T12:00:00+00:00",
+                    "criteria_verified": 1,
+                    "criteria_total": 1,
+                }
+            ],
+            "success_criteria": [
+                {"id": "sc-1", "description": "Tests pass", "status": "verified"}
+            ],
+            "gates": [],
+        }
+        base.update(overrides)
+        return base
+
+    def test_body_contains_what_why_how(self):
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, [], [], [])
+        self.assertIn("## What / Why / How", body)
+        self.assertIn("Add export feature", body)
+
+    def test_body_contains_changes_section(self):
+        ts = "2026-05-01 12:00 UTC"
+        text = f"# Handoff Notes\n\n## [{ts}]\n\nDone.\nSTATUS: DONE\nChanged: billing/export.py\n"
+        handoffs = [
+            {"name": "t1", "text": text, "status": "DONE", "changed_files": ["billing/export.py"], "has_blockers": False}
+        ]
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, handoffs, [], ["t1"])
+        self.assertIn("## Changes", body)
+        self.assertIn("billing/export.py", body)
+
+    def test_body_contains_decision_points(self):
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, [], [], [])
+        self.assertIn("## Decision Points", body)
+        self.assertIn("iter-1: **complete**", body)
+
+    def test_body_contains_unresolved_blockers(self):
+        ts = "2026-05-01 12:00 UTC"
+        text = f"# Handoff Notes\n\n## [{ts}]\n\nBlocked on rate limit.\nSTATUS: BLOCKED\n"
+        handoffs = [
+            {"name": "t-blocked", "text": text, "status": "BLOCKED", "changed_files": [], "has_blockers": True}
+        ]
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, handoffs, [], ["t-blocked"])
+        self.assertIn("## Unresolved Blockers", body)
+        self.assertIn("t-blocked", body)
+        self.assertIn("BLOCKED", body)
+
+    def test_body_no_blockers_message(self):
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, [], [], [])
+        self.assertIn("## Unresolved Blockers", body)
+        self.assertIn("None", body)
+
+    def test_body_contains_test_results(self):
+        verifs = [
+            {"tentacle": "t1", "label": "tests", "exit_code": 0, "command": "python test_fixes.py", "duration_seconds": 5.0}
+        ]
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, [], verifs, ["t1"])
+        self.assertIn("## Test Results", body)
+        self.assertIn("1/1 verification", body)
+        self.assertIn("✅", body)
+
+    def test_body_includes_closing_keyword_when_issue_given(self):
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, [], [], [], issue_ref="#114")
+        self.assertIn("Closes #114", body)
+
+    def test_body_no_closing_keyword_when_no_issue(self):
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, [], [], [])
+        self.assertNotIn("Closes", body)
+
+    def test_no_changes_shows_placeholder(self):
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, [], [], [])
+        self.assertIn("No file-level change records", body)
+
+    def test_criteria_summary_in_what_section(self):
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, [], [], [])
+        self.assertIn("1/1 verified", body)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: cmd_pr goal-complete gate
+# ---------------------------------------------------------------------------
+
+
+class TestCmdPrGoalGate(unittest.TestCase):
+    """cmd_pr must exit 1 when goal is not completed."""
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "cmd_pr_gate"
+        _rmtree(self.base)
+        self.octogent, self.tentacles = _make_env(self.base)
+
+    def tearDown(self):
+        _rmtree(self.base)
+
+    def _run_pr(self, **kwargs) -> int:
+        """Run cmd_pr; return the SystemExit code (or 0 on success)."""
+        env_patch = patch.dict(os.environ, {"TENTACLE_SESSION_DIR": str(self.tentacles)})
+        args = _fake_args(
+            dry_run=True,
+            title=None,
+            base="main",
+            commit_msg=None,
+            issue=None,
+            label=[],
+            reviewer=None,
+            repo=None,
+            **kwargs,
+        )
+        with env_patch:
+            try:
+                with patch("builtins.print"):
+                    T.cmd_pr(args)
+                return 0
+            except SystemExit as exc:
+                return exc.code if isinstance(exc.code, int) else 1
+
+    def test_exits_when_no_goal_json(self):
+        rc = self._run_pr()
+        self.assertEqual(rc, 1)
+
+    def test_exits_when_goal_is_active(self):
+        _init_goal(self.tentacles, "My goal")
+        rc = self._run_pr()
+        self.assertEqual(rc, 1)
+
+    def test_exits_when_goal_is_paused(self):
+        _init_goal(self.tentacles, "My goal")
+        T._goal_update(self.tentacles, status=T.GOAL_STATUS_PAUSED)
+        rc = self._run_pr()
+        self.assertEqual(rc, 1)
+
+    def test_exits_when_goal_is_abandoned(self):
+        _init_goal(self.tentacles, "My goal")
+        T._goal_update(self.tentacles, status=T.GOAL_STATUS_ABANDONED)
+        rc = self._run_pr()
+        self.assertEqual(rc, 1)
+
+    def test_succeeds_when_goal_is_completed_dry_run(self):
+        _init_goal(self.tentacles, "My goal")
+        _set_goal_completed(self.tentacles)
+        rc = self._run_pr()
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: cmd_pr dry-run output
+# ---------------------------------------------------------------------------
+
+
+class TestCmdPrDryRun(unittest.TestCase):
+    """cmd_pr --dry-run should print body and commit message without running subprocesses."""
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "cmd_pr_dry_run"
+        _rmtree(self.base)
+        self.octogent, self.tentacles = _make_env(self.base)
+
+    def tearDown(self):
+        _rmtree(self.base)
+
+    def _run_pr_dry(self, title: str | None = None, **kwargs) -> list[str]:
+        """Run cmd_pr --dry-run; capture and return all printed lines."""
+        _init_goal(self.tentacles, "Implement feature #114", force=True)
+        _set_goal_completed(self.tentacles)
+        _make_tentacle(
+            "wave1-worker",
+            self.tentacles,
+            changed_files=["tentacle.py", "tests/test_tentacle_pr.py"],
+        )
+        # Link tentacle to goal
+        T._goal_update(self.tentacles, tentacles=["wave1-worker"])
+
+        env_patch = patch.dict(os.environ, {"TENTACLE_SESSION_DIR": str(self.tentacles)})
+        args = _fake_args(
+            dry_run=True,
+            title=title,
+            base="main",
+            commit_msg=None,
+            issue="114",
+            label=[],
+            reviewer=None,
+            repo=None,
+            **kwargs,
+        )
+        printed: list[str] = []
+        with env_patch:
+            with patch("builtins.print", side_effect=lambda *a, **kw: printed.append(" ".join(str(x) for x in a))):
+                T.cmd_pr(args)
+        return printed
+
+    def test_dry_run_prints_commit_message(self):
+        lines = self._run_pr_dry()
+        combined = "\n".join(lines)
+        self.assertIn("feat(", combined)
+
+    def test_dry_run_prints_pr_body_sections(self):
+        lines = self._run_pr_dry()
+        combined = "\n".join(lines)
+        self.assertIn("## What / Why / How", combined)
+        self.assertIn("## Changes", combined)
+        self.assertIn("## Decision Points", combined)
+        self.assertIn("## Unresolved Blockers", combined)
+        self.assertIn("## Test Results", combined)
+
+    def test_dry_run_no_subprocess_called(self):
+        with patch("subprocess.run") as mock_sub:
+            lines = self._run_pr_dry()
+            mock_sub.assert_not_called()
+
+    def test_dry_run_includes_closes_issue(self):
+        lines = self._run_pr_dry()
+        combined = "\n".join(lines)
+        self.assertIn("Closes #114", combined)
+
+    def test_dry_run_pr_title_defaults_to_goal_title(self):
+        lines = self._run_pr_dry()
+        combined = "\n".join(lines)
+        self.assertIn("Implement feature #114", combined)
+
+    def test_dry_run_custom_title_is_used(self):
+        lines = self._run_pr_dry(title="My custom PR title")
+        combined = "\n".join(lines)
+        self.assertIn("My custom PR title", combined)
+
+    def test_dry_run_does_not_exit_nonzero(self):
+        _init_goal(self.tentacles, "Test feature", force=True)
+        _set_goal_completed(self.tentacles)
+        env_patch = patch.dict(os.environ, {"TENTACLE_SESSION_DIR": str(self.tentacles)})
+        args = _fake_args(
+            dry_run=True,
+            title=None,
+            base="main",
+            commit_msg=None,
+            issue=None,
+            label=[],
+            reviewer=None,
+            repo=None,
+        )
+        with env_patch:
+            with patch("builtins.print"):
+                try:
+                    T.cmd_pr(args)
+                    exited = 0
+                except SystemExit as exc:
+                    exited = exc.code
+        self.assertEqual(exited, 0)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: issue reference normalization
+# ---------------------------------------------------------------------------
+
+
+class TestIssueRefNormalization(unittest.TestCase):
+    """_pr_generate_body should normalize issue_ref properly."""
+
+    def _make_goal_state(self) -> dict:
+        return {
+            "title": "Test goal",
+            "description": "",
+            "eval_history": [],
+            "success_criteria": [],
+            "gates": [],
+        }
+
+    def test_bare_number_prefixed_with_hash(self):
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, [], [], [], issue_ref="#42")
+        self.assertIn("Closes #42", body)
+
+    def test_hash_number_preserved(self):
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, [], [], [], issue_ref="#114")
+        self.assertIn("Closes #114", body)
+
+    def test_full_repo_ref_preserved(self):
+        state = self._make_goal_state()
+        body = T._pr_generate_body(state, [], [], [], issue_ref="owner/repo#114")
+        self.assertIn("Closes owner/repo#114", body)
+
+
+class TestCmdPrIssueRefNormalization(unittest.TestCase):
+    """cmd_pr must normalize issue refs passed via --issue without corrupting cross-repo refs.
+
+    This covers the normalization path in cmd_pr (not _pr_generate_body directly).
+    Regression for: owner/repo#NNN was incorrectly prefixed to #owner/repo#NNN.
+    """
+
+    def setUp(self):
+        self.base = SCRATCH_DIR / "cmd_pr_ref_norm"
+        _rmtree(self.base)
+        self.octogent, self.tentacles = _make_env(self.base)
+        _init_goal(self.tentacles, "Ref norm test goal", force=True)
+        _set_goal_completed(self.tentacles)
+
+    def tearDown(self):
+        _rmtree(self.base)
+
+    def _run_pr_capture(self, issue_value: str) -> str:
+        env_patch = patch.dict(os.environ, {"TENTACLE_SESSION_DIR": str(self.tentacles)})
+        args = _fake_args(
+            dry_run=True,
+            title=None,
+            base="main",
+            commit_msg=None,
+            issue=issue_value,
+            label=[],
+            reviewer=None,
+            repo=None,
+        )
+        lines: list[str] = []
+        with env_patch:
+            with patch("builtins.print", side_effect=lambda *a, **kw: lines.append(" ".join(str(x) for x in a))):
+                T.cmd_pr(args)
+        return "\n".join(lines)
+
+    def test_bare_number_becomes_hash_nnn(self):
+        output = self._run_pr_capture("42")
+        self.assertIn("Closes #42", output)
+        self.assertNotIn("Closes ##", output)
+
+    def test_hash_nnn_unchanged(self):
+        output = self._run_pr_capture("#114")
+        self.assertIn("Closes #114", output)
+        self.assertNotIn("Closes ##", output)
+
+    def test_cross_repo_ref_not_prefixed(self):
+        """owner/repo#NNN must not become #owner/repo#NNN."""
+        output = self._run_pr_capture("owner/repo#114")
+        self.assertIn("Closes owner/repo#114", output)
+        self.assertNotIn("#owner/repo#114", output)
+
+    def test_url_ref_unchanged(self):
+        url = "https://github.com/owner/repo/issues/114"
+        output = self._run_pr_capture(url)
+        self.assertIn(f"Closes {url}", output)
+        self.assertNotIn(f"Closes #{url}", output)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `tentacle.py pr` to automate git add, commit, push, and `gh pr create` once goal completion is proven
- generate a structured PR body from tentacle handoffs, changed files, decision points, blockers, and test results
- add focused regression coverage for goal gating and issue reference normalization plus usage docs

Closes #114