### PR TITLE
feat(audit-hooks): add hook effectiveness audit

### DIFF
--- a/audit-hooks.py
+++ b/audit-hooks.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""
+audit-hooks.py — Hook effectiveness audit for copilot-session-knowledge.
+
+Parses ~/.copilot/markers/audit.jsonl (written by hooks/hook_runner.py and the
+native Rust hook runner) and reports per-hook effectiveness metrics plus a
+time-based trend analysis.
+
+Classification rules
+--------------------
+useful-block  : decision == "deny"    — a real enforcement action
+false-positive: decision == "deny-dry" — dry-run / test noise (hook fired but
+                                         did not actually block)
+
+Metrics reported per hook rule
+-------------------------------
+- fire_count        : total entries for this rule
+- fire_rate_pct     : fire_count / total entries × 100
+- block_count       : useful-block count (decision=="deny")
+- fp_count          : false-positive count (decision=="deny-dry")
+- block_rate_pct    : block_count / fire_count × 100
+- useful_block_rate : block_count / (block_count + fp_count) × 100 (or n/a)
+
+Trend analysis
+--------------
+Entries are bucketed by calendar day.  For each day the report shows:
+- total hook firings
+- deny count (useful-blocks)
+- deny-dry count (false-positives)
+- daily deny rate
+
+Usage
+-----
+    python3 audit-hooks.py                         # full text report
+    python3 audit-hooks.py --json                  # JSON output
+    python3 audit-hooks.py --days N                # limit to last N days (default all)
+    python3 audit-hooks.py --audit-file /path/...  # override audit.jsonl path
+    python3 audit-hooks.py --top N                 # show top-N rules (default 15)
+
+Exit codes
+----------
+0  — report produced successfully
+1  — audit.jsonl not found or empty
+2  — bad arguments
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from collections import defaultdict, deque
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Windows UTF-8 encoding fix (must be first code)
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+MARKERS_DIR = Path.home() / ".copilot" / "markers"
+DEFAULT_AUDIT_JSONL = MARKERS_DIR / "audit.jsonl"
+
+# Safety cap on lines read from audit.jsonl (matches retro.py convention)
+_AUDIT_MAX_LINES = 5_000
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def _load_entries(audit_path: Path, days: int | None = None) -> list[dict]:
+    """Load and optionally filter audit entries from audit.jsonl.
+
+    Reads from the *tail* of the file (last ``_AUDIT_MAX_LINES`` non-blank
+    lines) so that ``--days`` filtering on large append-only logs correctly
+    considers recent entries rather than silently stopping at the head.
+    """
+    if not audit_path.exists():
+        return []
+    cutoff_ts: float | None = None
+    if days is not None and days > 0:
+        cutoff_ts = time.time() - days * 86_400
+
+    # Collect the last _AUDIT_MAX_LINES non-blank lines so recent entries at
+    # the tail are always visible even when the log exceeds the safety cap.
+    raw_lines: deque[str] = deque(maxlen=_AUDIT_MAX_LINES)
+    try:
+        with open(audit_path, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if stripped:
+                    raw_lines.append(stripped)
+    except OSError:
+        return []
+
+    entries: list[dict] = []
+    for line in raw_lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        if cutoff_ts is not None:
+            ts = entry.get("ts", 0)
+            if isinstance(ts, (int, float)) and ts < cutoff_ts:
+                continue
+        entries.append(entry)
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Classification helpers
+# ---------------------------------------------------------------------------
+
+
+def _classify(decision: str) -> str:
+    """Return classification label for a single audit entry."""
+    if decision == "deny":
+        return "useful-block"
+    if decision == "deny-dry":
+        return "false-positive"
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Metric computation
+# ---------------------------------------------------------------------------
+
+
+def _per_hook_metrics(entries: list[dict], top_n: int = 15) -> list[dict]:
+    """Compute per-rule effectiveness metrics, sorted by fire count descending."""
+    rule_stats: dict[str, dict] = defaultdict(lambda: {
+        "fire_count": 0,
+        "useful_block": 0,
+        "false_positive": 0,
+        "allow": 0,
+        "other": 0,
+    })
+    total = len(entries)
+
+    for e in entries:
+        rule = e.get("rule") or "(no-rule)"
+        decision = e.get("decision", "")
+        stats = rule_stats[rule]
+        stats["fire_count"] += 1
+        classification = _classify(decision)
+        if classification == "useful-block":
+            stats["useful_block"] += 1
+        elif classification == "false-positive":
+            stats["false_positive"] += 1
+        elif decision == "allow":
+            stats["allow"] += 1
+        else:
+            stats["other"] += 1
+
+    rows: list[dict] = []
+    for rule, st in rule_stats.items():
+        fc = st["fire_count"]
+        ub = st["useful_block"]
+        fp = st["false_positive"]
+        fire_rate = round(fc / total * 100, 1) if total > 0 else 0.0
+        block_rate = round(ub / fc * 100, 1) if fc > 0 else 0.0
+        ub_denom = ub + fp
+        useful_block_rate: float | None = round(ub / ub_denom * 100, 1) if ub_denom > 0 else None
+        rows.append({
+            "rule": rule,
+            "fire_count": fc,
+            "fire_rate_pct": fire_rate,
+            "block_count": ub,
+            "fp_count": fp,
+            "allow_count": st["allow"],
+            "block_rate_pct": block_rate,
+            "useful_block_rate": useful_block_rate,
+        })
+
+    rows.sort(key=lambda r: -r["fire_count"])
+    return rows[:top_n]
+
+
+def _global_summary(entries: list[dict]) -> dict:
+    """Compute global summary stats across all entries."""
+    total = len(entries)
+    by_decision: dict[str, int] = defaultdict(int)
+    for e in entries:
+        by_decision[e.get("decision", "")] += 1
+
+    useful_blocks = by_decision.get("deny", 0)
+    false_positives = by_decision.get("deny-dry", 0)
+    ub_denom = useful_blocks + false_positives
+
+    return {
+        "total_entries": total,
+        "decisions": dict(by_decision),
+        "useful_block_count": useful_blocks,
+        "false_positive_count": false_positives,
+        "deny_rate_pct": round(useful_blocks / total * 100, 1) if total > 0 else 0.0,
+        "fp_rate_pct": round(false_positives / total * 100, 1) if total > 0 else 0.0,
+        "useful_block_rate": round(useful_blocks / ub_denom * 100, 1) if ub_denom > 0 else None,
+    }
+
+
+def _trend_analysis(entries: list[dict]) -> list[dict]:
+    """Bucket entries by calendar day (UTC) and compute per-day metrics."""
+    day_stats: dict[str, dict] = defaultdict(lambda: {
+        "total": 0, "deny": 0, "deny_dry": 0, "allow": 0
+    })
+
+    for e in entries:
+        ts = e.get("ts", 0)
+        try:
+            day = datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%Y-%m-%d")
+        except (TypeError, ValueError, OSError):
+            day = "unknown"
+        decision = e.get("decision", "")
+        st = day_stats[day]
+        st["total"] += 1
+        if decision == "deny":
+            st["deny"] += 1
+        elif decision == "deny-dry":
+            st["deny_dry"] += 1
+        elif decision == "allow":
+            st["allow"] += 1
+
+    rows: list[dict] = []
+    for day, st in sorted(day_stats.items()):
+        total = st["total"]
+        deny = st["deny"]
+        rows.append({
+            "date": day,
+            "total": total,
+            "deny": deny,
+            "deny_dry": st["deny_dry"],
+            "allow": st["allow"],
+            "deny_rate_pct": round(deny / total * 100, 1) if total > 0 else 0.0,
+        })
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+def _render_text(summary: dict, per_hook: list[dict], trend: list[dict]) -> None:
+    """Print a human-readable audit report to stdout."""
+    print("=" * 66)
+    print("  sk audit-hooks — Hook Effectiveness Audit")
+    print("=" * 66)
+
+    print("\n── Global Summary ──────────────────────────────────────────────")
+    total = summary["total_entries"]
+    print(f"  Total entries     : {total}")
+    if total == 0:
+        print("  (no audit entries found)")
+        return
+    print(f"  Useful blocks     : {summary['useful_block_count']}  ({summary['deny_rate_pct']:.1f}%)")
+    print(f"  False positives   : {summary['false_positive_count']}  ({summary['fp_rate_pct']:.1f}%)")
+    ub_rate = summary["useful_block_rate"]
+    ub_label = f"{ub_rate:.1f}%" if ub_rate is not None else "n/a"
+    print(f"  Useful-block rate : {ub_label}  (deny / (deny + deny-dry))")
+    decisions = summary["decisions"]
+    if decisions:
+        dec_str = ", ".join(f"{k}={v}" for k, v in sorted(decisions.items()))
+        print(f"  Decision counts   : {dec_str}")
+
+    if per_hook:
+        print("\n── Per-Hook Effectiveness ──────────────────────────────────────")
+        hdr = f"  {'Rule':<38} {'Fires':>6} {'Rate%':>6} {'Blocks':>7} {'FPs':>5} {'Blk%':>6} {'UB-rate':>8}"
+        print(hdr)
+        print("  " + "-" * 64)
+        for row in per_hook:
+            ubr = f"{row['useful_block_rate']:.1f}%" if row["useful_block_rate"] is not None else "n/a"
+            rule_trunc = row["rule"][:37]
+            print(
+                f"  {rule_trunc:<38} {row['fire_count']:>6} "
+                f"{row['fire_rate_pct']:>5.1f}% {row['block_count']:>7} "
+                f"{row['fp_count']:>5} {row['block_rate_pct']:>5.1f}% {ubr:>8}"
+            )
+
+    if trend:
+        print("\n── Daily Trend ─────────────────────────────────────────────────")
+        hdr2 = f"  {'Date':<12} {'Total':>7} {'Deny':>6} {'DryDeny':>8} {'Allow':>7} {'DenyRate%':>10}"
+        print(hdr2)
+        print("  " + "-" * 54)
+        for row in trend:
+            print(
+                f"  {row['date']:<12} {row['total']:>7} {row['deny']:>6} "
+                f"{row['deny_dry']:>8} {row['allow']:>7} {row['deny_rate_pct']:>9.1f}%"
+            )
+    print()
+
+
+def _render_json(summary: dict, per_hook: list[dict], trend: list[dict]) -> None:
+    """Print JSON payload to stdout."""
+    payload = {
+        "summary": summary,
+        "per_hook": per_hook,
+        "trend": trend,
+    }
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="audit-hooks",
+        description="Hook effectiveness audit — parses audit.jsonl and reports metrics.",
+    )
+    parser.add_argument(
+        "--json", action="store_true", dest="json_out",
+        help="Emit JSON instead of text",
+    )
+    parser.add_argument(
+        "--days", type=int, default=None, metavar="N",
+        help="Restrict analysis to the last N days (default: all)",
+    )
+    parser.add_argument(
+        "--audit-file", type=Path, default=DEFAULT_AUDIT_JSONL, metavar="PATH",
+        help="Override path to audit.jsonl",
+    )
+    parser.add_argument(
+        "--top", type=int, default=15, metavar="N",
+        help="Show top-N rules in per-hook table (default 15)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    entries = _load_entries(args.audit_file, days=args.days)
+    if not entries:
+        msg = f"audit-hooks: no entries found in {args.audit_file}"
+        if args.json_out:
+            print(json.dumps({"error": msg, "total_entries": 0}))
+        else:
+            print(msg, file=sys.stderr)
+        return 1
+
+    summary = _global_summary(entries)
+    per_hook = _per_hook_metrics(entries, top_n=args.top)
+    trend = _trend_analysis(entries)
+
+    if args.json_out:
+        _render_json(summary, per_hook, trend)
+    else:
+        _render_text(summary, per_hook, trend)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/audit-hooks.py
+++ b/audit-hooks.py
@@ -8,26 +8,36 @@ time-based trend analysis.
 
 Classification rules
 --------------------
-useful-block  : decision == "deny"    — a real enforcement action
-false-positive: decision == "deny-dry" — dry-run / test noise (hook fired but
-                                         did not actually block)
+useful-block  : decision == "deny"     — a real enforcement action
+dry-run-noise : decision == "deny-dry" — hook fired in dry-run/test mode
+                                         (HOOK_DRY_RUN=1); the hook logic
+                                         triggered correctly but the action was
+                                         not actually blocked.  This is NOT a
+                                         false positive — it is test-mode noise
+                                         that should be tracked separately.
 
 Metrics reported per hook rule
 -------------------------------
 - fire_count        : total entries for this rule
 - fire_rate_pct     : fire_count / total entries × 100
 - block_count       : useful-block count (decision=="deny")
-- fp_count          : false-positive count (decision=="deny-dry")
+- dry_run_count     : dry-run-noise count (decision=="deny-dry")
 - block_rate_pct    : block_count / fire_count × 100
-- useful_block_rate : block_count / (block_count + fp_count) × 100 (or n/a)
+- useful_block_rate : block_count / (block_count + dry_run_count) × 100 (or n/a)
 
 Trend analysis
 --------------
 Entries are bucketed by calendar day.  For each day the report shows:
 - total hook firings
 - deny count (useful-blocks)
-- deny-dry count (false-positives)
+- deny-dry count (dry-run noise)
 - daily deny rate
+
+Never-fired hooks
+-----------------
+The tool scans the registered hook rule inventory (hooks/rules/*.py) and
+compares against rules seen in the audit log.  Rules with zero audit entries in
+the analysis window are reported as simplification candidates per issue #127.
 
 Usage
 -----
@@ -36,6 +46,7 @@ Usage
     python3 audit-hooks.py --days N                # limit to last N days (default all)
     python3 audit-hooks.py --audit-file /path/...  # override audit.jsonl path
     python3 audit-hooks.py --top N                 # show top-N rules (default 15)
+    python3 audit-hooks.py --hooks-dir /path/hooks # override hooks directory
 
 Exit codes
 ----------
@@ -47,6 +58,7 @@ Exit codes
 import argparse
 import json
 import os
+import re
 import sys
 import time
 from collections import defaultdict, deque
@@ -61,6 +73,8 @@ if os.name == "nt":
 
 MARKERS_DIR = Path.home() / ".copilot" / "markers"
 DEFAULT_AUDIT_JSONL = MARKERS_DIR / "audit.jsonl"
+# Default hooks directory relative to this script's location
+DEFAULT_HOOKS_DIR = Path(__file__).resolve().parent / "hooks"
 
 # Safety cap on lines read from audit.jsonl (matches retro.py convention)
 _AUDIT_MAX_LINES = 5_000
@@ -122,7 +136,7 @@ def _classify(decision: str) -> str:
     if decision == "deny":
         return "useful-block"
     if decision == "deny-dry":
-        return "false-positive"
+        return "dry-run-noise"
     return "other"
 
 
@@ -136,7 +150,7 @@ def _per_hook_metrics(entries: list[dict], top_n: int = 15) -> list[dict]:
     rule_stats: dict[str, dict] = defaultdict(lambda: {
         "fire_count": 0,
         "useful_block": 0,
-        "false_positive": 0,
+        "dry_run": 0,
         "allow": 0,
         "other": 0,
     })
@@ -150,8 +164,8 @@ def _per_hook_metrics(entries: list[dict], top_n: int = 15) -> list[dict]:
         classification = _classify(decision)
         if classification == "useful-block":
             stats["useful_block"] += 1
-        elif classification == "false-positive":
-            stats["false_positive"] += 1
+        elif classification == "dry-run-noise":
+            stats["dry_run"] += 1
         elif decision == "allow":
             stats["allow"] += 1
         else:
@@ -161,17 +175,17 @@ def _per_hook_metrics(entries: list[dict], top_n: int = 15) -> list[dict]:
     for rule, st in rule_stats.items():
         fc = st["fire_count"]
         ub = st["useful_block"]
-        fp = st["false_positive"]
+        dr = st["dry_run"]
         fire_rate = round(fc / total * 100, 1) if total > 0 else 0.0
         block_rate = round(ub / fc * 100, 1) if fc > 0 else 0.0
-        ub_denom = ub + fp
+        ub_denom = ub + dr
         useful_block_rate: float | None = round(ub / ub_denom * 100, 1) if ub_denom > 0 else None
         rows.append({
             "rule": rule,
             "fire_count": fc,
             "fire_rate_pct": fire_rate,
             "block_count": ub,
-            "fp_count": fp,
+            "dry_run_count": dr,
             "allow_count": st["allow"],
             "block_rate_pct": block_rate,
             "useful_block_rate": useful_block_rate,
@@ -189,16 +203,16 @@ def _global_summary(entries: list[dict]) -> dict:
         by_decision[e.get("decision", "")] += 1
 
     useful_blocks = by_decision.get("deny", 0)
-    false_positives = by_decision.get("deny-dry", 0)
-    ub_denom = useful_blocks + false_positives
+    dry_run = by_decision.get("deny-dry", 0)
+    ub_denom = useful_blocks + dry_run
 
     return {
         "total_entries": total,
         "decisions": dict(by_decision),
         "useful_block_count": useful_blocks,
-        "false_positive_count": false_positives,
+        "dry_run_count": dry_run,
         "deny_rate_pct": round(useful_blocks / total * 100, 1) if total > 0 else 0.0,
-        "fp_rate_pct": round(false_positives / total * 100, 1) if total > 0 else 0.0,
+        "dry_run_rate_pct": round(dry_run / total * 100, 1) if total > 0 else 0.0,
         "useful_block_rate": round(useful_blocks / ub_denom * 100, 1) if ub_denom > 0 else None,
     }
 
@@ -241,11 +255,72 @@ def _trend_analysis(entries: list[dict]) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Hook inventory — never-fired detection
+# ---------------------------------------------------------------------------
+
+# Matches class-level `    name = "rule-name"` in hook rule source files.
+# Uses 4-space indent to distinguish class attributes from local variables.
+_RULE_NAME_RE = re.compile(r'^    name\s*=\s*"([^"]+)"', re.MULTILINE)
+
+
+def _load_hook_inventory(hooks_dir: Path) -> list[str] | None:
+    """Scan hooks/rules/*.py for registered rule names (class-level name attrs).
+
+    Returns a deduplicated list of rule name strings found across all
+    non-__init__ rule files.  Ignores dynamic names (e.g. ``name = f.name``).
+
+    Return values:
+    - ``None``       — inventory unavailable (rules directory absent or unreadable)
+    - ``[]``         — inventory attempted but no static rule names matched (e.g.
+                       all files use dynamic names or unsupported format).  Callers
+                       computing ``never_fired`` must treat this as "unknown" (same
+                       as ``None``) — an empty list is indistinguishable from "all
+                       hooks fired" without at least one discovered name to compare.
+    - ``[name, …]``  — at least one rule name found; callers can safely compute
+                       the never-fired set and emit ``[]`` when all names are seen.
+
+    Callers must distinguish ``None``/``[]`` (scan not useful) from ``[name, …]``
+    (scan found names).  Treating both as "empty" silently hides inventory
+    failures from automation.
+    """
+    rules_dir = hooks_dir / "rules"
+    if not rules_dir.is_dir():
+        return None
+    names: list[str] = []
+    seen: set[str] = set()
+    for py_file in sorted(rules_dir.glob("*.py")):
+        if py_file.name == "__init__.py":
+            continue
+        try:
+            content = py_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for match in _RULE_NAME_RE.finditer(content):
+            name_val = match.group(1)
+            if name_val and name_val not in seen:
+                seen.add(name_val)
+                names.append(name_val)
+    return names
+
+
+def _never_fired_hooks(entries: list[dict], inventory: list[str]) -> list[str]:
+    """Return inventory rule names that have zero audit entries in *entries*.
+
+    These are simplification candidates: registered rules that produced no
+    audit log entries in the analysis window (or ever, if no ``--days`` filter
+    is applied).
+    """
+    seen_rules: set[str] = {e.get("rule") or "(no-rule)" for e in entries}
+    return [name for name in inventory if name not in seen_rules]
+
+
+# ---------------------------------------------------------------------------
 # Output formatters
 # ---------------------------------------------------------------------------
 
 
-def _render_text(summary: dict, per_hook: list[dict], trend: list[dict]) -> None:
+def _render_text(summary: dict, per_hook: list[dict], trend: list[dict],
+                 never_fired: list[str] | None = None) -> None:
     """Print a human-readable audit report to stdout."""
     print("=" * 66)
     print("  sk audit-hooks — Hook Effectiveness Audit")
@@ -258,7 +333,7 @@ def _render_text(summary: dict, per_hook: list[dict], trend: list[dict]) -> None
         print("  (no audit entries found)")
         return
     print(f"  Useful blocks     : {summary['useful_block_count']}  ({summary['deny_rate_pct']:.1f}%)")
-    print(f"  False positives   : {summary['false_positive_count']}  ({summary['fp_rate_pct']:.1f}%)")
+    print(f"  Dry-run noise     : {summary['dry_run_count']}  ({summary['dry_run_rate_pct']:.1f}%)")
     ub_rate = summary["useful_block_rate"]
     ub_label = f"{ub_rate:.1f}%" if ub_rate is not None else "n/a"
     print(f"  Useful-block rate : {ub_label}  (deny / (deny + deny-dry))")
@@ -269,16 +344,16 @@ def _render_text(summary: dict, per_hook: list[dict], trend: list[dict]) -> None
 
     if per_hook:
         print("\n── Per-Hook Effectiveness ──────────────────────────────────────")
-        hdr = f"  {'Rule':<38} {'Fires':>6} {'Rate%':>6} {'Blocks':>7} {'FPs':>5} {'Blk%':>6} {'UB-rate':>8}"
+        hdr = f"  {'Rule':<38} {'Fires':>6} {'Rate%':>6} {'Blocks':>7} {'DryRun':>7} {'Blk%':>6} {'UB-rate':>8}"
         print(hdr)
-        print("  " + "-" * 64)
+        print("  " + "-" * 66)
         for row in per_hook:
             ubr = f"{row['useful_block_rate']:.1f}%" if row["useful_block_rate"] is not None else "n/a"
             rule_trunc = row["rule"][:37]
             print(
                 f"  {rule_trunc:<38} {row['fire_count']:>6} "
                 f"{row['fire_rate_pct']:>5.1f}% {row['block_count']:>7} "
-                f"{row['fp_count']:>5} {row['block_rate_pct']:>5.1f}% {ubr:>8}"
+                f"{row['dry_run_count']:>7} {row['block_rate_pct']:>5.1f}% {ubr:>8}"
             )
 
     if trend:
@@ -291,15 +366,35 @@ def _render_text(summary: dict, per_hook: list[dict], trend: list[dict]) -> None
                 f"  {row['date']:<12} {row['total']:>7} {row['deny']:>6} "
                 f"{row['deny_dry']:>8} {row['allow']:>7} {row['deny_rate_pct']:>9.1f}%"
             )
+
+    if never_fired is not None:
+        print("\n── Never-Fired Hooks (simplification candidates) ───────────────")
+        if never_fired:
+            for name in never_fired:
+                print(f"  {name}")
+        else:
+            print("  (all registered hooks have audit entries — none to report)")
     print()
 
 
-def _render_json(summary: dict, per_hook: list[dict], trend: list[dict]) -> None:
-    """Print JSON payload to stdout."""
+def _render_json(summary: dict, per_hook: list[dict], trend: list[dict],
+                 never_fired: list[str] | None = None) -> None:
+    """Print JSON payload to stdout.
+
+    ``never_fired`` encoding:
+    - ``null``   — inventory unavailable: hooks dir missing/unreadable, OR the
+                   static regex found zero rule names (e.g. all dynamic names).
+                   Automation must treat this as "unknown", not "all hooks fired".
+    - ``[]``     — inventory loaded with ≥1 discovered name and every registered
+                   hook has audit entries in the analysis window
+    - ``[…]``    — inventory loaded with ≥1 discovered name; listed rules have
+                   zero entries in the window (simplification candidates)
+    """
     payload = {
         "summary": summary,
         "per_hook": per_hook,
         "trend": trend,
+        "never_fired": never_fired,
     }
     print(json.dumps(payload, indent=2, ensure_ascii=False))
 
@@ -330,6 +425,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--top", type=int, default=15, metavar="N",
         help="Show top-N rules in per-hook table (default 15)",
     )
+    parser.add_argument(
+        "--hooks-dir", type=Path, default=DEFAULT_HOOKS_DIR, metavar="DIR",
+        help="Override hooks directory for never-fired inventory scan (default: hooks/ sibling)",
+    )
     return parser.parse_args(argv)
 
 
@@ -349,10 +448,20 @@ def main(argv: list[str] | None = None) -> int:
     per_hook = _per_hook_metrics(entries, top_n=args.top)
     trend = _trend_analysis(entries)
 
+    inventory = _load_hook_inventory(args.hooks_dir)
+    # inventory is None  → hooks dir absent; never_fired = None (unknown)
+    # inventory is []    → dir exists but zero static names discovered (e.g.
+    #                       dynamic-only or unsupported format); never_fired = None
+    #                       (cannot distinguish from "all hooks fired" — treat as
+    #                       unknown so automation does not misread [] as success)
+    # inventory is [...] → dir exists, ≥1 name found; compute missing set
+    #                       (result may be [] meaning all fired, or [name, …])
+    never_fired = _never_fired_hooks(entries, inventory) if inventory else None
+
     if args.json_out:
-        _render_json(summary, per_hook, trend)
+        _render_json(summary, per_hook, trend, never_fired)
     else:
-        _render_text(summary, per_hook, trend)
+        _render_text(summary, per_hook, trend, never_fired)
 
     return 0
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -25,6 +25,9 @@ sk skill-suggest                         # → skill-suggest.py
 sk skill-suggest --min-occurrences 3 --format json
 sk skill-patch path/to/SKILL.md --old "old text" --new "new text"  # → skill-patch.py
 sk skill-patch path/to/SKILL.md --old "old text" --new "new text" --replace-all
+sk audit-hooks                               # → audit-hooks.py
+sk audit-hooks --json
+sk audit-hooks --days 7
 ```
 
 ### `sk skill-suggest` — knowledge-to-skill pipeline
@@ -103,6 +106,37 @@ python skill-metrics.py   # shows patch_history section when records exist
 ```
 
 > Direct-script form: `python skill-patch.py path/to/SKILL.md --old "..." --new "..." [opts]`
+
+### `sk audit-hooks` — hook effectiveness audit
+
+Parses `~/.copilot/markers/audit.jsonl` (written by `hooks/hook_runner.py` and
+the native Rust hook runner) and reports per-hook effectiveness metrics plus a
+time-based trend analysis.
+
+**Classification:**
+- `useful-block` — `decision == "deny"`: a real enforcement action
+- `false-positive` — `decision == "deny-dry"`: dry-run / test noise (hook fired
+  but did not actually block)
+
+```bash
+sk audit-hooks                        # full text report
+sk audit-hooks --json                 # JSON output for scripting
+sk audit-hooks --days 7               # restrict to last 7 days
+sk audit-hooks --top 20               # show top-20 rules in per-hook table
+sk audit-hooks --audit-file /path/to/audit.jsonl  # override log path
+```
+
+**Per-hook metrics reported:**
+- `fire_count` / `fire_rate_pct` — how often each rule fires relative to total entries
+- `block_count` — useful-block count (real `deny` decisions)
+- `fp_count` — false-positive count (`deny-dry` decisions)
+- `block_rate_pct` — block_count / fire_count
+- `useful_block_rate` — block_count / (block_count + fp_count)
+
+**Trend analysis:** entries are bucketed by calendar day (UTC), reporting total
+firings, deny count, dry-deny count, and deny rate per day.
+
+> Direct-script form: `python audit-hooks.py [--json] [--days N] [--top N]`
 
 ### `sk index` — knowledge index lifecycle
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -28,6 +28,7 @@ sk skill-patch path/to/SKILL.md --old "old text" --new "new text" --replace-all
 sk audit-hooks                               # → audit-hooks.py
 sk audit-hooks --json
 sk audit-hooks --days 7
+sk audit-hooks --hooks-dir /path/to/hooks    # override hook inventory directory
 ```
 
 ### `sk skill-suggest` — knowledge-to-skill pipeline
@@ -115,8 +116,10 @@ time-based trend analysis.
 
 **Classification:**
 - `useful-block` — `decision == "deny"`: a real enforcement action
-- `false-positive` — `decision == "deny-dry"`: dry-run / test noise (hook fired
-  but did not actually block)
+- `dry-run-noise` — `decision == "deny-dry"`: hook fired in dry-run/test mode
+  (`HOOK_DRY_RUN=1`); the hook logic triggered but the action was not actually
+  blocked.  This is **not** a false positive — it is test-mode noise tracked
+  separately.
 
 ```bash
 sk audit-hooks                        # full text report
@@ -124,19 +127,29 @@ sk audit-hooks --json                 # JSON output for scripting
 sk audit-hooks --days 7               # restrict to last 7 days
 sk audit-hooks --top 20               # show top-20 rules in per-hook table
 sk audit-hooks --audit-file /path/to/audit.jsonl  # override log path
+sk audit-hooks --hooks-dir /path/to/hooks         # override hooks directory
 ```
 
 **Per-hook metrics reported:**
 - `fire_count` / `fire_rate_pct` — how often each rule fires relative to total entries
 - `block_count` — useful-block count (real `deny` decisions)
-- `fp_count` — false-positive count (`deny-dry` decisions)
+- `dry_run_count` — dry-run-noise count (`deny-dry` decisions; test-mode only)
 - `block_rate_pct` — block_count / fire_count
-- `useful_block_rate` — block_count / (block_count + fp_count)
+- `useful_block_rate` — block_count / (block_count + dry_run_count)
+
+**Never-fired hooks:** the tool scans the registered hook rule inventory
+(`hooks/rules/*.py`) and reports rules with zero audit entries in the analysis
+window.  These are surfaced as simplification candidates per issue #127.
+
+JSON `never_fired` field semantics (important for automation):
+- `null`  — inventory unavailable (hooks dir missing or unreadable); treat as *unknown*, not "all hooks fired"
+- `[]`    — inventory loaded and every registered hook has audit entries in the window
+- `[…]`  — inventory loaded; listed rules have zero entries in the analysis window
 
 **Trend analysis:** entries are bucketed by calendar day (UTC), reporting total
 firings, deny count, dry-deny count, and deny rate per day.
 
-> Direct-script form: `python audit-hooks.py [--json] [--days N] [--top N]`
+> Direct-script form: `python audit-hooks.py [--json] [--days N] [--top N] [--hooks-dir DIR]`
 
 ### `sk index` — knowledge index lifecycle
 

--- a/sk-rust/src/main.rs
+++ b/sk-rust/src/main.rs
@@ -148,6 +148,12 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Audit hook effectiveness from audit.jsonl
+    #[command(name = "audit-hooks")]
+    AuditHooks {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }
 
 // Map a grouped namespace command (e.g. "index build") to a Python script name.
@@ -279,6 +285,7 @@ fn main() -> ExitCode {
         }
         Some(Commands::SkillSuggest { args }) => run_fallback("skill-suggest.py", &args),
         Some(Commands::SkillPatch { args }) => run_fallback("skill-patch.py", &args),
+        Some(Commands::AuditHooks { args }) => run_fallback("audit-hooks.py", &args),
     };
 
     if cli.time {

--- a/sk.py
+++ b/sk.py
@@ -27,6 +27,7 @@ Usage:
     sk skill-suggest [<args>...]      Run skill-suggest.py
     sk skill-patch  [<args>...]       Run skill-patch.py
     sk hooks        run|list|<event>  Run hooks/hook_runner.py
+    sk audit-hooks  [<args>...]       Run audit-hooks.py
 
     sk index  build|extract|migrate|status|health|embed|tag [<args>...]
     sk sync   run|config|status|gateway|merge [<args>...]
@@ -81,6 +82,7 @@ _DIRECT: dict[str, str] = {
     "anatomy": "anatomy-map.py",
     "skill-suggest": "skill-suggest.py",
     "skill-patch": "skill-patch.py",
+    "audit-hooks": "audit-hooks.py",
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}

--- a/tests/test_audit_hooks.py
+++ b/tests/test_audit_hooks.py
@@ -201,8 +201,8 @@ class TestClassify(unittest.TestCase):
     def test_deny_is_useful_block(self):
         self.assertEqual(ah._classify("deny"), "useful-block")
 
-    def test_deny_dry_is_false_positive(self):
-        self.assertEqual(ah._classify("deny-dry"), "false-positive")
+    def test_deny_dry_is_dry_run_noise(self):
+        self.assertEqual(ah._classify("deny-dry"), "dry-run-noise")
 
     def test_allow_is_other(self):
         self.assertEqual(ah._classify("allow"), "other")
@@ -243,9 +243,9 @@ class TestGlobalSummary(unittest.TestCase):
         s = ah._global_summary(entries)
         self.assertEqual(s["total_entries"], 10)
         self.assertEqual(s["useful_block_count"], 3)
-        self.assertEqual(s["false_positive_count"], 1)
+        self.assertEqual(s["dry_run_count"], 1)
         self.assertAlmostEqual(s["deny_rate_pct"], 30.0)
-        self.assertAlmostEqual(s["fp_rate_pct"], 10.0)
+        self.assertAlmostEqual(s["dry_run_rate_pct"], 10.0)
         # useful_block_rate = 3 / (3+1) * 100 = 75.0
         self.assertAlmostEqual(s["useful_block_rate"], 75.0)
 
@@ -253,9 +253,9 @@ class TestGlobalSummary(unittest.TestCase):
         entries = [_make_entry("deny")] * 4
         s = ah._global_summary(entries)
         self.assertEqual(s["useful_block_count"], 4)
-        self.assertEqual(s["false_positive_count"], 0)
+        self.assertEqual(s["dry_run_count"], 0)
         self.assertEqual(s["deny_rate_pct"], 100.0)
-        # no FPs so useful_block_rate = 100%
+        # no dry-run so useful_block_rate = 100%
         self.assertAlmostEqual(s["useful_block_rate"], 100.0)
 
 
@@ -281,7 +281,7 @@ class TestPerHookMetrics(unittest.TestCase):
         self.assertEqual(row["rule"], "rule-a")
         self.assertEqual(row["fire_count"], 10)
         self.assertEqual(row["block_count"], 2)
-        self.assertEqual(row["fp_count"], 1)
+        self.assertEqual(row["dry_run_count"], 1)
         self.assertAlmostEqual(row["block_rate_pct"], 20.0)
         # useful_block_rate = 2/(2+1)*100 = 66.7
         self.assertAlmostEqual(row["useful_block_rate"], 66.7, places=0)
@@ -423,9 +423,11 @@ class TestMain(unittest.TestCase):
             sys.stdout = old_stdout
         payload = json.loads(captured.getvalue())
         s = payload["summary"]
-        for key in ("total_entries", "useful_block_count", "false_positive_count",
-                    "deny_rate_pct", "fp_rate_pct", "useful_block_rate"):
+        for key in ("total_entries", "useful_block_count", "dry_run_count",
+                    "deny_rate_pct", "dry_run_rate_pct", "useful_block_rate"):
             self.assertIn(key, s, f"Missing key in summary: {key}")
+        # never_fired must be present in JSON output
+        self.assertIn("never_fired", payload)
 
     def test_days_filter_works(self):
         import io
@@ -465,6 +467,252 @@ class TestMain(unittest.TestCase):
     def test_missing_file_json_flag_returns_1(self):
         rc = ah.main(["--audit-file", str(Path(self._tmpdir) / "nope.jsonl"), "--json"])
         self.assertEqual(rc, 1)
+
+
+# ---------------------------------------------------------------------------
+# _load_hook_inventory / _never_fired_hooks
+# ---------------------------------------------------------------------------
+
+
+class TestHookInventory(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp(prefix="ah-inv-test-")
+        self._hooks_dir = Path(self._tmpdir) / "hooks"
+        self._rules_dir = self._hooks_dir / "rules"
+        self._rules_dir.mkdir(parents=True)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _write_rule(self, filename: str, names: list[str]) -> None:
+        lines = []
+        for n in names:
+            lines.append(f'class SomeRule:\n    name = "{n}"\n    events = []\n')
+        (self._rules_dir / filename).write_text("\n".join(lines), encoding="utf-8")
+
+    def test_empty_rules_dir_returns_empty(self):
+        result = ah._load_hook_inventory(self._hooks_dir)
+        self.assertEqual(result, [])
+
+    def test_missing_hooks_dir_returns_none(self):
+        result = ah._load_hook_inventory(Path(self._tmpdir) / "nonexistent")
+        self.assertIsNone(result)
+
+    def test_single_rule_file(self):
+        self._write_rule("my_rule.py", ["my-rule"])
+        result = ah._load_hook_inventory(self._hooks_dir)
+        self.assertIn("my-rule", result)
+
+    def test_multiple_rules_across_files(self):
+        self._write_rule("rule_a.py", ["rule-alpha"])
+        self._write_rule("rule_b.py", ["rule-beta", "rule-gamma"])
+        result = ah._load_hook_inventory(self._hooks_dir)
+        self.assertIn("rule-alpha", result)
+        self.assertIn("rule-beta", result)
+        self.assertIn("rule-gamma", result)
+        self.assertEqual(len(result), 3)
+
+    def test_init_py_is_skipped(self):
+        # __init__.py has a base class name = "" that must not appear
+        (self._rules_dir / "__init__.py").write_text(
+            'class Rule:\n    name = ""\n    events = []\n', encoding="utf-8"
+        )
+        self._write_rule("real_rule.py", ["real-rule"])
+        result = ah._load_hook_inventory(self._hooks_dir)
+        self.assertNotIn("", result)
+        self.assertIn("real-rule", result)
+
+    def test_deduplicated(self):
+        # Same name in two files → appears once
+        self._write_rule("rule_a.py", ["shared-name"])
+        self._write_rule("rule_b.py", ["shared-name"])
+        result = ah._load_hook_inventory(self._hooks_dir)
+        self.assertEqual(result.count("shared-name"), 1)
+
+    def test_never_fired_empty_entries(self):
+        inventory = ["rule-a", "rule-b"]
+        result = ah._never_fired_hooks([], inventory)
+        self.assertEqual(result, ["rule-a", "rule-b"])
+
+    def test_never_fired_all_seen(self):
+        entries = [_make_entry("allow", rule="rule-a"), _make_entry("deny", rule="rule-b")]
+        result = ah._never_fired_hooks(entries, ["rule-a", "rule-b"])
+        self.assertEqual(result, [])
+
+    def test_never_fired_partial_overlap(self):
+        entries = [_make_entry("allow", rule="rule-a")]
+        result = ah._never_fired_hooks(entries, ["rule-a", "rule-b", "rule-c"])
+        self.assertNotIn("rule-a", result)
+        self.assertIn("rule-b", result)
+        self.assertIn("rule-c", result)
+
+    def test_never_fired_empty_inventory(self):
+        entries = [_make_entry("deny", rule="rule-a")]
+        result = ah._never_fired_hooks(entries, [])
+        self.assertEqual(result, [])
+
+    def test_load_real_hooks_dir(self):
+        """Smoke test: load inventory from the actual hooks/rules dir if available."""
+        real_hooks = TOOLS_DIR / "hooks"
+        if not (real_hooks / "rules").is_dir():
+            self.skipTest("hooks/rules not present")
+        result = ah._load_hook_inventory(real_hooks)
+        # Spot-check: core rules that exist in every install
+        core_rules = {"enforce-briefing", "enforce-learn", "syntax-gate", "subagent-git-guard"}
+        found = set(result) & core_rules
+        self.assertTrue(
+            len(found) > 0,
+            f"Expected at least one core rule in inventory, got: {result}",
+        )
+
+    def test_never_fired_in_json_output(self):
+        """main() must include never_fired in JSON output when hooks-dir is given."""
+        import io, tempfile, shutil
+        tmpdir = Path(tempfile.mkdtemp(prefix="ah-nf-json-"))
+        try:
+            audit = tmpdir / "audit.jsonl"
+            hooks = tmpdir / "hooks"
+            rules = hooks / "rules"
+            rules.mkdir(parents=True)
+            (rules / "a_rule.py").write_text(
+                'class ARule:\n    name = "a-rule"\n    events = []\n', encoding="utf-8"
+            )
+            (rules / "b_rule.py").write_text(
+                'class BRule:\n    name = "b-rule"\n    events = []\n', encoding="utf-8"
+            )
+            _write_jsonl(audit, [_make_entry("deny", rule="a-rule")])
+            captured = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = captured
+            try:
+                rc = ah.main([
+                    "--audit-file", str(audit),
+                    "--hooks-dir", str(hooks),
+                    "--json",
+                ])
+            finally:
+                sys.stdout = old_stdout
+            self.assertEqual(rc, 0)
+            payload = json.loads(captured.getvalue())
+            self.assertIn("never_fired", payload)
+            self.assertIn("b-rule", payload["never_fired"])
+            self.assertNotIn("a-rule", payload["never_fired"])
+        finally:
+            shutil.rmtree(str(tmpdir), ignore_errors=True)
+
+    def test_json_never_fired_null_when_inventory_missing(self):
+        """JSON never_fired must be null (not []) when hooks-dir is absent."""
+        import io, tempfile, shutil
+        tmpdir = Path(tempfile.mkdtemp(prefix="ah-nf-null-"))
+        try:
+            audit = tmpdir / "audit.jsonl"
+            _write_jsonl(audit, [_make_entry("deny", rule="some-rule")])
+            missing_hooks = tmpdir / "no-such-hooks"
+            captured = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = captured
+            try:
+                rc = ah.main([
+                    "--audit-file", str(audit),
+                    "--hooks-dir", str(missing_hooks),
+                    "--json",
+                ])
+            finally:
+                sys.stdout = old_stdout
+            self.assertEqual(rc, 0)
+            payload = json.loads(captured.getvalue())
+            self.assertIn("never_fired", payload)
+            # Must be null (None in Python), NOT an empty list — inventory was unavailable
+            self.assertIsNone(
+                payload["never_fired"],
+                "never_fired should be null when inventory dir is missing, not []",
+            )
+        finally:
+            shutil.rmtree(str(tmpdir), ignore_errors=True)
+
+    def test_json_never_fired_empty_list_when_all_hooks_fired(self):
+        """JSON never_fired must be [] (not null) when inventory loaded and all hooks fired."""
+        import io, tempfile, shutil
+        tmpdir = Path(tempfile.mkdtemp(prefix="ah-nf-empty-"))
+        try:
+            audit = tmpdir / "audit.jsonl"
+            hooks = tmpdir / "hooks"
+            rules = hooks / "rules"
+            rules.mkdir(parents=True)
+            (rules / "only_rule.py").write_text(
+                'class OnlyRule:\n    name = "only-rule"\n    events = []\n', encoding="utf-8"
+            )
+            # The one registered rule fires → never_fired should be [], not null
+            _write_jsonl(audit, [_make_entry("deny", rule="only-rule")])
+            captured = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = captured
+            try:
+                rc = ah.main([
+                    "--audit-file", str(audit),
+                    "--hooks-dir", str(hooks),
+                    "--json",
+                ])
+            finally:
+                sys.stdout = old_stdout
+            self.assertEqual(rc, 0)
+            payload = json.loads(captured.getvalue())
+            self.assertIn("never_fired", payload)
+            # Must be [] (inventory loaded, all hooks fired), NOT null
+            self.assertIsNotNone(
+                payload["never_fired"],
+                "never_fired should be [] when inventory loaded and all hooks fired, not null",
+            )
+            self.assertEqual(
+                payload["never_fired"], [],
+                "never_fired should be empty list when all registered hooks fired",
+            )
+        finally:
+            shutil.rmtree(str(tmpdir), ignore_errors=True)
+
+    def test_json_never_fired_null_when_zero_names_discovered(self):
+        """JSON never_fired must be null when hooks-dir exists but static regex finds no names.
+
+        This covers the case where rules dir is present but all names are dynamic
+        (e.g. ``name = f.name``) — the regex returns [] which is indistinguishable
+        from "all hooks fired", so we must emit null to avoid misleading automation.
+        """
+        import io, tempfile, shutil
+        tmpdir = Path(tempfile.mkdtemp(prefix="ah-nf-zero-"))
+        try:
+            audit = tmpdir / "audit.jsonl"
+            hooks = tmpdir / "hooks"
+            rules = hooks / "rules"
+            rules.mkdir(parents=True)
+            # Write a rule file that uses a dynamic name — the static regex won't match it
+            (rules / "dynamic_rule.py").write_text(
+                'class DynRule:\n    name = some_variable\n    events = []\n', encoding="utf-8"
+            )
+            _write_jsonl(audit, [_make_entry("deny", rule="dynamic-rule")])
+            captured = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = captured
+            try:
+                rc = ah.main([
+                    "--audit-file", str(audit),
+                    "--hooks-dir", str(hooks),
+                    "--json",
+                ])
+            finally:
+                sys.stdout = old_stdout
+            self.assertEqual(rc, 0)
+            payload = json.loads(captured.getvalue())
+            self.assertIn("never_fired", payload)
+            # inventory returned [] (dir exists, zero names matched) →
+            # never_fired must be null so automation doesn't misread it as "all fired"
+            self.assertIsNone(
+                payload["never_fired"],
+                "never_fired should be null when zero names were discovered by the static regex",
+            )
+        finally:
+            shutil.rmtree(str(tmpdir), ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_audit_hooks.py
+++ b/tests/test_audit_hooks.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""
+test_audit_hooks.py — Focused tests for audit-hooks.py.
+
+Covers:
+  - _load_entries: empty file, missing file, valid entries, malformed lines
+  - _classify: each decision value
+  - _global_summary: counts and rates
+  - _per_hook_metrics: ranking, rate computation, top-N cap
+  - _trend_analysis: day bucketing and deny_rate
+  - main(): no-entries → exit 1; with entries → exit 0
+  - main(): --json flag emits valid JSON with expected keys
+  - main(): --days filter
+  - main(): --top N cap
+  - script is importable and audit-hooks.py exists in tools dir
+
+Run: python tests/test_audit_hooks.py
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import time
+import unittest
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+TOOLS_DIR = Path(__file__).parent.parent
+SCRIPT_PATH = TOOLS_DIR / "audit-hooks.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("audit_hooks", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ah = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(decision: str, rule: str = "test-rule", event: str = "preToolUse",
+                tool: str = "edit", ts: float | None = None) -> dict:
+    return {
+        "ts": ts if ts is not None else time.time(),
+        "event": event,
+        "tool": tool,
+        "rule": rule,
+        "decision": decision,
+        "detail": "",
+    }
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        for e in entries:
+            fh.write(json.dumps(e) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Existence check
+# ---------------------------------------------------------------------------
+
+
+class TestScriptExists(unittest.TestCase):
+    def test_audit_hooks_py_exists(self):
+        self.assertTrue(
+            SCRIPT_PATH.exists(),
+            f"audit-hooks.py not found at {SCRIPT_PATH}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# _load_entries
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEntries(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp(prefix="ah-test-")
+        self._audit = Path(self._tmpdir) / "audit.jsonl"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_missing_file_returns_empty(self):
+        result = ah._load_entries(Path(self._tmpdir) / "missing.jsonl")
+        self.assertEqual(result, [])
+
+    def test_empty_file_returns_empty(self):
+        self._audit.write_text("", encoding="utf-8")
+        result = ah._load_entries(self._audit)
+        self.assertEqual(result, [])
+
+    def test_valid_entries_loaded(self):
+        entries = [_make_entry("allow"), _make_entry("deny")]
+        _write_jsonl(self._audit, entries)
+        result = ah._load_entries(self._audit)
+        self.assertEqual(len(result), 2)
+
+    def test_malformed_lines_skipped(self):
+        self._audit.write_text(
+            '{"decision":"allow","ts":1}\nnot json\n{"decision":"deny","ts":2}\n',
+            encoding="utf-8",
+        )
+        result = ah._load_entries(self._audit)
+        self.assertEqual(len(result), 2)
+
+    def test_blank_lines_skipped(self):
+        self._audit.write_text(
+            '\n{"decision":"allow","ts":1}\n\n\n{"decision":"deny","ts":2}\n\n',
+            encoding="utf-8",
+        )
+        result = ah._load_entries(self._audit)
+        self.assertEqual(len(result), 2)
+
+    def test_days_filter_excludes_old_entries(self):
+        old_ts = time.time() - 10 * 86_400  # 10 days ago
+        new_ts = time.time() - 1 * 86_400   # 1 day ago
+        entries = [
+            _make_entry("allow", ts=old_ts),
+            _make_entry("deny", ts=new_ts),
+        ]
+        _write_jsonl(self._audit, entries)
+        result = ah._load_entries(self._audit, days=5)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["decision"], "deny")
+
+    def test_days_none_returns_all(self):
+        old_ts = time.time() - 100 * 86_400
+        entries = [_make_entry("allow", ts=old_ts), _make_entry("deny")]
+        _write_jsonl(self._audit, entries)
+        result = ah._load_entries(self._audit, days=None)
+        self.assertEqual(len(result), 2)
+
+    def test_large_log_days_reads_from_tail(self):
+        """--days must find recent entries even when total lines exceed the cap."""
+        original_cap = ah._AUDIT_MAX_LINES
+        ah._AUDIT_MAX_LINES = 10  # lower cap so 20-entry log triggers the old bug
+        try:
+            old_ts = time.time() - 20 * 86_400   # 20 days ago — outside --days 5
+            new_ts = time.time() - 1 * 86_400    # 1 day ago  — inside  --days 5
+            # 15 old entries (would fill & overflow old head-read cap of 10)
+            # followed by 5 new entries at the tail
+            entries = (
+                [_make_entry("allow", ts=old_ts)] * 15
+                + [_make_entry("deny", ts=new_ts)] * 5
+            )
+            _write_jsonl(self._audit, entries)
+            result = ah._load_entries(self._audit, days=5)
+            self.assertEqual(
+                len(result), 5,
+                "Tail-read must surface 5 recent entries even when log exceeds safety cap",
+            )
+            self.assertTrue(
+                all(e["decision"] == "deny" for e in result),
+                "All returned entries should be the recent 'deny' entries",
+            )
+        finally:
+            ah._AUDIT_MAX_LINES = original_cap
+
+    def test_large_log_no_days_returns_tail(self):
+        """Without --days, safety cap keeps the most-recent (tail) entries."""
+        original_cap = ah._AUDIT_MAX_LINES
+        ah._AUDIT_MAX_LINES = 5
+        try:
+            old_ts = time.time() - 30 * 86_400
+            new_ts = time.time()
+            # 8 old + 5 new; cap=5 → should keep the 5 newest
+            entries = (
+                [_make_entry("allow", ts=old_ts)] * 8
+                + [_make_entry("deny", ts=new_ts)] * 5
+            )
+            _write_jsonl(self._audit, entries)
+            result = ah._load_entries(self._audit, days=None)
+            self.assertEqual(len(result), 5)
+            self.assertTrue(all(e["decision"] == "deny" for e in result))
+        finally:
+            ah._AUDIT_MAX_LINES = original_cap
+
+
+# ---------------------------------------------------------------------------
+# _classify
+# ---------------------------------------------------------------------------
+
+
+class TestClassify(unittest.TestCase):
+    def test_deny_is_useful_block(self):
+        self.assertEqual(ah._classify("deny"), "useful-block")
+
+    def test_deny_dry_is_false_positive(self):
+        self.assertEqual(ah._classify("deny-dry"), "false-positive")
+
+    def test_allow_is_other(self):
+        self.assertEqual(ah._classify("allow"), "other")
+
+    def test_empty_is_other(self):
+        self.assertEqual(ah._classify(""), "other")
+
+    def test_parse_error_is_other(self):
+        self.assertEqual(ah._classify("parse-error"), "other")
+
+
+# ---------------------------------------------------------------------------
+# _global_summary
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalSummary(unittest.TestCase):
+    def test_empty_entries(self):
+        s = ah._global_summary([])
+        self.assertEqual(s["total_entries"], 0)
+        self.assertEqual(s["useful_block_count"], 0)
+        self.assertEqual(s["deny_rate_pct"], 0.0)
+
+    def test_all_allow(self):
+        entries = [_make_entry("allow")] * 5
+        s = ah._global_summary(entries)
+        self.assertEqual(s["total_entries"], 5)
+        self.assertEqual(s["useful_block_count"], 0)
+        self.assertEqual(s["deny_rate_pct"], 0.0)
+        self.assertIsNone(s["useful_block_rate"])
+
+    def test_mixed_decisions(self):
+        entries = (
+            [_make_entry("deny")] * 3
+            + [_make_entry("deny-dry")] * 1
+            + [_make_entry("allow")] * 6
+        )
+        s = ah._global_summary(entries)
+        self.assertEqual(s["total_entries"], 10)
+        self.assertEqual(s["useful_block_count"], 3)
+        self.assertEqual(s["false_positive_count"], 1)
+        self.assertAlmostEqual(s["deny_rate_pct"], 30.0)
+        self.assertAlmostEqual(s["fp_rate_pct"], 10.0)
+        # useful_block_rate = 3 / (3+1) * 100 = 75.0
+        self.assertAlmostEqual(s["useful_block_rate"], 75.0)
+
+    def test_deny_only(self):
+        entries = [_make_entry("deny")] * 4
+        s = ah._global_summary(entries)
+        self.assertEqual(s["useful_block_count"], 4)
+        self.assertEqual(s["false_positive_count"], 0)
+        self.assertEqual(s["deny_rate_pct"], 100.0)
+        # no FPs so useful_block_rate = 100%
+        self.assertAlmostEqual(s["useful_block_rate"], 100.0)
+
+
+# ---------------------------------------------------------------------------
+# _per_hook_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestPerHookMetrics(unittest.TestCase):
+    def test_empty_entries(self):
+        rows = ah._per_hook_metrics([])
+        self.assertEqual(rows, [])
+
+    def test_single_rule(self):
+        entries = (
+            [_make_entry("deny", rule="rule-a")] * 2
+            + [_make_entry("deny-dry", rule="rule-a")] * 1
+            + [_make_entry("allow", rule="rule-a")] * 7
+        )
+        rows = ah._per_hook_metrics(entries)
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["rule"], "rule-a")
+        self.assertEqual(row["fire_count"], 10)
+        self.assertEqual(row["block_count"], 2)
+        self.assertEqual(row["fp_count"], 1)
+        self.assertAlmostEqual(row["block_rate_pct"], 20.0)
+        # useful_block_rate = 2/(2+1)*100 = 66.7
+        self.assertAlmostEqual(row["useful_block_rate"], 66.7, places=0)
+
+    def test_sorted_by_fire_count_descending(self):
+        entries = (
+            [_make_entry("allow", rule="rare")] * 1
+            + [_make_entry("allow", rule="common")] * 9
+        )
+        rows = ah._per_hook_metrics(entries)
+        self.assertEqual(rows[0]["rule"], "common")
+        self.assertEqual(rows[1]["rule"], "rare")
+
+    def test_top_n_cap(self):
+        entries = [_make_entry("allow", rule=f"rule-{i}") for i in range(20)]
+        rows = ah._per_hook_metrics(entries, top_n=5)
+        self.assertEqual(len(rows), 5)
+
+    def test_no_rule_key_uses_fallback(self):
+        entry = {"ts": time.time(), "event": "preToolUse", "tool": "edit",
+                 "decision": "deny", "detail": ""}
+        # No "rule" key
+        rows = ah._per_hook_metrics([entry])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["rule"], "(no-rule)")
+
+    def test_fire_rate_sums_to_100_for_single_rule(self):
+        entries = [_make_entry("allow", rule="only")] * 10
+        rows = ah._per_hook_metrics(entries)
+        self.assertAlmostEqual(rows[0]["fire_rate_pct"], 100.0)
+
+    def test_useful_block_rate_none_when_no_deny(self):
+        entries = [_make_entry("allow", rule="harmless")] * 5
+        rows = ah._per_hook_metrics(entries)
+        self.assertIsNone(rows[0]["useful_block_rate"])
+
+
+# ---------------------------------------------------------------------------
+# _trend_analysis
+# ---------------------------------------------------------------------------
+
+
+class TestTrendAnalysis(unittest.TestCase):
+    def test_empty_entries(self):
+        rows = ah._trend_analysis([])
+        self.assertEqual(rows, [])
+
+    def test_single_day(self):
+        ts = time.time()
+        entries = [
+            _make_entry("deny", ts=ts),
+            _make_entry("allow", ts=ts),
+            _make_entry("deny-dry", ts=ts),
+        ]
+        rows = ah._trend_analysis(entries)
+        self.assertEqual(len(rows), 1)
+        r = rows[0]
+        self.assertEqual(r["total"], 3)
+        self.assertEqual(r["deny"], 1)
+        self.assertEqual(r["deny_dry"], 1)
+        self.assertEqual(r["allow"], 1)
+        self.assertAlmostEqual(r["deny_rate_pct"], 33.3, places=0)
+
+    def test_sorted_by_date_ascending(self):
+        ts_now = time.time()
+        ts_old = ts_now - 2 * 86_400
+        entries = [
+            _make_entry("allow", ts=ts_now),
+            _make_entry("deny", ts=ts_old),
+        ]
+        rows = ah._trend_analysis(entries)
+        self.assertEqual(len(rows), 2)
+        self.assertLess(rows[0]["date"], rows[1]["date"])
+
+    def test_deny_rate_zero_when_no_deny(self):
+        ts = time.time()
+        entries = [_make_entry("allow", ts=ts)] * 5
+        rows = ah._trend_analysis(entries)
+        self.assertEqual(rows[0]["deny_rate_pct"], 0.0)
+
+
+# ---------------------------------------------------------------------------
+# main() integration
+# ---------------------------------------------------------------------------
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp(prefix="ah-main-test-")
+        self._audit = Path(self._tmpdir) / "audit.jsonl"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_missing_file_returns_1(self):
+        rc = ah.main(["--audit-file", str(Path(self._tmpdir) / "missing.jsonl")])
+        self.assertEqual(rc, 1)
+
+    def test_empty_file_returns_1(self):
+        self._audit.write_text("", encoding="utf-8")
+        rc = ah.main(["--audit-file", str(self._audit)])
+        self.assertEqual(rc, 1)
+
+    def test_with_entries_returns_0(self):
+        entries = [_make_entry("deny"), _make_entry("allow")]
+        _write_jsonl(self._audit, entries)
+        rc = ah.main(["--audit-file", str(self._audit)])
+        self.assertEqual(rc, 0)
+
+    def test_json_flag_emits_valid_json(self):
+        import io
+        entries = [_make_entry("deny"), _make_entry("deny-dry"), _make_entry("allow")]
+        _write_jsonl(self._audit, entries)
+        captured = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            rc = ah.main(["--audit-file", str(self._audit), "--json"])
+        finally:
+            sys.stdout = old_stdout
+        self.assertEqual(rc, 0)
+        payload = json.loads(captured.getvalue())
+        self.assertIn("summary", payload)
+        self.assertIn("per_hook", payload)
+        self.assertIn("trend", payload)
+
+    def test_json_summary_keys_present(self):
+        import io
+        entries = [_make_entry("deny")] * 3 + [_make_entry("allow")] * 7
+        _write_jsonl(self._audit, entries)
+        captured = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            ah.main(["--audit-file", str(self._audit), "--json"])
+        finally:
+            sys.stdout = old_stdout
+        payload = json.loads(captured.getvalue())
+        s = payload["summary"]
+        for key in ("total_entries", "useful_block_count", "false_positive_count",
+                    "deny_rate_pct", "fp_rate_pct", "useful_block_rate"):
+            self.assertIn(key, s, f"Missing key in summary: {key}")
+
+    def test_days_filter_works(self):
+        import io
+        old_ts = time.time() - 10 * 86_400
+        new_ts = time.time()
+        entries = [
+            _make_entry("deny", ts=old_ts),
+            _make_entry("allow", ts=new_ts),
+        ]
+        _write_jsonl(self._audit, entries)
+        captured = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            rc = ah.main(["--audit-file", str(self._audit), "--json", "--days", "5"])
+        finally:
+            sys.stdout = old_stdout
+        self.assertEqual(rc, 0)
+        payload = json.loads(captured.getvalue())
+        # Only the new entry should be present
+        self.assertEqual(payload["summary"]["total_entries"], 1)
+
+    def test_top_n_respected(self):
+        import io
+        entries = [_make_entry("allow", rule=f"rule-{i}") for i in range(20)]
+        _write_jsonl(self._audit, entries)
+        captured = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            ah.main(["--audit-file", str(self._audit), "--json", "--top", "3"])
+        finally:
+            sys.stdout = old_stdout
+        payload = json.loads(captured.getvalue())
+        self.assertLessEqual(len(payload["per_hook"]), 3)
+
+    def test_missing_file_json_flag_returns_1(self):
+        rc = ah.main(["--audit-file", str(Path(self._tmpdir) / "nope.jsonl"), "--json"])
+        self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -216,6 +216,31 @@ class TestSkDirectCommands(unittest.TestCase):
             "skill-patch.py not found — sk skill-patch would break",
         )
 
+    def test_audit_hooks(self):
+        self._assert_routes("audit-hooks", "audit-hooks.py")
+
+    def test_audit_hooks_json(self):
+        self._assert_routes("audit-hooks", "audit-hooks.py", ["--json"])
+
+    def test_audit_hooks_days(self):
+        self._assert_routes("audit-hooks", "audit-hooks.py", ["--days", "7"])
+
+    def test_audit_hooks_top(self):
+        self._assert_routes("audit-hooks", "audit-hooks.py", ["--top", "20"])
+
+    def test_audit_hooks_combined_flags(self):
+        self._assert_routes(
+            "audit-hooks", "audit-hooks.py",
+            ["--json", "--days", "14", "--top", "10"],
+        )
+
+    def test_audit_hooks_script_exists(self):
+        """audit-hooks.py must exist in the tools directory."""
+        self.assertTrue(
+            (TOOLS_DIR / "audit-hooks.py").exists(),
+            "audit-hooks.py not found — sk audit-hooks would break",
+        )
+
 
 class TestSkHooksCompat(unittest.TestCase):
     def test_hooks_run_drops_run_subcommand(self):


### PR DESCRIPTION
## Summary
- add a new stdlib-only audit-hooks.py command to analyze audit.jsonl and report per-hook effectiveness metrics plus daily trends
- wire the new top-level sk audit-hooks command through both sk.py and the Rust sk front door
- add focused routing and large-log audit parsing coverage, including the tail-window fix for --days on append-only logs

Closes #127