### PR TITLE
feat(skills): add improvement signal tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- **Event-level skill usage tracking (#119):**
+- **Explicit improvement signal tracking (#126):**
+  - `migrate.py` v24: new `improvement_signals` table in the session knowledge DB — stores explicit user-reported `missed_match`, `wrong_skill`, and `outdated_skill` signals linked to session IDs, with `consumed` tracking and indexes on `consumed`, `signal_type`, `created_at`, and `mentioned_skill`.
+  - `improvement-signals.py`: new standalone stdlib-only script exposing `record`, `list`, `consume`, and `stats` subcommands. Supports `--format json` throughout. Fail-open on missing DB. Creates the table itself if migration has not yet run.
+  - `sk.py`: `improvement-signals` added to `_DIRECT` command map → `improvement-signals.py`.
+  - `skill-suggest.py`: new `_load_improvement_signals()` and `_signals_to_candidates()` functions. `suggest()` now merges unconsumed signal-derived candidates with knowledge-derived candidates (boost existing or append new). Consumed rows never surface. Fail-open: behavior is identical to pre-signal when the table is absent. New `improvement_signal_count` field in the result dict.
+  - `tests/test_improvement_signals.py`: new test file covering table creation, all signal types, consumed filtering, list/consume/stats, and CLI dispatch.
+  - `tests/test_skill_suggest.py`: `TestSignalIntegration` class added — covers fail-open (no table, missing DB), signal-derived candidate appearance, consumed exclusion, score boosting of existing candidates, patch_guidance for wrong/outdated signals, and `improvement_signal_count` key presence.
+  - `tests/test_sk_cli.py`: `improvement-signals` direct command routing tests added.
+  - `docs/USAGE.md`: `sk improvement-signals` section documenting signal types, record/list/consume/stats usage, and skill-suggest integration.
+
+
   - `hooks/rules/skill_usage.py`: New `SkillUsageRule` (postToolUse, `skill` tool only) — records `triggered`, `loaded`, or `skipped` events in `skill_usage_events` table of `skill-metrics.db`. Exit code 0 always yields `loaded`; non-zero yields `skipped`; absent exit code falls back to short-output skip-marker heuristic. Fail-open; never blocks tool use.
   - `hooks/rules/__init__.py`: `SkillUsageRule` registered in the postToolUse rule list.
   - `skill-metrics.py`: Event-level skill usage is included in the default output and `--json` status surface (`total_skill_events` plus per-skill triggered/loaded/skipped counts); no separate `--events` flag is needed.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -29,6 +29,10 @@ sk audit-hooks                               # → audit-hooks.py
 sk audit-hooks --json
 sk audit-hooks --days 7
 sk audit-hooks --hooks-dir /path/to/hooks    # override hook inventory directory
+sk improvement-signals record --query "docker run fails" --type missed_match  # → improvement-signals.py
+sk improvement-signals list
+sk improvement-signals consume --id 3
+sk improvement-signals stats --format json
 ```
 
 ### `sk skill-suggest` — knowledge-to-skill pipeline
@@ -57,6 +61,53 @@ python validate-skill.py path/to/SKILL.md
 ```
 
 > Direct-script form: `python skill-suggest.py [args...]`
+
+### `sk improvement-signals` — explicit session-linked improvement signal tracking
+
+Record user-reported improvement signals (missed skill matches, wrong skills, outdated skills)
+in the session knowledge DB. Unconsumed signals feed into `sk skill-suggest` to influence
+candidate generation without any automatic background inference.
+
+**Signal types:**
+- `missed_match` — a query returned no useful result; a new skill may be needed
+- `wrong_skill` — the wrong skill was triggered; use `--skill` to name it
+- `outdated_skill` — an existing skill is stale; use `--skill` to name it
+
+```bash
+# Record a signal
+sk improvement-signals record --query "docker run fails with permission error" --type missed_match
+sk improvement-signals record --query "wrong skill fired for API design" --type wrong_skill --skill my-api-skill
+sk improvement-signals record --query "outdated react patterns" --type outdated_skill --skill react-dev
+
+# List unconsumed signals (default)
+sk improvement-signals list
+sk improvement-signals list --format json
+sk improvement-signals list --type missed_match
+sk improvement-signals list --limit 20
+
+# List consumed signals
+sk improvement-signals list --consumed
+
+# Mark signal(s) as consumed (stops them surfacing in skill-suggest)
+sk improvement-signals consume --id 3
+sk improvement-signals consume --all
+sk improvement-signals consume --all --type missed_match
+
+# View statistics
+sk improvement-signals stats
+sk improvement-signals stats --format json
+```
+
+**Integration with `sk skill-suggest`:**
+Unconsumed signals with a `mentioned_skill` automatically boost or create skill candidates
+in `skill-suggest` output. Once acted on (skill created, patched, or reviewed), mark the
+signal consumed so it stops surfacing:
+
+```bash
+sk improvement-signals consume --id <ID>
+```
+
+> Direct-script form: `python improvement-signals.py [args...]`
 
 ### `sk skill-patch` — targeted SKILL.md patch
 

--- a/improvement-signals.py
+++ b/improvement-signals.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""improvement-signals.py — Explicit session-linked improvement signal recorder.
+
+Records user-reported "missed match", "wrong skill", or "outdated skill" signals
+in the session knowledge DB. Signals can later be listed, consumed, and are fed
+into `sk skill-suggest` to influence skill candidate generation.
+
+SIGNAL TYPES:
+  missed_match   — a query returned no useful result; a new skill may be needed
+  wrong_skill    — the wrong skill was triggered; mentioned_skill identifies it
+  outdated_skill — an existing skill is stale; mentioned_skill identifies it
+
+CONSUMED FLAG:
+  Once a signal is acted on (skill created / patched / reviewed), mark it consumed
+  so it stops surfacing in suggestion output.
+
+Usage:
+    python improvement-signals.py record --query TEXT --type TYPE [--skill SKILL]
+    python improvement-signals.py list [--consumed] [--type TYPE] [--limit N] [--format json]
+    python improvement-signals.py consume --id ID
+    python improvement-signals.py consume --all [--type TYPE]
+    python improvement-signals.py stats [--format json]
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+SESSION_STATE = Path.home() / ".copilot" / "session-state"
+DB_PATH = SESSION_STATE / "knowledge.db"
+
+VALID_SIGNAL_TYPES = ("missed_match", "wrong_skill", "outdated_skill")
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS improvement_signals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL DEFAULT '',
+    query TEXT NOT NULL DEFAULT '',
+    signal_type TEXT NOT NULL CHECK(signal_type IN ('missed_match', 'wrong_skill', 'outdated_skill')),
+    mentioned_skill TEXT NOT NULL DEFAULT '',
+    consumed INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_is_consumed ON improvement_signals(consumed);
+CREATE INDEX IF NOT EXISTS idx_is_signal_type ON improvement_signals(signal_type);
+CREATE INDEX IF NOT EXISTS idx_is_created ON improvement_signals(created_at);
+CREATE INDEX IF NOT EXISTS idx_is_mentioned_skill ON improvement_signals(mentioned_skill);
+"""
+
+
+def _open_db(db_path: Path) -> sqlite3.Connection:
+    """Open DB in read-write mode, creating file and table if needed."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = sqlite3.connect(str(db_path))
+    db.row_factory = sqlite3.Row
+    db.execute("PRAGMA journal_mode=WAL")
+    # Ensure the table exists regardless of migration state.
+    for stmt in _SCHEMA_SQL.strip().split(";"):
+        stmt = stmt.strip()
+        if stmt:
+            try:
+                db.execute(stmt)
+            except sqlite3.OperationalError as e:
+                if "already exists" not in str(e).lower() and "duplicate" not in str(e).lower():
+                    raise
+    db.commit()
+    return db
+
+
+def cmd_record(args, db_path: Path) -> int:
+    """Record a new improvement signal."""
+    signal_type = args.type.strip().lower()
+    if signal_type not in VALID_SIGNAL_TYPES:
+        print(
+            f"ERROR: --type must be one of: {', '.join(VALID_SIGNAL_TYPES)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    query = (args.query or "").strip()
+    if not query:
+        print("ERROR: --query is required and must not be empty.", file=sys.stderr)
+        return 2
+
+    mentioned_skill = (args.skill or "").strip()
+    session_id = (args.session_id or "").strip()
+    now = datetime.now(timezone.utc).isoformat()
+
+    db = _open_db(db_path)
+    try:
+        cur = db.execute(
+            """
+            INSERT INTO improvement_signals
+                (session_id, query, signal_type, mentioned_skill, consumed, created_at)
+            VALUES (?, ?, ?, ?, 0, ?)
+            """,
+            (session_id, query, signal_type, mentioned_skill, now),
+        )
+        db.commit()
+        row_id = cur.lastrowid
+        print(f"Recorded improvement signal #{row_id}: [{signal_type}] {query!r}")
+        if mentioned_skill:
+            print(f"  Mentioned skill: {mentioned_skill}")
+    finally:
+        db.close()
+    return 0
+
+
+def cmd_list(args, db_path: Path) -> int:
+    """List improvement signals."""
+    if not db_path.exists():
+        if getattr(args, "output_format", "text") == "json":
+            print(json.dumps({"signals": [], "total": 0, "db_exists": False}, indent=2))
+        else:
+            print("No knowledge DB found. Use 'record' to create the first signal.")
+        return 0
+
+    db = _open_db(db_path)
+    try:
+        where_parts = []
+        params: list = []
+
+        if not getattr(args, "consumed", False):
+            where_parts.append("consumed = 0")
+        else:
+            # Show only consumed
+            where_parts.append("consumed = 1")
+
+        filter_type = getattr(args, "type", None)
+        if filter_type:
+            ft = filter_type.strip().lower()
+            if ft not in VALID_SIGNAL_TYPES:
+                print(
+                    f"ERROR: --type must be one of: {', '.join(VALID_SIGNAL_TYPES)}",
+                    file=sys.stderr,
+                )
+                db.close()
+                return 2
+            where_parts.append("signal_type = ?")
+            params.append(ft)
+
+        where_clause = "WHERE " + " AND ".join(where_parts) if where_parts else ""
+        limit = max(1, getattr(args, "limit", 50))
+        params.append(limit)
+
+        rows = db.execute(
+            f"""
+            SELECT id, session_id, query, signal_type, mentioned_skill, consumed, created_at
+            FROM improvement_signals
+            {where_clause}
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+
+        fmt = getattr(args, "output_format", "text")
+        if fmt == "json":
+            data = [dict(r) for r in rows]
+            print(json.dumps({"signals": data, "total": len(data), "db_exists": True}, indent=2, ensure_ascii=False))
+        else:
+            if not rows:
+                label = "consumed" if getattr(args, "consumed", False) else "unconsumed"
+                print(f"No {label} improvement signals found.")
+            else:
+                label = "consumed" if getattr(args, "consumed", False) else "unconsumed"
+                print(f"\n📋 Improvement Signals ({label}, {len(rows)} shown)\n")
+                for r in rows:
+                    icon = "✅" if r["consumed"] else "🔔"
+                    skill_part = f" → {r['mentioned_skill']}" if r["mentioned_skill"] else ""
+                    print(
+                        f"  {icon} #{r['id']:>4}  [{r['signal_type']}]{skill_part}"
+                        f"\n         query: {r['query']}"
+                        f"\n         session: {r['session_id'] or '(none)'}  at: {r['created_at']}"
+                    )
+                    print()
+    finally:
+        db.close()
+    return 0
+
+
+def cmd_consume(args, db_path: Path) -> int:
+    """Mark signal(s) as consumed."""
+    if not db_path.exists():
+        print("ERROR: knowledge DB not found.", file=sys.stderr)
+        return 1
+
+    db = _open_db(db_path)
+    try:
+        consume_all = getattr(args, "all", False)
+        if consume_all:
+            filter_type = getattr(args, "type", None)
+            if filter_type:
+                ft = filter_type.strip().lower()
+                if ft not in VALID_SIGNAL_TYPES:
+                    print(f"ERROR: --type must be one of: {', '.join(VALID_SIGNAL_TYPES)}", file=sys.stderr)
+                    db.close()
+                    return 2
+                cur = db.execute(
+                    "UPDATE improvement_signals SET consumed=1 WHERE consumed=0 AND signal_type=?",
+                    (ft,),
+                )
+            else:
+                cur = db.execute("UPDATE improvement_signals SET consumed=1 WHERE consumed=0")
+            db.commit()
+            print(f"Marked {cur.rowcount} signal(s) as consumed.")
+        else:
+            signal_id = getattr(args, "id", None)
+            if signal_id is None:
+                print("ERROR: --id or --all is required.", file=sys.stderr)
+                return 2
+            cur = db.execute(
+                "UPDATE improvement_signals SET consumed=1 WHERE id=?",
+                (signal_id,),
+            )
+            db.commit()
+            if cur.rowcount == 0:
+                print(f"WARNING: Signal #{signal_id} not found.", file=sys.stderr)
+                return 1
+            print(f"Signal #{signal_id} marked as consumed.")
+    finally:
+        db.close()
+    return 0
+
+
+def cmd_stats(args, db_path: Path) -> int:
+    """Print signal statistics."""
+    if not db_path.exists():
+        if getattr(args, "output_format", "text") == "json":
+            print(json.dumps({"db_exists": False, "total": 0, "unconsumed": 0, "consumed": 0, "by_type": {}}, indent=2))
+        else:
+            print("No knowledge DB found.")
+        return 0
+
+    db = _open_db(db_path)
+    try:
+        total = db.execute("SELECT COUNT(*) FROM improvement_signals").fetchone()[0]
+        unconsumed = db.execute("SELECT COUNT(*) FROM improvement_signals WHERE consumed=0").fetchone()[0]
+        consumed = total - unconsumed
+
+        type_rows = db.execute(
+            "SELECT signal_type, COUNT(*) AS cnt FROM improvement_signals GROUP BY signal_type"
+        ).fetchall()
+        by_type = {r["signal_type"]: r["cnt"] for r in type_rows}
+
+        fmt = getattr(args, "output_format", "text")
+        if fmt == "json":
+            print(json.dumps(
+                {"db_exists": True, "total": total, "unconsumed": unconsumed, "consumed": consumed, "by_type": by_type},
+                indent=2,
+            ))
+        else:
+            print("\n📊 Improvement Signal Statistics\n")
+            print(f"  Total:      {total}")
+            print(f"  Unconsumed: {unconsumed}")
+            print(f"  Consumed:   {consumed}")
+            if by_type:
+                print("\n  By type:")
+                for st, cnt in sorted(by_type.items()):
+                    print(f"    {st:<20} {cnt}")
+    finally:
+        db.close()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for sk improvement-signals."""
+    parser = argparse.ArgumentParser(
+        prog="improvement-signals",
+        description="Explicit session-linked improvement signal recorder for skill-suggest integration.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python improvement-signals.py record --query "docker run failed" --type missed_match
+  python improvement-signals.py record --query "wrong skill" --type wrong_skill --skill my-skill
+  python improvement-signals.py list
+  python improvement-signals.py list --consumed --format json
+  python improvement-signals.py consume --id 3
+  python improvement-signals.py consume --all --type missed_match
+  python improvement-signals.py stats --format json
+        """,
+    )
+    parser.add_argument("--db", type=str, default=None, metavar="PATH",
+                        help=f"Path to knowledge.db (default: {DB_PATH})")
+
+    subs = parser.add_subparsers(dest="subcommand")
+
+    # record
+    p_record = subs.add_parser("record", help="Record a new improvement signal.")
+    p_record.add_argument("--query", required=True, metavar="TEXT",
+                          help="The query or scenario that triggered the signal.")
+    p_record.add_argument("--type", required=True, dest="type",
+                          choices=VALID_SIGNAL_TYPES,
+                          help="Signal type: missed_match | wrong_skill | outdated_skill")
+    p_record.add_argument("--skill", default="", metavar="SKILL",
+                          help="Skill name involved (for wrong_skill / outdated_skill).")
+    p_record.add_argument("--session-id", default="", metavar="ID",
+                          help="Session ID to link this signal to (optional).")
+
+    # list
+    p_list = subs.add_parser("list", help="List signals.")
+    p_list.add_argument("--consumed", action="store_true",
+                        help="Show consumed signals instead of unconsumed ones.")
+    p_list.add_argument("--type", dest="type", default=None, choices=VALID_SIGNAL_TYPES,
+                        help="Filter by signal type.")
+    p_list.add_argument("--limit", type=int, default=50, metavar="N",
+                        help="Max rows to return (default: 50).")
+    p_list.add_argument("--format", dest="output_format", choices=["text", "json"], default="text",
+                        help="Output format.")
+
+    # consume
+    p_consume = subs.add_parser("consume", help="Mark signal(s) as consumed.")
+    p_consume.add_argument("--id", type=int, default=None, metavar="ID",
+                           help="Signal ID to mark consumed.")
+    p_consume.add_argument("--all", action="store_true",
+                           help="Mark all unconsumed signals as consumed.")
+    p_consume.add_argument("--type", dest="type", default=None, choices=VALID_SIGNAL_TYPES,
+                           help="With --all: only consume signals of this type.")
+
+    # stats
+    p_stats = subs.add_parser("stats", help="Print statistics.")
+    p_stats.add_argument("--format", dest="output_format", choices=["text", "json"], default="text",
+                         help="Output format.")
+
+    args = parser.parse_args(argv)
+
+    db_path = Path(args.db).expanduser() if args.db else DB_PATH
+
+    if args.subcommand == "record":
+        return cmd_record(args, db_path)
+    elif args.subcommand == "list":
+        return cmd_list(args, db_path)
+    elif args.subcommand == "consume":
+        return cmd_consume(args, db_path)
+    elif args.subcommand == "stats":
+        return cmd_stats(args, db_path)
+    else:
+        parser.print_help()
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/migrate.py
+++ b/migrate.py
@@ -841,6 +841,28 @@ if __name__ == "__main__":
                 "CREATE INDEX IF NOT EXISTS idx_fa_repo_root ON file_annotations(repo_root)",
             ],
         ),
+        # v24: issue #126 — Explicit improvement signal tracking.
+        # Records user-reported missed_match / wrong_skill / outdated_skill signals
+        # linked to session IDs, consumable by skill-suggest for candidate boosting.
+        (
+            24,
+            "improvement_signals",
+            [
+                """CREATE TABLE IF NOT EXISTS improvement_signals (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL DEFAULT '',
+                    query TEXT NOT NULL DEFAULT '',
+                    signal_type TEXT NOT NULL CHECK(signal_type IN ('missed_match', 'wrong_skill', 'outdated_skill')),
+                    mentioned_skill TEXT NOT NULL DEFAULT '',
+                    consumed INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )""",
+                "CREATE INDEX IF NOT EXISTS idx_is_consumed ON improvement_signals(consumed)",
+                "CREATE INDEX IF NOT EXISTS idx_is_signal_type ON improvement_signals(signal_type)",
+                "CREATE INDEX IF NOT EXISTS idx_is_created ON improvement_signals(created_at)",
+                "CREATE INDEX IF NOT EXISTS idx_is_mentioned_skill ON improvement_signals(mentioned_skill)",
+            ],
+        ),
     ]
     applied = 0
     for ver, name, stmts in MIGRATIONS:

--- a/sk.py
+++ b/sk.py
@@ -28,6 +28,7 @@ Usage:
     sk skill-patch  [<args>...]       Run skill-patch.py
     sk hooks        run|list|<event>  Run hooks/hook_runner.py
     sk audit-hooks  [<args>...]       Run audit-hooks.py
+    sk improvement-signals [<args>...] Run improvement-signals.py
 
     sk index  build|extract|migrate|status|health|embed|tag [<args>...]
     sk sync   run|config|status|gateway|merge [<args>...]
@@ -83,6 +84,7 @@ _DIRECT: dict[str, str] = {
     "skill-suggest": "skill-suggest.py",
     "skill-patch": "skill-patch.py",
     "audit-hooks": "audit-hooks.py",
+    "improvement-signals": "improvement-signals.py",
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}

--- a/skill-suggest.py
+++ b/skill-suggest.py
@@ -261,6 +261,138 @@ def _table_exists(db: sqlite3.Connection, name: str) -> bool:
     return row is not None
 
 
+# Signal-type score weights for boosting improvement-signal-derived candidates.
+_SIGNAL_TYPE_WEIGHT: dict[str, float] = {
+    "missed_match": 2.0,    # Strong: no skill existed — high priority to create one
+    "wrong_skill": 1.5,     # Medium: wrong skill fired — patch candidate
+    "outdated_skill": 1.5,  # Medium: skill is stale — update candidate
+}
+
+
+def _load_improvement_signals(db_path: Path, limit: int = 100) -> list[dict]:
+    """Load unconsumed improvement signals from the knowledge DB.
+
+    Returns an empty list if the table does not exist or the DB is unavailable.
+    Fail-open: any exception yields an empty list.
+    """
+    db = _open_db_readonly(db_path)
+    if db is None:
+        return []
+    try:
+        if not _table_exists(db, "improvement_signals"):
+            return []
+        rows = db.execute(
+            """
+            SELECT id, session_id, query, signal_type, mentioned_skill, created_at
+            FROM improvement_signals
+            WHERE consumed = 0
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:
+        return []
+    finally:
+        try:
+            db.close()
+        except Exception:
+            pass
+
+
+def _signals_to_candidates(signals: list[dict]) -> list[dict]:
+    """Convert unconsumed improvement signals into skill candidates.
+
+    Only signals with a non-empty `mentioned_skill` produce named candidates.
+    Signals without a `mentioned_skill` are grouped by slugified query text as
+    a lower-priority fallback.
+
+    Returns a list of candidate dicts compatible with mine_patterns() output.
+    """
+    # --- Group by mentioned_skill slug first ---
+    named: dict[str, list[dict]] = {}
+    unnamed: dict[str, list[dict]] = {}
+
+    for sig in signals:
+        ms = (sig.get("mentioned_skill") or "").strip()
+        if ms:
+            key = _slugify(ms)
+            if key and key != "unnamed-skill":
+                named.setdefault(key, []).append(sig)
+                continue
+        # fallback: group by query slug
+        qk = _slugify(sig.get("query") or "")
+        if qk and qk != "unnamed-skill":
+            unnamed.setdefault(qk, []).append(sig)
+
+    candidates: list[dict] = []
+
+    for slug, sigs in named.items():
+        signal_types = list({s["signal_type"] for s in sigs})
+        weight = max(_SIGNAL_TYPE_WEIGHT.get(st, 1.0) for st in signal_types)
+        score = len(sigs) * weight
+
+        rep = sigs[0]
+        rep_title = (rep.get("mentioned_skill") or "").strip() or slug
+        patch_note = ""
+        if any(st in ("wrong_skill", "outdated_skill") for st in signal_types):
+            patch_note = f"Signal suggests skill '{rep_title}' may need updating."
+
+        candidates.append(
+            {
+                "candidate_name": slug,
+                "source_cluster": rep.get("mentioned_skill") or slug,
+                "cluster_type": "improvement_signal",
+                "score": round(score, 2),
+                "total_occurrences": len(sigs),
+                "entry_count": len(sigs),
+                "avg_confidence": 1.0,
+                "category": "pattern",
+                "top_tags": signal_types,
+                "representative_title": rep_title,
+                "sample_entries": [
+                    {"title": s.get("query", ""), "content": s.get("query", ""), "tags": s["signal_type"]}
+                    for s in sigs[:3]
+                ],
+                "signal_count": len(sigs),
+                "signal_types": signal_types,
+                "patch_guidance": patch_note,
+            }
+        )
+
+    for slug, sigs in unnamed.items():
+        signal_types = list({s["signal_type"] for s in sigs})
+        weight = max(_SIGNAL_TYPE_WEIGHT.get(st, 1.0) for st in signal_types) * 0.5  # lower weight, no named skill
+        score = len(sigs) * weight
+
+        rep = sigs[0]
+        rep_query = (rep.get("query") or "").strip() or slug
+        candidates.append(
+            {
+                "candidate_name": slug,
+                "source_cluster": rep_query,
+                "cluster_type": "improvement_signal_query",
+                "score": round(score, 2),
+                "total_occurrences": len(sigs),
+                "entry_count": len(sigs),
+                "avg_confidence": 0.7,
+                "category": "pattern",
+                "top_tags": signal_types,
+                "representative_title": rep_query,
+                "sample_entries": [
+                    {"title": s.get("query", ""), "content": s.get("query", ""), "tags": s["signal_type"]}
+                    for s in sigs[:3]
+                ],
+                "signal_count": len(sigs),
+                "signal_types": signal_types,
+                "patch_guidance": "",
+            }
+        )
+
+    return candidates
+
+
 def mine_patterns(
     db_path: Path,
     min_occurrences: int = 3,
@@ -477,6 +609,14 @@ def suggest(
 
     Returns a result dict suitable for JSON serialisation.
     Does NOT write any files or modify any state.
+
+    Signal integration (fail-open):
+    - Loads unconsumed improvement_signals rows if the table exists.
+    - Signal-derived candidates are merged with knowledge-derived candidates.
+    - If a signal candidate name already exists from knowledge mining, its score
+      is boosted rather than duplicated.
+    - If the improvement_signals table is absent the output is identical to
+      the pre-signal behavior.
     """
     if db_path is None:
         db_path = DB_PATH
@@ -489,6 +629,43 @@ def suggest(
     existing_skill_names = [s["name"] for s in existing_skills]
 
     raw_candidates = mine_patterns(db_path, min_occurrences=min_occurrences, limit=limit * 2)
+
+    # Load and merge unconsumed improvement signals (fail-open).
+    try:
+        raw_signals = _load_improvement_signals(db_path, limit=200)
+        signal_candidates = _signals_to_candidates(raw_signals)
+        signal_count = len(raw_signals)
+    except Exception:
+        raw_signals = []
+        signal_candidates = []
+        signal_count = 0
+
+    # Build a lookup from name → index for knowledge candidates.
+    name_to_idx: dict[str, int] = {}
+    for i, c in enumerate(raw_candidates):
+        name_to_idx[c["candidate_name"]] = i
+
+    # Merge: boost existing candidate or append new signal candidate.
+    for sc in signal_candidates:
+        name = sc["candidate_name"]
+        if name in name_to_idx:
+            # Boost existing knowledge candidate's score.
+            existing = raw_candidates[name_to_idx[name]]
+            existing["score"] = round(existing["score"] + sc["score"], 2)
+            existing.setdefault("signal_count", 0)
+            existing["signal_count"] = existing.get("signal_count", 0) + sc.get("signal_count", 0)
+            existing.setdefault("signal_types", [])
+            for st in sc.get("signal_types", []):
+                if st not in existing["signal_types"]:
+                    existing["signal_types"].append(st)
+            if sc.get("patch_guidance"):
+                existing["patch_guidance"] = sc["patch_guidance"]
+        else:
+            raw_candidates.append(sc)
+            name_to_idx[name] = len(raw_candidates) - 1
+
+    # Sort merged list by score descending.
+    raw_candidates.sort(key=lambda c: -c["score"])
 
     suggestions: list[dict] = []
     seen_names: set[str] = set()
@@ -507,20 +684,26 @@ def suggest(
             sample_entries=cand["sample_entries"],
         )
 
-        suggestions.append(
-            {
-                "candidate_name": name,
-                "source_cluster": cand["source_cluster"],
-                "cluster_type": cand["cluster_type"],
-                "score": cand["score"],
-                "total_occurrences": cand["total_occurrences"],
-                "entry_count": cand["entry_count"],
-                "avg_confidence": cand["avg_confidence"],
-                "top_tags": cand["top_tags"],
-                "overlap_with_existing": overlaps,
-                "skill_draft": draft,
-            }
-        )
+        sug_entry = {
+            "candidate_name": name,
+            "source_cluster": cand["source_cluster"],
+            "cluster_type": cand["cluster_type"],
+            "score": cand["score"],
+            "total_occurrences": cand["total_occurrences"],
+            "entry_count": cand["entry_count"],
+            "avg_confidence": cand["avg_confidence"],
+            "top_tags": cand["top_tags"],
+            "overlap_with_existing": overlaps,
+            "skill_draft": draft,
+        }
+        if "signal_count" in cand:
+            sug_entry["signal_count"] = cand["signal_count"]
+        if "signal_types" in cand:
+            sug_entry["signal_types"] = cand["signal_types"]
+        if cand.get("patch_guidance"):
+            sug_entry["patch_guidance"] = cand["patch_guidance"]
+
+        suggestions.append(sug_entry)
 
         if len(suggestions) >= limit:
             break
@@ -533,6 +716,7 @@ def suggest(
         "skills_dir": str(skills_dir),
         "existing_skills_checked": existing_skill_names,
         "suggestion_count": len(suggestions),
+        "improvement_signal_count": signal_count,
         "suggestions": suggestions,
     }
 
@@ -543,6 +727,8 @@ def _print_text(result: dict) -> None:
     print(f"   DB: {result['db_path']} (exists: {result['db_exists']})")
     print(f"   Min occurrences: {result['min_occurrences']}")
     print(f"   Existing skills checked: {len(result['existing_skills_checked'])}")
+    if result.get("improvement_signal_count", 0):
+        print(f"   Improvement signals (unconsumed): {result['improvement_signal_count']}")
     print(f"   Suggestions found: {result['suggestion_count']}")
     print()
 
@@ -564,6 +750,10 @@ def _print_text(result: dict) -> None:
         print(f"  Source: {sug['source_cluster']} ({sug['cluster_type']})")
         if sug["top_tags"]:
             print(f"  Tags: {', '.join(sug['top_tags'][:5])}")
+        if sug.get("signal_count"):
+            print(f"  \U0001f4e1 Improvement signals: {sug['signal_count']} ({', '.join(sug.get('signal_types', []))})")
+        if sug.get("patch_guidance"):
+            print(f"  \U0001f527 {sug['patch_guidance']}")
         if overlaps:
             print(f"  \u26a0\ufe0f  Overlap with existing skills: {', '.join(overlaps)}")
         else:

--- a/tests/test_improvement_signals.py
+++ b/tests/test_improvement_signals.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+test_improvement_signals.py — Regression tests for improvement-signals.py.
+
+Covers:
+  - Table creation via _open_db
+  - record: accepted/rejected signal_type values, required fields, consumed=0 default
+  - list: filtering by consumed, type, limit
+  - consume: single ID, --all, with type filter
+  - stats: counts and by_type breakdown
+  - DB-absent edge cases (fail-open)
+  - CLI argument parsing (--help exits 0, subcommands dispatch correctly)
+
+Run: python tests/test_improvement_signals.py
+"""
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).parent.parent
+SCRIPT_PATH = REPO / "improvement-signals.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("improvement_signals", str(SCRIPT_PATH))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load_module()
+
+
+class _TmpDB:
+    """Context manager that yields a temp Path with no DB file (or an empty one)."""
+
+    def __init__(self, create: bool = False):
+        self._dir = None
+        self._create = create
+
+    def __enter__(self):
+        self._dir = tempfile.mkdtemp()
+        p = Path(self._dir) / "knowledge.db"
+        if self._create:
+            db = mod._open_db(p)
+            db.close()
+        return p
+
+    def __exit__(self, *_):
+        import shutil
+        if self._dir:
+            shutil.rmtree(self._dir, ignore_errors=True)
+
+
+class TestOpenDb(unittest.TestCase):
+    def test_creates_table(self):
+        with _TmpDB() as db_path:
+            db = mod._open_db(db_path)
+            row = db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='improvement_signals'"
+            ).fetchone()
+            db.close()
+            self.assertIsNotNone(row)
+
+    def test_idempotent(self):
+        with _TmpDB(create=True) as db_path:
+            db = mod._open_db(db_path)  # second open, table already exists
+            count = db.execute("SELECT COUNT(*) FROM improvement_signals").fetchone()[0]
+            db.close()
+            self.assertEqual(count, 0)
+
+
+class TestRecord(unittest.TestCase):
+    def test_record_creates_row(self):
+        with _TmpDB() as db_path:
+            rc = mod.cmd_record(
+                _args(type="missed_match", query="docker run fails", skill="", session_id="s1"),
+                db_path,
+            )
+            self.assertEqual(rc, 0)
+            db = mod._open_db(db_path)
+            rows = db.execute("SELECT * FROM improvement_signals").fetchall()
+            db.close()
+            self.assertEqual(len(rows), 1)
+            r = rows[0]
+            self.assertEqual(r["signal_type"], "missed_match")
+            self.assertEqual(r["query"], "docker run fails")
+            self.assertEqual(r["consumed"], 0)
+            self.assertEqual(r["session_id"], "s1")
+
+    def test_record_with_skill(self):
+        with _TmpDB() as db_path:
+            rc = mod.cmd_record(
+                _args(type="wrong_skill", query="k8s deploy", skill="kubernetes", session_id=""),
+                db_path,
+            )
+            self.assertEqual(rc, 0)
+            db = mod._open_db(db_path)
+            r = db.execute("SELECT * FROM improvement_signals").fetchone()
+            db.close()
+            self.assertEqual(r["mentioned_skill"], "kubernetes")
+
+    def test_record_outdated_skill(self):
+        with _TmpDB() as db_path:
+            rc = mod.cmd_record(
+                _args(type="outdated_skill", query="old rust patterns", skill="rust-dev", session_id=""),
+                db_path,
+            )
+            self.assertEqual(rc, 0)
+
+    def test_record_invalid_type_returns_2(self):
+        with _TmpDB() as db_path:
+            rc = mod.cmd_record(
+                _args(type="bogus_type", query="something", skill="", session_id=""),
+                db_path,
+            )
+            self.assertEqual(rc, 2)
+
+    def test_record_empty_query_returns_2(self):
+        with _TmpDB() as db_path:
+            rc = mod.cmd_record(
+                _args(type="missed_match", query="", skill="", session_id=""),
+                db_path,
+            )
+            self.assertEqual(rc, 2)
+
+    def test_record_all_valid_types(self):
+        with _TmpDB() as db_path:
+            for st in mod.VALID_SIGNAL_TYPES:
+                rc = mod.cmd_record(
+                    _args(type=st, query=f"query for {st}", skill="s", session_id=""),
+                    db_path,
+                )
+                self.assertEqual(rc, 0, f"Failed for type={st}")
+            db = mod._open_db(db_path)
+            count = db.execute("SELECT COUNT(*) FROM improvement_signals").fetchone()[0]
+            db.close()
+            self.assertEqual(count, 3)
+
+
+class TestList(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.mkdtemp()
+        self.db_path = Path(self._dir) / "knowledge.db"
+        db = mod._open_db(self.db_path)
+        db.execute(
+            "INSERT INTO improvement_signals (query, signal_type, mentioned_skill, consumed) VALUES (?,?,?,?)",
+            ("q1", "missed_match", "sk1", 0),
+        )
+        db.execute(
+            "INSERT INTO improvement_signals (query, signal_type, mentioned_skill, consumed) VALUES (?,?,?,?)",
+            ("q2", "wrong_skill", "sk2", 0),
+        )
+        db.execute(
+            "INSERT INTO improvement_signals (query, signal_type, mentioned_skill, consumed) VALUES (?,?,?,?)",
+            ("q3", "missed_match", "sk3", 1),
+        )
+        db.commit()
+        db.close()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._dir, ignore_errors=True)
+
+    def test_list_unconsumed_default(self):
+        with capture_stdout() as out:
+            rc = mod.cmd_list(_list_args(consumed=False), self.db_path)
+        self.assertEqual(rc, 0)
+        self.assertIn("q1", out.getvalue())
+        self.assertIn("q2", out.getvalue())
+        self.assertNotIn("q3", out.getvalue())
+
+    def test_list_consumed(self):
+        with capture_stdout() as out:
+            rc = mod.cmd_list(_list_args(consumed=True), self.db_path)
+        self.assertEqual(rc, 0)
+        self.assertIn("q3", out.getvalue())
+        self.assertNotIn("q1", out.getvalue())
+
+    def test_list_filter_type(self):
+        with capture_stdout() as out:
+            rc = mod.cmd_list(_list_args(consumed=False, filter_type="wrong_skill"), self.db_path)
+        self.assertEqual(rc, 0)
+        self.assertIn("q2", out.getvalue())
+        self.assertNotIn("q1", out.getvalue())
+
+    def test_list_json(self):
+        with capture_stdout() as out:
+            rc = mod.cmd_list(_list_args(consumed=False, output_format="json"), self.db_path)
+        self.assertEqual(rc, 0)
+        data = json.loads(out.getvalue())
+        self.assertIn("signals", data)
+        self.assertEqual(len(data["signals"]), 2)
+
+    def test_list_no_db(self):
+        missing = Path(self._dir) / "missing.db"
+        with capture_stdout():
+            rc = mod.cmd_list(_list_args(), missing)
+        self.assertEqual(rc, 0)
+
+
+class TestConsume(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.mkdtemp()
+        self.db_path = Path(self._dir) / "knowledge.db"
+        db = mod._open_db(self.db_path)
+        for i in range(4):
+            db.execute(
+                "INSERT INTO improvement_signals (query, signal_type, mentioned_skill, consumed) VALUES (?,?,?,?)",
+                (f"q{i}", "missed_match" if i % 2 == 0 else "wrong_skill", "", 0),
+            )
+        db.commit()
+        db.close()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._dir, ignore_errors=True)
+
+    def _get_consumed_count(self):
+        db = mod._open_db(self.db_path)
+        count = db.execute("SELECT COUNT(*) FROM improvement_signals WHERE consumed=1").fetchone()[0]
+        db.close()
+        return count
+
+    def test_consume_single_id(self):
+        with capture_stdout():
+            rc = mod.cmd_consume(_consume_args(id=1), self.db_path)
+        self.assertEqual(rc, 0)
+        self.assertEqual(self._get_consumed_count(), 1)
+
+    def test_consume_all(self):
+        with capture_stdout():
+            rc = mod.cmd_consume(_consume_args(all_flag=True), self.db_path)
+        self.assertEqual(rc, 0)
+        self.assertEqual(self._get_consumed_count(), 4)
+
+    def test_consume_all_with_type(self):
+        with capture_stdout():
+            rc = mod.cmd_consume(_consume_args(all_flag=True, filter_type="missed_match"), self.db_path)
+        self.assertEqual(rc, 0)
+        # 2 missed_match rows (id 1 and 3 → q0, q2)
+        self.assertEqual(self._get_consumed_count(), 2)
+
+    def test_consume_unknown_id_returns_1(self):
+        with capture_stdout():
+            rc = mod.cmd_consume(_consume_args(id=9999), self.db_path)
+        self.assertEqual(rc, 1)
+
+    def test_consume_missing_both_id_and_all_returns_2(self):
+        with capture_stdout():
+            rc = mod.cmd_consume(_consume_args(), self.db_path)
+        self.assertEqual(rc, 2)
+
+    def test_consumed_rows_not_in_list(self):
+        with capture_stdout():
+            mod.cmd_consume(_consume_args(id=1), self.db_path)
+        with capture_stdout() as out:
+            mod.cmd_list(_list_args(consumed=False, output_format="json"), self.db_path)
+        data = json.loads(out.getvalue())
+        ids = [r["id"] for r in data["signals"]]
+        self.assertNotIn(1, ids)
+
+
+class TestStats(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.mkdtemp()
+        self.db_path = Path(self._dir) / "knowledge.db"
+        db = mod._open_db(self.db_path)
+        for st in ("missed_match", "missed_match", "wrong_skill"):
+            db.execute(
+                "INSERT INTO improvement_signals (query, signal_type, mentioned_skill, consumed) VALUES (?,?,?,?)",
+                (f"q-{st}", st, "", 0),
+            )
+        db.execute(
+            "INSERT INTO improvement_signals (query, signal_type, mentioned_skill, consumed) VALUES (?,?,?,?)",
+            ("consumed-q", "outdated_skill", "", 1),
+        )
+        db.commit()
+        db.close()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._dir, ignore_errors=True)
+
+    def test_stats_json(self):
+        with capture_stdout() as out:
+            rc = mod.cmd_stats(_stats_args(output_format="json"), self.db_path)
+        self.assertEqual(rc, 0)
+        data = json.loads(out.getvalue())
+        self.assertEqual(data["total"], 4)
+        self.assertEqual(data["unconsumed"], 3)
+        self.assertEqual(data["consumed"], 1)
+        self.assertEqual(data["by_type"]["missed_match"], 2)
+
+    def test_stats_no_db(self):
+        missing = Path(self._dir) / "missing.db"
+        with capture_stdout() as out:
+            rc = mod.cmd_stats(_stats_args(output_format="json"), missing)
+        self.assertEqual(rc, 0)
+        data = json.loads(out.getvalue())
+        self.assertFalse(data["db_exists"])
+
+
+class TestMainDispatch(unittest.TestCase):
+    def test_help_exits_0(self):
+        with self.assertRaises(SystemExit) as cm:
+            mod.main(["--help"])
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_no_subcommand_prints_help(self):
+        with capture_stdout():
+            rc = mod.main([])
+        self.assertEqual(rc, 0)
+
+    def test_record_subcommand_dispatches(self):
+        with _TmpDB() as db_path:
+            with capture_stdout():
+                rc = mod.main(["--db", str(db_path), "record", "--query", "test q", "--type", "missed_match"])
+            self.assertEqual(rc, 0)
+
+    def test_list_subcommand_dispatches(self):
+        with _TmpDB(create=True) as db_path:
+            with capture_stdout():
+                rc = mod.main(["--db", str(db_path), "list"])
+            self.assertEqual(rc, 0)
+
+    def test_stats_subcommand_dispatches(self):
+        with _TmpDB(create=True) as db_path:
+            with capture_stdout():
+                rc = mod.main(["--db", str(db_path), "stats", "--format", "json"])
+            self.assertEqual(rc, 0)
+
+    def test_consume_subcommand_dispatches(self):
+        with _TmpDB() as db_path:
+            mod.main(["--db", str(db_path), "record", "--query", "q", "--type", "missed_match"])
+            with capture_stdout():
+                rc = mod.main(["--db", str(db_path), "consume", "--id", "1"])
+            self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+import contextlib
+import io
+
+
+@contextlib.contextmanager
+def capture_stdout():
+    buf = io.StringIO()
+    with patch("builtins.print", side_effect=lambda *a, **kw: buf.write(" ".join(str(x) for x in a) + "\n")):
+        yield buf
+
+
+class _SimpleNamespace:
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _args(**kw):
+    defaults = dict(type="missed_match", query="q", skill="", session_id="")
+    defaults.update(kw)
+    return _SimpleNamespace(**defaults)
+
+
+def _list_args(consumed=False, filter_type=None, limit=50, output_format="text"):
+    ns = _SimpleNamespace(consumed=consumed, type=filter_type, limit=limit, output_format=output_format)
+    return ns
+
+
+def _consume_args(id=None, all_flag=False, filter_type=None):
+    ns = _SimpleNamespace(id=id, all=all_flag, type=filter_type)
+    return ns
+
+
+def _stats_args(output_format="text"):
+    return _SimpleNamespace(output_format=output_format)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -241,6 +241,46 @@ class TestSkDirectCommands(unittest.TestCase):
             "audit-hooks.py not found — sk audit-hooks would break",
         )
 
+    def test_improvement_signals(self):
+        self._assert_routes("improvement-signals", "improvement-signals.py")
+
+    def test_improvement_signals_record(self):
+        self._assert_routes(
+            "improvement-signals", "improvement-signals.py",
+            ["record", "--query", "some query", "--type", "missed_match"],
+        )
+
+    def test_improvement_signals_list(self):
+        self._assert_routes(
+            "improvement-signals", "improvement-signals.py",
+            ["list", "--format", "json"],
+        )
+
+    def test_improvement_signals_consume(self):
+        self._assert_routes(
+            "improvement-signals", "improvement-signals.py",
+            ["consume", "--id", "1"],
+        )
+
+    def test_improvement_signals_consume_all(self):
+        self._assert_routes(
+            "improvement-signals", "improvement-signals.py",
+            ["consume", "--all"],
+        )
+
+    def test_improvement_signals_stats(self):
+        self._assert_routes(
+            "improvement-signals", "improvement-signals.py",
+            ["stats", "--format", "json"],
+        )
+
+    def test_improvement_signals_script_exists(self):
+        """improvement-signals.py must exist in the tools directory."""
+        self.assertTrue(
+            (TOOLS_DIR / "improvement-signals.py").exists(),
+            "improvement-signals.py not found — sk improvement-signals would break",
+        )
+
 
 class TestSkHooksCompat(unittest.TestCase):
     def test_hooks_run_drops_run_subcommand(self):

--- a/tests/test_skill_suggest.py
+++ b/tests/test_skill_suggest.py
@@ -674,5 +674,166 @@ class TestCliMain(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Improvement signal integration tests
+# ---------------------------------------------------------------------------
+
+def _add_improvement_signals(db_path: Path, signals: list[dict]) -> None:
+    """Insert improvement_signals rows directly into a test DB."""
+    db = sqlite3.connect(str(db_path))
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS improvement_signals (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL DEFAULT '',
+            query TEXT NOT NULL DEFAULT '',
+            signal_type TEXT NOT NULL,
+            mentioned_skill TEXT NOT NULL DEFAULT '',
+            consumed INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """)
+    for s in signals:
+        db.execute(
+            "INSERT INTO improvement_signals (session_id, query, signal_type, mentioned_skill, consumed) VALUES (?,?,?,?,?)",
+            (
+                s.get("session_id", ""),
+                s.get("query", ""),
+                s.get("signal_type", "missed_match"),
+                s.get("mentioned_skill", ""),
+                s.get("consumed", 0),
+            ),
+        )
+    db.commit()
+    db.close()
+
+
+class TestSignalIntegration(unittest.TestCase):
+    """Tests for improvement_signals influence on suggest()."""
+
+    @classmethod
+    def setUpClass(cls):
+        _reset_artifacts()
+        cls.mod = _load_module("skill_suggest_signals", "skill-suggest.py")
+
+    def _make_db(self, name: str, knowledge_entries: list[dict], signals: list[dict]) -> Path:
+        db_path = ARTIFACT_DIR / name
+        _make_knowledge_db(db_path, knowledge_entries)
+        if signals:
+            _add_improvement_signals(db_path, signals)
+        return db_path
+
+    def test_fail_open_no_table(self):
+        """suggest() must not crash when improvement_signals table is absent."""
+        db_path = self._make_db("sig-no-table.db", [], [])
+        result = self.mod.suggest(db_path=db_path, min_occurrences=1)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result.get("improvement_signal_count", 0), 0)
+
+    def test_fail_open_missing_db(self):
+        """suggest() must not crash when DB file is entirely missing."""
+        result = self.mod.suggest(db_path=ARTIFACT_DIR / "sig-missing.db", min_occurrences=1)
+        self.assertIsInstance(result, dict)
+        self.assertFalse(result["db_exists"])
+
+    def test_signal_derived_candidate_appears(self):
+        """A missed_match signal with mentioned_skill produces a candidate."""
+        db_path = self._make_db(
+            "sig-candidate.db",
+            [],  # no knowledge entries
+            [
+                {"query": "deploy to production", "signal_type": "missed_match", "mentioned_skill": "prod-deploy"},
+                {"query": "deploy to staging", "signal_type": "missed_match", "mentioned_skill": "prod-deploy"},
+            ],
+        )
+        result = self.mod.suggest(db_path=db_path, min_occurrences=1)
+        names = [s["candidate_name"] for s in result["suggestions"]]
+        self.assertIn("prod-deploy", names)
+        self.assertGreater(result.get("improvement_signal_count", 0), 0)
+
+    def test_consumed_signals_excluded(self):
+        """Consumed signals must NOT surface as candidates."""
+        db_path = self._make_db(
+            "sig-consumed.db",
+            [],
+            [
+                {"query": "old query", "signal_type": "missed_match", "mentioned_skill": "consumed-skill", "consumed": 1},
+                {"query": "other query", "signal_type": "missed_match", "mentioned_skill": "consumed-skill", "consumed": 1},
+            ],
+        )
+        result = self.mod.suggest(db_path=db_path, min_occurrences=1)
+        names = [s["candidate_name"] for s in result["suggestions"]]
+        self.assertNotIn("consumed-skill", names)
+        # signal_count should be 0 since all signals are consumed
+        self.assertEqual(result.get("improvement_signal_count", 0), 0)
+
+    def test_signal_boosts_existing_knowledge_candidate(self):
+        """A signal for an existing knowledge candidate boosts its score, not duplicates it."""
+        db_path = self._make_db(
+            "sig-boost.db",
+            [
+                {
+                    "title": "Docker networking",
+                    "content": "Use bridge networks.",
+                    "tags": "docker,network",
+                    "category": "pattern",
+                    "occurrence_count": 4,
+                    "topic_key": "docker",
+                },
+            ],
+            [
+                {"query": "docker dns", "signal_type": "missed_match", "mentioned_skill": "docker"},
+            ],
+        )
+        result = self.mod.suggest(db_path=db_path, min_occurrences=3)
+        docker_suggestions = [s for s in result["suggestions"] if s["candidate_name"] == "docker"]
+        # Should appear exactly once (not duplicated)
+        self.assertEqual(len(docker_suggestions), 1)
+        # Score should include the signal boost
+        self.assertGreater(docker_suggestions[0]["score"], 4.0)  # base from knowledge alone is 4*2.0=8.0 at most
+        self.assertGreater(docker_suggestions[0].get("signal_count", 0), 0)
+
+    def test_wrong_skill_signal_adds_patch_guidance(self):
+        """A wrong_skill signal attaches patch_guidance to the candidate."""
+        db_path = self._make_db(
+            "sig-wrong.db",
+            [],
+            [
+                {"query": "wrong skill fired", "signal_type": "wrong_skill", "mentioned_skill": "my-skill"},
+            ],
+        )
+        result = self.mod.suggest(db_path=db_path, min_occurrences=1)
+        suggestions = [s for s in result["suggestions"] if s["candidate_name"] == "my-skill"]
+        if suggestions:
+            self.assertIn("patch_guidance", suggestions[0])
+            self.assertTrue(suggestions[0]["patch_guidance"])
+
+    def test_improvement_signal_count_in_result(self):
+        """result dict always includes improvement_signal_count key."""
+        db_path = self._make_db(
+            "sig-count.db",
+            [],
+            [
+                {"query": "q1", "signal_type": "missed_match", "mentioned_skill": "test-skill"},
+            ],
+        )
+        result = self.mod.suggest(db_path=db_path, min_occurrences=1)
+        self.assertIn("improvement_signal_count", result)
+        self.assertEqual(result["improvement_signal_count"], 1)
+
+    def test_signal_type_in_cluster_type(self):
+        """Signal-derived candidates have cluster_type containing 'signal'."""
+        db_path = self._make_db(
+            "sig-cluster-type.db",
+            [],
+            [
+                {"query": "new query", "signal_type": "missed_match", "mentioned_skill": "new-skill"},
+            ],
+        )
+        result = self.mod.suggest(db_path=db_path, min_occurrences=1)
+        new_skill = [s for s in result["suggestions"] if s["candidate_name"] == "new-skill"]
+        if new_skill:
+            self.assertIn("signal", new_skill[0]["cluster_type"])
+
+
+# ---------------------------------------------------------------------------
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add explicit improvement signal tracking in the session DB with consumed state
- add sk improvement-signals record/list/consume/stats CLI surface
- feed unconsumed signals into sk skill-suggest without breaking fail-open behavior when the table is absent

## Verification
- python tests\\test_improvement_signals.py
- python tests\\test_skill_suggest.py
- python tests\\test_sk_cli.py
- python test_fixes.py
- python test_security.py
- end-to-end scratch DB smoke via python sk.py improvement-signals ... and python sk.py skill-suggest ...

Closes #126