### PR TITLE
feat: add context-aware briefing budget

### DIFF
--- a/briefing.py
+++ b/briefing.py
@@ -3096,7 +3096,7 @@ def main():
             if len(output) > budget and task_fmt != "json":
                 footer = f"\n[BUDGET {budget} chars / ~{task_budget_tokens} tok — injected ~{task_injected_tokens} tok → hard-truncated to fit]"
                 avail = budget - len(footer)
-                body = output[:max(0, avail)].rsplit("\n", 1)[0] if avail > 0 else ""
+                body = output[: max(0, avail)].rsplit("\n", 1)[0] if avail > 0 else ""
                 output = (body + footer)[:budget]
             elif task_fmt != "json" and task_injected_tokens > task_budget_tokens:
                 footer = f"\n[BUDGET ~{task_budget_tokens} tok — reduced from ~{task_injected_tokens} tok via entry reduction]"
@@ -3289,7 +3289,7 @@ def main():
         if len(output) > budget and fmt not in ("json", "pack") and not subagent_mode:
             footer = f"\n[BUDGET {budget} chars / ~{budget_tokens} tok — injected ~{injected_tokens} tok → hard-truncated to fit]"
             avail = budget - len(footer)
-            body = output[:max(0, avail)].rsplit("\n", 1)[0] if avail > 0 else ""
+            body = output[: max(0, avail)].rsplit("\n", 1)[0] if avail > 0 else ""
             output = (body + footer)[:budget]
         elif fmt not in ("json", "pack") and not subagent_mode and injected_tokens > budget_tokens:
             footer = f"\n[BUDGET ~{budget_tokens} tok — reduced from ~{injected_tokens} tok via entry reduction]"

--- a/briefing.py
+++ b/briefing.py
@@ -290,7 +290,9 @@ def _compute_dynamic_budget(explicit_budget: int, available_tokens: int = 0) -> 
     if explicit_budget > 0:
         return explicit_budget
     if available_tokens > 0:
-        return min(2000, int(available_tokens * 0.05))
+        # max(1, ...) ensures budget stays active (>0) even for very small contexts
+        # where int(available_tokens * 0.05) would round to 0 (i.e., available_tokens < 20).
+        return max(1, min(2000, int(available_tokens * 0.05)))
     return 0
 
 
@@ -3092,10 +3094,14 @@ def main():
                     break
             # Final fallback: line-boundary truncation for text only (never JSON).
             if len(output) > budget and task_fmt != "json":
-                output = output[:budget].rsplit("\n", 1)[0]
-                output += f"\n[BUDGET {budget} chars / ~{task_budget_tokens} tok — injected ~{task_injected_tokens} tok → hard-truncated to fit]"
+                footer = f"\n[BUDGET {budget} chars / ~{task_budget_tokens} tok — injected ~{task_injected_tokens} tok → hard-truncated to fit]"
+                avail = budget - len(footer)
+                body = output[:max(0, avail)].rsplit("\n", 1)[0] if avail > 0 else ""
+                output = (body + footer)[:budget]
             elif task_fmt != "json" and task_injected_tokens > task_budget_tokens:
-                output += f"\n[BUDGET ~{task_budget_tokens} tok — reduced from ~{task_injected_tokens} tok via entry reduction]"
+                footer = f"\n[BUDGET ~{task_budget_tokens} tok — reduced from ~{task_injected_tokens} tok via entry reduction]"
+                if len(output) + len(footer) <= budget:
+                    output += footer
         if task_fmt == "json" and isinstance(task_meta, dict):
             _record_recall_event(
                 event_kind="recall",
@@ -3280,11 +3286,15 @@ def main():
         # JSON and subagent-context (XML-like) output are not truncated — that
         # would corrupt their structure.  Those formats must fit within budget
         # via the progressive-limit loop above.
-        if len(output) > budget and fmt not in ("json", "pack"):
-            output = output[:budget].rsplit("\n", 1)[0]
-            output += f"\n[BUDGET {budget} chars / ~{budget_tokens} tok — injected ~{injected_tokens} tok → hard-truncated to fit]"
-        elif fmt not in ("json", "pack") and injected_tokens > budget_tokens:
-            output += f"\n[BUDGET ~{budget_tokens} tok — reduced from ~{injected_tokens} tok via entry reduction]"
+        if len(output) > budget and fmt not in ("json", "pack") and not subagent_mode:
+            footer = f"\n[BUDGET {budget} chars / ~{budget_tokens} tok — injected ~{injected_tokens} tok → hard-truncated to fit]"
+            avail = budget - len(footer)
+            body = output[:max(0, avail)].rsplit("\n", 1)[0] if avail > 0 else ""
+            output = (body + footer)[:budget]
+        elif fmt not in ("json", "pack") and not subagent_mode and injected_tokens > budget_tokens:
+            footer = f"\n[BUDGET ~{budget_tokens} tok — reduced from ~{injected_tokens} tok via entry reduction]"
+            if len(output) + len(footer) <= budget:
+                output += footer
 
     if (not subagent_mode) and isinstance(output_meta, dict):
         _record_recall_event(

--- a/briefing.py
+++ b/briefing.py
@@ -3083,7 +3083,9 @@ def main():
             # Mirrors the main-path degradation strategy so --task is not a second-class path.
             for reduced_limit in range(max(1, limit - 1), 0, -1):
                 if task_fmt == "json":
-                    output, task_meta = generate_task_briefing(task_id, limit=reduced_limit, fmt=task_fmt, with_meta=True)
+                    output, task_meta = generate_task_briefing(
+                        task_id, limit=reduced_limit, fmt=task_fmt, with_meta=True
+                    )
                 else:
                     output = generate_task_briefing(task_id, limit=reduced_limit, fmt=task_fmt)
                 if len(output) <= budget:
@@ -3174,7 +3176,14 @@ def main():
         # position, so query terms matching those values are preserved.
         consumed_value_indices = set()
         for i, a in enumerate(args):
-            if a in ("--format", "--limit", "--min-confidence", "--budget", "--mode", "--available-tokens") and i + 1 < len(args):
+            if a in (
+                "--format",
+                "--limit",
+                "--min-confidence",
+                "--budget",
+                "--mode",
+                "--available-tokens",
+            ) and i + 1 < len(args):
                 consumed_value_indices.add(i + 1)
         query_parts = [
             a

--- a/briefing.py
+++ b/briefing.py
@@ -20,15 +20,19 @@ Usage:
     python briefing.py --wing backend                     # Filter by wing
     python briefing.py --titles-only                      # Progressive disclosure layer 1 (~10 tok/entry)
     python briefing.py --titles-only --limit 20           # More entries in titles mode
-    python briefing.py "task desc" --budget 3000           # Cap output to 3000 chars (frozen snapshot)
+    python briefing.py "task desc" --budget 3000           # Cap output to 3000 chars (explicit override)
     python briefing.py --task "memory-surface"              # Task-scoped recall for a task ID
     python briefing.py "project" --budget 2000 --session-start  # sessionStart: Level 0 skill index + briefing
+    python briefing.py "task" --available-tokens 40000     # Dynamic budget: 5% of context (≤2000 chars)
 
 Default output is compact (~500 tokens): titles + 1-line summaries with entry IDs.
 Use --titles-only for ultra-compact index (~10 tokens/entry). Then --detail <id> for full.
 Use --wakeup for ultra-compact AI wake-up context (~170 tokens).
 Use --full for complete content with tags, confidence scores, and full text.
 Use --session-start (hook callers only) to prepend the Level 0 installed-skill index.
+Use --available-tokens N to let briefing compute an effective budget dynamically from
+context pressure (5% of N, capped at 2000 chars/~500 tokens) so output adapts to
+context pressure automatically. Explicit --budget always takes precedence over --available-tokens.
 """
 
 import datetime
@@ -267,6 +271,27 @@ def _detect_session_id() -> str:
 
 def _estimate_tokens(output_chars: int) -> int:
     return int(math.ceil(output_chars / 4)) if output_chars > 0 else 0
+
+
+def _compute_dynamic_budget(explicit_budget: int, available_tokens: int = 0) -> int:
+    """Compute effective char-budget for briefing output (issue #125).
+
+    Priority order:
+      1. If ``explicit_budget > 0``, return it unchanged (caller override wins).
+      2. If ``available_tokens > 0``, derive: min(2000, int(available_tokens * 0.05)).
+         This reserves at most 5% of the estimated context window for briefing output,
+         capped at 2000 chars (~500 tokens). No floor is applied — very small contexts
+         receive proportionally small budgets.
+      3. Otherwise return 0 (no budget cap — existing behaviour preserved).
+
+    ``available_tokens`` is accepted from the caller via ``--available-tokens N``; briefing
+    does not probe the context window itself, keeping the function deterministic and testable.
+    """
+    if explicit_budget > 0:
+        return explicit_budget
+    if available_tokens > 0:
+        return min(2000, int(available_tokens * 0.05))
+    return 0
 
 
 def _record_recall_event(
@@ -3029,21 +3054,46 @@ def main():
             idx2 = args.index("--limit")
             limit = int(args[idx2 + 1]) if idx2 + 1 < len(args) else 30
         task_fmt = "json" if "--json" in args else "text"
-        budget = 0
+        task_explicit_budget = 0
         if "--budget" in args:
             idx3 = args.index("--budget")
             try:
-                budget = int(args[idx3 + 1]) if idx3 + 1 < len(args) else 3000
+                task_explicit_budget = int(args[idx3 + 1]) if idx3 + 1 < len(args) else 3000
             except ValueError:
-                budget = 3000
+                task_explicit_budget = 3000
+        task_avail_tokens = 0
+        if "--available-tokens" in args:
+            idx4 = args.index("--available-tokens")
+            if idx4 + 1 < len(args) and not args[idx4 + 1].startswith("--"):
+                try:
+                    task_avail_tokens = int(args[idx4 + 1])
+                except ValueError:
+                    task_avail_tokens = 0
+        budget = _compute_dynamic_budget(task_explicit_budget, task_avail_tokens)
         task_meta = None
         if task_fmt == "json":
             output, task_meta = generate_task_briefing(task_id, limit=limit, fmt=task_fmt, with_meta=True)
         else:
             output = generate_task_briefing(task_id, limit=limit, fmt=task_fmt)
-        if budget > 0 and len(output) > budget and task_fmt != "json":
-            output = output[:budget].rsplit("\n", 1)[0]
-            output += f"\n[BUDGET {budget} chars — showing highest-confidence entries only]"
+        if budget > 0 and len(output) > budget:
+            # Token tracking: measure initial injected size before reduction.
+            task_injected_tokens = _estimate_tokens(len(output))
+            task_budget_tokens = _estimate_tokens(budget)
+            # Progressive limit reduction: keep complete entries, highest-confidence first.
+            # Mirrors the main-path degradation strategy so --task is not a second-class path.
+            for reduced_limit in range(max(1, limit - 1), 0, -1):
+                if task_fmt == "json":
+                    output, task_meta = generate_task_briefing(task_id, limit=reduced_limit, fmt=task_fmt, with_meta=True)
+                else:
+                    output = generate_task_briefing(task_id, limit=reduced_limit, fmt=task_fmt)
+                if len(output) <= budget:
+                    break
+            # Final fallback: line-boundary truncation for text only (never JSON).
+            if len(output) > budget and task_fmt != "json":
+                output = output[:budget].rsplit("\n", 1)[0]
+                output += f"\n[BUDGET {budget} chars / ~{task_budget_tokens} tok — injected ~{task_injected_tokens} tok → hard-truncated to fit]"
+            elif task_fmt != "json" and task_injected_tokens > task_budget_tokens:
+                output += f"\n[BUDGET ~{task_budget_tokens} tok — reduced from ~{task_injected_tokens} tok via entry reduction]"
         if task_fmt == "json" and isinstance(task_meta, dict):
             _record_recall_event(
                 event_kind="recall",
@@ -3120,11 +3170,11 @@ def main():
         query = auto_detect_context()
         print(f"[briefing] auto-detected: {query}", file=sys.stderr)
     else:
-        # Filter out values that follow flags (including --budget) by argument
+        # Filter out values that follow flags (including --budget, --available-tokens) by argument
         # position, so query terms matching those values are preserved.
         consumed_value_indices = set()
         for i, a in enumerate(args):
-            if a in ("--format", "--limit", "--min-confidence", "--budget", "--mode") and i + 1 < len(args):
+            if a in ("--format", "--limit", "--min-confidence", "--budget", "--mode", "--available-tokens") and i + 1 < len(args):
                 consumed_value_indices.add(i + 1)
         query_parts = [
             a
@@ -3139,18 +3189,29 @@ def main():
         print("Error: Provide a task description or use --auto")
         return
 
-    # Memory budget: cap output to N chars (Hermes frozen snapshot pattern)
-    # Budget-aware: reduce limit progressively to fit, rather than dumb truncation
-    budget = 0
+    # Memory budget: cap output to N chars (issue #125 dynamic-budget path).
+    # --budget N overrides everything (explicit caller cap).
+    # --available-tokens N enables dynamic sizing: min(2000, N * 0.05).
+    # No flags → budget=0 (no cap, existing behaviour preserved).
+    explicit_budget = 0
     if "--budget" in args:
         idx = args.index("--budget")
         if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
             try:
-                budget = int(args[idx + 1])
+                explicit_budget = int(args[idx + 1])
             except ValueError:
-                budget = 3000  # default on non-numeric value
+                explicit_budget = 3000  # default on non-numeric value
         else:
-            budget = 3000
+            explicit_budget = 3000
+    available_tokens = 0
+    if "--available-tokens" in args:
+        idx = args.index("--available-tokens")
+        if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+            try:
+                available_tokens = int(args[idx + 1])
+            except ValueError:
+                available_tokens = 0
+    budget = _compute_dynamic_budget(explicit_budget, available_tokens)
 
     if subagent_mode:
         infer_auto_mode = mode_explicit
@@ -3172,6 +3233,14 @@ def main():
         )
 
     if budget > 0 and len(output) > budget:
+        # Token tracking (issue #125): measure injected size before committing output.
+        # _estimate_tokens converts chars to approximate token count (ceil(chars/4)).
+        # Priority order for degradation: mistakes + blast_radius (highest) stay visible
+        # longest; patterns/decisions/tools degrade next; past_work/file_index last.
+        # This ordering is already encoded in _format_compact and generate_briefing's
+        # category ordering — progressive limit reduction respects it automatically.
+        injected_tokens = _estimate_tokens(len(output))
+        budget_tokens = _estimate_tokens(budget)
         # Smart budget: re-generate with progressively fewer entries until it fits.
         # This ensures we keep COMPLETE entries (not half-cut ones) and the most
         # relevant entries are preserved (search is ordered by confidence + relevance).
@@ -3204,7 +3273,9 @@ def main():
         # via the progressive-limit loop above.
         if len(output) > budget and fmt not in ("json", "pack"):
             output = output[:budget].rsplit("\n", 1)[0]
-            output += f"\n[BUDGET {budget} chars — showing highest-confidence entries only]"
+            output += f"\n[BUDGET {budget} chars / ~{budget_tokens} tok — injected ~{injected_tokens} tok → hard-truncated to fit]"
+        elif fmt not in ("json", "pack") and injected_tokens > budget_tokens:
+            output += f"\n[BUDGET ~{budget_tokens} tok — reduced from ~{injected_tokens} tok via entry reduction]"
 
     if (not subagent_mode) and isinstance(output_meta, dict):
         _record_recall_event(

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -363,7 +363,7 @@ brief --task "memory-surface" --json # Includes source_document + code-location/
 brief "fix Docker" --json            # JSON output for programmatic use
 ```
 
-Token-distillation flags: `--compact` produces an XML compact block; `--budget N` hard-caps output to N characters (explicit override, highest-confidence entries first); `--available-tokens N` enables dynamic budget sizing — N is a token count; briefing derives a char budget of `min(2000, int(N * 0.05))` chars (~5% of available tokens, capped at 2000 chars/~500 tokens) so output adapts to context pressure automatically; `--titles-only` gives ~10 tok/entry for progressive disclosure.  `--budget` always takes precedence over `--available-tokens`.
+Token-distillation flags: `--compact` produces an XML compact block; `--budget N` hard-caps output to N characters (explicit override, highest-confidence entries first); `--available-tokens N` enables dynamic budget sizing — N is a token count; for positive N briefing derives a char budget of `max(1, min(2000, int(N * 0.05)))` chars (~5% of available tokens, capped at 2000 chars/~500 tokens) so output adapts to context pressure automatically; N=0 disables the dynamic cap; `--titles-only` gives ~10 tok/entry for progressive disclosure.  `--budget` always takes precedence over `--available-tokens`.
 
 For tentacle delegation, prefer `tentacle.py ... --briefing`: it injects bounded `[KNOWLEDGE EVIDENCE]` from task-scoped JSON recall first, then `--pack` fallback when task recall is empty. Bullets stay unchanged; runtime may add one optional bounded `From:` provenance line. Keep `--for-subagent` for manual compatibility and ad hoc prompts.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -363,7 +363,7 @@ brief --task "memory-surface" --json # Includes source_document + code-location/
 brief "fix Docker" --json            # JSON output for programmatic use
 ```
 
-Token-distillation flags: `--compact` produces an XML compact block; `--budget N` hard-caps output to N characters (frozen snapshot, highest-confidence entries first); `--titles-only` gives ~10 tok/entry for progressive disclosure.
+Token-distillation flags: `--compact` produces an XML compact block; `--budget N` hard-caps output to N characters (explicit override, highest-confidence entries first); `--available-tokens N` enables dynamic budget sizing — N is a token count; briefing derives a char budget of `min(2000, int(N * 0.05))` chars (~5% of available tokens, capped at 2000 chars/~500 tokens) so output adapts to context pressure automatically; `--titles-only` gives ~10 tok/entry for progressive disclosure.  `--budget` always takes precedence over `--available-tokens`.
 
 For tentacle delegation, prefer `tentacle.py ... --briefing`: it injects bounded `[KNOWLEDGE EVIDENCE]` from task-scoped JSON recall first, then `--pack` fallback when task recall is empty. Bullets stay unchanged; runtime may add one optional bounded `From:` provenance line. Keep `--for-subagent` for manual compatibility and ad hoc prompts.
 

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -1031,6 +1031,94 @@ finally:
     _shutil.rmtree(str(_proc_tmp), ignore_errors=True)
 
 
+# ── 17. _compute_dynamic_budget (issue #125) ─────────────────────────────────
+
+print("\n💰 _compute_dynamic_budget  (issue #125)")
+
+# 17a. Explicit budget always wins regardless of available_tokens
+test("17a: explicit_budget=3000 → 3000 (ignores available_tokens)", _b._compute_dynamic_budget(3000, 0) == 3000)
+test("17a: explicit_budget=1000, available_tokens=200000 → 1000", _b._compute_dynamic_budget(1000, 200000) == 1000)
+test("17a: explicit_budget=500, available_tokens=40000 → 500", _b._compute_dynamic_budget(500, 40000) == 500)
+
+# 17b. Dynamic formula: min(2000, int(N * 0.05)) — no floor
+# available_tokens=40000 → 40000 * 0.05 = 2000 → capped at 2000
+test("17b: avail=40000 → min(2000, 2000) = 2000", _b._compute_dynamic_budget(0, 40000) == 2000)
+# available_tokens=60000 → 60000 * 0.05 = 3000 → capped at 2000
+test("17b: avail=60000 → capped at 2000", _b._compute_dynamic_budget(0, 60000) == 2000)
+# available_tokens=8000 → 8000 * 0.05 = 400 → no floor, result is 400
+test("17b: avail=8000 → 400 (5% of 8000, no floor)", _b._compute_dynamic_budget(0, 8000) == 400)
+# available_tokens=20000 → 20000 * 0.05 = 1000 → within (0, 2000]
+test("17b: avail=20000 → 1000", _b._compute_dynamic_budget(0, 20000) == 1000)
+# available_tokens=10000 → 10000 * 0.05 = 500 → exactly at 5%
+test("17b: avail=10000 → 500 (exactly 5% of 10000)", _b._compute_dynamic_budget(0, 10000) == 500)
+
+# 17c. Fallback: no budget (available_tokens=0 or negative) → 0 (no cap)
+test("17c: explicit=0, avail=0 → 0 (no cap)", _b._compute_dynamic_budget(0, 0) == 0)
+test("17c: explicit=0, avail negative → 0", _b._compute_dynamic_budget(0, -1) == 0)
+test("17c: no args → 0", _b._compute_dynamic_budget(0) == 0)
+
+# 17d. Token tracking: _estimate_tokens round-trips correctly
+_budget_chars = _b._compute_dynamic_budget(0, 40000)  # 2000
+_budget_tokens = _b._estimate_tokens(_budget_chars)
+test("17d: budget=2000 chars → ~500 tokens", _budget_tokens == 500)
+_budget_chars2 = _b._compute_dynamic_budget(0, 20000)  # 1000
+_budget_tokens2 = _b._estimate_tokens(_budget_chars2)
+test("17d: budget=1000 chars → ~250 tokens", _budget_tokens2 == 250)
+
+# 17e. Priority order: _format_compact puts mistakes before patterns/decisions/tools
+# Build minimal data with one entry per category
+_fc_data = {
+    "mistake": [{"title": "MISTAKE_ENTRY", "content": "A mistake was made here today."}],
+    "pattern": [{"title": "PATTERN_ENTRY", "content": "Use this proven pattern always."}],
+    "decision": [{"title": "DECISION_ENTRY", "content": "Architecture decided this way."}],
+    "tool": [{"title": "TOOL_ENTRY", "content": "A relevant tool configuration."}],
+}
+_fc_out = _b._format_compact("test query", _fc_data, [], {})
+_pos_mistake = _fc_out.find("MISTAKE_ENTRY")
+_pos_pattern = _fc_out.find("PATTERN_ENTRY")
+_pos_decision = _fc_out.find("DECISION_ENTRY")
+_pos_tool = _fc_out.find("TOOL_ENTRY")
+test("17e: mistakes appear before patterns in compact output", _pos_mistake < _pos_pattern, f"mistake@{_pos_mistake} pattern@{_pos_pattern}")
+test("17e: mistakes appear before decisions", _pos_mistake < _pos_decision, f"mistake@{_pos_mistake} decision@{_pos_decision}")
+test("17e: mistakes appear before tools", _pos_mistake < _pos_tool, f"mistake@{_pos_mistake} tool@{_pos_tool}")
+test("17e: patterns appear before decisions", _pos_pattern < _pos_decision, f"pattern@{_pos_pattern} decision@{_pos_decision}")
+
+# 17f. Graceful degradation: explicit budget — structured outputs (json/pack) are not truncated
+# Simulate a budget scenario: if output is a JSON string that exceeds budget, it must not be
+# truncated (the budget enforcement in main() has fmt not in ("json","pack") guard).
+# We verify this guard is present in the source code (structural safety guarantee).
+_br_src_125 = (REPO / "briefing.py").read_text(encoding="utf-8")
+test("17f: source guards json/pack from truncation (fmt not in json/pack check)", 'fmt not in ("json", "pack")' in _br_src_125)
+test("17f: source uses _compute_dynamic_budget", "_compute_dynamic_budget" in _br_src_125)
+test("17f: source has --available-tokens flag handling", "--available-tokens" in _br_src_125)
+
+# 17g. _compute_dynamic_budget is exposed as a module attribute
+test("17g: _compute_dynamic_budget exposed on module", hasattr(_b, "_compute_dynamic_budget"))
+test("17g: callable", callable(_b._compute_dynamic_budget))
+
+# 17h. Formula contract: no floor — small available_tokens return proportional budget
+# available_tokens=4000 → 4000 * 0.05 = 200 (well below the old 500 floor)
+test("17h: avail=4000 → 200 (no floor applied)", _b._compute_dynamic_budget(0, 4000) == 200)
+# available_tokens=100 → 100 * 0.05 = 5
+test("17h: avail=100 → 5 (no floor applied)", _b._compute_dynamic_budget(0, 100) == 5)
+# available_tokens=2000 → 2000 * 0.05 = 100 (old formula would floor this to 500)
+test("17h: avail=2000 → 100 (old floor was 500, new formula 5% = 100)", _b._compute_dynamic_budget(0, 2000) == 100)
+
+# 17i. Token tracking: source uses injected/budget tokens in footer (not dead locals)
+_br_src_125_full = (REPO / "briefing.py").read_text(encoding="utf-8")
+test("17i: source uses injected_tokens in footer comment", "injected_tokens" in _br_src_125_full)
+test("17i: source uses budget_tokens in footer comment", "budget_tokens" in _br_src_125_full)
+test("17i: dead-locals pattern removed (no _ = (injected_tokens, budget_tokens))", "_ = (injected_tokens, budget_tokens)" not in _br_src_125_full)
+
+# 17j. --task path uses progressive reduction (not just hard truncation)
+# Verify the source has the loop for --task path as well as the main path
+test("17j: --task path has progressive-limit loop", "task_injected_tokens" in _br_src_125_full)
+test("17j: --task path has graceful degradation footer", "task_budget_tokens" in _br_src_125_full)
+test("17j: --task path does not hard-truncate immediately (has reduce loop before fallback)",
+     "for reduced_limit in range" in _br_src_125_full)
+
+
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 print(f"\n{'=' * 50}")

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -1143,33 +1143,84 @@ test("17l: entry-reduction footer only added when it fits (len check)",
      "len(output) + len(footer) <= budget" in _br_src_125_full)
 
 # 17m. --task --available-tokens behavioral CLI test (end-to-end through main()/CLI parsing)
+# Root cause of CI-only failure: get_db() calls sys.exit(1) when knowledge.db is absent,
+# so the subprocess exited 1 on Linux CI (no live DB) but 0 locally (live DB present).
+# Fix: use an isolated temp HOME with a minimal fixture DB so the subprocess is deterministic
+# on any machine regardless of ambient ~/.copilot/session-state/knowledge.db presence.
 print("\n🔧 17m: --task --available-tokens CLI behavioral test (PR review finding #3)")
 import subprocess as _sp
 
-_task_budget_result = _sp.run(
-    [sys.executable, str(_briefing_py), "--task", "nonexistent-test-task-id-17m", "--available-tokens", "400"],
-    capture_output=True, text=True, timeout=30
-)
-# Should exit 0 or gracefully (not crash on budget parsing)
-test("17m: --task --available-tokens exits without crash", _task_budget_result.returncode == 0)
-_task_budget_output = _task_budget_result.stdout
-# budget = max(1, min(2000, int(400 * 0.05))) = max(1, min(2000, 20)) = 20 chars
-# Output should not exceed 20 chars (or should be gracefully empty/within budget)
-test("17m: --task --available-tokens output length ≤ computed budget (20 chars) OR empty",
-     len(_task_budget_output) <= 20 or len(_task_budget_output) == 0 or
-     # If DB has data, it may degrade to minimal. Accept outputs that contain BUDGET footer.
-     "[BUDGET" in _task_budget_output or len(_task_budget_output.strip()) == 0)
+_17m_home = Path(tempfile.mkdtemp(prefix="test-17m-"))
+try:
+    # Build minimal fixture DB: knowledge_entries + documents (empty tables).
+    # This satisfies get_db() and generate_task_briefing() without any real data.
+    # ke_fts (FTS5) is optional — OperationalError is caught in briefing.py.
+    _17m_db_dir = _17m_home / ".copilot" / "session-state"
+    _17m_db_dir.mkdir(parents=True, exist_ok=True)
+    _17m_conn = sqlite3.connect(str(_17m_db_dir / "knowledge.db"))
+    _17m_conn.execute(
+        "CREATE TABLE knowledge_entries ("
+        "id INTEGER PRIMARY KEY, category TEXT, title TEXT, content TEXT,"
+        " confidence REAL, affected_files TEXT, tags TEXT, occurrence_count INTEGER,"
+        " task_id TEXT, document_id INTEGER, source_section TEXT,"
+        " source_file TEXT, start_line INTEGER, end_line INTEGER,"
+        " code_language TEXT, code_snippet TEXT)"
+    )
+    _17m_conn.execute(
+        "CREATE TABLE documents ("
+        "id INTEGER PRIMARY KEY, doc_type TEXT, title TEXT, file_path TEXT, seq INTEGER)"
+    )
+    _17m_conn.commit()
+    _17m_conn.close()
 
-# Also test with a large available-tokens value: budget=2000, output must be ≤2000
-_task_large_result = _sp.run(
-    [sys.executable, str(_briefing_py), "--task", "nonexistent-test-task-id-17m", "--available-tokens", "40000"],
-    capture_output=True, text=True, timeout=30
-)
-test("17m: --task --available-tokens 40000 exits without crash", _task_large_result.returncode == 0)
-_task_large_output = _task_large_result.stdout
-# Budget = 2000; output must be ≤ 2000 chars (or empty/no data)
-test("17m: --task large available-tokens output ≤ 2000 chars",
-     len(_task_large_output) <= 2000 or len(_task_large_output.strip()) == 0)
+    _17m_env = os.environ.copy()
+    _17m_env["HOME"] = str(_17m_home)
+    _17m_env["USERPROFILE"] = str(_17m_home)
+
+    # Tight budget: available_tokens=400 → budget = max(1, min(2000, int(400*0.05))) = 20 chars
+    _task_budget_result = _sp.run(
+        [sys.executable, str(_briefing_py), "--task", "nonexistent-test-task-id-17m",
+         "--available-tokens", "400"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        timeout=30, cwd=str(REPO), env=_17m_env,
+    )
+    test(
+        "17m: --task --available-tokens exits 0 (fixture DB present, deterministic on CI)",
+        _task_budget_result.returncode == 0,
+        f"rc={_task_budget_result.returncode} stderr={_task_budget_result.stderr[:300]}",
+    )
+    _task_budget_output = _task_budget_result.stdout
+    # With empty DB: no entries → output is empty or a "no entries" notice.
+    # Budget is 20 chars; any output must respect that cap or be empty.
+    test(
+        "17m: --task --available-tokens output ≤ 20 chars OR empty (budget enforced)",
+        len(_task_budget_output.strip()) == 0
+        or len(_task_budget_output) <= 20
+        or "[BUDGET" in _task_budget_output,
+        f"len={len(_task_budget_output)} out={_task_budget_output[:100]}",
+    )
+
+    # Large budget: available_tokens=40000 → budget = min(2000, 2000) = 2000 chars
+    _task_large_result = _sp.run(
+        [sys.executable, str(_briefing_py), "--task", "nonexistent-test-task-id-17m",
+         "--available-tokens", "40000"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        timeout=30, cwd=str(REPO), env=_17m_env,
+    )
+    test(
+        "17m: --task --available-tokens 40000 exits 0",
+        _task_large_result.returncode == 0,
+        f"rc={_task_large_result.returncode} stderr={_task_large_result.stderr[:300]}",
+    )
+    _task_large_output = _task_large_result.stdout
+    # Budget = 2000 chars; output must be ≤ 2000 or empty (no data in fixture DB)
+    test(
+        "17m: --task large available-tokens output ≤ 2000 chars",
+        len(_task_large_output.strip()) == 0 or len(_task_large_output) <= 2000,
+        f"len={len(_task_large_output)} out={_task_large_output[:100]}",
+    )
+finally:
+    _shutil.rmtree(str(_17m_home), ignore_errors=True)
 
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -1117,6 +1117,59 @@ test("17j: --task path has graceful degradation footer", "task_budget_tokens" in
 test("17j: --task path does not hard-truncate immediately (has reduce loop before fallback)",
      "for reduced_limit in range" in _br_src_125_full)
 
+# 17k. Tight-context bug: available_tokens < 20 must NOT return 0 (which would disable cap)
+print("\n🔒 17k: tight-context _compute_dynamic_budget fix (PR review finding #2)")
+# available_tokens=10 → int(10 * 0.05) = 0 without fix; with fix: max(1, 0) = 1
+test("17k: avail=10 → 1 (budget stays active, not 0)", _b._compute_dynamic_budget(0, 10) == 1)
+# available_tokens=1 → int(1 * 0.05) = 0; with fix: max(1, 0) = 1
+test("17k: avail=1 → 1 (tightest context stays active)", _b._compute_dynamic_budget(0, 1) == 1)
+# available_tokens=19 → int(19 * 0.05) = int(0.95) = 0; with fix: max(1, 0) = 1
+test("17k: avail=19 → 1 (boundary just below avail=20)", _b._compute_dynamic_budget(0, 19) == 1)
+# available_tokens=20 → int(20 * 0.05) = 1; no change needed (max(1,1)=1)
+test("17k: avail=20 → 1 (first value that formula covers without max guard)", _b._compute_dynamic_budget(0, 20) == 1)
+# Verify existing tests still pass (no floor for larger values)
+test("17k: avail=100 → 5 (proportional, no floor)", _b._compute_dynamic_budget(0, 100) == 5)
+test("17k: avail=0 → 0 (no-cap preserved when no context given)", _b._compute_dynamic_budget(0, 0) == 0)
+
+# 17l. Footer-budget safety: final emitted output must not exceed the enforced cap
+print("\n📏 17l: footer-budget safety (PR review finding #1)")
+# Verify source uses footer-length-aware truncation (reserves room before adding footer)
+test("17l: main path reserves footer length before truncating (avail = budget - len(footer))",
+     "avail = budget - len(footer)" in _br_src_125_full)
+test("17l: --task path reserves footer length before truncating",
+     # The task path uses the same pattern
+     _br_src_125_full.count("avail = budget - len(footer)") >= 2)
+test("17l: entry-reduction footer only added when it fits (len check)",
+     "len(output) + len(footer) <= budget" in _br_src_125_full)
+
+# 17m. --task --available-tokens behavioral CLI test (end-to-end through main()/CLI parsing)
+print("\n🔧 17m: --task --available-tokens CLI behavioral test (PR review finding #3)")
+import subprocess as _sp
+
+_task_budget_result = _sp.run(
+    [sys.executable, str(_briefing_py), "--task", "nonexistent-test-task-id-17m", "--available-tokens", "400"],
+    capture_output=True, text=True, timeout=30
+)
+# Should exit 0 or gracefully (not crash on budget parsing)
+test("17m: --task --available-tokens exits without crash", _task_budget_result.returncode == 0)
+_task_budget_output = _task_budget_result.stdout
+# budget = max(1, min(2000, int(400 * 0.05))) = max(1, min(2000, 20)) = 20 chars
+# Output should not exceed 20 chars (or should be gracefully empty/within budget)
+test("17m: --task --available-tokens output length ≤ computed budget (20 chars) OR empty",
+     len(_task_budget_output) <= 20 or len(_task_budget_output) == 0 or
+     # If DB has data, it may degrade to minimal. Accept outputs that contain BUDGET footer.
+     "[BUDGET" in _task_budget_output or len(_task_budget_output.strip()) == 0)
+
+# Also test with a large available-tokens value: budget=2000, output must be ≤2000
+_task_large_result = _sp.run(
+    [sys.executable, str(_briefing_py), "--task", "nonexistent-test-task-id-17m", "--available-tokens", "40000"],
+    capture_output=True, text=True, timeout=30
+)
+test("17m: --task --available-tokens 40000 exits without crash", _task_large_result.returncode == 0)
+_task_large_output = _task_large_result.stdout
+# Budget = 2000; output must be ≤ 2000 chars (or empty/no data)
+test("17m: --task large available-tokens output ≤ 2000 chars",
+     len(_task_large_output) <= 2000 or len(_task_large_output.strip()) == 0)
 
 
 # ── Summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add dynamic briefing budget sizing from `--available-tokens` with no undocumented floor
- degrade the `--task` path progressively before any hard truncation fallback
- surface token tracking in briefing output and document the new behavior

## Verification
- `python tests\test_briefing.py`
- `python test_fixes.py`
- `python test_security.py`
- `python -c "import briefing; ..."` (`100`, `400`, `2000` for 2k/8k/40k token inputs)

Closes #125
