### PR TITLE
feat(tentacle): add rich handoff sections

### DIFF
--- a/tentacle.py
+++ b/tentacle.py
@@ -5579,6 +5579,137 @@ def _parse_handoff_quota_metadata(handoff_content: str) -> "tuple[str | None, st
     return None, None
 
 
+def _parse_bullet_list(text: str) -> "list[str]":
+    """Extract items from a bullet list (lines starting with ``-`` or ``*``).
+
+    Returns an empty list for empty/None text or non-list content.
+    """
+    items = []
+    for line in (text or "").splitlines():
+        m = re.match(r"^\s*[-*]\s+(.+)", line)
+        if m:
+            items.append(m.group(1).strip())
+    return items
+
+
+def _parse_files_read(text: str) -> "list[dict]":
+    """Parse ``FILES READ`` section content into path + optional line-range dicts.
+
+    Accepted entry formats::
+
+        - path/to/file.py (lines 1-50)
+        - path/to/file.py (line 42)
+        - path/to/file.py
+
+    Returns a list of ``{"path": str, "lines": str | None}`` dicts.
+    """
+    entries: list[dict] = []
+    for line in (text or "").splitlines():
+        m = re.match(r"^\s*[-*]\s+(.+)", line)
+        if not m:
+            continue
+        item = m.group(1).strip()
+        range_m = re.match(r"^(.+?)\s+\(lines?\s+([0-9]+-[0-9]+|[0-9]+)\)\s*$", item, re.IGNORECASE)
+        if range_m:
+            entries.append({"path": range_m.group(1).strip(), "lines": range_m.group(2).strip()})
+        else:
+            entries.append({"path": item, "lines": None})
+    return entries
+
+
+def _strip_trailing_legacy_receipts(text: str) -> str:
+    """Remove the appended legacy receipt block from the end of the last rich section.
+
+    Rich handoffs append the backward-compatible ``STATUS:``, ``Changed:``,
+    ``Bridge:``, ``QUOTA_REASON:``, and ``RETRY_HINT:`` lines *after* all rich
+    sections, separated from the final section body by a blank line. Only that
+    trailing receipt block should be removed; section content that merely
+    contains lookalike lines must be preserved.
+    """
+    if not text:
+        return text
+    allowlisted_statuses = "|".join(re.escape(status) for status in sorted(HANDOFF_STATUS_ALLOWLIST))
+    receipt_line = (
+        rf"(?:STATUS:\s*(?:{allowlisted_statuses})"
+        r"|Changed:\s*.+"
+        r"|Bridge:\s*.+"
+        r"|QUOTA_REASON:\s*.+"
+        r"|RETRY_HINT:\s*.+)"
+    )
+    match = re.search(
+        rf"\n\n(?=(?:{receipt_line})(?:\n(?:{receipt_line}))*\s*\Z)",
+        text,
+    )
+    if match:
+        return text[: match.start()]
+    return text
+
+
+def _rich_optional_text(value: str | None) -> str | None:
+    """Normalize absent rich text sections to ``None``.
+
+    The writer uses the literal text ``None`` as a human-readable placeholder for
+    omitted optional rich text sections. Machine readers should see those as
+    missing values rather than the string ``"None"``.
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped or stripped == "None":
+        return None
+    return stripped
+
+
+def _parse_rich_handoff_sections(handoff_content: str) -> dict:
+    """Parse rich 8-section handoff data from the most-recent handoff entry.
+
+    Looks for ``### SECTION NAME`` markers within the most-recent timestamp
+    section (``## [...]``).  Returns a dict with parsed rich section data, or
+    an empty dict when the handoff is a legacy free-form / STATUS+Changed-only
+    entry (backward-compatible: never raises).
+
+    Returned keys (all optional / None / [] when absent):
+    ``summary``, ``decision_points``, ``unresolved_blockers``, ``files_read``,
+    ``files_modified``, ``next_agent_instructions``, ``output``.
+    """
+    if not handoff_content:
+        return {}
+    raw_sections = re.split(r"^## \[", handoff_content, flags=re.MULTILINE)
+    # Inspect ONLY the latest entry.  If the latest entry has no rich ### markers
+    # return {} immediately — this prevents stale rich sections from an older entry
+    # bleeding into meta when the most-recent handoff is a legacy free-form entry.
+    if len(raw_sections) < 2:
+        return {}
+    target = raw_sections[-1]
+    if not re.search(r"^### ", target, flags=re.MULTILINE):
+        return {}
+
+    # Split on ### headers → alternating [pre, name, content, name, content, ...]
+    parts = re.split(r"^### (.+)$", target, flags=re.MULTILINE)
+    rich: dict = {}
+    i = 1
+    while i < len(parts) - 1:
+        section_name = parts[i].strip()
+        section_body = parts[i + 1]
+        if i + 1 == len(parts) - 1:
+            section_body = _strip_trailing_legacy_receipts(section_body)
+        rich[section_name] = section_body.strip()
+        i += 2
+
+    return {
+        # SUMMARY is required for rich handoffs, so preserve literal text such
+        # as "None" instead of treating it like an omitted optional section.
+        "summary": rich.get("SUMMARY") or None,
+        "status": _rich_optional_text(rich.get("STATUS")),
+        "decision_points": _parse_bullet_list(rich.get("DECISION POINTS", "")),
+        "unresolved_blockers": _parse_bullet_list(rich.get("UNRESOLVED BLOCKERS", "")),
+        "files_read": _parse_files_read(rich.get("FILES READ", "")),
+        "files_modified": _parse_bullet_list(rich.get("FILES MODIFIED", "")),
+        "next_agent_instructions": _rich_optional_text(rich.get("NEXT AGENT INSTRUCTIONS")),
+        "output": _rich_optional_text(rich.get("OUTPUT")),
+    }
+
+
 def cmd_handoff(args):
     """Write a handoff message for a tentacle (agent output)."""
     tentacles = get_tentacles_dir(args.session_dir)
@@ -5608,10 +5739,90 @@ def cmd_handoff(args):
         )
         sys.exit(1)
 
+    # Collect optional rich-section args (all are None/[] when omitted).
+    rich_summary: str | None = getattr(args, "summary", None) or None
+    rich_decisions: list[str] = list(getattr(args, "decision", None) or [])
+    rich_blockers: list[str] = list(getattr(args, "blocker", None) or [])
+    rich_files_read: list[str] = list(getattr(args, "file_read", None) or [])
+    rich_next_instructions: str | None = getattr(args, "next_instructions", None) or None
+    rich_output: str | None = getattr(args, "output_text", None) or None
+
+    # FILES MODIFIED rich section mirrors the legacy changed_file receipts so
+    # both the new parser and the legacy Changed: parser see the same paths.
+    rich_files_modified: list[str] = list(changed_files)
+
+    # Rich sections are written only when at least one explicitly new rich arg
+    # is provided.  Presence of --changed-file alone keeps the legacy format.
+    use_rich_sections = any(
+        [
+            rich_summary,
+            rich_decisions,
+            rich_blockers,
+            rich_files_read,
+            rich_next_instructions,
+            rich_output,
+        ]
+    )
+
     handoff_path = tentacle_dir / "handoff.md"
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
-    entry = f"\n## [{timestamp}]\n\n{args.message}\n"
+    if use_rich_sections:
+        # Build the rich 8-section body.
+        body = f"\n## [{timestamp}]\n"
+
+        # Include bare message as a true preamble only when --summary overrides it.
+        # It must stay outside the SUMMARY section so parsing the section returns the
+        # explicit summary text rather than "summary + message" concatenated together.
+        if rich_summary:
+            body += f"\n{args.message}\n"
+
+        # SUMMARY section (falls back to args.message when --summary not given).
+        summary_text = rich_summary or args.message
+        body += f"\n### SUMMARY\n{summary_text}\n"
+
+        body += "\n### DECISION POINTS\n"
+        if rich_decisions:
+            for d in rich_decisions:
+                body += f"- {d}\n"
+        else:
+            body += "None\n"
+
+        body += "\n### UNRESOLVED BLOCKERS\n"
+        if rich_blockers:
+            for b in rich_blockers:
+                body += f"- {b}\n"
+        else:
+            body += "None\n"
+
+        body += "\n### FILES READ\n"
+        if rich_files_read:
+            for fr in rich_files_read:
+                body += f"- {fr}\n"
+        else:
+            body += "None\n"
+
+        body += "\n### FILES MODIFIED\n"
+        if rich_files_modified:
+            for fm in rich_files_modified:
+                body += f"- {fm}\n"
+        else:
+            body += "None\n"
+
+        body += "\n### NEXT AGENT INSTRUCTIONS\n"
+        body += (rich_next_instructions or "None") + "\n"
+
+        body += "\n### OUTPUT\n"
+        body += (rich_output or "None") + "\n"
+
+        body += "\n### STATUS\n"
+        body += (status or "None") + "\n"
+
+        entry = body + "\n"
+    else:
+        entry = f"\n## [{timestamp}]\n\n{args.message}\n"
+
+    # Always append legacy structured lines for backward-compatible parsing.
     if status:
         entry += f"STATUS: {status}\n"
     for cf in changed_files:
@@ -5745,6 +5956,17 @@ def cmd_complete(args):
         changed_files = _parse_handoff_changed_files(raw_handoff)
         bridge_links = _parse_handoff_bridge_links(raw_handoff)
         quota_reason, retry_hint = _parse_handoff_quota_metadata(raw_handoff)
+        # Parse rich 8-section data and merge FILES MODIFIED into changed_files.
+        rich_sections = _parse_rich_handoff_sections(raw_handoff)
+        if rich_sections:
+            for fm_path in rich_sections.get("files_modified") or []:
+                if fm_path and fm_path not in changed_files:
+                    changed_files.append(fm_path)
+            meta["handoff_sections"] = rich_sections
+        elif "handoff_sections" in meta:
+            meta.pop("handoff_sections", None)
+    else:
+        rich_sections = {}
     if terminal_status:
         meta["terminal_status"] = terminal_status
     if changed_files:
@@ -7228,6 +7450,54 @@ def main():
         default=None,
         metavar="HINT",
         help="Optional retry-after hint (ISO timestamp or human-readable) for quota-blocked handoffs",
+    )
+    # Rich 8-section handoff args
+    p_handoff.add_argument(
+        "--summary",
+        dest="summary",
+        default=None,
+        metavar="TEXT",
+        help="Rich SUMMARY section (overrides message as section body; message still echoed as preamble)",
+    )
+    p_handoff.add_argument(
+        "--decision",
+        action="append",
+        dest="decision",
+        metavar="TEXT",
+        default=[],
+        help="DECISION POINTS bullet item (repeatable)",
+    )
+    p_handoff.add_argument(
+        "--blocker",
+        action="append",
+        dest="blocker",
+        metavar="TEXT",
+        default=[],
+        help="UNRESOLVED BLOCKERS bullet item (repeatable)",
+    )
+    p_handoff.add_argument(
+        "--file-read",
+        action="append",
+        dest="file_read",
+        metavar="PATH_OR_RANGE",
+        default=[],
+        help=(
+            "FILES READ entry (repeatable); path or 'path (lines L1-L2)'; e.g. --file-read 'src/foo.py (lines 1-50)'"
+        ),
+    )
+    p_handoff.add_argument(
+        "--next-instructions",
+        dest="next_instructions",
+        default=None,
+        metavar="TEXT",
+        help="NEXT AGENT INSTRUCTIONS section content",
+    )
+    p_handoff.add_argument(
+        "--output-text",
+        dest="output_text",
+        default=None,
+        metavar="TEXT",
+        help="OUTPUT section content",
     )
 
     # swarm

--- a/tests/test_tentacle_runtime.py
+++ b/tests/test_tentacle_runtime.py
@@ -5683,8 +5683,368 @@ class TestHandoffContract(unittest.TestCase):
             ["src/partial.py", "src/shared.py", "src/final.py"],
         )
 
+    # -- Rich 8-section helpers --
 
-# ---------------------------------------------------------------------------
+    def test_parse_bullet_list_empty(self):
+        self.assertEqual(T._parse_bullet_list(""), [])
+        self.assertEqual(T._parse_bullet_list("None"), [])
+
+    def test_parse_bullet_list_basic(self):
+        text = "- item one\n- item two\n* item three\n"
+        self.assertEqual(T._parse_bullet_list(text), ["item one", "item two", "item three"])
+
+    def test_parse_files_read_no_range(self):
+        text = "- src/foo.py\n- tests/bar.py\n"
+        result = T._parse_files_read(text)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], {"path": "src/foo.py", "lines": None})
+        self.assertEqual(result[1], {"path": "tests/bar.py", "lines": None})
+
+    def test_parse_files_read_with_range(self):
+        text = "- src/foo.py (lines 1-50)\n- tests/bar.py (line 42)\n"
+        result = T._parse_files_read(text)
+        self.assertEqual(result[0], {"path": "src/foo.py", "lines": "1-50"})
+        self.assertEqual(result[1], {"path": "tests/bar.py", "lines": "42"})
+
+    def test_parse_files_read_mixed(self):
+        text = "- src/foo.py (lines 1-100)\n- src/bar.py\n"
+        result = T._parse_files_read(text)
+        self.assertEqual(result[0]["lines"], "1-100")
+        self.assertIsNone(result[1]["lines"])
+
+    def test_parse_rich_handoff_sections_returns_empty_for_legacy(self):
+        """Legacy handoff without ### sections returns {}."""
+        content = "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\nAll done.\nSTATUS: DONE\n"
+        result = T._parse_rich_handoff_sections(content)
+        self.assertEqual(result, {})
+
+    def test_parse_rich_handoff_sections_basic(self):
+        content = (
+            "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\n"
+            "### SUMMARY\nAll good.\n\n"
+            "### DECISION POINTS\n- Used X\n\n"
+            "### UNRESOLVED BLOCKERS\nNone\n\n"
+            "### FILES READ\n- src/foo.py (lines 1-10)\n\n"
+            "### FILES MODIFIED\n- src/bar.py\n\n"
+            "### NEXT AGENT INSTRUCTIONS\nRun tests.\n\n"
+            "### OUTPUT\nOutput text here.\n\n"
+            "STATUS: DONE\n"
+        )
+        result = T._parse_rich_handoff_sections(content)
+        self.assertEqual(result["summary"], "All good.")
+        self.assertEqual(result["decision_points"], ["Used X"])
+        self.assertEqual(result["unresolved_blockers"], [])
+        self.assertEqual(result["files_read"], [{"path": "src/foo.py", "lines": "1-10"}])
+        self.assertEqual(result["files_modified"], ["src/bar.py"])
+        self.assertEqual(result["next_agent_instructions"], "Run tests.")
+        self.assertEqual(result["output"], "Output text here.")
+
+    def test_parse_rich_handoff_sections_uses_most_recent_section(self):
+        """When multiple entries exist the most-recent entry's rich sections win."""
+        content = (
+            "# Handoff Notes\n\n## [2024-01-01 11:00 UTC]\n\n"
+            "### SUMMARY\nOld summary.\n\n"
+            "STATUS: BLOCKED\n"
+            "\n## [2024-01-01 12:00 UTC]\n\n"
+            "### SUMMARY\nNew summary.\n\n"
+            "STATUS: DONE\n"
+        )
+        result = T._parse_rich_handoff_sections(content)
+        self.assertEqual(result["summary"], "New summary.")
+
+    def test_parse_rich_handoff_sections_legacy_entry_followed_by_rich(self):
+        """Legacy entry then rich entry → only rich entry's sections returned."""
+        content = (
+            "# Handoff Notes\n\n## [2024-01-01 11:00 UTC]\n\nLegacy prose.\nSTATUS: BLOCKED\n"
+            "\n## [2024-01-01 12:00 UTC]\n\n### SUMMARY\nDone now.\n\nSTATUS: DONE\n"
+        )
+        result = T._parse_rich_handoff_sections(content)
+        self.assertEqual(result["summary"], "Done now.")
+
+    def test_parse_rich_handoff_sections_stale_cleared_by_legacy_latest(self):
+        """Regression: rich older entry + legacy latest entry must return {} (not stale data)."""
+        content = (
+            "# Handoff Notes\n\n## [2024-01-01 11:00 UTC]\n\n"
+            "### SUMMARY\nOld rich summary.\n\n"
+            "### DECISION POINTS\n- Old decision\n\n"
+            "STATUS: BLOCKED\n"
+            "\n## [2024-01-01 12:00 UTC]\n\nNew legacy prose only.\nSTATUS: DONE\n"
+        )
+        result = T._parse_rich_handoff_sections(content)
+        self.assertEqual(result, {}, "Latest legacy entry must clear stale rich sections")
+
+    def test_parse_rich_handoff_sections_preserves_status_like_lines_inside_sections(self):
+        content = (
+            "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\n"
+            "### SUMMARY\nAll good.\n\n"
+            "### DECISION POINTS\n- Used X\n\n"
+            "### UNRESOLVED BLOCKERS\nNone\n\n"
+            "### FILES READ\n- src/foo.py (lines 1-10)\n\n"
+            "### FILES MODIFIED\n- src/bar.py\n\n"
+            "### NEXT AGENT INSTRUCTIONS\nRun tests.\n\nChanged: approach to use Y instead.\nThen deploy.\n\n"
+            "### OUTPUT\nExit code: 0\n\nSTATUS: 4 tests passed\nAll green.\n\n"
+            "STATUS: DONE\nChanged: src/bar.py\n"
+        )
+        result = T._parse_rich_handoff_sections(content)
+        self.assertEqual(
+            result["next_agent_instructions"],
+            "Run tests.\n\nChanged: approach to use Y instead.\nThen deploy.",
+        )
+        self.assertEqual(result["output"], "Exit code: 0\n\nSTATUS: 4 tests passed\nAll green.")
+
+    # -- cmd_handoff with rich sections --
+
+    def test_handoff_rich_sections_written_to_file(self):
+        make_tentacle("ho-rich-write", self.base)
+        args = fake_args(
+            name="ho-rich-write",
+            message="All done",
+            status="DONE",
+            changed_file=["src/a.py"],
+            learn=False,
+            summary="Rich summary",
+            decision=["Chose X"],
+            blocker=["Waiting on Y"],
+            file_read=["src/a.py (lines 1-20)"],
+            next_instructions="Run tests next.",
+            output_text="Tests passed.",
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            T.cmd_handoff(args)
+        content = self._read_handoff("ho-rich-write")
+        self.assertIn("### SUMMARY", content)
+        self.assertIn("Rich summary", content)
+        self.assertIn("### DECISION POINTS", content)
+        self.assertIn("- Chose X", content)
+        self.assertIn("### UNRESOLVED BLOCKERS", content)
+        self.assertIn("- Waiting on Y", content)
+        self.assertIn("### FILES READ", content)
+        self.assertIn("- src/a.py (lines 1-20)", content)
+        self.assertIn("### FILES MODIFIED", content)
+        self.assertIn("- src/a.py", content)
+        self.assertIn("### NEXT AGENT INSTRUCTIONS", content)
+        self.assertIn("Run tests next.", content)
+        self.assertIn("### OUTPUT", content)
+        self.assertIn("Tests passed.", content)
+        self.assertIn("### STATUS", content)
+        self.assertIn("DONE", content)
+        # Legacy lines must still be present for backward compat
+        self.assertIn("STATUS: DONE", content)
+        self.assertIn("Changed: src/a.py", content)
+
+    def test_handoff_rich_summary_round_trips_without_message_bleed(self):
+        """When --summary is supplied, the positional message must not be parsed into SUMMARY."""
+        make_tentacle("ho-rich-summary-roundtrip", self.base)
+        args = fake_args(
+            name="ho-rich-summary-roundtrip",
+            message="Original message preamble",
+            status="DONE",
+            changed_file=["src/a.py"],
+            learn=False,
+            summary="Structured summary",
+            decision=["Chose X"],
+            blocker=[],
+            file_read=["src/a.py (lines 1-20)"],
+            next_instructions="None",
+            output_text="Tests passed.",
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            T.cmd_handoff(args)
+        content = self._read_handoff("ho-rich-summary-roundtrip")
+        parsed = T._parse_rich_handoff_sections(content)
+        self.assertEqual(parsed["summary"], "Structured summary")
+
+    def test_handoff_rich_summary_literal_none_is_preserved(self):
+        """SUMMARY is required, so a literal 'None' summary stays as text."""
+        make_tentacle("ho-rich-summary-literal-none", self.base)
+        args = fake_args(
+            name="ho-rich-summary-literal-none",
+            message="Original message preamble",
+            status="DONE",
+            changed_file=["src/a.py"],
+            learn=False,
+            summary="None",
+            decision=["Chose X"],
+            blocker=[],
+            file_read=["src/a.py (lines 1-20)"],
+            next_instructions="None",
+            output_text="Tests passed.",
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            T.cmd_handoff(args)
+        content = self._read_handoff("ho-rich-summary-literal-none")
+        parsed = T._parse_rich_handoff_sections(content)
+        self.assertEqual(parsed["summary"], "None")
+
+    def test_handoff_rich_optional_text_sections_round_trip_to_none(self):
+        """Omitted optional text sections must parse as None, not the literal string 'None'."""
+        make_tentacle("ho-rich-optional-none", self.base)
+        args = fake_args(
+            name="ho-rich-optional-none",
+            message="Base message",
+            status=None,
+            changed_file=[],
+            learn=False,
+            summary=None,
+            decision=["Chose X"],
+            blocker=[],
+            file_read=[],
+            next_instructions=None,
+            output_text=None,
+        )
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            T.cmd_handoff(args)
+        content = self._read_handoff("ho-rich-optional-none")
+        parsed = T._parse_rich_handoff_sections(content)
+        self.assertIsNone(parsed["status"])
+        self.assertIsNone(parsed["next_agent_instructions"])
+        self.assertIsNone(parsed["output"])
+
+    def test_handoff_without_rich_args_writes_legacy_format(self):
+        """Omitting all rich args produces legacy format (no ### sections)."""
+        make_tentacle("ho-legacy-no-rich", self.base)
+        args = self._handoff_args("ho-legacy-no-rich", "Just a message", status="DONE", changed_file=["src/x.py"])
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            T.cmd_handoff(args)
+        content = self._read_handoff("ho-legacy-no-rich")
+        self.assertNotIn("### SUMMARY", content)
+        self.assertIn("Just a message", content)
+        self.assertIn("STATUS: DONE", content)
+        self.assertIn("Changed: src/x.py", content)
+
+    # -- cmd_complete persists rich sections into meta.json --
+
+    def test_complete_persists_rich_sections_to_meta(self):
+        make_tentacle("ho-complete-rich", self.base)
+        handoff_path = self.base / "ho-complete-rich" / "handoff.md"
+        handoff_path.write_text(
+            "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\n"
+            "### SUMMARY\nAll done.\n\n"
+            "### DECISION POINTS\n- Used X\n\n"
+            "### FILES READ\n- src/foo.py (lines 1-50)\n\n"
+            "### FILES MODIFIED\n- src/bar.py\n\n"
+            "### UNRESOLVED BLOCKERS\nNone\n\n"
+            "### NEXT AGENT INSTRUCTIONS\nNone\n\n"
+            "### OUTPUT\nPassed.\n\n"
+            "STATUS: DONE\nChanged: src/bar.py\n",
+            encoding="utf-8",
+        )
+        args = self._complete_args("ho-complete-rich")
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            T.cmd_complete(args)
+        meta = self._read_meta("ho-complete-rich")
+        self.assertIn("handoff_sections", meta)
+        hs = meta["handoff_sections"]
+        self.assertEqual(hs["summary"], "All done.")
+        self.assertEqual(hs["decision_points"], ["Used X"])
+        self.assertEqual(hs["files_read"], [{"path": "src/foo.py", "lines": "1-50"}])
+        self.assertEqual(hs["files_modified"], ["src/bar.py"])
+        self.assertEqual(hs["output"], "Passed.")
+
+    def test_complete_merges_files_modified_into_changed_files(self):
+        """FILES MODIFIED paths not already in Changed: lines are merged into changed_files."""
+        make_tentacle("ho-merge-fm", self.base)
+        handoff_path = self.base / "ho-merge-fm" / "handoff.md"
+        handoff_path.write_text(
+            "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\n"
+            "### SUMMARY\nDone.\n\n"
+            "### FILES MODIFIED\n- src/extra.py\n- src/shared.py\n\n"
+            "STATUS: DONE\nChanged: src/shared.py\n",
+            encoding="utf-8",
+        )
+        args = self._complete_args("ho-merge-fm")
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            T.cmd_complete(args)
+        meta = self._read_meta("ho-merge-fm")
+        changed = meta.get("changed_files", [])
+        self.assertIn("src/shared.py", changed)
+        self.assertIn("src/extra.py", changed)
+
+    def test_complete_legacy_handoff_no_rich_sections_no_handoff_sections_key(self):
+        """Legacy handoff without ### sections must not write handoff_sections to meta."""
+        make_tentacle("ho-complete-legacy-rich", self.base)
+        handoff_path = self.base / "ho-complete-legacy-rich" / "handoff.md"
+        handoff_path.write_text(
+            "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\nAll done.\nSTATUS: DONE\n",
+            encoding="utf-8",
+        )
+        args = self._complete_args("ho-complete-legacy-rich")
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            T.cmd_complete(args)
+        meta = self._read_meta("ho-complete-legacy-rich")
+        self.assertNotIn("handoff_sections", meta)
+        # Terminal status still extracted
+        self.assertEqual(meta.get("terminal_status"), "DONE")
+
+    def test_complete_rich_sections_do_not_break_terminal_status(self):
+        """Rich-section handoff must still populate terminal_status in meta."""
+        make_tentacle("ho-rich-status", self.base)
+        handoff_path = self.base / "ho-rich-status" / "handoff.md"
+        handoff_path.write_text(
+            "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\n### SUMMARY\nDone.\n\nSTATUS: DONE\n",
+            encoding="utf-8",
+        )
+        args = self._complete_args("ho-rich-status")
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            T.cmd_complete(args)
+        meta = self._read_meta("ho-rich-status")
+        self.assertEqual(meta.get("terminal_status"), "DONE")
+        self.assertIn("handoff_sections", meta)
+
+    def test_parse_rich_handoff_sections_status_field(self):
+        """### STATUS section value is returned in handoff_sections['status']."""
+        content = (
+            "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\n"
+            "### SUMMARY\nAll good.\n\n"
+            "### STATUS\nDONE\n\n"
+            "STATUS: DONE\n"
+        )
+        result = T._parse_rich_handoff_sections(content)
+        self.assertEqual(result["status"], "DONE")
+        self.assertEqual(result["summary"], "All good.")
+
+    def test_complete_persists_handoff_sections_with_status(self):
+        """handoff_sections in meta.json must include 'status' when ### STATUS is present."""
+        make_tentacle("ho-complete-with-status", self.base)
+        handoff_path = self.base / "ho-complete-with-status" / "handoff.md"
+        handoff_path.write_text(
+            "# Handoff Notes\n\n## [2024-01-01 12:00 UTC]\n\n"
+            "### SUMMARY\nAll done.\n\n"
+            "### STATUS\nDONE\n\n"
+            "### FILES MODIFIED\n- src/foo.py\n\n"
+            "STATUS: DONE\nChanged: src/foo.py\n",
+            encoding="utf-8",
+        )
+        args = self._complete_args("ho-complete-with-status")
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            T.cmd_complete(args)
+        meta = self._read_meta("ho-complete-with-status")
+        self.assertIn("handoff_sections", meta)
+        hs = meta["handoff_sections"]
+        self.assertEqual(hs["status"], "DONE")
+        self.assertEqual(hs["summary"], "All done.")
+
+    def test_complete_stale_rich_cleared_when_latest_entry_is_legacy(self):
+        """Regression: if earlier entry is rich but latest is legacy, handoff_sections is absent."""
+        make_tentacle("ho-stale-rich", self.base)
+        handoff_path = self.base / "ho-stale-rich" / "handoff.md"
+        handoff_path.write_text(
+            "# Handoff Notes\n\n## [2024-01-01 11:00 UTC]\n\n"
+            "### SUMMARY\nOld rich entry.\n\n"
+            "STATUS: BLOCKED\n"
+            "\n## [2024-01-01 12:00 UTC]\n\nNew legacy entry.\nSTATUS: DONE\n",
+            encoding="utf-8",
+        )
+        args = self._complete_args("ho-stale-rich")
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            T.cmd_complete(args)
+        meta = self._read_meta("ho-stale-rich")
+        # Stale rich sections from older entry must NOT appear
+        self.assertNotIn("handoff_sections", meta)
+        # But legacy terminal_status from latest entry must still work
+        self.assertEqual(meta.get("terminal_status"), "DONE")
+
+
 # Concurrent marker stress tests — verify file_locked prevents data loss
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add the rich 8-section tentacle handoff writer/parser
- persist parsed handoff sections into meta.json while preserving legacy STATUS:/Changed: behavior
- add runtime regression coverage for rich and legacy handoffs

## Verification
- python -m py_compile tentacle.py tests/test_tentacle_runtime.py tests/test_tentacle_goal.py tests/test_sk_cli.py
- ruff check tentacle.py tests/test_tentacle_runtime.py
- ruff format --check tentacle.py tests/test_tentacle_runtime.py
- python tests/test_tentacle_runtime.py
- python tests/test_tentacle_goal.py
- python tests/test_sk_cli.py
- python test_fixes.py
- python test_security.py

Closes #106