### PR TITLE
feat(briefing): add session-start skill index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - `browse/routes/skills.py`: `event_skill_usage` data (per-skill triggered/loaded/skipped counts) is returned inline inside the existing `/api/skills/metrics` response; there is no separate `/api/skills/usage-events` route.
   - `docs/HOOKS.md`: `skill-usage` rule added to the registered-rules table.
 
+- **Level 0 progressive skill loading at sessionStart (#118):**
+  - `briefing.py`: `--session-start` flag causes a compact skill index to be printed to stdout *before* any knowledge-DB access. Index is generated from `skills/*/SKILL.md` YAML frontmatter (stdlib-only parsing); descriptions longer than 60 chars are truncated to the first 57 characters followed by `"..."` (total 60 chars). Fail-open: missing skills dir, unreadable files, or parse errors produce empty output silently. No leakage into normal `sk briefing` / `sk query` paths.
+  - `briefing.py`: `_parse_skill_frontmatter()` — pure-stdlib YAML frontmatter parser; handles folded/literal block scalars (`>`, `|`, `>-`, `|-`, `>+`, `|+`).
+  - `briefing.py`: `_generate_skill_index()` — discovers `skills/*/SKILL.md`, builds formatted index block, wraps entire body in try/except for fail-open contract.
+  - `hooks/rules/briefing.py`: `AutoBriefingRule` now passes `--session-start` to the `briefing.py` subprocess on `sessionStart`.
+  - `hooks/auto-briefing.py`: legacy sessionStart path now passes `--session-start` to the `briefing.py` subprocess.
+  - `sk-rust/src/hooks/rules.rs`: Rust `AutoBriefingRule::evaluate()` now chains `--session-start` with `--budget 2000` in the subprocess args.
+  - `tests/test_briefing.py`: Section 16 — regression tests for `_parse_skill_frontmatter`, `_generate_skill_index`, constants, no-leakage, and subprocess behavior (tests 16a–16i).
+  - `tests/test_hooks.py`: Sections 27–29 — Section 27 covers SkillUsageRule (#119); Section 28 covers `--session-start` wiring in all three caller paths and skill index emission (#118); Section 29 covers SK_TOOLS_DIR existence guard (#118 follow-up).
+  - `sk-rust/tests/integration_test.rs`: `auto_briefing_passes_session_start_flag` integration test — uses a stub `briefing.py` to verify `--session-start` reaches the subprocess.
+  - `docs/HOOKS.md`: Updated `auto-briefing` rule description to document `--session-start` flag and Level 0 skill index.
+  - `docs/SKILLS.md`: New *Progressive Skill Loading* section describing L0/L1/L2 loading levels, index format, fail-open contract, and implementation surface.
+
 - **Quota-blocked handoff metadata and retry queue (#187):**
   - `tentacle.py`: `_classify_quota_signal(text)` — classifies raw dispatch output into a machine-readable `quota_reason` token (`rate_limit`, `quota_exceeded`, `daily_quota`, `monthly_quota`, `token_quota`, `context_limit`). Pattern list is intentionally minimal pending `#183`.
   - `tentacle.py handoff` gains `--quota-reason <reason>` and `--retry-hint <hint>` optional flags for `BLOCKED` handoffs. These serialize as `QUOTA_REASON:` / `RETRY_HINT:` lines in `handoff.md`.

--- a/briefing.py
+++ b/briefing.py
@@ -166,9 +166,9 @@ def _parse_skill_frontmatter(text: str) -> dict:
             line = fm_lines[i]
             stripped = line.strip()
             if stripped.startswith("name:"):
-                name = stripped[len("name:"):].strip().strip('"').strip("'")
+                name = stripped[len("name:") :].strip().strip('"').strip("'")
             elif stripped.startswith("description:"):
-                rest = stripped[len("description:"):].strip()
+                rest = stripped[len("description:") :].strip()
                 if rest in (">", "|", ">-", "|-", ">+", "|+"):
                     # Folded/literal block scalar — collect indented continuation lines.
                     desc_parts = []

--- a/briefing.py
+++ b/briefing.py
@@ -22,11 +22,13 @@ Usage:
     python briefing.py --titles-only --limit 20           # More entries in titles mode
     python briefing.py "task desc" --budget 3000           # Cap output to 3000 chars (frozen snapshot)
     python briefing.py --task "memory-surface"              # Task-scoped recall for a task ID
+    python briefing.py "project" --budget 2000 --session-start  # sessionStart: Level 0 skill index + briefing
 
 Default output is compact (~500 tokens): titles + 1-line summaries with entry IDs.
 Use --titles-only for ultra-compact index (~10 tokens/entry). Then --detail <id> for full.
 Use --wakeup for ultra-compact AI wake-up context (~170 tokens).
 Use --full for complete content with tags, confidence scores, and full text.
+Use --session-start (hook callers only) to prepend the Level 0 installed-skill index.
 """
 
 import datetime
@@ -127,6 +129,108 @@ MODE_PROFILES = {
         "weights": {"mistake": 1.3, "pattern": 1.4, "decision": 0.9, "tool": 1.1},
     },
 }
+
+# ── Level 0 skill index constants (issue #118) ───────────────────────────────
+# Total maximum description characters displayed in the skill index.
+# When the source description exceeds this, it is truncated to the first 57
+# characters followed by the three-character ASCII suffix "..." (total = 60).
+_SKILL_DESC_MAX = 60
+
+
+def _parse_skill_frontmatter(text: str) -> dict:
+    """Parse YAML-ish frontmatter from a SKILL.md file using stdlib only.
+
+    Extracts ``name`` and ``description`` from the first ``---``-delimited block.
+    Handles folded YAML scalars (``description: >`` with indented continuation
+    lines) without PyYAML.
+
+    Returns a dict with keys ``name`` and ``description`` (may be empty strings
+    on parse failure).  Never raises.
+    """
+    try:
+        lines = text.replace("\r\n", "\n").split("\n")
+        if not lines or lines[0].strip() != "---":
+            return {"name": "", "description": ""}
+        end = -1
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                end = i
+                break
+        if end == -1:
+            return {"name": "", "description": ""}
+        fm_lines = lines[1:end]
+        name = ""
+        description = ""
+        i = 0
+        while i < len(fm_lines):
+            line = fm_lines[i]
+            stripped = line.strip()
+            if stripped.startswith("name:"):
+                name = stripped[len("name:"):].strip().strip('"').strip("'")
+            elif stripped.startswith("description:"):
+                rest = stripped[len("description:"):].strip()
+                if rest in (">", "|", ">-", "|-", ">+", "|+"):
+                    # Folded/literal block scalar — collect indented continuation lines.
+                    desc_parts = []
+                    i += 1
+                    while i < len(fm_lines):
+                        next_line = fm_lines[i]
+                        if next_line and (next_line[0] in (" ", "\t")):
+                            desc_parts.append(next_line.strip())
+                        elif next_line.strip() == "":
+                            desc_parts.append("")
+                        else:
+                            i -= 1
+                            break
+                        i += 1
+                    description = " ".join(p for p in desc_parts if p)
+                else:
+                    description = rest.strip('"').strip("'")
+            i += 1
+        return {"name": name, "description": description}
+    except Exception:
+        return {"name": "", "description": ""}
+
+
+def _generate_skill_index(skills_dir: "Path | None" = None) -> str:
+    """Scan skills/*/SKILL.md and produce a Level 0 compact index string.
+
+    Only called when ``--session-start`` is explicitly passed to ``briefing.py``
+    (issue #118).  Returns an empty string when the skills directory is absent,
+    has no readable SKILL.md files, or any error occurs (fail-open).
+
+    Each entry is formatted as ``  <name> — <description>`` where description
+    longer than ``_SKILL_DESC_MAX`` characters is truncated to 57 chars + ``"..."``
+    (total ``_SKILL_DESC_MAX`` = 60 displayed characters).
+    """
+    try:
+        base = skills_dir if skills_dir is not None else TOOLS_DIR / "skills"
+        if not base.is_dir():
+            return ""
+        entries = []
+        for skill_path in sorted(base.glob("*/SKILL.md")):
+            try:
+                text = skill_path.read_text(encoding="utf-8", errors="replace")
+                meta = _parse_skill_frontmatter(text)
+                skill_name = meta.get("name", "") or skill_path.parent.name
+                desc = (meta.get("description", "") or "").strip()
+                if len(desc) > _SKILL_DESC_MAX:
+                    desc = desc[:57] + "..."
+                entries.append((skill_name, desc))
+            except Exception:
+                continue  # fail-open per skill
+        if not entries:
+            return ""
+        lines = [f"\U0001f4e6 Skills ({len(entries)} available):"]
+        for skill_name, desc in entries:
+            if desc:
+                lines.append(f"  {skill_name} \u2014 {desc}")
+            else:
+                lines.append(f"  {skill_name}")
+        lines.append("  " + "\u2500" * 33)
+        return "\n".join(lines)
+    except Exception:
+        return ""  # always fail-open
 
 
 def get_db() -> sqlite3.Connection:
@@ -2878,6 +2982,20 @@ def generate_task_briefing(task_id: str, limit: int = 30, fmt: str = "text", wit
 
 def main():
     args = sys.argv[1:]
+
+    # ── Level 0 skill index (issue #118): detect --session-start early ──────
+    # Strip the flag so it is never treated as a query term by later argument
+    # parsing.  Print the skill index immediately — before any early-return paths
+    # and before DB access that may sys.exit — so callers that capture stdout
+    # still receive the index even when the knowledge DB is absent.
+    session_start_mode = "--session-start" in args
+    if session_start_mode:
+        args = [a for a in args if a != "--session-start"]
+        _skill_idx = _generate_skill_index()
+        if _skill_idx:
+            print(_skill_idx)
+            sys.stdout.flush()  # ensure skill index is visible before any timeout
+    # ── end Level 0 ──────────────────────────────────────────────────────────
 
     if not args or "--help" in args or "-h" in args:
         print(__doc__)

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -29,7 +29,7 @@ hooks/
 
 | Rule | Event | Description |
 |------|-------|-------------|
-| `auto-briefing` | sessionStart | Auto-runs briefing.py + refreshes codebase-map.py, creates HMAC-signed marker; also surfaces paused-goal resume banner from `.octogent/goal-resume-breadcrumb.json` when a goal was paused at last session end (issue #185) |
+| `auto-briefing` | sessionStart | Auto-runs briefing.py (with `--session-start` flag) + refreshes codebase-map.py, creates HMAC-signed marker; also surfaces paused-goal resume banner from `.octogent/goal-resume-breadcrumb.json` when a goal was paused at last session end (issue #185). The `--session-start` flag causes briefing.py to prepend a **Level 0 skill index** — a compact list of installed `skills/*/SKILL.md` entries with 60-char truncated descriptions — before the normal knowledge briefing (issue #118). |
 | `integrity` | sessionStart | Verifies hook files via SHA256 manifest |
 | `session-end` | sessionEnd | Cleans up marker files, writes session.log entry, opt-in checkpoint reminder (`COPILOT_CHECKPOINT_REMIND=1`) |
 | `recurrence-detector` | sessionEnd | Detects briefed mistakes that recurred in the same session; increments `recurrence_after_briefing` counter |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -18,6 +18,39 @@ This repo contains both **Skills** (SKILL.md) and **Agent templates** (.agent.md
 
 **Key rule:** Skills use `allowed-tools` (optional string). Agents use `tools` (YAML list). Don't mix them.
 
+## Progressive Skill Loading (issue #118)
+
+At `sessionStart`, the `auto-briefing` hook passes `--session-start` to `briefing.py`, which prepends a **Level 0 skill index** to the normal knowledge briefing output. This gives the agent a compact, token-efficient overview of all installed skills immediately when a new session opens.
+
+### Loading levels
+
+| Level | What | When triggered |
+|-------|------|----------------|
+| **L0 — Index** | Compact list: skill name + description (max 60 chars: first 57 + `"..."` when truncated), one line per skill | Automatically at every `sessionStart` via `briefing.py --session-start` |
+| **L1 — Full SKILL.md** | Complete `SKILL.md` content with usage instructions | Platform-native: loaded by AI on demand when skill is invoked |
+| **L2 — References** | `references/` context files alongside the skill | Platform-native: loaded on demand for deep context |
+
+### L0 index format
+
+```
+📦 Skills installed (15 total)
+  agent-creator — Generate project-specific .agent.md files from curated tem...
+  code-reviewer — Skeptical, high signal-to-noise code review that surfaces o...
+  ...
+```
+
+- Source: `skills/*/SKILL.md` YAML frontmatter (stdlib-only parsing)
+- Description: first 57 characters, followed by `"..."` if truncated (total max 60 chars)
+- **Fail-open**: missing `skills/` dir, unreadable files, or parse errors → empty/silent
+- **No leakage**: skill index is only emitted when `--session-start` is explicitly passed; normal `sk briefing` and `sk query` paths are unaffected
+
+### Implementation
+
+- `briefing.py`: `_parse_skill_frontmatter()`, `_generate_skill_index()`, `--session-start` flag
+- `hooks/rules/briefing.py`: `AutoBriefingRule` adds `"--session-start"` to subprocess args
+- `hooks/auto-briefing.py`: legacy path adds `"--session-start"` to subprocess args
+- `sk-rust/src/hooks/rules.rs`: Rust `AutoBriefingRule` adds `"--session-start"` to command
+
 ## Available Skills
 
 | Skill | Purpose |

--- a/hooks/auto-briefing.py
+++ b/hooks/auto-briefing.py
@@ -307,7 +307,7 @@ def main():
 
     try:
         subprocess.run(
-            [sys.executable, str(BRIEFING), project, "--budget", "500"],
+            [sys.executable, str(BRIEFING), project, "--budget", "500", "--session-start"],
             timeout=10,
             stderr=subprocess.DEVNULL,
             encoding="utf-8",

--- a/hooks/rules/briefing.py
+++ b/hooks/rules/briefing.py
@@ -337,7 +337,7 @@ class AutoBriefingRule(Rule):
         # Run briefing subprocess, capturing output so it follows MEMORY.md in the message
         try:
             briefing_proc = subprocess.run(
-                [sys.executable, str(BRIEFING_SCRIPT), project, "--budget", "2000"],
+                [sys.executable, str(BRIEFING_SCRIPT), project, "--budget", "2000", "--session-start"],
                 timeout=10,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
@@ -347,7 +347,17 @@ class AutoBriefingRule(Rule):
             )
             if briefing_proc.stdout.strip():
                 lines.append(briefing_proc.stdout.rstrip())
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as exc:
+            # Preserve any partial stdout already produced before the timeout
+            # (e.g., the Level 0 skill index emitted by --session-start mode).
+            _partial = (exc.stdout or "").rstrip() if isinstance(getattr(exc, "stdout", None), str) else ""
+            if not _partial and isinstance(getattr(exc, "stdout", None), bytes):
+                try:
+                    _partial = exc.stdout.decode("utf-8", errors="replace").rstrip()
+                except Exception:
+                    _partial = ""
+            if _partial:
+                lines.append(_partial)
             lines.append("  \u23f1 Briefing timed out (10s)")
         except Exception:
             pass

--- a/hooks/rules/common.py
+++ b/hooks/rules/common.py
@@ -3,11 +3,16 @@
 Single source of truth for constants, path helpers, and result constructors.
 """
 
+import os
 import re
 from pathlib import Path
 
 MARKERS_DIR = Path.home() / ".copilot" / "markers"
-TOOLS_DIR = Path.home() / ".copilot" / "tools"
+# SK_TOOLS_DIR env var mirrors the Rust resolve_tools_dir() override used in tests
+# and developer worktrees.  Only accepted when the path exists (parity with Rust);
+# otherwise falls back to the standard installed-tools path.
+_sk_tools_override = Path(os.environ["SK_TOOLS_DIR"]) if os.environ.get("SK_TOOLS_DIR") else None
+TOOLS_DIR = _sk_tools_override if (_sk_tools_override is not None and _sk_tools_override.is_dir()) else Path.home() / ".copilot" / "tools"
 
 SAFE_PATH_PREFIXES = ("/tmp/", "/var/", "/dev/", "/proc/")
 

--- a/hooks/rules/common.py
+++ b/hooks/rules/common.py
@@ -12,7 +12,11 @@ MARKERS_DIR = Path.home() / ".copilot" / "markers"
 # and developer worktrees.  Only accepted when the path exists (parity with Rust);
 # otherwise falls back to the standard installed-tools path.
 _sk_tools_override = Path(os.environ["SK_TOOLS_DIR"]) if os.environ.get("SK_TOOLS_DIR") else None
-TOOLS_DIR = _sk_tools_override if (_sk_tools_override is not None and _sk_tools_override.is_dir()) else Path.home() / ".copilot" / "tools"
+TOOLS_DIR = (
+    _sk_tools_override
+    if (_sk_tools_override is not None and _sk_tools_override.is_dir())
+    else Path.home() / ".copilot" / "tools"
+)
 
 SAFE_PATH_PREFIXES = ("/tmp/", "/var/", "/dev/", "/proc/")
 

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -679,7 +679,7 @@ impl HookRule for AutoBriefingRule {
         match Command::new(python)
             .arg(&briefing_script)
             .arg(&project)
-            .args(["--budget", "2000"])
+            .args(["--budget", "2000", "--session-start"])
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()
@@ -712,9 +712,18 @@ impl HookRule for AutoBriefingRule {
                     }
                 }
                 if timed_out {
-                    // Reap the reader thread (pipe is closed after kill+wait).
+                    // Reap the reader thread (pipe is closed after kill+wait),
+                    // then preserve any partial output already collected before
+                    // the timeout — e.g. the Level 0 skill index emitted by
+                    // --session-start mode before the knowledge DB work begins.
                     if let Some(handle) = reader_thread {
-                        let _ = handle.join();
+                        if let Ok(bytes) = handle.join() {
+                            let partial = String::from_utf8_lossy(&bytes);
+                            let partial_out = partial.trim_end().to_string();
+                            if !partial_out.is_empty() {
+                                lines.push(partial_out);
+                            }
+                        }
                     }
                     lines.push("  \u{23f1} Briefing timed out (10s)".to_string());
                 } else if let Some(handle) = reader_thread {

--- a/sk-rust/tests/integration_test.rs
+++ b/sk-rust/tests/integration_test.rs
@@ -1364,6 +1364,40 @@ fn hooks_run_session_start_never_denies() {
     let _ = fs::remove_dir_all(&tmp);
 }
 
+/// `AutoBriefingRule` must pass `--session-start` to the `briefing.py` subprocess.
+///
+/// Creates a minimal `briefing.py` stub that echoes its arguments to stdout.
+/// Verifies that `sk hooks run sessionStart` includes `--session-start` in
+/// the subprocess invocation (issue #118).
+#[test]
+fn auto_briefing_passes_session_start_flag() {
+    use std::fs;
+
+    let tmp = std::env::temp_dir().join("sk_hooks_session_start_flag_test");
+    let _ = fs::remove_dir_all(&tmp);
+    fs::create_dir_all(&tmp).unwrap();
+
+    // Write a stub briefing.py that prints its argv to stdout so we can verify
+    // the caller passed --session-start.
+    let stub = "import sys\nprint('ARGS:' + ' '.join(sys.argv[1:]))\n";
+    fs::write(tmp.join("briefing.py"), stub).unwrap();
+
+    let mut cmd = assert_cmd::Command::cargo_bin("sk").unwrap();
+    cmd.args(["hooks", "run", "sessionStart"])
+        .env("SK_TOOLS_DIR", &tmp)
+        .write_stdin(r#"{}"#);
+
+    let output = cmd.assert().success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+
+    assert!(
+        stdout.contains("--session-start"),
+        "AutoBriefingRule must pass --session-start to briefing.py; got:\n{stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&tmp);
+}
+
 /// `sk hooks run sessionEnd` with no session ID must be fail-open (RecurrenceDetectorRule).
 ///
 /// When COPILOT_SESSION_ID is absent and the DB is absent, RecurrenceDetectorRule

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -902,6 +902,135 @@ except Exception as _e_sk:
     test("skill-briefing tests ran without exception", False, str(_e_sk))
 
 
+# ── 16. Level 0 skill index (issue #118) ────────────────────────────────────
+
+print("\n📦 Level 0 skill index (issue #118)")
+
+import shutil as _shutil
+
+# 16a. _parse_skill_frontmatter — folded description
+_fm_folded = "---\nname: test-skill\ndescription: >\n  This is a long description that spans multiple\n  lines and should be joined together.\n---\n# Body\n"
+_meta_f = _b._parse_skill_frontmatter(_fm_folded)
+test("16a: _parse_skill_frontmatter extracts name from folded fm", _meta_f.get("name") == "test-skill")
+test("16a: _parse_skill_frontmatter joins folded description", "long description" in _meta_f.get("description", ""))
+test("16a: _parse_skill_frontmatter folded desc has no embedded newline", "\n" not in _meta_f.get("description", ""))
+
+# 16b. _parse_skill_frontmatter — inline description
+_fm_inline = "---\nname: another-skill\ndescription: Short inline description.\n---\n"
+_meta_i = _b._parse_skill_frontmatter(_fm_inline)
+test("16b: _parse_skill_frontmatter extracts inline description", _meta_i.get("description") == "Short inline description.")
+
+# 16c. _parse_skill_frontmatter — missing frontmatter returns empty
+_meta_no = _b._parse_skill_frontmatter("# No frontmatter\nJust body content")
+test("16c: _parse_skill_frontmatter missing frontmatter → empty name", _meta_no.get("name") == "")
+test("16c: _parse_skill_frontmatter missing frontmatter → empty description", _meta_no.get("description") == "")
+
+# 16d. _generate_skill_index with a temp skills directory
+_skill_tmp = Path(tempfile.mkdtemp(prefix="test-skills-"))
+try:
+    _sa = _skill_tmp / "skill-a"
+    _sa.mkdir()
+    (_sa / "SKILL.md").write_text(
+        "---\nname: skill-a\ndescription: Short description here.\n---\n# Body\n",
+        encoding="utf-8",
+    )
+    _sb = _skill_tmp / "skill-b"
+    _sb.mkdir()
+    _long_d = "A" * 80
+    (_sb / "SKILL.md").write_text(
+        f"---\nname: skill-b\ndescription: {_long_d}\n---\n",
+        encoding="utf-8",
+    )
+    _idx = _b._generate_skill_index(_skill_tmp)
+    test("16d: _generate_skill_index non-empty for populated dir", bool(_idx))
+    test("16d: _generate_skill_index includes skill-a", "skill-a" in _idx)
+    test("16d: _generate_skill_index includes skill-b", "skill-b" in _idx)
+    # Description for skill-b must be truncated to 57 chars + "..." (total 60)
+    _sb_line = next((l for l in _idx.splitlines() if "skill-b" in l), "")
+    _sb_desc_part = _sb_line.split("\u2014", 1)[-1].strip() if "\u2014" in _sb_line else ""
+    test(
+        "16d: _generate_skill_index truncates long description to 57 chars + '...' (total 60)",
+        _sb_desc_part.endswith("...") and len(_sb_desc_part) == _b._SKILL_DESC_MAX,
+        f"got: {_sb_desc_part!r}",
+    )
+finally:
+    _shutil.rmtree(str(_skill_tmp), ignore_errors=True)
+
+# 16e. _generate_skill_index with empty dir returns ""
+_empty_tmp = Path(tempfile.mkdtemp(prefix="test-skills-empty-"))
+try:
+    test("16e: _generate_skill_index empty dir → empty string", _b._generate_skill_index(_empty_tmp) == "")
+finally:
+    _shutil.rmtree(str(_empty_tmp), ignore_errors=True)
+
+# 16f. _generate_skill_index with nonexistent dir returns ""
+_missing = Path(tempfile.mkdtemp(prefix="test-")) / "nonexistent-skills"
+test("16f: _generate_skill_index missing dir → empty string", _b._generate_skill_index(_missing) == "")
+
+# 16g. Constants exist
+test("16g: briefing.py exposes _SKILL_DESC_MAX", hasattr(_b, "_SKILL_DESC_MAX"))
+test("16g: briefing.py _SKILL_DESC_MAX == 60", _b._SKILL_DESC_MAX == 60)
+test("16g: briefing.py exposes _generate_skill_index", hasattr(_b, "_generate_skill_index"))
+test("16g: briefing.py exposes _parse_skill_frontmatter", hasattr(_b, "_parse_skill_frontmatter"))
+
+# 16h. --session-start flag is handled in main() source
+_br_src_118 = (REPO / "briefing.py").read_text(encoding="utf-8")
+test("16h: briefing.py source handles --session-start", "--session-start" in _br_src_118)
+test("16h: briefing.py strips --session-start before query assembly", "session_start_mode" in _br_src_118)
+
+# 16i. Subprocess: --session-start triggers skill index; normal invocation does not
+# Use an isolated HOME/USERPROFILE so the child never finds the live knowledge DB.
+# This makes the subprocess deterministic: it exits quickly with rc=1 (DB absent)
+# but still emits the skill index before attempting DB access.
+import subprocess as _sp118
+
+_proc_tmp = Path(tempfile.mkdtemp(prefix="test-skills-proc-"))
+try:
+    # Build an isolated env: copy the current env but redirect home dirs so the
+    # knowledge DB is absent; the skill index is printed before any DB access.
+    _isolated_env = os.environ.copy()
+    _isolated_env["HOME"] = str(_proc_tmp)
+    _isolated_env["USERPROFILE"] = str(_proc_tmp)
+
+    _briefing_py = REPO / "briefing.py"
+    # Run with --session-start in the isolated env; the child will fail to open
+    # the knowledge DB (rc=1, stderr has "not found") but must still emit the
+    # skill index on stdout before reaching the DB.
+    _r_session = _sp118.run(
+        [sys.executable, str(_briefing_py), "test-project", "--budget", "100", "--session-start"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+        cwd=str(REPO),
+        env=_isolated_env,
+    )
+    test(
+        "16i: briefing.py --session-start emits Skills block",
+        "\U0001f4e6 Skills" in _r_session.stdout or "Skills" in _r_session.stdout,
+        f"rc={_r_session.returncode} stdout={_r_session.stdout[:300]} stderr={_r_session.stderr[:200]}",
+    )
+    # Normal invocation (no --session-start, no DB) must NOT emit skill index
+    _r_normal = _sp118.run(
+        [sys.executable, str(_briefing_py), "--wakeup"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+        cwd=str(REPO),
+        env=_isolated_env,
+    )
+    test(
+        "16i: briefing.py normal invocation has no skill index",
+        "\U0001f4e6 Skills" not in _r_normal.stdout,
+        f"rc={_r_normal.returncode} stdout={_r_normal.stdout[:300]}",
+    )
+finally:
+    _shutil.rmtree(str(_proc_tmp), ignore_errors=True)
+
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 print(f"\n{'=' * 50}")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -5370,8 +5370,270 @@ except Exception as _e27:
 
 
 # ═══════════════════════════════════════════════════════════════════
-#  Results
+#  Section 28: sessionStart Level 0 skill-index signal (issue #118)
 # ═══════════════════════════════════════════════════════════════════
+
+print("\n📦 Section 28: sessionStart Level 0 skill-index signal (issue #118)")
+
+# 27a. hooks/rules/briefing.py AutoBriefingRule passes --session-start to briefing.py
+_ab_rule_src = (REPO / "hooks" / "rules" / "briefing.py").read_text(encoding="utf-8")
+test(
+    "27a: AutoBriefingRule subprocess call includes --session-start flag",
+    "--session-start" in _ab_rule_src,
+    "AutoBriefingRule must pass --session-start to briefing.py at sessionStart",
+)
+
+# 27b. hooks/auto-briefing.py passes --session-start to briefing.py
+_auto_br_src = (REPO / "hooks" / "auto-briefing.py").read_text(encoding="utf-8")
+test(
+    "27b: hooks/auto-briefing.py subprocess call includes --session-start flag",
+    "--session-start" in _auto_br_src,
+    "auto-briefing.py must pass --session-start to briefing.py at sessionStart",
+)
+
+# 27c. briefing.py handles --session-start without crashing (subprocess test)
+# Use an isolated HOME/USERPROFILE so the child finds no knowledge DB and exits
+# quickly with rc=1, but must still emit the skill index before any DB access.
+_briefing_py_27 = REPO / "briefing.py"
+_td27c = Path(tempfile.mkdtemp(prefix="test-27c-"))
+try:
+    _isolated_env27c = os.environ.copy()
+    _isolated_env27c["HOME"] = str(_td27c)
+    _isolated_env27c["USERPROFILE"] = str(_td27c)
+    _r27 = subprocess.run(
+        [sys.executable, str(_briefing_py_27), "test-project", "--budget", "100", "--session-start"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+        cwd=str(REPO),
+        env=_isolated_env27c,
+    )
+finally:
+    shutil.rmtree(str(_td27c), ignore_errors=True)
+test(
+    "27c: briefing.py --session-start exits without unexpected crash",
+    _r27.returncode in (0, 1),  # 0=ok, 1=no DB (expected in test env)
+    f"exit={_r27.returncode} stderr={_r27.stderr[:100]}",
+)
+test(
+    "27c: briefing.py --session-start emits skill index block",
+    "\U0001f4e6 Skills" in _r27.stdout,
+    f"stdout={_r27.stdout[:300]}",
+)
+
+# 27d. No skill index leakage in normal (non-sessionStart) auto-briefing path
+# source-level: verify skill index is only generated when session_start_mode is True
+_br_src_27 = _briefing_py_27.read_text(encoding="utf-8")
+test(
+    "27d: briefing.py skill index gated by session_start_mode flag",
+    "session_start_mode" in _br_src_27 and "_generate_skill_index" in _br_src_27,
+    "briefing.py must gate _generate_skill_index() on session_start_mode",
+)
+
+# 27e. Rust AutoBriefingRule source passes --session-start
+_rust_rules_src = (REPO / "sk-rust" / "src" / "hooks" / "rules.rs").read_text(encoding="utf-8")
+test(
+    "27e: sk-rust AutoBriefingRule source passes --session-start to briefing.py",
+    "--session-start" in _rust_rules_src,
+    "AutoBriefingRule in rules.rs must include --session-start in subprocess args",
+)
+
+# 27f. briefing.py flushes stdout immediately after printing skill index (source check)
+_br_src_27f = (REPO / "briefing.py").read_text(encoding="utf-8")
+_flush_after_idx = _br_src_27f.find("sys.stdout.flush()")
+_skill_print_idx = _br_src_27f.find("print(_skill_idx)")
+test(
+    "27f: briefing.py flushes stdout after printing skill index",
+    "sys.stdout.flush()" in _br_src_27f and _flush_after_idx > _skill_print_idx,
+    "briefing.py must call sys.stdout.flush() after print(_skill_idx)",
+)
+
+# 27g. hooks/rules/briefing.py AutoBriefingRule preserves partial stdout on timeout
+_py_hook_src_27g = (REPO / "hooks" / "rules" / "briefing.py").read_text(encoding="utf-8")
+test(
+    "27g: Python AutoBriefingRule catches TimeoutExpired and preserves exc.stdout",
+    "TimeoutExpired as" in _py_hook_src_27g and "exc.stdout" in _py_hook_src_27g,
+    "hooks/rules/briefing.py must catch TimeoutExpired as exc and use exc.stdout",
+)
+test(
+    "27g: Python AutoBriefingRule appends partial output BEFORE timeout notice",
+    _py_hook_src_27g.index("lines.append(_partial)") < _py_hook_src_27g.index("timed out (10s)")
+    if "_partial" in _py_hook_src_27g and "timed out (10s)" in _py_hook_src_27g
+    else False,
+    "hooks/rules/briefing.py must emit partial output before the timeout notice",
+)
+
+# 27g. Functional: AutoBriefingRule timeout preserves partial output
+# Use unittest.mock to simulate TimeoutExpired with partial stdout already captured
+# (mirrors what subprocess.run does: kill + drain + attach to exc.stdout).
+_td27g = Path(tempfile.mkdtemp(prefix="test-27g-"))
+_markers27g = _td27g / ".copilot" / "markers"
+_markers27g.mkdir(parents=True, exist_ok=True)
+
+# A dummy briefing.py that EXISTS on disk (the path-check in evaluate() must pass).
+_dummy_exists27g = _td27g / "briefing.py"
+_dummy_exists27g.write_text("# placeholder\n", encoding="utf-8")
+
+try:
+    from unittest.mock import patch as _mock_patch27g
+    sys.path.insert(0, str(REPO / "hooks"))
+    import rules.briefing as _rb27g
+    from rules.briefing import AutoBriefingRule as _ABR27g
+
+    _rule27g = _ABR27g()
+    _orig_bs27g = _rb27g.BRIEFING_SCRIPT
+    _orig_mdir27g = _rb27g.MARKERS_DIR
+    _orig_sm27g = _rb27g.sign_marker
+    _orig_lmm27g = _rb27g._load_memory_md
+
+    _rb27g.BRIEFING_SCRIPT = _dummy_exists27g
+    _rb27g.MARKERS_DIR = _markers27g
+    _rb27g.sign_marker = lambda p, n: None
+    _rb27g._load_memory_md = lambda **kw: None
+
+    # Simulate a TimeoutExpired with the skill index already in exc.stdout.
+    # This mirrors the real behavior: subprocess.run kills the slow child, drains
+    # the pipe, attaches drained bytes to exc.stdout, then re-raises.
+    _sim_stdout27g = "\U0001f4e6 Skills (1 installed)\n"
+    _te27g = subprocess.TimeoutExpired(cmd=["briefing.py"], timeout=10, output=_sim_stdout27g)
+
+    def _mock_run27g(*a, **kw):
+        # Pass through fast commands (git, etc.); simulate timeout for briefing.py.
+        args = a[0] if a else kw.get("args", [])
+        if isinstance(args, list) and len(args) >= 2 and str(args[-1]).endswith("briefing.py") or \
+           (isinstance(args, list) and "--session-start" in args):
+            raise _te27g
+        return subprocess.run.__wrapped__(*a, **kw) if hasattr(subprocess.run, "__wrapped__") else _orig_sp_run27g(*a, **kw)
+
+    _orig_sp_run27g = _rb27g.subprocess.run
+
+    try:
+        with _mock_patch27g.object(_rb27g.subprocess, "run", side_effect=lambda *a, **kw: (
+            (_ for _ in ()).throw(_te27g)
+            if (a and isinstance(a[0], list) and any("briefing.py" in str(x) or x == "--session-start" for x in a[0]))
+            else _orig_sp_run27g(*a, **kw)
+        )):
+            _result27g = _rule27g.evaluate("sessionStart", {})
+    except Exception:
+        # mock.patch.object doesn't work as context manager for side_effect on non-method
+        # Fall back: directly replace subprocess.run on the module
+        _rb27g.subprocess.run = _mock_run27g
+        try:
+            _result27g = _rule27g.evaluate("sessionStart", {})
+        finally:
+            _rb27g.subprocess.run = _orig_sp_run27g
+
+    _msg27g = _result27g.get("message", "") if isinstance(_result27g, dict) else ""
+    test(
+        "27g: AutoBriefingRule timeout preserves partial skill-index output",
+        "\U0001f4e6 Skills" in _msg27g,
+        f"message={_msg27g[:300]!r}",
+    )
+    test(
+        "27g: AutoBriefingRule timeout notice still present",
+        "timed out" in _msg27g,
+        f"message={_msg27g[:300]!r}",
+    )
+    test(
+        "27g: AutoBriefingRule skill index appears before timeout notice",
+        _msg27g.index("\U0001f4e6 Skills") < _msg27g.index("timed out")
+        if "\U0001f4e6 Skills" in _msg27g and "timed out" in _msg27g
+        else False,
+        f"message={_msg27g[:300]!r}",
+    )
+except Exception as _e27g:
+    test("27g: AutoBriefingRule timeout preserves partial output (setup failed)", False, str(_e27g))
+    test("27g: AutoBriefingRule timeout notice still present (setup failed)", False, str(_e27g))
+    test("27g: AutoBriefingRule skill index appears before timeout notice (setup failed)", False, str(_e27g))
+finally:
+    if "_rb27g" in dir() and "_orig_bs27g" in dir():
+        _rb27g.BRIEFING_SCRIPT = _orig_bs27g
+        _rb27g.MARKERS_DIR = _orig_mdir27g
+        _rb27g.sign_marker = _orig_sm27g
+        _rb27g._load_memory_md = _orig_lmm27g
+    shutil.rmtree(str(_td27g), ignore_errors=True)
+
+# 27h. Rust AutoBriefingRule source: on timeout, joins reader thread and appends partial bytes
+_rust_rules_src_27h = (REPO / "sk-rust" / "src" / "hooks" / "rules.rs").read_text(encoding="utf-8")
+test(
+    "27h: Rust AutoBriefingRule joins reader thread on timeout and appends partial output",
+    "timed_out" in _rust_rules_src_27h and "handle.join()" in _rust_rules_src_27h
+    and "partial_out" in _rust_rules_src_27h
+    and _rust_rules_src_27h.index("partial_out") < _rust_rules_src_27h.index("Briefing timed out"),
+    "sk-rust AutoBriefingRule must join reader thread and append partial output before timeout notice",
+)
+
+
+
+
+# ── Section 29: SK_TOOLS_DIR parity guard (issue #118 follow-up) ──
+print("\n── Section 29: SK_TOOLS_DIR existence guard (parity with Rust) ──")
+
+import importlib
+import types as _types
+
+def _reload_common_with_env(env_overrides: dict):
+    """Import hooks.rules.common with a patched environment and return TOOLS_DIR."""
+    import sys as _sys
+    _saved = os.environ.copy()
+    for k, v in env_overrides.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    # Force re-execution of module-level code by reloading
+    mod_name = "hooks.rules.common"
+    if mod_name in _sys.modules:
+        del _sys.modules[mod_name]
+    import importlib as _il
+    try:
+        mod = _il.import_module(mod_name)
+        return mod.TOOLS_DIR
+    finally:
+        os.environ.clear()
+        os.environ.update(_saved)
+        if mod_name in _sys.modules:
+            del _sys.modules[mod_name]
+
+try:
+    import tempfile, pathlib
+
+    # 28a: SK_TOOLS_DIR unset → default path
+    _td28_result = _reload_common_with_env({"SK_TOOLS_DIR": None})
+    test(
+        "28a: SK_TOOLS_DIR unset → default ~/.copilot/tools",
+        _td28_result == pathlib.Path.home() / ".copilot" / "tools",
+        f"got {_td28_result!r}",
+    )
+
+    # 28b: SK_TOOLS_DIR set to a NON-EXISTENT path → fall back to default
+    _fake_path = str(pathlib.Path.home() / ".copilot" / "nonexistent_sk_tools_28b_test")
+    _td28_result2 = _reload_common_with_env({"SK_TOOLS_DIR": _fake_path})
+    test(
+        "28b: SK_TOOLS_DIR points to non-existent dir → fallback to default",
+        _td28_result2 == pathlib.Path.home() / ".copilot" / "tools",
+        f"got {_td28_result2!r} for env={_fake_path!r}",
+    )
+
+    # 28c: SK_TOOLS_DIR set to an EXISTING directory → use override
+    _tmpdir28 = tempfile.mkdtemp()
+    try:
+        _td28_result3 = _reload_common_with_env({"SK_TOOLS_DIR": _tmpdir28})
+        test(
+            "28c: SK_TOOLS_DIR points to existing dir → use override",
+            _td28_result3 == pathlib.Path(_tmpdir28),
+            f"got {_td28_result3!r} for env={_tmpdir28!r}",
+        )
+    finally:
+        import shutil as _sh28
+        _sh28.rmtree(_tmpdir28, ignore_errors=True)
+
+except Exception as _e28:
+    test("28a: SK_TOOLS_DIR unset → default (setup failed)", False, str(_e28))
+    test("28b: SK_TOOLS_DIR non-existent → fallback (setup failed)", False, str(_e28))
+    test("28c: SK_TOOLS_DIR existing → override (setup failed)", False, str(_e28))
 
 print(f"\n{'=' * 50}")
 print(f"Results: {PASS} passed, {FAIL} failed out of {PASS + FAIL}")


### PR DESCRIPTION
## Summary
- add a sessionStart-only Level 0 skill index in `briefing.py` with 60-char description truncation
- plumb `--session-start` through Python, legacy, and Rust hook callers without leaking the skill block into normal briefing usage
- preserve the skill index when the downstream knowledge briefing times out, and add Python/Rust regression coverage for the timeout path

## Notes
- Level 1 full `SKILL.md` loading and Level 2 `references/` loading remain platform-native; this PR documents and verifies that model while adding the missing Level 0 repo/runtime surface

## Verification
- `python tests\test_briefing.py`
- `python tests\test_hooks.py`
- `python test_fixes.py`
- `python test_security.py`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test auto_briefing -- --nocapture`
- `python hooks\hook_runner.py sessionStart` with `SK_TOOLS_DIR` pointed at the worktree
- `cargo run --quiet -- hooks run sessionStart` with `SK_TOOLS_DIR` pointed at the worktree

Closes #118