### PR TITLE
feat(skill-patch): add sk skill-patch command

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -23,6 +23,8 @@ sk retro                                 # → retro.py
 sk heal                                  # → copilot-cli-healer.py
 sk skill-suggest                         # → skill-suggest.py
 sk skill-suggest --min-occurrences 3 --format json
+sk skill-patch path/to/SKILL.md --old "old text" --new "new text"  # → skill-patch.py
+sk skill-patch path/to/SKILL.md --old "old text" --new "new text" --replace-all
 ```
 
 ### `sk skill-suggest` — knowledge-to-skill pipeline
@@ -51,6 +53,56 @@ python validate-skill.py path/to/SKILL.md
 ```
 
 > Direct-script form: `python skill-suggest.py [args...]`
+
+### `sk skill-patch` — targeted SKILL.md patch
+
+Apply a focused, fuzzy-whitespace-tolerant replacement to a SKILL.md without
+rewriting the whole file.  Writes atomically, re-validates, and logs the patch
+history to `skill-metrics.db`.
+
+```bash
+# Replace first occurrence
+sk skill-patch path/to/SKILL.md --old "old text" --new "new text"
+
+# Replace all occurrences
+sk skill-patch path/to/SKILL.md --old "old text" --new "new text" --replace-all
+
+# Preview without writing (dry-run shows a unified diff)
+sk skill-patch path/to/SKILL.md --old "old text" --new "new text" --dry-run
+
+# Skip post-patch validation
+sk skill-patch path/to/SKILL.md --old "old text" --new "new text" --no-validate
+
+# Skip metrics logging
+sk skill-patch path/to/SKILL.md --old "old text" --new "new text" --no-metrics
+
+# Override metrics DB path
+sk skill-patch path/to/SKILL.md --old "old text" --new "new text" \
+    --metrics-db /path/to/custom/skill-metrics.db
+
+# Pass a skill directory (SKILL.md resolved automatically)
+sk skill-patch skills/my-skill/ --old "old text" --new "new text"
+```
+
+**Fuzzy matching:** whitespace differences (extra spaces, tabs, different
+indentation) between `--old` and the file are ignored during search.  The
+replacement preserves the original indentation of the matched region.
+
+**Atomic write:** the file is first written to a sibling tempfile, then
+renamed with `os.replace`, so a crash during write never leaves a partial file.
+
+**Validation:** after writing, `validate-skill.py` is invoked.  Exit code 1 is
+returned if the patched skill has errors.
+
+**Metrics:** each non-dry-run patch is appended to `skill_patch_history` in
+`~/.copilot/session-state/skill-metrics.db`.  View history with:
+
+```bash
+sk skill-suggest          # note: skill-metrics visible via skill-metrics.py
+python skill-metrics.py   # shows patch_history section when records exist
+```
+
+> Direct-script form: `python skill-patch.py path/to/SKILL.md --old "..." --new "..." [opts]`
 
 ### `sk index` — knowledge index lifecycle
 

--- a/sk-rust/src/main.rs
+++ b/sk-rust/src/main.rs
@@ -142,6 +142,12 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Apply a targeted patch to a SKILL.md file
+    #[command(name = "skill-patch")]
+    SkillPatch {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }
 
 // Map a grouped namespace command (e.g. "index build") to a Python script name.
@@ -272,6 +278,7 @@ fn main() -> ExitCode {
             }
         }
         Some(Commands::SkillSuggest { args }) => run_fallback("skill-suggest.py", &args),
+        Some(Commands::SkillPatch { args }) => run_fallback("skill-patch.py", &args),
     };
 
     if cli.time {

--- a/sk.py
+++ b/sk.py
@@ -25,6 +25,7 @@ Usage:
     sk dream    [<args>...]       Run dream.py
     sk anatomy      [<args>...]       Run anatomy-map.py
     sk skill-suggest [<args>...]      Run skill-suggest.py
+    sk skill-patch  [<args>...]       Run skill-patch.py
     sk hooks        run|list|<event>  Run hooks/hook_runner.py
 
     sk index  build|extract|migrate|status|health|embed|tag [<args>...]
@@ -79,6 +80,7 @@ _DIRECT: dict[str, str] = {
     "dream": "dream.py",
     "anatomy": "anatomy-map.py",
     "skill-suggest": "skill-suggest.py",
+    "skill-patch": "skill-patch.py",
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}

--- a/skill-metrics.py
+++ b/skill-metrics.py
@@ -67,6 +67,8 @@ def collect_status(db_path: Path = None) -> dict:
         "verifications_failed": 0,
         "skill_usage": [],
         "recent_outcomes": [],
+        "patch_history": [],
+        "total_patches": 0,
     }
 
     db = _open_db(db_path)
@@ -139,6 +141,31 @@ def collect_status(db_path: Path = None) -> dict:
             out["verifications_failed"] = db.execute(
                 "SELECT COUNT(*) FROM tentacle_verifications WHERE exit_code!=0"
             ).fetchone()[0]
+
+        if _table_exists(db, "skill_patch_history"):
+            out["total_patches"] = db.execute(
+                "SELECT COUNT(*) FROM skill_patch_history"
+            ).fetchone()[0]
+            rows = db.execute(
+                "SELECT id, skill_path, patched_at, occurrences_replaced, "
+                "replace_all, dry_run, validation_passed, "
+                "validation_errors, validation_warnings "
+                "FROM skill_patch_history ORDER BY id DESC LIMIT 10"
+            ).fetchall()
+            out["patch_history"] = [
+                {
+                    "id": r["id"],
+                    "skill_path": r["skill_path"],
+                    "patched_at": r["patched_at"],
+                    "occurrences_replaced": r["occurrences_replaced"],
+                    "replace_all": bool(r["replace_all"]),
+                    "dry_run": bool(r["dry_run"]),
+                    "validation_passed": None if r["validation_passed"] is None else bool(r["validation_passed"]),
+                    "validation_errors": r["validation_errors"],
+                    "validation_warnings": r["validation_warnings"],
+                }
+                for r in rows
+            ]
     finally:
         db.close()
 
@@ -226,6 +253,17 @@ def format_status(status: dict) -> str:
             lines.append(
                 f"  [{r['outcome_status']:<8}] {r['tentacle_name']:<30}"
                 f"  verify={vpass}✓/{vfail}✗  {r['recorded_at']}"
+            )
+    total_patches = status.get("total_patches", 0)
+    patch_history = status.get("patch_history", [])
+    if total_patches or patch_history:
+        lines.append("")
+        lines.append(f"Skill patch history ({total_patches} total)")
+        for p in patch_history[:5]:
+            vmark = "✓" if p.get("validation_passed") else ("?" if p.get("validation_passed") is None else "✗")
+            lines.append(
+                f"  {p['patched_at']}  {Path(p['skill_path']).name:<30}"
+                f"  n={p['occurrences_replaced']}  valid={vmark}"
             )
     return "\n".join(lines)
 

--- a/skill-patch.py
+++ b/skill-patch.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""
+skill-patch.py — Targeted patch tool for SKILL.md files.
+
+Performs fuzzy-whitespace-tolerant targeted replacement inside a SKILL.md,
+writes atomically via a tempfile + os.replace, re-validates with
+validate-skill.py, and logs the patch to skill-metrics.db.
+
+Usage:
+    python skill-patch.py <path> --old "old text" --new "new text" [options]
+
+Arguments:
+    path                Path to SKILL.md or skill directory
+
+Options:
+    --old TEXT          Text to find (fuzzy whitespace / indentation matching)
+    --new TEXT          Replacement text
+    --replace-all       Replace all occurrences (default: first occurrence only)
+    --dry-run           Show diff; do NOT write or log anything
+    --no-validate       Skip post-patch validation via validate-skill.py
+    --no-metrics        Skip logging patch history to skill-metrics.db
+    --metrics-db PATH   Override the skill-metrics.db path
+    -h, --help          Show this help and exit
+
+Exit codes:
+    0   Patch applied (and, if not --no-validate, skill is valid)
+    1   Patch failed (no match found or validation errors)
+    2   Usage error
+"""
+
+import argparse
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SESSION_STATE = Path.home() / ".copilot" / "session-state"
+DEFAULT_METRICS_DB = SESSION_STATE / "skill-metrics.db"
+
+_SKILL_PATCH_HISTORY_DDL = """
+CREATE TABLE IF NOT EXISTS skill_patch_history (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    skill_path           TEXT NOT NULL,
+    patched_at           TEXT NOT NULL,
+    old_text             TEXT NOT NULL,
+    new_text             TEXT NOT NULL,
+    occurrences_replaced INTEGER NOT NULL DEFAULT 0,
+    replace_all          INTEGER NOT NULL DEFAULT 0,
+    dry_run              INTEGER NOT NULL DEFAULT 0,
+    validation_passed    INTEGER,
+    validation_errors    INTEGER NOT NULL DEFAULT 0,
+    validation_warnings  INTEGER NOT NULL DEFAULT 0
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy-whitespace matching
+# ---------------------------------------------------------------------------
+
+def _fuzzy_pattern(text: str) -> re.Pattern:
+    """
+    Build a regex that matches *text* modulo leading/trailing whitespace on
+    each line and collapsed internal whitespace runs.
+
+    Strategy:
+    - Split on any whitespace token (\\s+) so the same logical content matches
+      regardless of extra spaces, tabs, or mixed indent levels.
+    - Each non-empty token is re.escape'd so literal characters are not
+      misinterpreted as regex metacharacters.
+    - Tokens are joined with \\s+ so any whitespace run between tokens matches.
+    - A leading/trailing \\s* allows the overall match to consume surrounding
+      whitespace that belongs to the indent/newline context, which the caller
+      then compensates for when building the replacement string.
+    """
+    tokens = [re.escape(t) for t in text.split() if t]
+    if not tokens:
+        raise ValueError("--old text contains only whitespace; nothing to match")
+    return re.compile(r"\s*" + r"\s+".join(tokens) + r"\s*", re.MULTILINE)
+
+
+def find_occurrences(content: str, old_text: str) -> list[re.Match]:
+    """Return a list of all non-overlapping matches of old_text (fuzzy) in content."""
+    pat = _fuzzy_pattern(old_text)
+    return list(pat.finditer(content))
+
+
+def apply_patch(
+    content: str,
+    old_text: str,
+    new_text: str,
+    *,
+    replace_all: bool = False,
+) -> tuple[str, int]:
+    """
+    Apply targeted replacement and return (patched_content, occurrences_replaced).
+
+    The replacement preserves the *leading* whitespace of each match so that
+    indentation is kept intact.  The matched span (including surrounding
+    whitespace captured by the fuzzy pattern) is replaced by new_text after
+    re-applying the leading whitespace of the original match.
+    """
+    pat = _fuzzy_pattern(old_text)
+    replaced = 0
+
+    def _replacer(m: re.Match) -> str:
+        nonlocal replaced
+        replaced += 1
+        # Determine leading whitespace of the match (newline + indent)
+        matched = m.group(0)
+        # Preserve leading whitespace from the matched span.
+        # Match a leading newline+indent first (block-level), then fall back
+        # to plain spaces/tabs (mid-line match like "1. Step one").
+        leading_ws_m = re.match(r"([\r\n][ \t]*|[ \t]+)", matched)
+        prefix = leading_ws_m.group(1) if leading_ws_m else ""
+        # Preserve any trailing newline from the matched span
+        trailing_ws_m = re.search(r"([\r\n][ \t]*)$", matched)
+        suffix = trailing_ws_m.group(1) if trailing_ws_m else ""
+        return prefix + new_text + suffix
+
+    if replace_all:
+        result = pat.sub(_replacer, content)
+    else:
+        result, n = pat.subn(_replacer, content, count=1)
+        replaced = n
+
+    return result, replaced
+
+
+# ---------------------------------------------------------------------------
+# Skill path resolution
+# ---------------------------------------------------------------------------
+
+def resolve_skill_path(raw: str) -> Path:
+    p = Path(raw).expanduser().resolve()
+    if p.is_dir():
+        candidate = p / "SKILL.md"
+        if not candidate.exists():
+            raise FileNotFoundError(f"No SKILL.md found in directory: {p}")
+        return candidate
+    if not p.exists():
+        raise FileNotFoundError(f"SKILL.md not found: {p}")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+def atomic_write(path: Path, content: str) -> None:
+    """Write *content* to *path* atomically via a sibling tempfile + os.replace."""
+    dir_ = path.parent
+    fd, tmp_path = tempfile.mkstemp(prefix=".skill-patch-", suffix=".tmp", dir=dir_)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Post-patch validation
+# ---------------------------------------------------------------------------
+
+def run_validation(skill_path: Path) -> tuple[bool, int, int]:
+    """
+    Run validate-skill.py against *skill_path* via subprocess.
+
+    Returns (passed: bool, errors: int, warnings: int).
+    Fails open on import/subprocess errors.
+    """
+    validate_script = Path(__file__).parent.resolve() / "validate-skill.py"
+    if not validate_script.exists():
+        # Can't validate — treat as passed with a note
+        return True, 0, 0
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(validate_script), str(skill_path)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        output = result.stdout + result.stderr
+        # Count error/warning markers in validate-skill.py's output
+        errors = len(re.findall(r"^  •", output, re.MULTILINE))
+        warnings = len(re.findall(r"^  •", output, re.MULTILINE))
+        # Verdict: exit 0 = pass (including warnings), exit 1 = fail
+        passed = result.returncode == 0
+        # Re-parse: validate-skill outputs "❌ ERRORS (N):" and "⚠️  WARNINGS (N):"
+        err_m = re.search(r"❌ ERRORS \((\d+)\)", output)
+        warn_m = re.search(r"WARNINGS \((\d+)\)", output)
+        n_errors = int(err_m.group(1)) if err_m else 0
+        n_warnings = int(warn_m.group(1)) if warn_m else 0
+        return passed, n_errors, n_warnings
+    except Exception:
+        return True, 0, 0
+
+
+# ---------------------------------------------------------------------------
+# Metrics logging
+# ---------------------------------------------------------------------------
+
+def _ensure_patch_history_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(_SKILL_PATCH_HISTORY_DDL)
+
+
+def log_patch_history(
+    skill_path: Path,
+    old_text: str,
+    new_text: str,
+    occurrences_replaced: int,
+    *,
+    replace_all: bool,
+    dry_run: bool,
+    validation_passed: bool | None,
+    validation_errors: int,
+    validation_warnings: int,
+    db_path: Path | None = None,
+) -> bool:
+    """
+    Write a patch-history record to skill-metrics.db.
+
+    Fail-open: returns False on any error without raising.
+    """
+    if db_path is None:
+        db_path = DEFAULT_METRICS_DB
+    try:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path))
+        try:
+            _ensure_patch_history_schema(conn)
+            conn.execute(
+                """
+                INSERT INTO skill_patch_history (
+                    skill_path, patched_at, old_text, new_text,
+                    occurrences_replaced, replace_all, dry_run,
+                    validation_passed, validation_errors, validation_warnings
+                ) VALUES (?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    str(skill_path),
+                    datetime.now(timezone.utc).isoformat(),
+                    old_text,
+                    new_text,
+                    occurrences_replaced,
+                    1 if replace_all else 0,
+                    1 if dry_run else 0,
+                    None if validation_passed is None else (1 if validation_passed else 0),
+                    validation_errors,
+                    validation_warnings,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return True
+    except Exception as exc:
+        print(f"skill-patch: warning: could not log metrics: {exc}", file=sys.stderr)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Simple unified-diff helper
+# ---------------------------------------------------------------------------
+
+def _simple_diff(before: str, after: str, path: Path) -> str:
+    lines_before = before.splitlines(keepends=True)
+    lines_after = after.splitlines(keepends=True)
+    import difflib
+    return "".join(
+        difflib.unified_diff(
+            lines_before, lines_after,
+            fromfile=f"a/{path.name}",
+            tofile=f"b/{path.name}",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="skill-patch",
+        description="Targeted patch tool for SKILL.md files.",
+        add_help=True,
+    )
+    parser.add_argument("path", help="Path to SKILL.md or skill directory")
+    parser.add_argument("--old", required=True, metavar="TEXT",
+                        help="Text to find (fuzzy whitespace matching)")
+    parser.add_argument("--new", required=True, metavar="TEXT",
+                        help="Replacement text", dest="new_text")
+    parser.add_argument("--replace-all", action="store_true",
+                        help="Replace all occurrences (default: first only)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show diff; do NOT write or log anything")
+    parser.add_argument("--no-validate", action="store_true",
+                        help="Skip post-patch validation via validate-skill.py")
+    parser.add_argument("--no-metrics", action="store_true",
+                        help="Skip logging patch history to skill-metrics.db")
+    parser.add_argument("--metrics-db", metavar="PATH",
+                        help="Override the skill-metrics.db path")
+
+    args = parser.parse_args(argv)
+
+    # Resolve skill path
+    try:
+        skill_path = resolve_skill_path(args.path)
+    except FileNotFoundError as exc:
+        print(f"skill-patch: error: {exc}", file=sys.stderr)
+        return 1
+
+    # Load content
+    try:
+        original = skill_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        print(f"skill-patch: error: cannot read {skill_path}: {exc}", file=sys.stderr)
+        return 1
+
+    old_text = args.old
+    new_text = args.new_text
+
+    # Validate that we have a real old pattern to search for
+    try:
+        matches = find_occurrences(original, old_text)
+    except ValueError as exc:
+        print(f"skill-patch: error: {exc}", file=sys.stderr)
+        return 2
+
+    if not matches:
+        print(
+            f"skill-patch: error: pattern not found in {skill_path.name}\n"
+            f"  searched for: {old_text!r}\n"
+            "  Hint: use --dry-run to preview matches before patching.",
+            file=sys.stderr,
+        )
+        return 1
+
+    count_found = len(matches)
+    count_label = "all" if args.replace_all else "first"
+    count_will = count_found if args.replace_all else 1
+
+    # Apply patch
+    patched, occurrences_replaced = apply_patch(
+        original, old_text, new_text, replace_all=args.replace_all
+    )
+
+    if occurrences_replaced == 0:
+        print("skill-patch: error: pattern matched but replacement yielded 0 substitutions",
+              file=sys.stderr)
+        return 1
+
+    # Diff display
+    diff_text = _simple_diff(original, patched, skill_path)
+    if args.dry_run:
+        print(f"skill-patch: DRY RUN — {occurrences_replaced}/{count_found} occurrence(s) would be replaced")
+        if diff_text:
+            print(diff_text, end="")
+        else:
+            print("(no textual diff detected)")
+        return 0
+
+    # Atomic write
+    try:
+        atomic_write(skill_path, patched)
+    except OSError as exc:
+        print(f"skill-patch: error: could not write {skill_path}: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"skill-patch: replaced {occurrences_replaced} occurrence(s) ({count_label}) in {skill_path}")
+    if diff_text:
+        print(diff_text, end="")
+
+    # Validation
+    validation_passed: bool | None = None
+    n_errors = 0
+    n_warnings = 0
+
+    if not args.no_validate:
+        validation_passed, n_errors, n_warnings = run_validation(skill_path)
+        if not validation_passed:
+            print(
+                f"skill-patch: validation FAILED — {n_errors} error(s), {n_warnings} warning(s)",
+                file=sys.stderr,
+            )
+        elif n_warnings:
+            print(f"skill-patch: validation OK — {n_warnings} warning(s)")
+        else:
+            print("skill-patch: validation passed ✓")
+
+    # Metrics
+    metrics_db: Path | None = None
+    if args.metrics_db:
+        metrics_db = Path(args.metrics_db).expanduser().resolve()
+
+    if not args.no_metrics:
+        log_patch_history(
+            skill_path=skill_path,
+            old_text=old_text,
+            new_text=new_text,
+            occurrences_replaced=occurrences_replaced,
+            replace_all=args.replace_all,
+            dry_run=False,
+            validation_passed=validation_passed,
+            validation_errors=n_errors,
+            validation_warnings=n_warnings,
+            db_path=metrics_db,
+        )
+
+    # Use returncode as source of truth: any non-zero exit from validate-skill
+    # is a failure even when the error-count regex does not match the output.
+    if validation_passed is False:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skill-patch.py
+++ b/skill-patch.py
@@ -176,6 +176,28 @@ def atomic_write(path: Path, content: str) -> None:
         raise
 
 
+def _write_to_temp(target_path: Path, content: str) -> Path:
+    """Write *content* to a sibling temp file and return its path.
+
+    The caller is responsible for either committing (os.replace) or
+    discarding (unlink) the temp file — the original *target_path* is
+    never touched by this function.
+    """
+    dir_ = target_path.parent
+    fd, tmp_str = tempfile.mkstemp(prefix=".skill-patch-", suffix=".tmp", dir=dir_)
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+    return tmp_path
+
+
 # ---------------------------------------------------------------------------
 # Post-patch validation
 # ---------------------------------------------------------------------------
@@ -201,9 +223,6 @@ def run_validation(skill_path: Path) -> tuple[bool, int, int]:
             errors="replace",
         )
         output = result.stdout + result.stderr
-        # Count error/warning markers in validate-skill.py's output
-        errors = len(re.findall(r"^  •", output, re.MULTILINE))
-        warnings = len(re.findall(r"^  •", output, re.MULTILINE))
         # Verdict: exit 0 = pass (including warnings), exit 1 = fail
         passed = result.returncode == 0
         # Re-parse: validate-skill outputs "❌ ERRORS (N):" and "⚠️  WARNINGS (N):"
@@ -381,9 +400,10 @@ def main(argv: list[str] | None = None) -> int:
             print("(no textual diff detected)")
         return 0
 
-    # Atomic write
+    # Write patched content to a sibling temp file first.
+    # The original file is NOT modified until validation has passed.
     try:
-        atomic_write(skill_path, patched)
+        tmp_path = _write_to_temp(skill_path, patched)
     except OSError as exc:
         print(f"skill-patch: error: could not write {skill_path}: {exc}", file=sys.stderr)
         return 1
@@ -392,22 +412,39 @@ def main(argv: list[str] | None = None) -> int:
     if diff_text:
         print(diff_text, end="")
 
-    # Validation
+    # Validation (runs against the temp file before committing to the final path)
     validation_passed: bool | None = None
     n_errors = 0
     n_warnings = 0
 
     if not args.no_validate:
-        validation_passed, n_errors, n_warnings = run_validation(skill_path)
+        validation_passed, n_errors, n_warnings = run_validation(tmp_path)
         if not validation_passed:
+            # Discard the temp file — the original is still intact on disk
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
             print(
                 f"skill-patch: validation FAILED — {n_errors} error(s), {n_warnings} warning(s)",
                 file=sys.stderr,
             )
+            return 1
         elif n_warnings:
             print(f"skill-patch: validation OK — {n_warnings} warning(s)")
         else:
             print("skill-patch: validation passed ✓")
+
+    # Commit: atomically replace the original with the validated (or --no-validate) patch
+    try:
+        os.replace(tmp_path, skill_path)
+    except OSError as exc:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        print(f"skill-patch: error: could not commit {skill_path}: {exc}", file=sys.stderr)
+        return 1
 
     # Metrics
     metrics_db: Path | None = None
@@ -428,10 +465,6 @@ def main(argv: list[str] | None = None) -> int:
             db_path=metrics_db,
         )
 
-    # Use returncode as source of truth: any non-zero exit from validate-skill
-    # is a failure even when the error-count regex does not match the output.
-    if validation_passed is False:
-        return 1
     return 0
 
 

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -188,6 +188,34 @@ class TestSkDirectCommands(unittest.TestCase):
             "skill-suggest.py not found — sk skill-suggest would break",
         )
 
+    def test_skill_patch(self):
+        self._assert_routes("skill-patch", "skill-patch.py")
+
+    def test_skill_patch_with_flags(self):
+        self._assert_routes(
+            "skill-patch", "skill-patch.py",
+            ["path/to/SKILL.md", "--old", "old text", "--new", "new text"],
+        )
+
+    def test_skill_patch_replace_all(self):
+        self._assert_routes(
+            "skill-patch", "skill-patch.py",
+            ["path/to/SKILL.md", "--old", "old", "--new", "new", "--replace-all"],
+        )
+
+    def test_skill_patch_dry_run(self):
+        self._assert_routes(
+            "skill-patch", "skill-patch.py",
+            ["path/to/SKILL.md", "--old", "old", "--new", "new", "--dry-run"],
+        )
+
+    def test_skill_patch_script_exists(self):
+        """skill-patch.py must exist in the tools directory."""
+        self.assertTrue(
+            (TOOLS_DIR / "skill-patch.py").exists(),
+            "skill-patch.py not found — sk skill-patch would break",
+        )
+
 
 class TestSkHooksCompat(unittest.TestCase):
     def test_hooks_run_drops_run_subcommand(self):

--- a/tests/test_skill_metrics.py
+++ b/tests/test_skill_metrics.py
@@ -435,6 +435,148 @@ audit_verified = skill_metrics_verified._runtime_audit(status_verified)
 test("audit ok", audit_verified["ok"] is True, str(audit_verified))
 
 # ---------------------------------------------------------------------------
+print("\n📊 skill-metrics.py — patch_history / skill_patch_history table")
+
+patch_db_path = ARTIFACT_DIR / "patch-skill-metrics.db"
+
+db_patch = sqlite3.connect(str(patch_db_path))
+db_patch.executescript(
+    """
+    CREATE TABLE IF NOT EXISTS tentacle_outcomes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        tentacle_name TEXT NOT NULL,
+        tentacle_id TEXT,
+        git_root TEXT,
+        description TEXT,
+        outcome_status TEXT NOT NULL,
+        recorded_at TEXT NOT NULL,
+        worktree_used INTEGER NOT NULL DEFAULT 0,
+        worktree_path TEXT,
+        verification_total INTEGER NOT NULL DEFAULT 0,
+        verification_passed INTEGER NOT NULL DEFAULT 0,
+        verification_failed INTEGER NOT NULL DEFAULT 0,
+        todo_total INTEGER NOT NULL DEFAULT 0,
+        todo_done INTEGER NOT NULL DEFAULT 0,
+        learned INTEGER NOT NULL DEFAULT 0,
+        duration_seconds REAL,
+        summary TEXT
+    );
+    CREATE TABLE IF NOT EXISTS tentacle_outcome_skills (
+        outcome_id INTEGER NOT NULL,
+        skill_name TEXT NOT NULL,
+        PRIMARY KEY (outcome_id, skill_name)
+    );
+    CREATE TABLE IF NOT EXISTS tentacle_verifications (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        outcome_id INTEGER,
+        tentacle_name TEXT NOT NULL,
+        tentacle_id TEXT,
+        label TEXT NOT NULL,
+        command TEXT NOT NULL,
+        cwd TEXT NOT NULL,
+        exit_code INTEGER NOT NULL,
+        started_at TEXT NOT NULL,
+        finished_at TEXT NOT NULL,
+        duration_seconds REAL NOT NULL,
+        log_path TEXT
+    );
+    CREATE TABLE IF NOT EXISTS skill_patch_history (
+        id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+        skill_path           TEXT NOT NULL,
+        patched_at           TEXT NOT NULL,
+        old_text             TEXT NOT NULL,
+        new_text             TEXT NOT NULL,
+        occurrences_replaced INTEGER NOT NULL DEFAULT 0,
+        replace_all          INTEGER NOT NULL DEFAULT 0,
+        dry_run              INTEGER NOT NULL DEFAULT 0,
+        validation_passed    INTEGER,
+        validation_errors    INTEGER NOT NULL DEFAULT 0,
+        validation_warnings  INTEGER NOT NULL DEFAULT 0
+    );
+    """
+)
+# Insert two patch history rows
+db_patch.execute(
+    "INSERT INTO skill_patch_history "
+    "(skill_path, patched_at, old_text, new_text, occurrences_replaced, "
+    "replace_all, dry_run, validation_passed, validation_errors, validation_warnings) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ("/skills/test-skill/SKILL.md", "2026-05-01T00:00:00+00:00",
+     "old text", "new text", 1, 0, 0, 1, 0, 0),
+)
+db_patch.execute(
+    "INSERT INTO skill_patch_history "
+    "(skill_path, patched_at, old_text, new_text, occurrences_replaced, "
+    "replace_all, dry_run, validation_passed, validation_errors, validation_warnings) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ("/skills/other-skill/SKILL.md", "2026-05-02T00:00:00+00:00",
+     "another old", "another new", 3, 1, 0, 1, 0, 2),
+)
+db_patch.commit()
+db_patch.close()
+
+skill_metrics_patch = load_module("skill_metrics_patch", "skill-metrics.py")
+skill_metrics_patch.METRICS_DB_PATH = patch_db_path
+status_patch = skill_metrics_patch.collect_status()
+
+test(
+    "patch-history: total_patches == 2",
+    status_patch.get("total_patches") == 2,
+    f"got {status_patch.get('total_patches')}",
+)
+test(
+    "patch-history: patch_history list has 2 entries",
+    len(status_patch.get("patch_history", [])) == 2,
+    f"got {len(status_patch.get('patch_history', []))}",
+)
+test(
+    "patch-history: first entry has skill_path",
+    "skill_path" in (status_patch.get("patch_history") or [{}])[0],
+)
+test(
+    "patch-history: first entry has patched_at",
+    "patched_at" in (status_patch.get("patch_history") or [{}])[0],
+)
+test(
+    "patch-history: first entry has occurrences_replaced",
+    "occurrences_replaced" in (status_patch.get("patch_history") or [{}])[0],
+)
+test(
+    "patch-history: first entry replace_all is True",
+    (status_patch.get("patch_history") or [{}])[0].get("replace_all") is True,
+)
+
+# Verify format_status includes patch history section
+formatted_patch = skill_metrics_patch.format_status(status_patch)
+test(
+    "patch-history: format_status includes patch history heading",
+    "patch" in formatted_patch.lower(),
+    formatted_patch,
+)
+
+# Verify collect_status on a DB without skill_patch_history table still works
+db_no_patch_path = ARTIFACT_DIR / "no-patch-skill-metrics.db"
+_make_metrics_db(db_no_patch_path, with_data=True)
+skill_metrics_no_patch = load_module("skill_metrics_no_patch", "skill-metrics.py")
+skill_metrics_no_patch.METRICS_DB_PATH = db_no_patch_path
+status_no_patch = skill_metrics_no_patch.collect_status()
+test(
+    "no-patch-table: total_patches defaults to 0",
+    status_no_patch.get("total_patches", 0) == 0,
+    f"got {status_no_patch.get('total_patches')}",
+)
+test(
+    "no-patch-table: patch_history defaults to empty list",
+    status_no_patch.get("patch_history", []) == [],
+    f"got {status_no_patch.get('patch_history')}",
+)
+test(
+    "no-patch-table: collect_status still has total_outcomes",
+    status_no_patch.get("total_outcomes", 0) > 0,
+    f"got {status_no_patch.get('total_outcomes')}",
+)
+
+# ---------------------------------------------------------------------------
 print("\n" + "=" * 72)
 print(f"PASS: {PASS}")
 print(f"FAIL: {FAIL}")

--- a/tests/test_skill_patch.py
+++ b/tests/test_skill_patch.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+test_skill_patch.py — Regression tests for skill-patch.py
+
+Run:
+    python tests/test_skill_patch.py
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).parent.parent
+SKILL_PATCH_PATH = REPO / "skill-patch.py"
+
+
+def _load_skill_patch():
+    spec = importlib.util.spec_from_file_location("skill_patch", str(SKILL_PATCH_PATH))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+sp = _load_skill_patch()
+
+# ---------------------------------------------------------------------------
+# Minimal valid SKILL.md content for tests
+# ---------------------------------------------------------------------------
+
+_MINIMAL_SKILL_MD = """\
+---
+name: test-skill
+description: Use when testing skill-patch functionality. Trigger on test requests.
+---
+
+# Test Skill
+
+## When to Use
+
+Use when you need to test skill-patch.
+
+## Workflow
+
+1. Step one
+2. Step two
+3. Step three
+
+<example>
+This is an example of using the test skill.
+</example>
+"""
+
+
+class TestFuzzyPattern(unittest.TestCase):
+    def test_basic_match(self):
+        matches = sp.find_occurrences("hello world", "hello world")
+        self.assertEqual(len(matches), 1)
+
+    def test_extra_spaces_match(self):
+        matches = sp.find_occurrences("hello   world", "hello world")
+        self.assertEqual(len(matches), 1)
+
+    def test_leading_spaces_match(self):
+        matches = sp.find_occurrences("  hello world", "hello world")
+        self.assertEqual(len(matches), 1)
+
+    def test_tab_indent_match(self):
+        matches = sp.find_occurrences("\thello world", "hello world")
+        self.assertEqual(len(matches), 1)
+
+    def test_multiline_content_match(self):
+        content = "Step one\nStep two\nStep three"
+        matches = sp.find_occurrences(content, "Step one\nStep two")
+        self.assertEqual(len(matches), 1)
+
+    def test_no_match(self):
+        matches = sp.find_occurrences("hello world", "goodbye world")
+        self.assertEqual(len(matches), 0)
+
+    def test_multiple_matches(self):
+        content = "foo bar\nfoo bar"
+        matches = sp.find_occurrences(content, "foo bar")
+        self.assertGreater(len(matches), 1)
+
+    def test_empty_old_text_raises(self):
+        with self.assertRaises(ValueError):
+            sp.find_occurrences("anything", "   ")
+
+
+class TestApplyPatch(unittest.TestCase):
+    def test_replace_first_only(self):
+        content = "foo bar\nfoo bar\nfoo bar"
+        patched, n = sp.apply_patch(content, "foo bar", "baz qux", replace_all=False)
+        self.assertEqual(n, 1)
+        self.assertEqual(patched.count("baz qux"), 1)
+
+    def test_replace_all(self):
+        content = "foo bar\nfoo bar\nfoo bar"
+        patched, n = sp.apply_patch(content, "foo bar", "baz qux", replace_all=True)
+        self.assertGreater(n, 1)
+        self.assertNotIn("foo bar", patched)
+
+    def test_replace_preserves_surrounding(self):
+        content = "prefix\nStep one\nStep two\nsuffix"
+        patched, n = sp.apply_patch(content, "Step one", "Step ONE", replace_all=False)
+        self.assertEqual(n, 1)
+        self.assertIn("Step ONE", patched)
+        self.assertIn("prefix", patched)
+        self.assertIn("suffix", patched)
+
+    def test_replace_fuzzy_whitespace(self):
+        content = "1. Step one\n2.  Step two\n3. Step three"
+        patched, n = sp.apply_patch(content, "Step two", "Step TWO", replace_all=False)
+        self.assertEqual(n, 1)
+        self.assertIn("Step TWO", patched)
+
+    def test_list_marker_space_preserved(self):
+        """Regression #122: mid-line leading space before matched text must not be swallowed."""
+        content = "1. Step one\n2. Step two\n3. Step three\n"
+        patched, n = sp.apply_patch(content, "Step one", "Step 1", replace_all=False)
+        self.assertEqual(n, 1)
+        # The space between "1." and "Step 1" must be preserved
+        self.assertIn("1. Step 1", patched)
+        self.assertNotIn("1.Step 1", patched)
+
+
+class TestResolveSkillPath(unittest.TestCase):
+    def test_direct_md_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            skill.write_text(_MINIMAL_SKILL_MD, encoding="utf-8")
+            resolved = sp.resolve_skill_path(str(skill))
+            # Compare case-insensitively to handle Windows 8.3 short name vs long name
+            self.assertEqual(str(resolved).lower(), str(skill.resolve()).lower())
+
+    def test_directory_with_skill_md(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            skill.write_text(_MINIMAL_SKILL_MD, encoding="utf-8")
+            resolved = sp.resolve_skill_path(tmp)
+            self.assertEqual(str(resolved).lower(), str(skill.resolve()).lower())
+
+    def test_directory_without_skill_md(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(FileNotFoundError):
+                sp.resolve_skill_path(tmp)
+
+    def test_nonexistent_path(self):
+        with self.assertRaises(FileNotFoundError):
+            sp.resolve_skill_path("/definitely/does/not/exist/SKILL.md")
+
+
+class TestAtomicWrite(unittest.TestCase):
+    def test_atomic_write_creates_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "SKILL.md"
+            sp.atomic_write(path, "hello world")
+            self.assertTrue(path.exists())
+            self.assertEqual(path.read_text(encoding="utf-8"), "hello world")
+
+    def test_atomic_write_replaces_existing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "SKILL.md"
+            path.write_text("original", encoding="utf-8")
+            sp.atomic_write(path, "updated")
+            self.assertEqual(path.read_text(encoding="utf-8"), "updated")
+
+    def test_no_temp_files_left_behind(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "SKILL.md"
+            sp.atomic_write(path, "content")
+            tmp_files = list(Path(tmp).glob(".skill-patch-*"))
+            self.assertEqual(len(tmp_files), 0)
+
+
+class TestLogPatchHistory(unittest.TestCase):
+    def test_logs_to_db(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "skill-metrics.db"
+            skill_path = Path(tmp) / "SKILL.md"
+            result = sp.log_patch_history(
+                skill_path=skill_path,
+                old_text="old",
+                new_text="new",
+                occurrences_replaced=1,
+                replace_all=False,
+                dry_run=False,
+                validation_passed=True,
+                validation_errors=0,
+                validation_warnings=0,
+                db_path=db_path,
+            )
+            self.assertTrue(result)
+            # Verify row was written (open and close explicitly to avoid lock on Windows)
+            conn = sqlite3.connect(str(db_path))
+            try:
+                row = conn.execute("SELECT * FROM skill_patch_history").fetchone()
+            finally:
+                conn.close()
+            self.assertIsNotNone(row)
+
+    def test_replace_all_flag_stored(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "skill-metrics.db"
+            skill_path = Path(tmp) / "SKILL.md"
+            sp.log_patch_history(
+                skill_path=skill_path,
+                old_text="old",
+                new_text="new",
+                occurrences_replaced=3,
+                replace_all=True,
+                dry_run=False,
+                validation_passed=True,
+                validation_errors=0,
+                validation_warnings=0,
+                db_path=db_path,
+            )
+            conn = sqlite3.connect(str(db_path))
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute("SELECT * FROM skill_patch_history").fetchone()
+            finally:
+                conn.close()
+            self.assertEqual(row["replace_all"], 1)
+            self.assertEqual(row["occurrences_replaced"], 3)
+
+    def test_dry_run_flag_stored(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "skill-metrics.db"
+            skill_path = Path(tmp) / "SKILL.md"
+            sp.log_patch_history(
+                skill_path=skill_path,
+                old_text="old",
+                new_text="new",
+                occurrences_replaced=0,
+                replace_all=False,
+                dry_run=True,
+                validation_passed=None,
+                validation_errors=0,
+                validation_warnings=0,
+                db_path=db_path,
+            )
+            conn = sqlite3.connect(str(db_path))
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute("SELECT * FROM skill_patch_history").fetchone()
+            finally:
+                conn.close()
+            self.assertEqual(row["dry_run"], 1)
+            self.assertIsNone(row["validation_passed"])
+
+    def test_log_fails_open_on_bad_path(self):
+        # Use a path whose parent directory cannot be created (permissions)
+        # Patch mkdir to simulate an OSError
+        from unittest.mock import patch as _patch
+        with _patch("pathlib.Path.mkdir", side_effect=OSError("permission denied")):
+            result = sp.log_patch_history(
+                skill_path=Path("/some/skill.md"),
+                old_text="old",
+                new_text="new",
+                occurrences_replaced=1,
+                replace_all=False,
+                dry_run=False,
+                validation_passed=True,
+                validation_errors=0,
+                validation_warnings=0,
+                db_path=Path("/nonexistent/skill-metrics.db"),
+            )
+        # Should return False (fail-open), not raise
+        self.assertFalse(result)
+
+
+class TestMain(unittest.TestCase):
+    """Integration tests for the main() entry point."""
+
+    def _write_skill(self, path: Path) -> None:
+        path.write_text(_MINIMAL_SKILL_MD, encoding="utf-8")
+
+    def test_main_no_args_exits_2(self):
+        with self.assertRaises(SystemExit) as ctx:
+            sp.main([])
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_main_missing_old_exits_2(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            with self.assertRaises(SystemExit) as ctx:
+                sp.main([str(skill), "--new", "replacement"])
+            self.assertEqual(ctx.exception.code, 2)
+
+    def test_main_missing_new_exits_2(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            with self.assertRaises(SystemExit) as ctx:
+                sp.main([str(skill), "--old", "Step one"])
+            self.assertEqual(ctx.exception.code, 2)
+
+    def test_main_pattern_not_found_returns_1(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            rc = sp.main([str(skill), "--old", "this text does not exist in the file",
+                          "--new", "replacement", "--no-metrics", "--no-validate"])
+            self.assertEqual(rc, 1)
+
+    def test_main_basic_patch_returns_0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            rc = sp.main([str(skill), "--old", "Step one",
+                          "--new", "Step 1", "--no-metrics", "--no-validate"])
+            self.assertEqual(rc, 0)
+            content = skill.read_text(encoding="utf-8")
+            self.assertIn("Step 1", content)
+
+    def test_main_replace_all_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            skill.write_text("foo\nfoo\nfoo\n", encoding="utf-8")
+            rc = sp.main([str(skill), "--old", "foo",
+                          "--new", "bar", "--replace-all", "--no-metrics", "--no-validate"])
+            self.assertEqual(rc, 0)
+            content = skill.read_text(encoding="utf-8")
+            self.assertNotIn("foo", content)
+            self.assertIn("bar", content)
+
+    def test_main_dry_run_does_not_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            original = skill.read_text(encoding="utf-8")
+            rc = sp.main([str(skill), "--old", "Step one",
+                          "--new", "Step 1", "--dry-run", "--no-metrics"])
+            self.assertEqual(rc, 0)
+            self.assertEqual(skill.read_text(encoding="utf-8"), original)
+
+    def test_main_dry_run_does_not_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "skill-metrics.db"
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            rc = sp.main([str(skill), "--old", "Step one",
+                          "--new", "Step 1", "--dry-run",
+                          "--metrics-db", str(db_path)])
+            self.assertEqual(rc, 0)
+            # DB should NOT have been created by a dry-run
+            self.assertFalse(db_path.exists())
+
+    def test_main_logs_to_custom_db(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "custom-metrics.db"
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            rc = sp.main([str(skill), "--old", "Step one",
+                          "--new", "Step 1",
+                          "--no-validate",
+                          "--metrics-db", str(db_path)])
+            self.assertEqual(rc, 0)
+            self.assertTrue(db_path.exists())
+            conn = sqlite3.connect(str(db_path))
+            try:
+                count = conn.execute("SELECT COUNT(*) FROM skill_patch_history").fetchone()[0]
+            finally:
+                conn.close()
+            self.assertEqual(count, 1)
+
+    def test_main_no_metrics_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "custom-metrics.db"
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            rc = sp.main([str(skill), "--old", "Step one",
+                          "--new", "Step 1",
+                          "--no-validate",
+                          "--no-metrics",
+                          "--metrics-db", str(db_path)])
+            self.assertEqual(rc, 0)
+            # DB should NOT exist (--no-metrics skips logging)
+            self.assertFalse(db_path.exists())
+
+    def test_main_accepts_directory_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            rc = sp.main([tmp, "--old", "Step one",
+                          "--new", "Step 1", "--no-metrics", "--no-validate"])
+            self.assertEqual(rc, 0)
+            self.assertIn("Step 1", skill.read_text(encoding="utf-8"))
+
+    def test_main_nonexistent_path_returns_1(self):
+        rc = sp.main(["/no/such/path/SKILL.md", "--old", "x",
+                      "--new", "y", "--no-metrics", "--no-validate"])
+        self.assertEqual(rc, 1)
+
+    def test_main_script_exists(self):
+        self.assertTrue(SKILL_PATCH_PATH.exists(), "skill-patch.py not found in tools dir")
+
+    def test_validation_nonzero_returncode_returns_1_even_when_no_regex_match(self):
+        """Regression #122: validate-skill nonzero exit must return 1 even if error-count
+        regex does not match output (returncode is the source of truth, not the regex)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            # Simulate validate-skill returning exit 1 with no parseable error count
+            with patch.object(sp, "run_validation", return_value=(False, 0, 0)):
+                rc = sp.main([str(skill), "--old", "Step one",
+                              "--new", "Step 1", "--no-metrics"])
+            self.assertEqual(rc, 1)
+
+    def test_validation_nonzero_returncode_prints_failed_not_passed(self):
+        """Regression #122: when validate-skill exits nonzero but regex-based error/warning
+        counters stay zero, status message must say FAILED (not 'validation passed')."""
+        import contextlib
+        import io
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            captured_out = io.StringIO()
+            captured_err = io.StringIO()
+            with patch.object(sp, "run_validation", return_value=(False, 0, 0)):
+                with contextlib.redirect_stdout(captured_out), contextlib.redirect_stderr(captured_err):
+                    rc = sp.main([str(skill), "--old", "Step one",
+                                  "--new", "Step 1", "--no-metrics"])
+        self.assertEqual(rc, 1)
+        stdout_text = captured_out.getvalue()
+        stderr_text = captured_err.getvalue()
+        # Must NOT print "validation passed" when the result is a failure
+        self.assertNotIn("validation passed", stdout_text)
+        # Must print FAILED to stderr
+        self.assertIn("FAILED", stderr_text)
+
+
+class TestSimpleDiff(unittest.TestCase):
+    def test_diff_shows_change(self):
+        before = "hello world\n"
+        after = "hello earth\n"
+        diff = sp._simple_diff(before, after, Path("SKILL.md"))
+        self.assertIn("-hello world", diff)
+        self.assertIn("+hello earth", diff)
+
+    def test_diff_empty_on_identical(self):
+        diff = sp._simple_diff("same\n", "same\n", Path("SKILL.md"))
+        self.assertEqual(diff, "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_skill_patch.py
+++ b/tests/test_skill_patch.py
@@ -407,6 +407,32 @@ class TestMain(unittest.TestCase):
     def test_main_script_exists(self):
         self.assertTrue(SKILL_PATCH_PATH.exists(), "skill-patch.py not found in tools dir")
 
+    def test_validation_failure_preserves_original_file(self):
+        """Regression #122 follow-up: when validation fails, the original SKILL.md
+        must not be modified — the invalid patched content must never be left on disk."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            original = skill.read_text(encoding="utf-8")
+            with patch.object(sp, "run_validation", return_value=(False, 1, 0)):
+                rc = sp.main([str(skill), "--old", "Step one",
+                              "--new", "INVALID REPLACEMENT", "--no-metrics"])
+            self.assertEqual(rc, 1)
+            # Original file must be completely unchanged
+            self.assertEqual(skill.read_text(encoding="utf-8"), original)
+
+    def test_no_temp_files_left_on_validation_failure(self):
+        """Regression #122 follow-up: no .skill-patch-*.tmp files must remain after
+        a validation failure."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = Path(tmp) / "SKILL.md"
+            self._write_skill(skill)
+            with patch.object(sp, "run_validation", return_value=(False, 1, 0)):
+                sp.main([str(skill), "--old", "Step one",
+                         "--new", "INVALID REPLACEMENT", "--no-metrics"])
+            tmp_files = list(Path(tmp).glob(".skill-patch-*"))
+            self.assertEqual(len(tmp_files), 0)
+
     def test_validation_nonzero_returncode_returns_1_even_when_no_regex_match(self):
         """Regression #122: validate-skill nonzero exit must return 1 even if error-count
         regex does not match output (returncode is the source of truth, not the regex)."""


### PR DESCRIPTION
## Summary
- add standalone `skill-patch.py` for targeted SKILL.md updates with fuzzy matching, atomic writes, and validation
- route `sk skill-patch` through both `sk.py` and the Rust `sk` front door
- log patch history in `skill-metrics.db`, add focused regression coverage, and document the new command

Closes #122