### PR TITLE
feat: classify tentacle verification blocker severity

### DIFF
--- a/tentacle.py
+++ b/tentacle.py
@@ -1465,12 +1465,19 @@ def _run_and_record_verification(
     cmd: str,
     label: str,
     timeout: int = 120,
+    severity: str = "HIGH",
+    source: str = "verify",
 ) -> tuple[int, dict]:
     """Run a shell command and append the result to meta["verifications"].
 
     Determines the working directory from the tentacle's worktree or git root.
     Writes a log file under tentacle_dir/verification/.
     Updates meta in-place and writes meta_path.
+
+    *severity* controls how cmd_complete handles a failing record:
+    CRITICAL/HIGH block completion; MEDIUM/LOW produce warnings only.
+    Defaults to HIGH for backward compatibility.
+    *source* distinguishes regular verify evidence from auto-verify evidence.
 
     Returns (exit_code, verif_record). Does NOT call sys.exit — callers decide.
     """
@@ -1517,11 +1524,17 @@ def _run_and_record_verification(
 
     log_path.write_text(output, encoding="utf-8")
 
+    severity_norm = str(severity or "HIGH").upper()
+    if severity_norm not in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
+        severity_norm = "HIGH"
+
     verif_record = {
         "label": label,
         "command": cmd,
         "cwd": cwd,
         "exit_code": exit_code,
+        "severity": severity_norm,
+        "source": str(source or "verify"),
         "started_at": started_at,
         "finished_at": finished_at,
         "duration_seconds": duration,
@@ -1534,6 +1547,32 @@ def _run_and_record_verification(
     meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
 
     return exit_code, verif_record
+
+
+def _is_legacy_auto_verify_match(record: dict, current_auto_verify_record: dict | None) -> bool:
+    """Best-effort match for pre-severity auto-verify records during a successful rerun.
+
+    Older records created before explicit source/severity fields are ambiguous when
+    they use the default label derived from the command text. To preserve fail-open
+    semantics without silently overriding unrelated failing evidence, treat only the
+    current invocation's successfully rerun same-command legacy records as auto-verify
+    evidence. A failing current auto-verify rerun does not suppress legacy records.
+    """
+    if not isinstance(current_auto_verify_record, dict):
+        return False
+    if current_auto_verify_record.get("exit_code") != 0:
+        return False
+
+    cmd_norm = str(current_auto_verify_record.get("command") or "").strip()
+    if not cmd_norm:
+        return False
+    if record.get("source") or record.get("severity"):
+        return False
+    if str(record.get("command") or "").strip() != cmd_norm:
+        return False
+
+    label = str(record.get("label") or "").strip()
+    return not label or label == cmd_norm[:40].strip()
 
 
 def cmd_verify(args) -> None:
@@ -1551,6 +1590,7 @@ def cmd_verify(args) -> None:
     cmd = getattr(args, "verify_command", None) or getattr(args, "command", "")
     label = args.label if getattr(args, "label", None) else cmd[:40].strip()
     timeout = getattr(args, "timeout", 120) or 120
+    severity = str(getattr(args, "severity", "HIGH") or "HIGH").upper()
 
     exit_code, verif_record = _run_and_record_verification(
         tentacle_dir=tentacle_dir,
@@ -1559,10 +1599,13 @@ def cmd_verify(args) -> None:
         cmd=cmd,
         label=label,
         timeout=timeout,
+        severity=severity,
     )
 
     icon = "✅" if exit_code == 0 else "❌"
-    print(f"{icon} verify [{label}]: exit={exit_code} ({verif_record['duration_seconds']:.1f}s)")
+    print(
+        f"{icon} verify [{label}] [{verif_record['severity']}]: exit={exit_code} ({verif_record['duration_seconds']:.1f}s)"
+    )
     print(f"   cwd: {verif_record['cwd']}")
     print(f"   log: {verif_record['log_path']}")
 
@@ -5896,6 +5939,7 @@ def cmd_complete(args):
     strict_verify = getattr(args, "strict_verify", False)
     auto_verify_cmd = getattr(args, "auto_verify", None)
     auto_verify_failed = False
+    current_auto_verify_record = None
     if auto_verify_cmd:
         meta_pre = json.loads(meta_path.read_text(encoding="utf-8")) if meta_path.exists() else {}
         label = auto_verify_cmd[:40].strip()
@@ -5908,7 +5952,10 @@ def cmd_complete(args):
             cmd=auto_verify_cmd,
             label=label,
             timeout=timeout,
+            severity="MEDIUM",
+            source="auto_verify",
         )
+        current_auto_verify_record = av_rec
         icon = "✅" if av_exit == 0 else "❌"
         print(f"{icon} auto-verify exit={av_exit} ({av_rec['duration_seconds']:.1f}s)")
         if av_exit != 0:
@@ -5937,12 +5984,47 @@ def cmd_complete(args):
 
     # 2. Update status
     meta = json.loads(meta_path.read_text(encoding="utf-8")) if meta_path.exists() else {}
-    meta["status"] = "completed"
-    meta["completed_at"] = datetime.now(timezone.utc).isoformat()
 
     # 2a. Warn if no verification evidence (fail-open: warn only, never block)
     if not (meta.get("verifications") or []):
         print("⚠️  No verification evidence recorded — run 'verify' or use --auto-verify before completing")
+
+    # 2b. Gate on failing CRITICAL/HIGH verification entries; MEDIUM/LOW are warnings only.
+    _BLOCKING_SEVERITIES = {"CRITICAL", "HIGH"}
+    blocking_failures = []
+    warning_failures = []
+    legacy_auto_verify_matches = []
+    for v in meta.get("verifications") or []:
+        if v.get("exit_code", 0) != 0:
+            if v.get("source") == "auto_verify":
+                continue
+            if _is_legacy_auto_verify_match(v, current_auto_verify_record):
+                legacy_auto_verify_matches.append(v)
+                continue
+            sev = str(v.get("severity", "HIGH") or "HIGH").upper()
+            if sev not in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
+                sev = "HIGH"
+            if sev in _BLOCKING_SEVERITIES:
+                blocking_failures.append(v)
+            else:
+                warning_failures.append(v)
+    if legacy_auto_verify_matches:
+        print(
+            "⚠️  Treating legacy verification record(s) matching the current successful "
+            "--auto-verify command as auto-verify evidence for backward compatibility"
+        )
+    for v in warning_failures:
+        sev = str(v.get("severity", "")).upper() or "UNKNOWN"
+        print(f"⚠️  [{sev}] verify failed [{v.get('label', '?')}]: exit={v.get('exit_code')} (warning only)")
+    if blocking_failures:
+        for v in blocking_failures:
+            sev = str(v.get("severity", "HIGH")).upper()
+            print(f"❌ [{sev}] verify failed [{v.get('label', '?')}]: exit={v.get('exit_code')} — BLOCKING")
+        print(f"❌ {len(blocking_failures)} CRITICAL/HIGH verification failure(s) — aborting completion")
+        sys.exit(1)
+
+    meta["status"] = "completed"
+    meta["completed_at"] = datetime.now(timezone.utc).isoformat()
 
     # 2a. Extract structured handoff fields (terminal_status, changed_files, bridge_links, quota metadata)
     terminal_status = None
@@ -7700,6 +7782,15 @@ def main():
         type=int,
         default=120,
         help="Command timeout in seconds (default: 120)",
+    )
+    p_verify.add_argument(
+        "--severity",
+        choices=["CRITICAL", "HIGH", "MEDIUM", "LOW"],
+        default="HIGH",
+        help=(
+            "Severity classification for this verification record (default: HIGH). "
+            "CRITICAL/HIGH failures block cmd_complete; MEDIUM/LOW produce warnings only."
+        ),
     )
 
     # goal subcommand

--- a/tests/test_tentacle_runtime.py
+++ b/tests/test_tentacle_runtime.py
@@ -5018,6 +5018,54 @@ class TestVerifyCommand(unittest.TestCase):
         self.assertTrue((self.tentacle_dir / "verification").exists())
         self.assertTrue(any("verify [cli-dispatch]" in line for line in captured))
 
+    def test_verify_default_severity_is_high(self):
+        """When no --severity is given, the record stores severity=HIGH."""
+        args = self._args("echo default-sev", label="default-sev")
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print"):
+                T.cmd_verify(args)
+        meta = json.loads((self.tentacle_dir / "meta.json").read_text(encoding="utf-8"))
+        verif = meta["verifications"][-1]
+        self.assertEqual(verif["severity"], "HIGH")
+
+    def test_verify_explicit_severity_stored_in_record(self):
+        """Explicit --severity value is stored verbatim (uppercased) in the record."""
+        for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW"):
+            args = fake_args(name="vtest", command=f"echo sev-{sev}", label=f"sev-{sev}", timeout=30, severity=sev)
+            with patch.object(T, "get_tentacles_dir", return_value=self.base):
+                with patch("builtins.print"):
+                    T.cmd_verify(args)
+            meta = json.loads((self.tentacle_dir / "meta.json").read_text(encoding="utf-8"))
+            verif = meta["verifications"][-1]
+            self.assertEqual(verif["severity"], sev, f"Expected severity={sev}")
+
+    def test_verify_severity_in_output(self):
+        """cmd_verify output includes the severity bracket."""
+        captured = []
+        args = fake_args(name="vtest", command="echo sev-out", label="sev-out", timeout=30, severity="CRITICAL")
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch("builtins.print", side_effect=lambda *a, **kw: captured.append(" ".join(str(x) for x in a))):
+                T.cmd_verify(args)
+        self.assertTrue(any("[CRITICAL]" in line for line in captured))
+
+    def test_run_and_record_verification_stores_severity(self):
+        """_run_and_record_verification stores the severity field in the record."""
+        meta_path = self.tentacle_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["verifications"] = []
+
+        _, record = T._run_and_record_verification(
+            tentacle_dir=self.tentacle_dir,
+            meta=meta,
+            meta_path=meta_path,
+            cmd="echo sev-helper",
+            label="sev-helper",
+            timeout=30,
+            severity="MEDIUM",
+        )
+        self.assertEqual(record["severity"], "MEDIUM")
+        self.assertEqual(meta["verifications"][-1]["severity"], "MEDIUM")
+
 
 class TestCompleteOutcomePersistence(unittest.TestCase):
     """cmd_complete writes durable outcome rows to skill-metrics.db."""
@@ -6597,6 +6645,8 @@ class TestCmdCompleteVerification(unittest.TestCase):
         auto_verifs = [v for v in verifications if "echo hello_verify" in v.get("command", "")]
         self.assertEqual(len(auto_verifs), 1)
         self.assertEqual(auto_verifs[0]["exit_code"], 0)
+        self.assertEqual(auto_verifs[0]["source"], "auto_verify")
+        self.assertEqual(auto_verifs[0]["severity"], "MEDIUM")
 
     def test_complete_auto_verify_failing_command_is_fail_open(self):
         """--auto-verify with a failing command warns but still completes (fail-open)."""
@@ -6621,6 +6671,8 @@ class TestCmdCompleteVerification(unittest.TestCase):
         output = out.getvalue()
         # Fail-open: should warn about failed auto-verify
         self.assertIn("auto-verify failed", output)
+        # The completion severity gate must not emit a second warning for the same auto-verify record.
+        self.assertNotIn("[MEDIUM] verify failed", output)
 
         # Status must still be completed
         meta = json.loads((self.tentacle_dir / "meta.json").read_text(encoding="utf-8"))
@@ -6719,10 +6771,208 @@ class TestCmdCompleteVerification(unittest.TestCase):
         # Still appended to meta
         self.assertEqual(len(meta["verifications"]), 1)
 
+    def _make_failing_verif(self, severity: str) -> dict:
+        """Return a verification record fixture with a nonzero exit and given severity."""
+        return {
+            "label": f"fail-{severity.lower()}",
+            "command": "false",
+            "cwd": "/repo",
+            "exit_code": 1,
+            "severity": severity,
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "finished_at": "2026-01-01T00:00:01+00:00",
+            "duration_seconds": 1.0,
+            "log_path": str(self.tentacle_dir / "verification" / f"fake-{severity.lower()}.log"),
+        }
 
-# ---------------------------------------------------------------------------
-# Goal-loop runtime-style verification flow
-# ---------------------------------------------------------------------------
+    def _make_passing_verif(self) -> dict:
+        """Return a passing verification record fixture."""
+        return {
+            "label": "passing",
+            "command": "true",
+            "cwd": "/repo",
+            "exit_code": 0,
+            "severity": "HIGH",
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "finished_at": "2026-01-01T00:00:01+00:00",
+            "duration_seconds": 1.0,
+            "log_path": str(self.tentacle_dir / "verification" / "fake-pass.log"),
+        }
+
+    def test_complete_blocks_on_failing_critical_verification(self):
+        """cmd_complete exits nonzero when a CRITICAL verification has failed."""
+        meta_path = self.tentacle_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["verifications"] = [self._make_failing_verif("CRITICAL")]
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+        import io
+        from contextlib import redirect_stdout
+
+        out = io.StringIO()
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch.object(T, "_clear_dispatched_subagent_marker"):
+                with patch.object(T, "_persist_outcome_metrics", return_value=True):
+                    with self.assertRaises(SystemExit) as cm:
+                        with redirect_stdout(out):
+                            T.cmd_complete(
+                                fake_args(name="verify-test", no_learn=True, auto_verify=None, auto_verify_timeout=120)
+                            )
+        self.assertNotEqual(cm.exception.code, 0)
+        self.assertIn("[CRITICAL]", out.getvalue())
+        self.assertIn("BLOCKING", out.getvalue())
+
+    def test_complete_blocks_on_failing_high_verification(self):
+        """cmd_complete exits nonzero when a HIGH verification has failed."""
+        meta_path = self.tentacle_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["verifications"] = [self._make_failing_verif("HIGH")]
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+        import io
+        from contextlib import redirect_stdout
+
+        out = io.StringIO()
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch.object(T, "_clear_dispatched_subagent_marker"):
+                with patch.object(T, "_persist_outcome_metrics", return_value=True):
+                    with self.assertRaises(SystemExit) as cm:
+                        with redirect_stdout(out):
+                            T.cmd_complete(
+                                fake_args(name="verify-test", no_learn=True, auto_verify=None, auto_verify_timeout=120)
+                            )
+        self.assertNotEqual(cm.exception.code, 0)
+        self.assertIn("[HIGH]", out.getvalue())
+
+    def test_complete_warns_not_blocks_on_failing_medium_verification(self):
+        """cmd_complete completes (does not block) when only a MEDIUM verification has failed."""
+        meta_path = self.tentacle_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["verifications"] = [self._make_failing_verif("MEDIUM")]
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+        import io
+        from contextlib import redirect_stdout
+
+        out = io.StringIO()
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch.object(T, "_clear_dispatched_subagent_marker"):
+                with patch.object(T, "_persist_outcome_metrics", return_value=True):
+                    with redirect_stdout(out):
+                        T.cmd_complete(
+                            fake_args(name="verify-test", no_learn=True, auto_verify=None, auto_verify_timeout=120)
+                        )
+
+        output = out.getvalue()
+        self.assertIn("[MEDIUM]", output)
+        self.assertIn("warning only", output)
+        meta2 = json.loads(meta_path.read_text(encoding="utf-8"))
+        self.assertEqual(meta2["status"], "completed")
+
+    def test_complete_warns_not_blocks_on_failing_low_verification(self):
+        """cmd_complete completes (does not block) when only a LOW verification has failed."""
+        meta_path = self.tentacle_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["verifications"] = [self._make_failing_verif("LOW")]
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+        import io
+        from contextlib import redirect_stdout
+
+        out = io.StringIO()
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch.object(T, "_clear_dispatched_subagent_marker"):
+                with patch.object(T, "_persist_outcome_metrics", return_value=True):
+                    with redirect_stdout(out):
+                        T.cmd_complete(
+                            fake_args(name="verify-test", no_learn=True, auto_verify=None, auto_verify_timeout=120)
+                        )
+
+        output = out.getvalue()
+        self.assertIn("[LOW]", output)
+        self.assertIn("warning only", output)
+        meta2 = json.loads(meta_path.read_text(encoding="utf-8"))
+        self.assertEqual(meta2["status"], "completed")
+
+    def test_complete_not_blocked_when_all_verifications_pass(self):
+        """cmd_complete does not block when all verification entries have exit_code=0."""
+        meta_path = self.tentacle_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["verifications"] = [self._make_passing_verif()]
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+        output = self._run_complete()
+        meta2 = json.loads(meta_path.read_text(encoding="utf-8"))
+        self.assertEqual(meta2["status"], "completed")
+        self.assertNotIn("BLOCKING", output)
+
+    def test_complete_backward_compat_missing_severity_treated_as_high(self):
+        """Records written before severity support (no severity key) block completion on failure."""
+        meta_path = self.tentacle_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        # Old record with no severity field
+        meta["verifications"] = [
+            {
+                "label": "legacy-fail",
+                "command": "false",
+                "cwd": "/repo",
+                "exit_code": 1,
+                "started_at": "2026-01-01T00:00:00+00:00",
+                "finished_at": "2026-01-01T00:00:01+00:00",
+                "duration_seconds": 1.0,
+                "log_path": str(self.tentacle_dir / "verification" / "legacy.log"),
+            }
+        ]
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+        import io
+        from contextlib import redirect_stdout
+
+        out = io.StringIO()
+        with patch.object(T, "get_tentacles_dir", return_value=self.base):
+            with patch.object(T, "_clear_dispatched_subagent_marker"):
+                with patch.object(T, "_persist_outcome_metrics", return_value=True):
+                    with self.assertRaises(SystemExit) as cm:
+                        with redirect_stdout(out):
+                            T.cmd_complete(
+                                fake_args(name="verify-test", no_learn=True, auto_verify=None, auto_verify_timeout=120)
+                            )
+        # Legacy failing record (no severity) defaults to HIGH → blocks
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_complete_backward_compat_matching_legacy_auto_verify_record_stays_fail_open(self):
+        """Legacy auto-verify records matching the current command are retrofitted and stay non-blocking."""
+        meta_path = self.tentacle_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        marker = self.tentacle_dir / "auto-verify-pass.txt"
+        legacy_cmd = (
+            f"{sys.executable} -c \"import pathlib,sys; sys.exit(0 if pathlib.Path(r'{marker}').exists() else 1)\""
+        )
+        meta["verifications"] = [
+            {
+                "label": legacy_cmd[:40].strip(),
+                "command": legacy_cmd,
+                "cwd": "/repo",
+                "exit_code": 1,
+                "started_at": "2026-01-01T00:00:00+00:00",
+                "finished_at": "2026-01-01T00:00:01+00:00",
+                "duration_seconds": 1.0,
+                "log_path": str(self.tentacle_dir / "verification" / "legacy-auto.log"),
+            }
+        ]
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        marker.write_text("ok", encoding="utf-8")
+
+        output = self._run_complete({"auto_verify": legacy_cmd, "auto_verify_timeout": 30})
+        self.assertNotIn("BLOCKING", output)
+        self.assertIn("Treating legacy verification record", output)
+
+        meta2 = json.loads(meta_path.read_text(encoding="utf-8"))
+        self.assertEqual(meta2["status"], "completed")
+        matching = [v for v in meta2.get("verifications", []) if v.get("command") == legacy_cmd]
+        self.assertGreaterEqual(len(matching), 2)
+        self.assertTrue(any(v.get("source") == "auto_verify" for v in matching))
+        self.assertTrue(any(not v.get("source") for v in matching))
 
 
 def _make_octogent_in(base: Path) -> tuple[Path, Path]:


### PR DESCRIPTION
## Summary
- persist explicit verification severity and CLI plumbing for 	entacle verify
- block completion only on failing CRITICAL/HIGH records while keeping --auto-verify fail-open
- cover duplicate-warning and legacy-compat rerun behavior in 	ests/test_tentacle_runtime.py

## Testing
- python -m py_compile tentacle.py tests/test_tentacle_runtime.py tests/test_sk_cli.py
- python -m ruff check tentacle.py tests/test_tentacle_runtime.py
- python -m ruff format --check tentacle.py tests/test_tentacle_runtime.py
- python tests/test_tentacle_runtime.py
- python tests/test_sk_cli.py
- python test_fixes.py
- python test_security.py

Closes #110