### PR TITLE
feat: add skill curator CLI

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -25,6 +25,11 @@ sk skill-suggest                         # → skill-suggest.py
 sk skill-suggest --min-occurrences 3 --format json
 sk skill-patch path/to/SKILL.md --old "old text" --new "new text"  # → skill-patch.py
 sk skill-patch path/to/SKILL.md --old "old text" --new "new text" --replace-all
+sk skill-curator list                        # → skill-curator.py list
+sk skill-curator archive --dry-run           # archive stale skills (preview)
+sk skill-curator pin <skill>                 # pin a skill (prevent archiving)
+sk skill-curator unpin <skill>               # unpin a skill
+sk skill-curator restore <skill>             # restore an archived skill
 sk audit-hooks                               # → audit-hooks.py
 sk audit-hooks --json
 sk audit-hooks --days 7
@@ -158,6 +163,57 @@ python skill-metrics.py   # shows patch_history section when records exist
 ```
 
 > Direct-script form: `python skill-patch.py path/to/SKILL.md --old "..." --new "..." [opts]`
+
+### `sk skill-curator` — skill lifecycle manager
+
+Manages the lifecycle of installed Agent Skills: classify by usage recency, pin
+important skills, archive stale ones (with backup), and restore archived skills.
+Usage data is read from `skill-metrics.db` (`skill_usage_events` table).
+
+**States:**
+- `active` — used within the last `--stale-days` days (default 30)
+- `stale` — unused for `--stale-days`..`--archive-days` (default 30–90 days)
+- `archived` — moved to `skills/.archive/<name>/`; a backup is written first
+
+**Pinning:** a pinned skill is never archived.  Pin marker: `<skills>/<name>/.pinned`.
+
+```bash
+# List all skills with their current status
+sk skill-curator list
+sk skill-curator list --json                   # machine-readable JSON
+
+# Archive stale/archived-candidate skills
+sk skill-curator archive                       # execute archiving
+sk skill-curator archive --dry-run             # preview only; zero writes
+sk skill-curator archive --stale-days 14       # override stale threshold
+sk skill-curator archive --archive-days 60     # override archive threshold
+sk skill-curator archive --dry-run --json      # JSON preview
+
+# Pin / unpin a skill (prevents archiving)
+sk skill-curator pin   my-skill
+sk skill-curator unpin my-skill
+
+# Restore an archived skill
+sk skill-curator restore my-skill
+sk skill-curator restore my-skill --dry-run    # preview restore; zero writes
+```
+
+**Global flags** (apply to all subcommands):
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--skills-dir PATH` | `./skills` | Override skills directory |
+| `--db PATH` | `~/.copilot/session-state/skill-metrics.db` | Override metrics DB path |
+| `--stale-days N` | 30 | Inactivity days before a skill is stale |
+| `--archive-days N` | 90 | Inactivity days before a skill is an archive candidate |
+| `--dry-run` | off | Show what would happen; perform **zero** writes |
+| `--json` | off | Emit machine-readable JSON output |
+
+**Backup layout:** before any archive move, a backup is written to
+`skills/.archive/.<name>.bak.<YYYYMMDDTHHMMSSz>/`.  The archive move is
+aborted if `skills/.archive/<name>` already exists (collision guard).
+
+> Direct-script form: `python skill-curator.py [list|archive|pin|unpin|restore] [args...]`
 
 ### `sk audit-hooks` — hook effectiveness audit
 

--- a/sk.py
+++ b/sk.py
@@ -26,6 +26,7 @@ Usage:
     sk anatomy      [<args>...]       Run anatomy-map.py
     sk skill-suggest [<args>...]      Run skill-suggest.py
     sk skill-patch  [<args>...]       Run skill-patch.py
+    sk skill-curator [<args>...]      Run skill-curator.py
     sk hooks        run|list|<event>  Run hooks/hook_runner.py
     sk audit-hooks  [<args>...]       Run audit-hooks.py
     sk improvement-signals [<args>...] Run improvement-signals.py
@@ -83,6 +84,7 @@ _DIRECT: dict[str, str] = {
     "anatomy": "anatomy-map.py",
     "skill-suggest": "skill-suggest.py",
     "skill-patch": "skill-patch.py",
+    "skill-curator": "skill-curator.py",
     "audit-hooks": "audit-hooks.py",
     "improvement-signals": "improvement-signals.py",
 }

--- a/skill-curator.py
+++ b/skill-curator.py
@@ -125,9 +125,9 @@ def _last_used(db, skill_name: str) -> datetime | None:
 
 
 def classify(last_used_dt: datetime | None, now: datetime, stale_days: int, archive_days: int) -> str:
-    """Return 'active', 'stale', or 'archived_candidate'."""
+    """Return 'active', 'stale', 'archived_candidate', or 'never_used'."""
     if last_used_dt is None:
-        # Never recorded — treat as archived candidate
+        # Never recorded — treat as never_used
         return "never_used"
     delta = now - last_used_dt
     days = delta.total_seconds() / 86400
@@ -184,16 +184,25 @@ def _timestamp_str() -> str:
 
 
 def _backup_skill(skills_dir: Path, skill_name: str, dry_run: bool) -> Path:
-    """Write a backup copy of skill_name to skills/.archive/.<skill_name>.bak.<ts>/.
+    """Write a backup copy of skill_name to skills/.archive/.<skill_name>.bak.<ts>[.<n>]/.
 
+    A counter suffix (<n>) is appended when the timestamp-only name is already taken,
+    making the backup name deterministically unique even for same-second calls.
     Always happens BEFORE any destructive move.  In dry-run mode, returns the
     would-be backup path without writing.
     """
     archive_dir = skills_dir / ARCHIVE_DIR_NAME
-    backup_name = f".{skill_name}.bak.{_timestamp_str()}"
-    backup_path = archive_dir / backup_name
+    ts = _timestamp_str()
+    base_name = f".{skill_name}.bak.{ts}"
+    backup_name = base_name
     if not dry_run:
         archive_dir.mkdir(parents=True, exist_ok=True)
+        counter = 0
+        while (archive_dir / backup_name).exists():
+            counter += 1
+            backup_name = f"{base_name}.{counter}"
+    backup_path = archive_dir / backup_name
+    if not dry_run:
         shutil.copytree(str(skills_dir / skill_name), str(backup_path))
     return backup_path
 
@@ -225,13 +234,15 @@ def _archive_skill(skills_dir: Path, skill_name: str, dry_run: bool) -> tuple[Pa
 def _restore_skill(skills_dir: Path, skill_name: str, dry_run: bool) -> Path:
     """Move an archived skill back to skills/<skill_name>/.
 
-    Returns the restored path.  Raises RuntimeError if source absent.
+    Returns the restored path.  Raises RuntimeError if source absent or
+    (in non-dry-run only) if the destination already exists.
+    Destination collision is not checked in dry-run mode because no writes occur.
     """
     archive_path = skills_dir / ARCHIVE_DIR_NAME / skill_name
     if not archive_path.exists():
         raise RuntimeError(f"archived skill '{skill_name}' not found at {archive_path}")
     dest = skills_dir / skill_name
-    if dest.exists():
+    if not dry_run and dest.exists():
         raise RuntimeError(f"destination '{dest}' already exists — cannot restore")
     if not dry_run:
         shutil.move(str(archive_path), str(dest))
@@ -421,7 +432,7 @@ def cmd_unpin(args, _db, _now: datetime) -> int:
             else:
                 print(f"'{skill_name}' was not pinned.")
         return 0
-    except Exception as exc:
+    except RuntimeError as exc:
         if args.json:
             print(json.dumps({"error": str(exc)}))
         else:

--- a/skill-curator.py
+++ b/skill-curator.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""
+skill-curator.py — Lifecycle manager for installed Agent Skills.
+
+Reads usage data from skill-metrics.db (skill_usage_events table) and
+classifies skills as active / stale / archived based on recency thresholds.
+Supports pinning (pin / unpin), archiving (with backup-before-mutation),
+restoration, and a strict --dry-run mode that performs zero writes.
+
+State machine
+-------------
+  active   — skill used within the last STALE_DAYS (default 30 days)
+  stale    — skill not used for STALE_DAYS..ARCHIVE_DAYS (default 30-90 days)
+             → candidate for archiving; shown in list with warning
+  archived — skill directory moved to skills/.archive/<name>/
+             → happens only if NOT pinned and only after a backup is written
+
+Pinning
+-------
+  A pinned skill is NEVER archived.
+  Pin marker: <skills_dir>/<skill_name>/.pinned  (empty file)
+
+Backup and archive layout
+-------------------------
+  skills/.archive/<skill_name>/   — archived skill directory
+  skills/.archive/.<skill_name>.bak.<timestamp>/  — backup written just before
+    the archive move; timestamp = YYYYMMDDTHHMMSSZ
+
+Usage
+-----
+    python skill-curator.py [list]            List all skills with status
+    python skill-curator.py archive           Archive stale/old skills
+    python skill-curator.py pin   <skill>     Pin a skill (prevent archiving)
+    python skill-curator.py unpin <skill>     Unpin a skill
+    python skill-curator.py restore <skill>   Restore an archived skill
+
+Options (global)
+    --skills-dir PATH   Override skills directory (default: ./skills)
+    --db PATH           Override skill-metrics.db path
+    --stale-days N      Days of inactivity before a skill is stale (default 30)
+    --archive-days N    Days of inactivity before a skill is archived (default 90)
+    --dry-run           Show what would happen; perform zero writes
+    --json              Emit machine-readable JSON output
+    -h, --help          Show this help and exit
+
+Exit codes
+    0  Success / no errors
+    1  Operational error (pinned skill blocked, restore failed, …)
+    2  Usage / argument error
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+SESSION_STATE = Path.home() / ".copilot" / "session-state"
+DEFAULT_METRICS_DB = SESSION_STATE / "skill-metrics.db"
+DEFAULT_SKILLS_DIR = Path(__file__).parent / "skills"
+
+STALE_DAYS_DEFAULT = 30
+ARCHIVE_DAYS_DEFAULT = 90
+
+PIN_MARKER = ".pinned"
+ARCHIVE_DIR_NAME = ".archive"
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _open_db(db_path: Path):
+    """Open skill-metrics.db in read-only mode; return None if absent."""
+    if not db_path.exists():
+        return None
+    try:
+        # Use URI mode for read-only access to avoid creating the file.
+        uri = "file:" + db_path.as_posix().replace("\\", "/") + "?mode=ro"
+        db = sqlite3.connect(uri, uri=True, timeout=5)
+        db.row_factory = sqlite3.Row
+        return db
+    except Exception:
+        return None
+
+
+def _last_used(db, skill_name: str) -> datetime | None:
+    """Return the UTC datetime of the most recent triggered/loaded event, or None."""
+    if db is None:
+        return None
+    try:
+        row = db.execute(
+            "SELECT MAX(timestamp) FROM skill_usage_events WHERE skill_name = ?",
+            (skill_name,),
+        ).fetchone()
+        if row and row[0]:
+            ts = row[0]
+            # Handle both 'Z' and '+00:00' suffix
+            ts = ts.replace("Z", "+00:00")
+            dt = datetime.fromisoformat(ts)
+            # Normalize timezone-naive timestamps (assume UTC)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+    except Exception:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def classify(last_used_dt: datetime | None, now: datetime, stale_days: int, archive_days: int) -> str:
+    """Return 'active', 'stale', or 'archived_candidate'."""
+    if last_used_dt is None:
+        # Never recorded — treat as archived candidate
+        return "never_used"
+    delta = now - last_used_dt
+    days = delta.total_seconds() / 86400
+    if days < stale_days:
+        return "active"
+    if days < archive_days:
+        return "stale"
+    return "archived_candidate"
+
+
+# ---------------------------------------------------------------------------
+# Skills directory helpers
+# ---------------------------------------------------------------------------
+
+
+def _discover_skills(skills_dir: Path) -> list[str]:
+    """Return sorted list of skill names (subdirectory names) in skills_dir.
+
+    Excludes the .archive directory and any entry that is not a directory.
+    """
+    if not skills_dir.is_dir():
+        return []
+    return sorted(
+        p.name
+        for p in skills_dir.iterdir()
+        if p.is_dir() and p.name != ARCHIVE_DIR_NAME and not p.name.startswith(".")
+    )
+
+
+def _is_pinned(skills_dir: Path, skill_name: str) -> bool:
+    """Return True if the skill has a .pinned marker file."""
+    return (skills_dir / skill_name / PIN_MARKER).exists()
+
+
+def _archived_skills(skills_dir: Path) -> list[str]:
+    """Return sorted list of skill names currently in skills/.archive/."""
+    archive_dir = skills_dir / ARCHIVE_DIR_NAME
+    if not archive_dir.is_dir():
+        return []
+    return sorted(
+        p.name
+        for p in archive_dir.iterdir()
+        if p.is_dir() and not p.name.startswith(".")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mutation helpers (all guarded by dry_run)
+# ---------------------------------------------------------------------------
+
+
+def _timestamp_str() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _backup_skill(skills_dir: Path, skill_name: str, dry_run: bool) -> Path:
+    """Write a backup copy of skill_name to skills/.archive/.<skill_name>.bak.<ts>/.
+
+    Always happens BEFORE any destructive move.  In dry-run mode, returns the
+    would-be backup path without writing.
+    """
+    archive_dir = skills_dir / ARCHIVE_DIR_NAME
+    backup_name = f".{skill_name}.bak.{_timestamp_str()}"
+    backup_path = archive_dir / backup_name
+    if not dry_run:
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(str(skills_dir / skill_name), str(backup_path))
+    return backup_path
+
+
+def _archive_skill(skills_dir: Path, skill_name: str, dry_run: bool) -> tuple[Path, Path]:
+    """Backup then move skill directory to skills/.archive/<skill_name>/.
+
+    Returns (archive_path, backup_path).
+    Raises RuntimeError if the skill is pinned or the archive destination already exists.
+    All preconditions (pin check, collision check) are verified before any I/O.
+    """
+    if _is_pinned(skills_dir, skill_name):
+        raise RuntimeError(f"skill '{skill_name}' is pinned — cannot archive")
+    archive_path = skills_dir / ARCHIVE_DIR_NAME / skill_name
+    # Check for destination collision before any backup I/O so a failed archive
+    # leaves no orphaned backup directory behind.
+    if not dry_run and archive_path.exists():
+        raise RuntimeError(
+            f"archive destination '{archive_path}' already exists — remove it first"
+        )
+    backup_path = _backup_skill(skills_dir, skill_name, dry_run)
+    if not dry_run:
+        archive_dir = skills_dir / ARCHIVE_DIR_NAME
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(skills_dir / skill_name), str(archive_path))
+    return archive_path, backup_path
+
+
+def _restore_skill(skills_dir: Path, skill_name: str, dry_run: bool) -> Path:
+    """Move an archived skill back to skills/<skill_name>/.
+
+    Returns the restored path.  Raises RuntimeError if source absent.
+    """
+    archive_path = skills_dir / ARCHIVE_DIR_NAME / skill_name
+    if not archive_path.exists():
+        raise RuntimeError(f"archived skill '{skill_name}' not found at {archive_path}")
+    dest = skills_dir / skill_name
+    if dest.exists():
+        raise RuntimeError(f"destination '{dest}' already exists — cannot restore")
+    if not dry_run:
+        shutil.move(str(archive_path), str(dest))
+    return dest
+
+
+def _pin_skill(skills_dir: Path, skill_name: str, dry_run: bool) -> Path:
+    """Create the .pinned marker inside skills/<skill_name>/."""
+    marker = skills_dir / skill_name / PIN_MARKER
+    skill_dir = skills_dir / skill_name
+    if not skill_dir.exists():
+        raise RuntimeError(f"skill '{skill_name}' not found at {skill_dir}")
+    if not dry_run:
+        marker.touch()
+    return marker
+
+
+def _unpin_skill(skills_dir: Path, skill_name: str, dry_run: bool) -> bool:
+    """Remove the .pinned marker from skills/<skill_name>/.
+
+    Returns True if the marker was present and removed (or would be in dry-run).
+    """
+    marker = skills_dir / skill_name / PIN_MARKER
+    if not marker.exists():
+        return False
+    if not dry_run:
+        marker.unlink()
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_list(args, db, now: datetime) -> int:
+    """List all skills with their lifecycle status."""
+    skills_dir: Path = args.skills_dir
+    stale_days: int = args.stale_days
+    archive_days: int = args.archive_days
+
+    active_skills = _discover_skills(skills_dir)
+    archived = _archived_skills(skills_dir)
+
+    rows = []
+    for name in active_skills:
+        last = _last_used(db, name)
+        status = classify(last, now, stale_days, archive_days)
+        pinned = _is_pinned(skills_dir, name)
+        rows.append(
+            {
+                "skill": name,
+                "status": status,
+                "pinned": pinned,
+                "last_used": last.isoformat() if last else None,
+            }
+        )
+    for name in archived:
+        rows.append(
+            {
+                "skill": name,
+                "status": "archived",
+                "pinned": False,
+                "last_used": None,
+            }
+        )
+
+    if args.json:
+        print(json.dumps({"skills": rows}, indent=2))
+        return 0
+
+    _print_table(rows, stale_days, archive_days)
+    return 0
+
+
+def _print_table(rows: list[dict], stale_days: int, archive_days: int) -> None:
+    if not rows:
+        print("No skills found.")
+        return
+    header = f"{'Skill':<36} {'Status':<20} {'Pinned':<7} {'Last used'}"
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        pinned_str = "📌" if r["pinned"] else ""
+        last = r["last_used"] or "never"
+        status_label = {
+            "active": "active",
+            "stale": f"⚠ stale (>{stale_days}d)",
+            "archived_candidate": f"🔴 archive-cand (>{archive_days}d)",
+            "never_used": "never used",
+            "archived": "archived",
+        }.get(r["status"], r["status"])
+        print(f"{r['skill']:<36} {status_label:<20} {pinned_str:<7} {last}")
+
+
+def cmd_archive(args, db, now: datetime) -> int:
+    """Archive skills whose last use exceeds --archive-days threshold."""
+    skills_dir: Path = args.skills_dir
+    stale_days: int = args.stale_days
+    archive_days: int = args.archive_days
+    dry_run: bool = args.dry_run
+
+    active_skills = _discover_skills(skills_dir)
+    results = []
+    errors = []
+
+    for name in active_skills:
+        last = _last_used(db, name)
+        status = classify(last, now, stale_days, archive_days)
+        # Only archive skills that have exceeded the full lifecycle (active→stale→archived).
+        # never_used skills have no usage history and must not bypass the 30d/90d state machine.
+        if status != "archived_candidate":
+            continue
+        if _is_pinned(skills_dir, name):
+            results.append(
+                {
+                    "skill": name,
+                    "action": "skipped",
+                    "reason": "pinned",
+                }
+            )
+            continue
+        try:
+            archive_path, backup_path = _archive_skill(skills_dir, name, dry_run)
+            results.append(
+                {
+                    "skill": name,
+                    "action": "archived" if not dry_run else "would-archive",
+                    "archive_path": str(archive_path),
+                    "backup_path": str(backup_path),
+                }
+            )
+        except Exception as exc:
+            errors.append({"skill": name, "error": str(exc)})
+
+    if args.json:
+        print(json.dumps({"dry_run": dry_run, "results": results, "errors": errors}, indent=2))
+    else:
+        prefix = "[DRY RUN] " if dry_run else ""
+        for r in results:
+            if r["action"] in ("archived", "would-archive"):
+                print(f"{prefix}Archived '{r['skill']}' → {r['archive_path']}  (backup: {r['backup_path']})")
+            else:
+                print(f"Skipped '{r['skill']}': {r.get('reason', '')}")
+        for e in errors:
+            print(f"ERROR '{e['skill']}': {e['error']}", file=sys.stderr)
+        if not results and not errors:
+            print("No skills qualify for archiving.")
+
+    return 1 if errors else 0
+
+
+def cmd_pin(args, _db, _now: datetime) -> int:
+    """Pin a skill to prevent archiving."""
+    skills_dir: Path = args.skills_dir
+    dry_run: bool = args.dry_run
+    skill_name: str = args.skill_name
+    try:
+        marker = _pin_skill(skills_dir, skill_name, dry_run)
+        prefix = "[DRY RUN] " if dry_run else ""
+        if args.json:
+            print(json.dumps({"skill": skill_name, "action": "pinned" if not dry_run else "would-pin", "marker": str(marker)}))
+        else:
+            print(f"{prefix}Pinned '{skill_name}' ({marker})")
+        return 0
+    except RuntimeError as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}))
+        else:
+            print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def cmd_unpin(args, _db, _now: datetime) -> int:
+    """Unpin a skill."""
+    skills_dir: Path = args.skills_dir
+    dry_run: bool = args.dry_run
+    skill_name: str = args.skill_name
+    try:
+        removed = _unpin_skill(skills_dir, skill_name, dry_run)
+        prefix = "[DRY RUN] " if dry_run else ""
+        if args.json:
+            print(json.dumps({"skill": skill_name, "action": "unpinned" if not dry_run else "would-unpin", "was_pinned": removed}))
+        else:
+            if removed:
+                print(f"{prefix}Unpinned '{skill_name}'")
+            else:
+                print(f"'{skill_name}' was not pinned.")
+        return 0
+    except Exception as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}))
+        else:
+            print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def cmd_restore(args, _db, _now: datetime) -> int:
+    """Restore an archived skill back to the active skills directory."""
+    skills_dir: Path = args.skills_dir
+    dry_run: bool = args.dry_run
+    skill_name: str = args.skill_name
+    try:
+        dest = _restore_skill(skills_dir, skill_name, dry_run)
+        prefix = "[DRY RUN] " if dry_run else ""
+        if args.json:
+            print(json.dumps({"skill": skill_name, "action": "restored" if not dry_run else "would-restore", "dest": str(dest)}))
+        else:
+            print(f"{prefix}Restored '{skill_name}' → {dest}")
+        return 0
+    except RuntimeError as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}))
+        else:
+            print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="skill-curator",
+        description="Lifecycle manager for installed Agent Skills.",
+        add_help=True,
+    )
+    parser.add_argument(
+        "--skills-dir",
+        type=Path,
+        default=DEFAULT_SKILLS_DIR,
+        metavar="PATH",
+        help=f"Skills directory (default: {DEFAULT_SKILLS_DIR})",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DEFAULT_METRICS_DB,
+        metavar="PATH",
+        help=f"skill-metrics.db path (default: {DEFAULT_METRICS_DB})",
+    )
+    parser.add_argument(
+        "--stale-days",
+        type=int,
+        default=STALE_DAYS_DEFAULT,
+        metavar="N",
+        help=f"Days before a skill is stale (default: {STALE_DAYS_DEFAULT})",
+    )
+    parser.add_argument(
+        "--archive-days",
+        type=int,
+        default=ARCHIVE_DAYS_DEFAULT,
+        metavar="N",
+        help=f"Days before a skill is archived (default: {ARCHIVE_DAYS_DEFAULT})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show proposed actions; perform zero writes",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+
+    sub = parser.add_subparsers(dest="command")
+
+    # list (default)
+    p_list = sub.add_parser("list", help="List skills with lifecycle status (default)")
+
+    # archive
+    p_archive = sub.add_parser("archive", help="Archive skills exceeding --archive-days")
+
+    # pin
+    p_pin = sub.add_parser("pin", help="Pin a skill to prevent archiving")
+    p_pin.add_argument("skill_name", metavar="SKILL")
+
+    # unpin
+    p_unpin = sub.add_parser("unpin", help="Unpin a skill")
+    p_unpin.add_argument("skill_name", metavar="SKILL")
+
+    # restore
+    p_restore = sub.add_parser("restore", help="Restore an archived skill")
+    p_restore.add_argument("skill_name", metavar="SKILL")
+
+    # Allow --dry-run and --json AFTER the subcommand as well as before it.
+    # Use SUPPRESS default so subparser flags only override the global default
+    # when explicitly given (preserving the global --dry-run / --json values).
+    for _sp in (p_list, p_archive, p_pin, p_unpin, p_restore):
+        _sp.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            default=argparse.SUPPRESS,
+            help="Show proposed actions; perform zero writes",
+        )
+        _sp.add_argument(
+            "--json",
+            action="store_true",
+            default=argparse.SUPPRESS,
+            help="Emit JSON output",
+        )
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    # Default subcommand is 'list'
+    if args.command is None:
+        args.command = "list"
+
+    now = datetime.now(timezone.utc)
+    db = _open_db(args.db)
+    try:
+        if args.command == "list":
+            return cmd_list(args, db, now)
+        if args.command == "archive":
+            return cmd_archive(args, db, now)
+        if args.command == "pin":
+            return cmd_pin(args, db, now)
+        if args.command == "unpin":
+            return cmd_unpin(args, db, now)
+        if args.command == "restore":
+            return cmd_restore(args, db, now)
+        print(f"skill-curator: unknown command '{args.command}'", file=sys.stderr)
+        return 2
+    finally:
+        if db is not None:
+            db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -281,6 +281,65 @@ class TestSkDirectCommands(unittest.TestCase):
             "improvement-signals.py not found — sk improvement-signals would break",
         )
 
+    # ------------------------------------------------------------------
+    # skill-curator routing
+    # ------------------------------------------------------------------
+
+    def test_skill_curator(self):
+        self._assert_routes("skill-curator", "skill-curator.py")
+
+    def test_skill_curator_list(self):
+        self._assert_routes("skill-curator", "skill-curator.py", ["list"])
+
+    def test_skill_curator_archive(self):
+        self._assert_routes("skill-curator", "skill-curator.py", ["archive"])
+
+    def test_skill_curator_archive_dry_run(self):
+        self._assert_routes(
+            "skill-curator", "skill-curator.py",
+            ["archive", "--dry-run"],
+        )
+
+    def test_skill_curator_pin(self):
+        self._assert_routes(
+            "skill-curator", "skill-curator.py",
+            ["pin", "my-skill"],
+        )
+
+    def test_skill_curator_unpin(self):
+        self._assert_routes(
+            "skill-curator", "skill-curator.py",
+            ["unpin", "my-skill"],
+        )
+
+    def test_skill_curator_restore(self):
+        self._assert_routes(
+            "skill-curator", "skill-curator.py",
+            ["restore", "my-skill"],
+        )
+
+    def test_skill_curator_json(self):
+        self._assert_routes("skill-curator", "skill-curator.py", ["--json"])
+
+    def test_skill_curator_stale_days(self):
+        self._assert_routes(
+            "skill-curator", "skill-curator.py",
+            ["--stale-days", "14"],
+        )
+
+    def test_skill_curator_archive_days(self):
+        self._assert_routes(
+            "skill-curator", "skill-curator.py",
+            ["--archive-days", "60"],
+        )
+
+    def test_skill_curator_script_exists(self):
+        """skill-curator.py must exist in the tools directory."""
+        self.assertTrue(
+            (TOOLS_DIR / "skill-curator.py").exists(),
+            "skill-curator.py not found — sk skill-curator would break",
+        )
+
 
 class TestSkHooksCompat(unittest.TestCase):
     def test_hooks_run_drops_run_subcommand(self):
@@ -1008,6 +1067,103 @@ class TestBuglogArgValidation(unittest.TestCase):
         rc, _ = self._call_main(["--limit", "50", "--min-confidence", "0.5"])
         self.assertEqual(rc, 0, "Valid --limit and --min-confidence must succeed")
 
+
+
+
+# ---------------------------------------------------------------------------
+# Runtime: prove actual skill-curator.py parser accepts --dry-run after subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestSkillCuratorParserRuntime(unittest.TestCase):
+    """Runtime coverage: load skill-curator.py and verify actual parser behaviour.
+
+    These tests do NOT mock _run; they invoke curator.main() directly so that
+    parser errors (exit code 2) surface as failures rather than being masked
+    by routing stubs.
+    """
+
+    def setUp(self):
+        curator_path = TOOLS_DIR / "skill-curator.py"
+        spec = importlib.util.spec_from_file_location("skill_curator_rt", curator_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        self.curator = mod
+
+        self.tmp = tempfile.mkdtemp(prefix="sc-rt-test-")
+        skill_dir = Path(self.tmp) / "old-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# old-skill\n", encoding="utf-8")
+
+        # Build a minimal DB with a 200-day-old event for old-skill
+        import sqlite3
+        from datetime import datetime, timedelta, timezone
+        db_path = Path(self.tmp) / "skill-metrics.db"
+        db = sqlite3.connect(str(db_path))
+        db.executescript(
+            "CREATE TABLE skill_usage_events ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, skill_name TEXT, "
+            "event TEXT, session_id TEXT, timestamp TEXT);"
+        )
+        ts = (datetime.now(timezone.utc) - timedelta(days=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        db.execute(
+            "INSERT INTO skill_usage_events VALUES (NULL, ?, ?, ?, ?)",
+            ("old-skill", "triggered", "s1", ts),
+        )
+        db.commit()
+        db.close()
+        self.db_path = str(db_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_archive_dry_run_after_subcommand_exits_0(self):
+        """archive --dry-run (flag AFTER subcommand) must exit 0, not 2."""
+        from unittest.mock import patch
+        with patch("builtins.print"):
+            rc = self.curator.main(
+                ["--skills-dir", self.tmp, "--db", self.db_path, "archive", "--dry-run"]
+            )
+        self.assertEqual(rc, 0, "archive --dry-run must not exit with code 2 (parser error)")
+
+    def test_archive_dry_run_zero_writes(self):
+        """archive --dry-run after subcommand must write nothing."""
+        from unittest.mock import patch
+        with patch("builtins.print"):
+            self.curator.main(
+                ["--skills-dir", self.tmp, "--db", self.db_path, "archive", "--dry-run"]
+            )
+        self.assertTrue(
+            (Path(self.tmp) / "old-skill").exists(),
+            "archive --dry-run must not move old-skill",
+        )
+
+    def test_archive_dry_run_json_after_subcommand(self):
+        """archive --dry-run --json (flags after subcommand) must emit parseable JSON."""
+        import json
+        from unittest.mock import patch
+        captured = []
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(a[0])):
+            rc = self.curator.main(
+                [
+                    "--skills-dir", self.tmp,
+                    "--db", self.db_path,
+                    "archive", "--dry-run", "--json",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        self.assertTrue(captured, "JSON output expected but nothing printed")
+        payload = json.loads(captured[0])
+        self.assertTrue(payload["dry_run"], "dry_run flag must be True in JSON output")
+
+    def test_global_dry_run_before_subcommand_still_works(self):
+        """--dry-run before subcommand (legacy form) must still work."""
+        from unittest.mock import patch
+        with patch("builtins.print"):
+            rc = self.curator.main(
+                ["--skills-dir", self.tmp, "--db", self.db_path, "--dry-run", "archive"]
+            )
+        self.assertEqual(rc, 0, "--dry-run before subcommand must exit 0")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_skill_curator.py
+++ b/tests/test_skill_curator.py
@@ -801,5 +801,120 @@ class TestTimezoneNaiveDatetimes(unittest.TestCase):
         self.assertIn(status, ("active", "stale", "archived_candidate"))
 
 
+
+# ---------------------------------------------------------------------------
+# Regression: same-second backup collision (PR review finding #2)
+# ---------------------------------------------------------------------------
+
+
+class TestBackupSameSecondCollision(unittest.TestCase):
+    """Prove _backup_skill() produces unique names even when called twice within the same second."""
+
+    def setUp(self):
+        self.tmp = _make_temp_skills(["my-skill"])
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_same_second_backup_names_are_unique(self):
+        """Two _backup_skill() calls with the same timestamp must not collide."""
+        with patch.object(curator, "_timestamp_str", return_value="20260515T120000Z"):
+            backup1 = curator._backup_skill(self.tmp, "my-skill", dry_run=False)
+            backup2 = curator._backup_skill(self.tmp, "my-skill", dry_run=False)
+        self.assertNotEqual(backup1, backup2, "backup paths must be unique even for same-second calls")
+        self.assertTrue(backup1.exists(), "first backup must be written")
+        self.assertTrue(backup2.exists(), "second backup must be written")
+
+    def test_same_second_counter_suffix_increments(self):
+        """Counter suffix must be appended as .1, .2, … when base name is taken."""
+        with patch.object(curator, "_timestamp_str", return_value="20260515T120000Z"):
+            backup1 = curator._backup_skill(self.tmp, "my-skill", dry_run=False)
+            backup2 = curator._backup_skill(self.tmp, "my-skill", dry_run=False)
+        self.assertTrue(
+            backup2.name.endswith(".1"),
+            f"second backup name should end with '.1', got {backup2.name!r}",
+        )
+
+    def test_dry_run_same_second_returns_same_path(self):
+        """dry_run path is computed without creating dirs, so no counter needed."""
+        with patch.object(curator, "_timestamp_str", return_value="20260515T120000Z"):
+            backup1 = curator._backup_skill(self.tmp, "my-skill", dry_run=True)
+            backup2 = curator._backup_skill(self.tmp, "my-skill", dry_run=True)
+        # Both are non-existent (dry_run); names will match but that's fine — no writes
+        self.assertFalse(backup1.exists(), "dry_run must not write backup")
+        self.assertFalse(backup2.exists(), "dry_run must not write backup")
+
+
+# ---------------------------------------------------------------------------
+# Regression: restore dry_run destination conflict (PR review finding #4)
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreDryRunDestinationConflict(unittest.TestCase):
+    """Prove _restore_skill() dry_run skips destination-exists check."""
+
+    def setUp(self):
+        self.tmp = _make_temp_skills(["live-skill"])
+        # Create archived skill AND a live directory with the same name
+        archive_dir = self.tmp / ".archive" / "conflict-skill"
+        archive_dir.mkdir(parents=True)
+        (archive_dir / "SKILL.md").write_text("# archived\n", encoding="utf-8")
+        live_dir = self.tmp / "conflict-skill"
+        live_dir.mkdir()
+        (live_dir / "SKILL.md").write_text("# live\n", encoding="utf-8")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_restore_dry_run_ignores_destination_conflict(self):
+        """restore --dry-run must succeed (exit 0) even when destination already exists."""
+        with patch("builtins.print"):
+            rc = curator.main(
+                ["--skills-dir", str(self.tmp), "--dry-run", "restore", "conflict-skill"]
+            )
+        self.assertEqual(rc, 0, "restore --dry-run should succeed even when destination exists")
+
+    def test_restore_dry_run_zero_writes_with_destination_conflict(self):
+        """restore --dry-run must not move or modify any files when destination exists."""
+        archive_before = (self.tmp / ".archive" / "conflict-skill").exists()
+        live_before_content = (self.tmp / "conflict-skill" / "SKILL.md").read_text()
+        with patch("builtins.print"):
+            curator.main(
+                ["--skills-dir", str(self.tmp), "--dry-run", "restore", "conflict-skill"]
+            )
+        # Archive source must still be present
+        self.assertTrue(
+            (self.tmp / ".archive" / "conflict-skill").exists(),
+            "dry_run must not move archived skill",
+        )
+        # Live destination must be unchanged
+        self.assertEqual(
+            (self.tmp / "conflict-skill" / "SKILL.md").read_text(),
+            live_before_content,
+            "dry_run must not modify existing destination",
+        )
+
+    def test_restore_non_dry_run_still_raises_on_destination_conflict(self):
+        """restore (non-dry-run) must raise RuntimeError when destination exists."""
+        with patch("builtins.print"), patch("sys.stderr"):
+            rc = curator.main(
+                ["--skills-dir", str(self.tmp), "restore", "conflict-skill"]
+            )
+        self.assertEqual(rc, 1, "restore must fail when destination exists (non-dry-run)")
+        # Archive must remain
+        self.assertTrue(
+            (self.tmp / ".archive" / "conflict-skill").exists(),
+            "archive must remain after failed restore",
+        )
+
+    def test_restore_dry_run_missing_archive_still_errors(self):
+        """restore --dry-run must still return 1 when the archive doesn't exist."""
+        with patch("builtins.print"), patch("sys.stderr"):
+            rc = curator.main(
+                ["--skills-dir", str(self.tmp), "--dry-run", "restore", "nonexistent-skill"]
+            )
+        self.assertEqual(rc, 1, "restore --dry-run must fail when archive is missing")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_skill_curator.py
+++ b/tests/test_skill_curator.py
@@ -1,0 +1,805 @@
+#!/usr/bin/env python3
+"""
+test_skill_curator.py — Regression tests for skill-curator.py.
+
+Covers:
+  - classify(): active / stale / archived_candidate / never_used
+  - _is_pinned(): reads .pinned marker
+  - cmd_archive: archives archive-candidates, skips pinned, backup-before-move
+  - cmd_archive --dry-run: zero writes
+  - pinned skill is never archived (lifecycle protection)
+  - cmd_pin / cmd_unpin: create / remove .pinned marker
+  - cmd_restore: moves archived skill back
+  - DB-less operation: graceful fallback when skill-metrics.db absent
+  - --json output: parseable JSON
+
+Run: python tests/test_skill_curator.py
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+TOOLS_DIR = Path(__file__).parent.parent
+CURATOR_PATH = TOOLS_DIR / "skill-curator.py"
+
+
+def _load_curator():
+    spec = importlib.util.spec_from_file_location("skill_curator", CURATOR_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+curator = _load_curator()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_temp_skills(skills: list[str]) -> Path:
+    """Create a temp skills directory with one SKILL.md per named skill."""
+    tmp = Path(tempfile.mkdtemp(prefix="sc-test-skills-"))
+    for name in skills:
+        skill_dir = tmp / name
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(f"# {name}\nTest skill.\n", encoding="utf-8")
+    return tmp
+
+
+def _make_temp_db(rows: list[tuple[str, str, str]]) -> Path:
+    """Create a temp skill-metrics.db with skill_usage_events rows.
+
+    rows: list of (skill_name, event, timestamp_iso)
+    """
+    tmp_dir = Path(tempfile.mkdtemp(prefix="sc-test-db-"))
+    db_path = tmp_dir / "skill-metrics.db"
+    db = sqlite3.connect(str(db_path))
+    db.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS skill_usage_events (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            skill_name TEXT NOT NULL,
+            event      TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            timestamp  TEXT NOT NULL
+        );
+        """
+    )
+    for skill_name, event, timestamp in rows:
+        db.execute(
+            "INSERT INTO skill_usage_events (skill_name, event, session_id, timestamp) VALUES (?, ?, ?, ?)",
+            (skill_name, event, "test-session", timestamp),
+        )
+    db.commit()
+    db.close()
+    return db_path
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _days_ago(days: float) -> str:
+    dt = _now() - timedelta(days=days)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: classify()
+# ---------------------------------------------------------------------------
+
+
+class TestClassify(unittest.TestCase):
+    def setUp(self):
+        self.now = _now()
+
+    def test_active(self):
+        last = self.now - timedelta(days=10)
+        self.assertEqual(curator.classify(last, self.now, 30, 90), "active")
+
+    def test_stale(self):
+        last = self.now - timedelta(days=45)
+        self.assertEqual(curator.classify(last, self.now, 30, 90), "stale")
+
+    def test_archived_candidate(self):
+        last = self.now - timedelta(days=95)
+        self.assertEqual(curator.classify(last, self.now, 30, 90), "archived_candidate")
+
+    def test_never_used(self):
+        self.assertEqual(curator.classify(None, self.now, 30, 90), "never_used")
+
+    def test_boundary_stale_start(self):
+        # Exactly at stale boundary (30.0d) → stale
+        last = self.now - timedelta(days=30)
+        self.assertEqual(curator.classify(last, self.now, 30, 90), "stale")
+
+    def test_boundary_archive_start(self):
+        # Exactly at archive boundary (90.0d) → archived_candidate
+        last = self.now - timedelta(days=90)
+        self.assertEqual(curator.classify(last, self.now, 30, 90), "archived_candidate")
+
+    def test_custom_thresholds(self):
+        last = self.now - timedelta(days=20)
+        self.assertEqual(curator.classify(last, self.now, 15, 60), "stale")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: pin helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPinHelpers(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_temp_skills(["alpha", "beta"])
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_not_pinned_by_default(self):
+        self.assertFalse(curator._is_pinned(self.tmp, "alpha"))
+
+    def test_pin_creates_marker(self):
+        curator._pin_skill(self.tmp, "alpha", dry_run=False)
+        self.assertTrue((self.tmp / "alpha" / ".pinned").exists())
+        self.assertTrue(curator._is_pinned(self.tmp, "alpha"))
+
+    def test_unpin_removes_marker(self):
+        curator._pin_skill(self.tmp, "alpha", dry_run=False)
+        removed = curator._unpin_skill(self.tmp, "alpha", dry_run=False)
+        self.assertTrue(removed)
+        self.assertFalse(curator._is_pinned(self.tmp, "alpha"))
+
+    def test_unpin_not_pinned_returns_false(self):
+        removed = curator._unpin_skill(self.tmp, "beta", dry_run=False)
+        self.assertFalse(removed)
+
+    def test_pin_dry_run_no_write(self):
+        curator._pin_skill(self.tmp, "alpha", dry_run=True)
+        self.assertFalse((self.tmp / "alpha" / ".pinned").exists())
+
+    def test_pin_missing_skill_raises(self):
+        with self.assertRaises(RuntimeError):
+            curator._pin_skill(self.tmp, "does-not-exist", dry_run=False)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: backup and archive helpers
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveHelpers(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_temp_skills(["my-skill"])
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_backup_creates_copy(self):
+        backup = curator._backup_skill(self.tmp, "my-skill", dry_run=False)
+        self.assertTrue(backup.exists())
+        self.assertTrue((backup / "SKILL.md").exists())
+
+    def test_backup_dry_run_no_write(self):
+        backup = curator._backup_skill(self.tmp, "my-skill", dry_run=True)
+        self.assertFalse(backup.exists())
+
+    def test_archive_moves_directory(self):
+        archive_path, backup_path = curator._archive_skill(self.tmp, "my-skill", dry_run=False)
+        self.assertTrue(archive_path.exists())
+        self.assertTrue(backup_path.exists())
+        # Source should be gone
+        self.assertFalse((self.tmp / "my-skill").exists())
+
+    def test_archive_backup_before_move(self):
+        """Backup must exist even when source is gone after the archive move."""
+        archive_path, backup_path = curator._archive_skill(self.tmp, "my-skill", dry_run=False)
+        # backup_path was written before the move
+        self.assertTrue(backup_path.exists())
+
+    def test_archive_dry_run_no_writes(self):
+        archive_path, backup_path = curator._archive_skill(self.tmp, "my-skill", dry_run=True)
+        # Neither archive path nor backup path should exist
+        self.assertFalse(archive_path.exists())
+        self.assertFalse(backup_path.exists())
+        # Original should still be there
+        self.assertTrue((self.tmp / "my-skill").exists())
+
+    def test_archive_pinned_raises(self):
+        curator._pin_skill(self.tmp, "my-skill", dry_run=False)
+        with self.assertRaises(RuntimeError):
+            curator._archive_skill(self.tmp, "my-skill", dry_run=False)
+
+
+# ---------------------------------------------------------------------------
+# Integration: cmd_archive
+# ---------------------------------------------------------------------------
+
+
+class TestCmdArchive(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_temp_skills(["new-skill", "old-skill", "pinned-skill"])
+        # new-skill: used 5 days ago → active
+        # old-skill: used 100 days ago → archived_candidate
+        # pinned-skill: used 100 days ago but pinned
+        curator._pin_skill(self.tmp, "pinned-skill", dry_run=False)
+        self.db_path = _make_temp_db(
+            [
+                ("new-skill", "triggered", _days_ago(5)),
+                ("new-skill", "loaded", _days_ago(5)),
+                ("old-skill", "triggered", _days_ago(100)),
+                ("old-skill", "loaded", _days_ago(100)),
+                ("pinned-skill", "triggered", _days_ago(100)),
+                ("pinned-skill", "loaded", _days_ago(100)),
+            ]
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        shutil.rmtree(self.db_path.parent, ignore_errors=True)
+
+    def _make_args(self, dry_run=False, json_out=False):
+        class Args:
+            skills_dir = self.tmp
+            db = self.db_path
+            stale_days = 30
+            archive_days = 90
+            dry_run = False
+            json = False
+
+        args = Args()
+        args.dry_run = dry_run
+        args.json = json_out
+        return args
+
+    def test_archive_moves_old_skill(self):
+        args = self._make_args()
+        db = curator._open_db(self.db_path)
+        now = _now()
+        rc = curator.cmd_archive(args, db, now)
+        db.close()
+        self.assertEqual(rc, 0)
+        self.assertFalse((self.tmp / "old-skill").exists())
+        self.assertTrue((self.tmp / ".archive" / "old-skill").exists())
+
+    def test_archive_keeps_active_skill(self):
+        args = self._make_args()
+        db = curator._open_db(self.db_path)
+        now = _now()
+        curator.cmd_archive(args, db, now)
+        db.close()
+        self.assertTrue((self.tmp / "new-skill").exists())
+
+    def test_archive_skips_pinned_skill(self):
+        args = self._make_args()
+        db = curator._open_db(self.db_path)
+        now = _now()
+        curator.cmd_archive(args, db, now)
+        db.close()
+        # pinned-skill should remain in place
+        self.assertTrue((self.tmp / "pinned-skill").exists())
+
+    def test_archive_backup_written_before_move(self):
+        args = self._make_args()
+        db = curator._open_db(self.db_path)
+        now = _now()
+        curator.cmd_archive(args, db, now)
+        db.close()
+        archive_dir = self.tmp / ".archive"
+        backups = [p for p in archive_dir.iterdir() if p.name.startswith(".old-skill.bak.")]
+        self.assertTrue(len(backups) >= 1, "No backup found for old-skill")
+
+    def test_archive_dry_run_no_writes(self):
+        args = self._make_args(dry_run=True)
+        db = curator._open_db(self.db_path)
+        now = _now()
+        with patch("builtins.print"):
+            rc = curator.cmd_archive(args, db, now)
+        db.close()
+        self.assertEqual(rc, 0)
+        # old-skill must still exist
+        self.assertTrue((self.tmp / "old-skill").exists())
+        # .archive must not exist (or be empty of non-backup dirs)
+        archive_dir = self.tmp / ".archive"
+        if archive_dir.exists():
+            real_dirs = [p for p in archive_dir.iterdir() if not p.name.startswith(".")]
+            self.assertEqual(real_dirs, [])
+
+    def test_archive_json_output(self):
+        args = self._make_args(json_out=True)
+        db = curator._open_db(self.db_path)
+        now = _now()
+        captured = []
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(a[0])):
+            curator.cmd_archive(args, db, now)
+        db.close()
+        payload = json.loads(captured[0])
+        self.assertIn("results", payload)
+        self.assertIn("dry_run", payload)
+
+
+# ---------------------------------------------------------------------------
+# Integration: cmd_list
+# ---------------------------------------------------------------------------
+
+
+class TestCmdList(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_temp_skills(["fresh", "old"])
+        self.db_path = _make_temp_db(
+            [
+                ("fresh", "triggered", _days_ago(3)),
+                ("old", "triggered", _days_ago(100)),
+            ]
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        shutil.rmtree(self.db_path.parent, ignore_errors=True)
+
+    def _make_args(self, json_out=False):
+        class Args:
+            skills_dir = self.tmp
+            db = self.db_path
+            stale_days = 30
+            archive_days = 90
+            json = json_out
+
+        return Args()
+
+    def test_list_shows_skills(self):
+        args = self._make_args()
+        db = curator._open_db(self.db_path)
+        captured = []
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(str(a[0]))):
+            curator.cmd_list(args, db, _now())
+        db.close()
+        output = "\n".join(captured)
+        self.assertIn("fresh", output)
+        self.assertIn("old", output)
+
+    def test_list_json_parseable(self):
+        args = self._make_args(json_out=True)
+        db = curator._open_db(self.db_path)
+        captured = []
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(a[0])):
+            curator.cmd_list(args, db, _now())
+        db.close()
+        payload = json.loads(captured[0])
+        self.assertIn("skills", payload)
+        names = [s["skill"] for s in payload["skills"]]
+        self.assertIn("fresh", names)
+        self.assertIn("old", names)
+
+    def test_list_no_db_graceful(self):
+        """cmd_list must not crash when skill-metrics.db is absent."""
+        args = self._make_args()
+        # Pass db=None (simulates missing DB)
+        captured = []
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(str(a[0]))):
+            rc = curator.cmd_list(args, None, _now())
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# Integration: cmd_pin / cmd_unpin via main()
+# ---------------------------------------------------------------------------
+
+
+class TestCmdPinUnpinMain(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_temp_skills(["my-skill"])
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_pin_via_main(self):
+        rc = curator.main(["--skills-dir", str(self.tmp), "pin", "my-skill"])
+        self.assertEqual(rc, 0)
+        self.assertTrue((self.tmp / "my-skill" / ".pinned").exists())
+
+    def test_unpin_via_main(self):
+        (self.tmp / "my-skill" / ".pinned").touch()
+        rc = curator.main(["--skills-dir", str(self.tmp), "unpin", "my-skill"])
+        self.assertEqual(rc, 0)
+        self.assertFalse((self.tmp / "my-skill" / ".pinned").exists())
+
+    def test_pin_dry_run_via_main(self):
+        with patch("builtins.print"):
+            rc = curator.main(["--skills-dir", str(self.tmp), "--dry-run", "pin", "my-skill"])
+        self.assertEqual(rc, 0)
+        self.assertFalse((self.tmp / "my-skill" / ".pinned").exists())
+
+    def test_pin_nonexistent_skill_returns_1(self):
+        with patch("builtins.print"), patch("sys.stderr"):
+            rc = curator.main(["--skills-dir", str(self.tmp), "pin", "ghost-skill"])
+        self.assertEqual(rc, 1)
+
+
+# ---------------------------------------------------------------------------
+# Integration: cmd_restore
+# ---------------------------------------------------------------------------
+
+
+class TestCmdRestore(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_temp_skills(["live-skill"])
+        # Archive one skill manually
+        archive_dir = self.tmp / ".archive" / "old-skill"
+        archive_dir.mkdir(parents=True)
+        (archive_dir / "SKILL.md").write_text("# old-skill\n", encoding="utf-8")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_restore_moves_back(self):
+        rc = curator.main(["--skills-dir", str(self.tmp), "restore", "old-skill"])
+        self.assertEqual(rc, 0)
+        self.assertTrue((self.tmp / "old-skill").exists())
+        self.assertFalse((self.tmp / ".archive" / "old-skill").exists())
+
+    def test_restore_dry_run_no_writes(self):
+        with patch("builtins.print"):
+            rc = curator.main(["--skills-dir", str(self.tmp), "--dry-run", "restore", "old-skill"])
+        self.assertEqual(rc, 0)
+        # archived skill must still be in .archive
+        self.assertTrue((self.tmp / ".archive" / "old-skill").exists())
+
+    def test_restore_missing_returns_1(self):
+        with patch("builtins.print"), patch("sys.stderr"):
+            rc = curator.main(["--skills-dir", str(self.tmp), "restore", "ghost-skill"])
+        self.assertEqual(rc, 1)
+
+
+# ---------------------------------------------------------------------------
+# Integration: default subcommand (list) via main()
+# ---------------------------------------------------------------------------
+
+
+class TestMainDefaultCommand(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_temp_skills(["skill-a"])
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_no_subcommand_defaults_to_list(self):
+        with patch("builtins.print") as mock_print:
+            rc = curator.main(["--skills-dir", str(self.tmp)])
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("skill-a", output)
+
+    def test_help_exits_0(self):
+        with self.assertRaises(SystemExit) as cm:
+            curator.main(["--help"])
+        self.assertEqual(cm.exception.code, 0)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle contract: pinned skill never archived
+# ---------------------------------------------------------------------------
+
+
+class TestPinnedProtection(unittest.TestCase):
+    """Prove the hard invariant: pinned skills are never archived."""
+
+    def setUp(self):
+        self.tmp = _make_temp_skills(["guarded"])
+        curator._pin_skill(self.tmp, "guarded", dry_run=False)
+        # Put it in archive-candidate territory (200 days ago)
+        self.db_path = _make_temp_db(
+            [("guarded", "triggered", _days_ago(200))]
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        shutil.rmtree(self.db_path.parent, ignore_errors=True)
+
+    def test_pinned_skill_not_archived(self):
+        """cmd_archive must never move a pinned skill."""
+        with patch("builtins.print"):
+            rc = curator.main(
+                [
+                    "--skills-dir", str(self.tmp),
+                    "--db", str(self.db_path),
+                    "archive",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        # guarded must still be in skills/
+        self.assertTrue((self.tmp / "guarded").exists())
+        # guarded must NOT be in .archive/
+        self.assertFalse((self.tmp / ".archive" / "guarded").exists())
+
+
+# ---------------------------------------------------------------------------
+# Dry-run contract: zero writes under all subcommands
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunZeroWrites(unittest.TestCase):
+    """Prove --dry-run performs zero filesystem writes in all mutation paths."""
+
+    def setUp(self):
+        self.tmp = _make_temp_skills(["new-one", "old-one"])
+        self.db_path = _make_temp_db(
+            [
+                ("new-one", "triggered", _days_ago(2)),
+                ("old-one", "triggered", _days_ago(200)),
+            ]
+        )
+        self._snapshot = self._take_snapshot()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        shutil.rmtree(self.db_path.parent, ignore_errors=True)
+
+    def _take_snapshot(self) -> set:
+        """Return a frozenset of (relative_path_str, size) for all paths under self.tmp."""
+        return frozenset(
+            (str(p.relative_to(self.tmp)), p.stat().st_size)
+            for p in self.tmp.rglob("*")
+            if p.is_file()
+        )
+
+    def test_dry_run_archive_zero_writes(self):
+        with patch("builtins.print"):
+            curator.main(
+                [
+                    "--skills-dir", str(self.tmp),
+                    "--db", str(self.db_path),
+                    "--dry-run", "archive",
+                ]
+            )
+        after = self._take_snapshot()
+        self.assertEqual(self._snapshot, after, "dry-run wrote files it should not have")
+
+    def test_dry_run_pin_zero_writes(self):
+        with patch("builtins.print"):
+            curator.main(
+                ["--skills-dir", str(self.tmp), "--dry-run", "pin", "new-one"]
+            )
+        after = self._take_snapshot()
+        self.assertEqual(self._snapshot, after, "dry-run pin wrote files it should not have")
+
+
+# ---------------------------------------------------------------------------
+# Regression: parser accepts --dry-run and --json AFTER the subcommand name
+# ---------------------------------------------------------------------------
+
+
+class TestParserSubcommandFlags(unittest.TestCase):
+    """Prove that `archive --dry-run` (flag after subcommand) works correctly."""
+
+    def setUp(self):
+        self.tmp = _make_temp_skills(["old-skill"])
+        self.db_path = _make_temp_db([("old-skill", "triggered", _days_ago(200))])
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        shutil.rmtree(self.db_path.parent, ignore_errors=True)
+
+    def test_archive_dry_run_after_subcommand_exits_0(self):
+        """skill-curator archive --dry-run must exit 0 (not 2)."""
+        with patch("builtins.print"):
+            rc = curator.main(
+                ["--skills-dir", str(self.tmp), "--db", str(self.db_path), "archive", "--dry-run"]
+            )
+        self.assertEqual(rc, 0, "archive --dry-run should exit 0")
+
+    def test_archive_dry_run_after_subcommand_zero_writes(self):
+        """skill-curator archive --dry-run must write nothing."""
+        snapshot_before = frozenset(
+            (str(p.relative_to(self.tmp)), p.stat().st_size)
+            for p in self.tmp.rglob("*") if p.is_file()
+        )
+        with patch("builtins.print"):
+            curator.main(
+                ["--skills-dir", str(self.tmp), "--db", str(self.db_path), "archive", "--dry-run"]
+            )
+        snapshot_after = frozenset(
+            (str(p.relative_to(self.tmp)), p.stat().st_size)
+            for p in self.tmp.rglob("*") if p.is_file()
+        )
+        self.assertEqual(snapshot_before, snapshot_after, "archive --dry-run must not write files")
+
+    def test_archive_json_after_subcommand(self):
+        """skill-curator archive --json must emit parseable JSON."""
+        captured = []
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(a[0])):
+            curator.main(
+                ["--skills-dir", str(self.tmp), "--db", str(self.db_path), "archive", "--json"]
+            )
+        payload = json.loads(captured[0])
+        self.assertIn("results", payload)
+        self.assertIn("dry_run", payload)
+
+    def test_dry_run_before_subcommand_still_works(self):
+        """Legacy form: --dry-run before subcommand must still work."""
+        with patch("builtins.print"):
+            rc = curator.main(
+                ["--skills-dir", str(self.tmp), "--db", str(self.db_path), "--dry-run", "archive"]
+            )
+        self.assertEqual(rc, 0)
+        self.assertTrue((self.tmp / "old-skill").exists(), "dry-run must not move old-skill")
+
+
+# ---------------------------------------------------------------------------
+# Regression: never-used skills must not bypass the 30d/90d lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestNeverUsedLifecycle(unittest.TestCase):
+    """Prove that a never-used skill (no DB row) is not archived by cmd_archive."""
+
+    def setUp(self):
+        self.tmp = _make_temp_skills(["brand-new"])
+        # No DB rows for brand-new → classify() returns "never_used"
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_never_used_not_archived_when_db_missing(self):
+        """With no metrics DB, brand-new skill must not be archived."""
+        with patch("builtins.print"):
+            rc = curator.main(
+                ["--skills-dir", str(self.tmp), "--db", "nonexistent.db", "--json", "archive"]
+            )
+        self.assertEqual(rc, 0)
+        self.assertTrue((self.tmp / "brand-new").exists(), "never-used skill must not be archived")
+
+    def test_never_used_not_archived_dry_run_json(self):
+        """Dry-run JSON output must show empty results for never-used skill."""
+        captured = []
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(a[0])):
+            curator.main(
+                [
+                    "--skills-dir", str(self.tmp),
+                    "--db", "nonexistent.db",
+                    "--dry-run", "--json", "archive",
+                ]
+            )
+        payload = json.loads(captured[0])
+        self.assertEqual(
+            payload["results"], [],
+            "never-used skill must not appear in would-archive results",
+        )
+
+    def test_never_used_shown_in_list(self):
+        """never_used status must still appear in list output."""
+        captured = []
+        with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(a[0])):
+            rc = curator.main(
+                [
+                    "--skills-dir", str(self.tmp),
+                    "--db", "nonexistent.db",
+                    "--json", "list",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        payload = json.loads(captured[0])
+        statuses = {s["skill"]: s["status"] for s in payload["skills"]}
+        self.assertEqual(statuses.get("brand-new"), "never_used")
+
+
+# ---------------------------------------------------------------------------
+# Regression: archive collision guard
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveCollisionGuard(unittest.TestCase):
+    """Prove that _archive_skill() raises when archive destination already exists."""
+
+    def setUp(self):
+        self.tmp = _make_temp_skills(["my-skill"])
+        # Pre-create the archive destination to simulate a collision
+        archive_dest = self.tmp / ".archive" / "my-skill"
+        archive_dest.mkdir(parents=True)
+        (archive_dest / "SKILL.md").write_text("# old-stale\n", encoding="utf-8")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_archive_collision_raises(self):
+        """_archive_skill() must raise RuntimeError when destination exists."""
+        with self.assertRaises(RuntimeError, msg="should raise on existing archive destination"):
+            curator._archive_skill(self.tmp, "my-skill", dry_run=False)
+
+    def test_archive_collision_no_partial_writes(self):
+        """Collision failure must leave the source intact and create no orphaned backup."""
+        try:
+            curator._archive_skill(self.tmp, "my-skill", dry_run=False)
+        except RuntimeError:
+            pass
+        # Source skill must still be present
+        self.assertTrue((self.tmp / "my-skill").exists(), "source skill must survive collision")
+        # No orphaned backup directory must exist — precondition check must fire before backup I/O
+        archive_dir = self.tmp / ".archive"
+        bak_dirs = [
+            p for p in archive_dir.iterdir()
+            if p.name.startswith(".my-skill.bak.")
+        ] if archive_dir.exists() else []
+        self.assertEqual(bak_dirs, [], "collision failure must not leave orphaned backup dirs")
+
+    def test_archive_dry_run_ignores_collision(self):
+        """dry_run must NOT check for collision (it never writes)."""
+        archive_path, backup_path = curator._archive_skill(self.tmp, "my-skill", dry_run=True)
+        # In dry-run, the archive_path is returned but nothing is written
+        self.assertFalse(backup_path.exists(), "dry-run must not write backup")
+        self.assertTrue((self.tmp / "my-skill").exists(), "dry-run must not move source")
+
+
+# ---------------------------------------------------------------------------
+# Regression: timezone-naive timestamps in DB
+# ---------------------------------------------------------------------------
+
+
+class TestTimezoneNaiveDatetimes(unittest.TestCase):
+    """Prove _last_used() normalizes timezone-naive timestamps to UTC."""
+
+    def setUp(self):
+        # Insert a timestamp WITHOUT timezone suffix (no Z, no +00:00)
+        self.tmp_dir = Path(tempfile.mkdtemp(prefix="sc-tz-"))
+        db_path = self.tmp_dir / "skill-metrics.db"
+        db = sqlite3.connect(str(db_path))
+        db.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS skill_usage_events (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                skill_name TEXT NOT NULL,
+                event      TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                timestamp  TEXT NOT NULL
+            );
+            """
+        )
+        # Naive timestamp (no tz suffix)
+        db.execute(
+            "INSERT INTO skill_usage_events (skill_name, event, session_id, timestamp) "
+            "VALUES (?, ?, ?, ?)",
+            ("tz-skill", "triggered", "s1", "2024-01-01T12:00:00"),
+        )
+        db.commit()
+        db.close()
+        self.db_path = db_path
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_naive_timestamp_is_normalized(self):
+        """_last_used() must return a UTC-aware datetime for a naive DB timestamp."""
+        db = curator._open_db(self.db_path)
+        result = curator._last_used(db, "tz-skill")
+        db.close()
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.tzinfo, "_last_used() must return timezone-aware datetime")
+
+    def test_naive_timestamp_classify_does_not_crash(self):
+        """classify() must not raise TypeError when last_used comes from a naive timestamp."""
+        db = curator._open_db(self.db_path)
+        last = curator._last_used(db, "tz-skill")
+        db.close()
+        now = datetime.now(timezone.utc)
+        # Must not raise
+        status = curator.classify(last, now, 30, 90)
+        self.assertIn(status, ("active", "stale", "archived_candidate"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add stdlib-only `sk skill-curator` lifecycle management with list/archive/pin/unpin/restore commands
- enforce archive safety with pinned protection, lifecycle gating, timezone normalization, and pre-I/O collision guards
- document the command surface and add focused CLI/runtime regression coverage

## Verification
- `python tests\test_skill_curator.py`
- `python tests\test_sk_cli.py`
- `python test_fixes.py`
- `python test_security.py`
- `python sk.py skill-curator --json --skills-dir <temp> --db <temp> list`
- `python sk.py skill-curator --dry-run --json --skills-dir <temp> --db <temp> archive`

Closes #124
