### PR TITLE
feat: add tentacle context packets to dispatch bundles

### DIFF
--- a/tentacle.py
+++ b/tentacle.py
@@ -661,10 +661,11 @@ def _render_dispatch_context(context: str, meta: dict, bundle_dir: Path | None) 
     return textwrap.dedent(f"""\
         Runtime bundle is authoritative; inline context is intentionally minimal.
         Read first:
-        1. `{bundle_dir}/manifest.json`
-        2. `{bundle_dir}/session-metadata.md`
-        3. `{bundle_dir}/recall-pack.json`
-        4. `{bundle_dir}/instructions.md` and relevant source files
+        1. `{bundle_dir}/context-packet.md`  ← unified context packet
+        2. `{bundle_dir}/manifest.json`
+        3. `{bundle_dir}/session-metadata.md`
+        4. `{bundle_dir}/recall-pack.json`
+        5. `{bundle_dir}/instructions.md` and relevant source files
 
         Scope: {_scope_summary(meta)}
         Context excerpt: {_context_excerpt(context)}
@@ -1065,6 +1066,205 @@ def _get_marker_state() -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# Context packet helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CONTEXT_PACKET_TEMPLATE = """\
+# Context Packet: {{tentacle_name}}
+
+## Tentacle / Scope / Iteration Header
+
+- **Tentacle:** {{tentacle_name}}
+- **Scope:** {{scope}}
+- **Iteration:** {{iteration}}
+- **Status:** {{status}}
+
+## Task Description
+
+{{task_description}}
+
+## Goal Context
+
+{{goal_context}}
+
+## Previous Handoffs
+
+{{previous_handoffs}}
+
+## Project Conventions
+
+{{project_conventions}}
+
+## Recall Pack
+
+{{recall_pack}}
+
+## Blocker Context
+
+{{blocker_context}}
+"""
+
+
+def _apply_context_packet_template(template: str, subs: dict) -> str:
+    """Replace {{key}} markers in *template* with values from *subs*.
+
+    Unknown keys are left as-is so custom templates with extra markers do not
+    crash.  Uses a regex replace to avoid conflicts with Python f-string braces
+    that might appear in literal template content.
+    """
+
+    def _replacer(m: re.Match) -> str:
+        return subs.get(m.group(1), m.group(0))
+
+    return re.sub(r"\{\{(\w+)\}\}", _replacer, template)
+
+
+def _load_context_packet_template(git_root: "Path | None") -> str:
+    """Load the project-level context-packet template if present.
+
+    Looks for ``.github/context-packet-template.md`` under *git_root*.
+    Falls back to ``_DEFAULT_CONTEXT_PACKET_TEMPLATE`` when the file is
+    absent or unreadable.
+    """
+    if git_root:
+        override = git_root / ".github" / "context-packet-template.md"
+        if override.is_file():
+            try:
+                return override.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                pass
+    return _DEFAULT_CONTEXT_PACKET_TEMPLATE
+
+
+def _blocker_context_from_meta(meta: dict, tentacle_dir: Path) -> str:
+    """Return substantive blocker context when the latest handoff is non-DONE terminal.
+
+    Returns a stable ``None`` placeholder otherwise so the packet is
+    deterministic regardless of run order.
+    """
+    terminal_status = meta.get("terminal_status")
+    if terminal_status not in HANDOFF_TRIAGE_STATUSES:
+        return "None"
+    handoff_path = tentacle_dir / "handoff.md"
+    if not handoff_path.is_file():
+        return f"STATUS: {terminal_status} (see handoff.md — file not present)"
+    try:
+        text = handoff_path.read_text(encoding="utf-8", errors="replace").strip()
+        return text[:600] if len(text) > 600 else text
+    except OSError:
+        return f"STATUS: {terminal_status} (handoff.md unreadable)"
+
+
+def _project_conventions_summary(instr_paths: "list[str]") -> str:
+    """Summarize available instruction sources for the context packet."""
+    if not instr_paths:
+        return "No project instruction files detected.\nSee `bundle/briefing.md` for session-knowledge guidance."
+    shown = instr_paths[:6]
+    lines = [f"- Sources: {', '.join(shown)}"]
+    if len(instr_paths) > len(shown):
+        lines.append(f"- Additional instruction files: {len(instr_paths) - len(shown)}")
+    lines.append("- Full excerpts: `bundle/instructions.md`")
+    lines.append("- Session knowledge: `bundle/briefing.md`")
+    return "\n".join(lines)
+
+
+def _recall_pack_summary(recall_pack_data: "dict | None", recall_source_mode: str | None) -> str:
+    """Summarize the machine-readable recall pack for the context packet."""
+    if not recall_pack_data:
+        return "None — no recall pack data available."
+
+    lines: list[str] = []
+    if recall_source_mode:
+        lines.append(f"- Source mode: {recall_source_mode}")
+
+    tagged = recall_pack_data.get("tagged_entries")
+    if isinstance(tagged, list) and tagged:
+        lines.append(f"- Tagged entries: {len(tagged)}")
+
+    related = recall_pack_data.get("related_entries")
+    if isinstance(related, list) and related:
+        lines.append(f"- Related entries: {len(related)}")
+
+    entries = recall_pack_data.get("entries")
+    if isinstance(entries, dict):
+        populated = []
+        for key, value in entries.items():
+            if isinstance(value, list) and value:
+                populated.append(f"{key}={len(value)}")
+        if populated:
+            lines.append(f"- Entry buckets: {', '.join(populated[:6])}")
+
+    file_matches = recall_pack_data.get("file_matches")
+    if isinstance(file_matches, list) and file_matches:
+        lines.append(f"- File matches: {len(file_matches)}")
+
+    lines.append("- Full payload: `bundle/recall-pack.json`")
+    return "\n".join(lines)
+
+
+def _build_context_packet(
+    name: str,
+    meta: dict,
+    tentacle_dir: Path,
+    context_text: str,
+    goal_context_text: str,
+    prior_handoffs: "list[dict]",
+    recall_pack_data: "dict | None",
+    recall_source_mode: str | None,
+    instr_paths: "list[str]",
+    git_root: "Path | None",
+) -> str:
+    """Render the context-packet.md content for a tentacle bundle.
+
+    Uses the project-level template when present
+    (``.github/context-packet-template.md``), falling back to the built-in
+    default.  All substitution keys use ``{{variable_name}}`` markers so they
+    do not clash with Python f-string syntax.
+    """
+    template = _load_context_packet_template(git_root)
+
+    # ── substitutions ────────────────────────────────────────────────────────
+    scope_str = _scope_summary(meta)
+    task_desc = context_text.strip() or meta.get("description") or "See bundle/session-metadata.md"
+    iteration_str = str(meta.get("goal_iteration") or meta.get("iteration") or "None")
+    status_str = meta.get("status") or "unknown"
+
+    if goal_context_text:
+        goal_section = goal_context_text.strip()
+    else:
+        goal_section = "None — tentacle is not linked to an active goal."
+
+    if prior_handoffs:
+        ph_lines: list[str] = []
+        for entry in prior_handoffs:
+            header = f"[iter-{entry['iteration']} / {entry['tentacle']}]"
+            first_line = entry["summary"].split("\n")[0][:160]
+            ph_lines.append(f"- {header} {first_line}")
+        prev_handoffs_section = "\n".join(ph_lines)
+    else:
+        prev_handoffs_section = "None — first iteration or no prior handoffs recorded."
+
+    project_conventions = _project_conventions_summary(instr_paths)
+    recall_pack_section = _recall_pack_summary(recall_pack_data, recall_source_mode)
+    blocker_section = _blocker_context_from_meta(meta, tentacle_dir)
+
+    subs = {
+        "tentacle_name": name,
+        "scope": scope_str,
+        "iteration": iteration_str,
+        "task_description": task_desc,
+        "status": status_str,
+        "goal_context": goal_section,
+        "previous_handoffs": prev_handoffs_section,
+        "project_conventions": project_conventions,
+        "recall_pack": recall_pack_section,
+        "blocker_context": blocker_section,
+    }
+
+    return _apply_context_packet_template(template, subs)
+
+
 def _build_runtime_bundle(
     tentacle_dir: Path,
     name: str,
@@ -1074,6 +1274,8 @@ def _build_runtime_bundle(
     recall_pack_data: dict | None = None,
     recall_source_mode: str | None = None,
     goal_context_text: str = "",
+    context_packet_goal_context_text: str | None = None,
+    prior_handoffs: "list[dict] | None" = None,
 ) -> Path:
     """Materialize a per-run context bundle under the tentacle workspace.
 
@@ -1190,26 +1392,33 @@ def _build_runtime_bundle(
     todo_path = tentacle_dir / "todo.md"
     handoff_path = tentacle_dir / "handoff.md"
 
+    # Load meta once for reuse in the context packet step below.
+    _bundle_meta: dict = {}
     if meta_path.exists():
         try:
-            meta = json.loads(meta_path.read_text(encoding="utf-8"))
-            meta_lines.append("## Tentacle Meta\n")
-            meta_lines.append(f"- Name: {meta.get('name', name)}")
-            # Surface the actual directory slug for collision-renamed tentacles so
-            # readers know which directory to look in when name != dir_name.
-            dir_name = meta.get("dir_name")
-            if dir_name:
-                meta_lines.append(f"- Slug: {dir_name}")
-            meta_lines.append(f"- Status: {meta.get('status', 'unknown')}")
-            meta_lines.append(f"- Description: {meta.get('description', '')}")
-            meta_lines.append(f"- Created: {meta.get('created_at', '')}")
-            meta_lines.append("")
+            _bundle_meta = json.loads(meta_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             pass
 
+    if _bundle_meta:
+        meta = _bundle_meta
+        meta_lines.append("## Tentacle Meta\n")
+        meta_lines.append(f"- Name: {meta.get('name', name)}")
+        # Surface the actual directory slug for collision-renamed tentacles so
+        # readers know which directory to look in when name != dir_name.
+        dir_name = meta.get("dir_name")
+        if dir_name:
+            meta_lines.append(f"- Slug: {dir_name}")
+        meta_lines.append(f"- Status: {meta.get('status', 'unknown')}")
+        meta_lines.append(f"- Description: {meta.get('description', '')}")
+        meta_lines.append(f"- Created: {meta.get('created_at', '')}")
+        meta_lines.append("")
+
+    context_text = ""
     if context_path.exists():
+        context_text = context_path.read_text(encoding="utf-8", errors="replace")
         meta_lines.append("## Context\n")
-        meta_lines.append(context_path.read_text(encoding="utf-8", errors="replace"))
+        meta_lines.append(context_text)
         meta_lines.append("")
 
     if todo_path.exists():
@@ -1256,7 +1465,32 @@ def _build_runtime_bundle(
             "populated": True,
         }
 
-    # ── 7. Manifest ───────────────────────────────────────────────────────────
+    # ── 7. Context packet (unified agent briefing) ────────────────────────────
+    cp_prior_handoffs: list[dict] = list(prior_handoffs or [])
+    cp_goal_context_text = (
+        context_packet_goal_context_text if context_packet_goal_context_text is not None else goal_context_text
+    )
+    cp_packet = _build_context_packet(
+        name=name,
+        meta=_bundle_meta,
+        tentacle_dir=tentacle_dir,
+        context_text=context_text,
+        goal_context_text=cp_goal_context_text,
+        prior_handoffs=cp_prior_handoffs,
+        recall_pack_data=recall_pack_data,
+        recall_source_mode=recall_source_mode,
+        instr_paths=instr_paths,
+        git_root=git_root,
+    )
+    (bundle_dir / "context-packet.md").write_text(cp_packet, encoding="utf-8")
+    manifest["artifacts"]["context_packet"] = {
+        "file": "context-packet.md",
+        "populated": True,
+        "has_prior_handoffs": bool(cp_prior_handoffs),
+        "has_goal_context": bool(goal_context_text),
+    }
+
+    # ── 8. Manifest ───────────────────────────────────────────────────────────
     if worktree_path:
         manifest["worktree_path"] = worktree_path
     (bundle_dir / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
@@ -4238,18 +4472,25 @@ def _goal_collect_prior_handoffs(state: dict, tentacles: Path, max_handoffs: int
     return summaries[:cap]
 
 
-def _goal_render_continuation_context(state: dict, tentacles: Path, max_handoffs: int = 5) -> str:
+def _goal_render_continuation_context(
+    state: dict,
+    tentacles: Path,
+    max_handoffs: int = 5,
+    include_prior_handoffs: bool = True,
+) -> str:
     """Render a compact goal continuation context block suitable for injection.
 
     Returns a markdown string with objective, iteration, budget, progress,
-    remaining criteria, and prior handoff summaries.
+    remaining criteria, and optionally prior handoff summaries.
     """
     bs = _goal_budget_status(state)
     current_iter = _goal_current_iteration(state)
     criteria: list = state.get("success_criteria") or []
     verified_count = sum(1 for c in criteria if c.get("status") == "verified")
     remaining = [c for c in criteria if c.get("status") != "verified"]
-    prior_handoffs = _goal_collect_prior_handoffs(state, tentacles, max_handoffs=max_handoffs)
+    prior_handoffs = (
+        _goal_collect_prior_handoffs(state, tentacles, max_handoffs=max_handoffs) if include_prior_handoffs else []
+    )
 
     lines: list[str] = ["## Goal Continuation Context"]
     lines.append(f"**Objective:** {state.get('title', '(untitled)')}")
@@ -4276,13 +4517,13 @@ def _goal_render_continuation_context(state: dict, tentacles: Path, max_handoffs
     else:
         lines.append("**Remaining criteria:** (none — all verified or no criteria defined)")
 
-    if prior_handoffs:
+    if include_prior_handoffs and prior_handoffs:
         lines.append(f"**Prior handoff summaries (last {len(prior_handoffs)}):**")
         for entry in prior_handoffs:
             header = f"[iter-{entry['iteration']} / {entry['tentacle']}]"
             summary_first_line = entry["summary"].split("\n")[0][:120]
             lines.append(f"- {header} {summary_first_line}")
-    else:
+    elif include_prior_handoffs:
         lines.append("**Prior handoff summaries:** (none — first iteration or no handoffs written)")
 
     return "\n".join(lines) + "\n"
@@ -6403,6 +6644,22 @@ def cmd_swarm(args):
         else:
             b_recall, b_recall_mode = _fetch_recall_pack_json(args.name, fallback_query=b_fallback)
             b_briefing = _render_recall_payload(args.name, b_recall, b_recall_mode)
+        # Gather goal context if this tentacle is linked to an active goal
+        swarm_goal_context_text = ""
+        swarm_packet_goal_context_text = ""
+        swarm_prior_handoffs: list[dict] = []
+        try:
+            swarm_goal_state = _goal_load(tentacles)
+            if swarm_goal_state and args.name in (swarm_goal_state.get("tentacles") or []):
+                swarm_goal_context_text = _goal_render_continuation_context(swarm_goal_state, tentacles)
+                swarm_packet_goal_context_text = _goal_render_continuation_context(
+                    swarm_goal_state,
+                    tentacles,
+                    include_prior_handoffs=False,
+                )
+                swarm_prior_handoffs = _goal_collect_prior_handoffs(swarm_goal_state, tentacles)
+        except Exception:
+            pass
         bundle_dir = _build_runtime_bundle(
             tentacle_dir=tentacle_dir,
             name=args.name,
@@ -6411,6 +6668,9 @@ def cmd_swarm(args):
             worktree_path=wt_path_str,
             recall_pack_data=b_recall,
             recall_source_mode=b_recall_mode,
+            goal_context_text=swarm_goal_context_text,
+            context_packet_goal_context_text=swarm_packet_goal_context_text,
+            prior_handoffs=swarm_prior_handoffs,
         )
         bundle_section = (
             "\n### Bundle Path\n\n"
@@ -6554,7 +6814,7 @@ Add `--changed-file <path>` once per modified file. Omit if no files changed (e.
                 "escalation": "If scope is insufficient, stop and write a scope escalation note to handoff",
                 "context_bundle": (
                     "Runtime bundles are the default. Read bundle_path/manifest.json first, then "
-                    "session-metadata.md and recall-pack.json before editing."
+                    "context-packet.md, session-metadata.md, and recall-pack.json before editing."
                     if bundle_dir is not None
                     else "No runtime bundle was requested; rely on context_file and inline prompt."
                 ),
@@ -6563,6 +6823,7 @@ Add `--changed-file <path>` once per modified file. Omit if no files changed (e.
         }
         if bundle_dir is not None:
             dispatch["bundle_path"] = str(bundle_dir)
+            dispatch["context_packet_path"] = str(bundle_dir / "context-packet.md")
         if wt_path_str is not None:
             dispatch["worktree_path"] = wt_path_str
         print(json.dumps(dispatch, indent=2))
@@ -6729,10 +6990,18 @@ def cmd_bundle(args):
 
     # Gather goal context text if this tentacle is linked to a goal
     goal_context_text = ""
+    context_packet_goal_context_text = ""
+    bundle_prior_handoffs: list[dict] = []
     try:
         goal_state = _goal_load(tentacles)
         if goal_state and args.name in (goal_state.get("tentacles") or []):
             goal_context_text = _goal_render_continuation_context(goal_state, tentacles)
+            context_packet_goal_context_text = _goal_render_continuation_context(
+                goal_state,
+                tentacles,
+                include_prior_handoffs=False,
+            )
+            bundle_prior_handoffs = _goal_collect_prior_handoffs(goal_state, tentacles)
             if not json_output:
                 print(f"   ✅ Goal context: {len(goal_context_text)} chars")
     except Exception:
@@ -6747,6 +7016,8 @@ def cmd_bundle(args):
         recall_pack_data=recall_pack_data,
         recall_source_mode=recall_source_mode,
         goal_context_text=goal_context_text,
+        context_packet_goal_context_text=context_packet_goal_context_text,
+        prior_handoffs=bundle_prior_handoffs,
     )
 
     # Write dispatched-subagent-active marker when materializing a bundle

--- a/tests/test_tentacle_goal.py
+++ b/tests/test_tentacle_goal.py
@@ -5239,6 +5239,123 @@ class TestGoalContext(unittest.TestCase):
         result = T._goal_collect_prior_handoffs(state, self.tentacles)
         self.assertEqual(result, [])
 
+    # ------------------------------------------------------------------
+    # Context packet — goal-linked bundle tests (issue #111)
+    # ------------------------------------------------------------------
+
+    def test_bundle_includes_context_packet_for_goal_linked_tentacle(self):
+        """Bundle for a goal-linked tentacle must contain context-packet.md."""
+        _make_tentacle("cp-linked", self.tentacles, status="idle")
+        state = T._goal_load(self.tentacles)
+        state["tentacles"] = ["cp-linked"]
+        T._goal_write(self.tentacles, state)
+
+        tentacle_dir = self.tentacles / "cp-linked"
+        goal_ctx = T._goal_render_continuation_context(state, self.tentacles)
+        bundle_dir = T._build_runtime_bundle(
+            tentacle_dir=tentacle_dir,
+            name="cp-linked",
+            goal_context_text=goal_ctx,
+        )
+        self.assertTrue((bundle_dir / "context-packet.md").exists())
+
+    def test_bundle_context_packet_contains_goal_context_for_linked_tentacle(self):
+        """context-packet.md must embed the goal objective when tentacle is linked."""
+        _make_tentacle("cp-goal-embed", self.tentacles, status="idle")
+        state = T._goal_load(self.tentacles)
+        state["tentacles"] = ["cp-goal-embed"]
+        T._goal_write(self.tentacles, state)
+
+        tentacle_dir = self.tentacles / "cp-goal-embed"
+        goal_ctx = T._goal_render_continuation_context(state, self.tentacles)
+        bundle_dir = T._build_runtime_bundle(
+            tentacle_dir=tentacle_dir,
+            name="cp-goal-embed",
+            goal_context_text=goal_ctx,
+        )
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("Context Test Goal", content)
+
+    def test_bundle_context_packet_prior_handoffs_from_goal_iterations(self):
+        """context-packet.md must surface prior handoff summaries when passed via prior_handoffs."""
+        _make_tentacle("cp-prior", self.tentacles, status="completed", terminal_status="DONE")
+        (self.tentacles / "cp-prior" / "handoff.md").write_text("## [DONE]\n\nFixed everything.\n", encoding="utf-8")
+        state = T._goal_load(self.tentacles)
+        state["tentacles"] = ["cp-prior", "cp-current"]
+        state.setdefault("iterations", {})["1"] = {
+            "tentacles": ["cp-prior"],
+            "eval_decision": "continue",
+        }
+        state["iteration"] = 2
+        T._goal_write(self.tentacles, state)
+
+        _make_tentacle("cp-current", self.tentacles, status="idle")
+        prior = T._goal_collect_prior_handoffs(state, self.tentacles)
+        tentacle_dir = self.tentacles / "cp-current"
+        bundle_dir = T._build_runtime_bundle(
+            tentacle_dir=tentacle_dir,
+            name="cp-current",
+            prior_handoffs=prior,
+        )
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("cp-prior", content)
+
+    def test_bundle_context_packet_manifest_has_goal_flags(self):
+        """Bundle manifest must expose has_goal_context and has_prior_handoffs flags."""
+        _make_tentacle("cp-flags", self.tentacles, status="idle")
+        state = T._goal_load(self.tentacles)
+        state["tentacles"] = ["cp-flags"]
+        T._goal_write(self.tentacles, state)
+
+        tentacle_dir = self.tentacles / "cp-flags"
+        goal_ctx = T._goal_render_continuation_context(state, self.tentacles)
+        bundle_dir = T._build_runtime_bundle(
+            tentacle_dir=tentacle_dir,
+            name="cp-flags",
+            goal_context_text=goal_ctx,
+        )
+        manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+        cp = manifest["artifacts"]["context_packet"]
+        self.assertIn("has_goal_context", cp)
+        self.assertIn("has_prior_handoffs", cp)
+        self.assertTrue(cp["has_goal_context"])
+
+    def test_bundle_context_packet_does_not_duplicate_prior_handoff_heading(self):
+        """Goal context and previous-handoffs sections must stay distinct in the packet."""
+        _make_tentacle("cp-prev-distinct", self.tentacles, status="completed", terminal_status="DONE")
+        (self.tentacles / "cp-prev-distinct" / "handoff.md").write_text(
+            "## [DONE]\n\nShipped prior wave.\n",
+            encoding="utf-8",
+        )
+        state = T._goal_load(self.tentacles)
+        state["tentacles"] = ["cp-prev-distinct", "cp-current-distinct"]
+        state.setdefault("iterations", {})["1"] = {
+            "tentacles": ["cp-prev-distinct"],
+            "eval_decision": "continue",
+        }
+        state["iteration"] = 2
+        T._goal_write(self.tentacles, state)
+
+        _make_tentacle("cp-current-distinct", self.tentacles, status="idle")
+        tentacle_dir = self.tentacles / "cp-current-distinct"
+        goal_ctx = T._goal_render_continuation_context(state, self.tentacles)
+        packet_goal_ctx = T._goal_render_continuation_context(
+            state,
+            self.tentacles,
+            include_prior_handoffs=False,
+        )
+        prior = T._goal_collect_prior_handoffs(state, self.tentacles)
+        bundle_dir = T._build_runtime_bundle(
+            tentacle_dir=tentacle_dir,
+            name="cp-current-distinct",
+            goal_context_text=goal_ctx,
+            context_packet_goal_context_text=packet_goal_ctx,
+            prior_handoffs=prior,
+        )
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertNotIn("**Prior handoff summaries", content)
+        self.assertIn("cp-prev-distinct", content)
+
 
 # ---------------------------------------------------------------------------
 # Regression: issue #131 — goal --help discoverability for verify-loop
@@ -5643,6 +5760,7 @@ class TestGoalLoop(unittest.TestCase):
 
     def tearDown(self):
         _rmtree(SCRATCH_DIR)
+
     # -- helpers --
 
     def _add_passing_criterion(self, cid: str = "sc-pass") -> None:
@@ -7108,9 +7226,7 @@ class TestCmdGoalResilienceStatus(unittest.TestCase):
         _, empty_tentacles = _make_octogent(SCRATCH_DIR / "empty_rs")
         captured: list[str] = []
         with patch("builtins.print", side_effect=lambda *a, **k: captured.append(str(a[0]))):
-            T._cmd_goal_resilience_status(
-                _fake_args(goal_action="resilience-status", format="text"), empty_tentacles
-            )
+            T._cmd_goal_resilience_status(_fake_args(goal_action="resilience-status", format="text"), empty_tentacles)
         self.assertTrue(any("No active goal" in line for line in captured))
 
     # --- text output: healthy state ---
@@ -7345,7 +7461,9 @@ class TestCmdGoalResilienceStatus(unittest.TestCase):
             quota_retry_queue=queue,
         )
         self.assertEqual(result["health"], "needs-action")
-        self.assertIsNotNone(result.get("retry_queue"), "retry_queue must be surfaced when quota_retry_queue is present")
+        self.assertIsNotNone(
+            result.get("retry_queue"), "retry_queue must be surfaced when quota_retry_queue is present"
+        )
         self.assertEqual(len(result["retry_queue"]), 1, "all queue entries must appear under retry_queue")
 
     def test_text_budget_limited_shows_needs_action(self):

--- a/tests/test_tentacle_runtime.py
+++ b/tests/test_tentacle_runtime.py
@@ -15,6 +15,7 @@ Does NOT write to /tmp — uses a subdirectory of the tools dir instead.
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import textwrap
@@ -1322,6 +1323,7 @@ class TestBuildRuntimeBundle(unittest.TestCase):
             "session-metadata.md",
             "recall-pack.json",
             "manifest.json",
+            "context-packet.md",
         ):
             self.assertTrue((bundle_dir / fname).exists(), f"Missing: {fname}")
 
@@ -1338,7 +1340,7 @@ class TestBuildRuntimeBundle(unittest.TestCase):
         d = self._make()
         bundle_dir = T._build_runtime_bundle(d, "test-bundle")
         data = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
-        for key in ("briefing", "instructions", "skills", "session_metadata", "recall_pack"):
+        for key in ("briefing", "instructions", "skills", "session_metadata", "recall_pack", "context_packet"):
             self.assertIn(key, data["artifacts"], f"Missing artifact key: {key}")
 
     # ── briefing content ─────────────────────────────────────────────────────
@@ -1538,6 +1540,196 @@ class TestBuildRuntimeBundle(unittest.TestCase):
         T._build_runtime_bundle(d, "test-bundle", recall_pack_data=pack2, recall_source_mode="task_json")
         raw = json.loads((d / "bundle" / "recall-pack.json").read_text(encoding="utf-8"))
         self.assertEqual(raw["tagged_entries"][0]["title"], "second")
+
+    # ── context packet artifact ───────────────────────────────────────────────
+
+    def test_context_packet_file_always_created(self):
+        d = self._make()
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        self.assertTrue((bundle_dir / "context-packet.md").exists())
+
+    def test_context_packet_manifest_key_present(self):
+        d = self._make()
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertIn("context_packet", manifest["artifacts"])
+        self.assertTrue(manifest["artifacts"]["context_packet"]["populated"])
+
+    def test_context_packet_contains_tentacle_name(self):
+        d = self._make()
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("test-bundle", content)
+
+    def test_context_packet_contains_scope_from_meta(self):
+        d = self._make()
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("src/foo.py", content)
+
+    def test_context_packet_contains_task_description(self):
+        d = self._make(desc="Do the special thing")
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("Do the special thing", content)
+
+    def test_context_packet_uses_context_md_content_as_task_description(self):
+        d = self._make(desc="Short meta desc")
+        custom_context = "# Custom Context\n\nDetailed task content from CONTEXT.md.\n"
+        (d / "CONTEXT.md").write_text(custom_context, encoding="utf-8")
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("Detailed task content from CONTEXT.md.", content)
+
+    def test_context_packet_contains_iteration_from_meta(self):
+        d = self._make()
+        meta_path = d / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["goal_iteration"] = 7
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("- **Iteration:** 7", content)
+
+    def test_context_packet_goal_context_none_when_absent(self):
+        d = self._make()
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle", goal_context_text="")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("None", content)
+
+    def test_context_packet_goal_context_injected_when_present(self):
+        d = self._make()
+        bundle_dir = T._build_runtime_bundle(
+            d, "test-bundle", goal_context_text="## Goal Continuation Context\nObjective: ship it"
+        )
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("ship it", content)
+
+    def test_context_packet_manifest_has_goal_context_flag_true(self):
+        d = self._make()
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle", goal_context_text="Some goal text")
+        manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertTrue(manifest["artifacts"]["context_packet"]["has_goal_context"])
+
+    def test_context_packet_manifest_has_goal_context_flag_false_when_absent(self):
+        d = self._make()
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertFalse(manifest["artifacts"]["context_packet"]["has_goal_context"])
+
+    def test_context_packet_prior_handoffs_included(self):
+        d = self._make()
+        prior = [{"tentacle": "prev-tentacle", "iteration": 1, "summary": "Did great things"}]
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle", prior_handoffs=prior)
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("prev-tentacle", content)
+        self.assertIn("Did great things", content)
+
+    def test_context_packet_manifest_has_prior_handoffs_flag_true(self):
+        d = self._make()
+        prior = [{"tentacle": "x", "iteration": 1, "summary": "ok"}]
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle", prior_handoffs=prior)
+        manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertTrue(manifest["artifacts"]["context_packet"]["has_prior_handoffs"])
+
+    def test_context_packet_manifest_has_prior_handoffs_flag_false_when_absent(self):
+        d = self._make()
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertFalse(manifest["artifacts"]["context_packet"]["has_prior_handoffs"])
+
+    def test_context_packet_blocker_context_none_for_done_status(self):
+        d = self._make()
+        meta_path = d / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["terminal_status"] = "DONE"
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        match = re.search(r"## Blocker Context\s*(.+?)\s*\Z", content, flags=re.S)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1).strip(), "None")
+
+    def test_context_packet_blocker_context_contains_handoff_for_blocked_status(self):
+        d = self._make()
+        meta_path = d / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["terminal_status"] = "BLOCKED"
+        meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        (d / "handoff.md").write_text("STATUS: BLOCKED\n\nCannot proceed without X\n", encoding="utf-8")
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        match = re.search(r"## Blocker Context\s*(.+?)\s*\Z", content, flags=re.S)
+        self.assertIsNotNone(match)
+        self.assertIn("Cannot proceed without X", match.group(1))
+
+    def test_context_packet_project_template_override_used_when_present(self):
+        d = self._make()
+        fake_root = self.base / "proj_tpl_repo"
+        fake_root.mkdir(parents=True, exist_ok=True)
+        github_dir = fake_root / ".github"
+        github_dir.mkdir(parents=True, exist_ok=True)
+        custom_tpl = "## CUSTOM HEADER\n\nTentacle: {{tentacle_name}}\nTask: {{task_description}}\n"
+        (github_dir / "context-packet-template.md").write_text(custom_tpl, encoding="utf-8")
+        with patch.object(T, "find_git_root", return_value=fake_root):
+            bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("CUSTOM HEADER", content)
+        self.assertIn("test-bundle", content)
+
+    def test_context_packet_falls_back_to_default_template_when_no_project_override(self):
+        d = self._make()
+        with patch.object(T, "find_git_root", return_value=None):
+            bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        # Default template includes standard sections
+        self.assertIn("Task Description", content)
+        self.assertIn("Goal Context", content)
+        self.assertIn("Blocker Context", content)
+
+    def test_context_packet_summarizes_instruction_sources(self):
+        d = self._make()
+        fake_root = self.base / "proj_conventions_repo"
+        github_dir = fake_root / ".github"
+        github_dir.mkdir(parents=True, exist_ok=True)
+        (github_dir / "copilot-instructions.md").write_text("# Project rules\n", encoding="utf-8")
+        with patch.object(T, "find_git_root", return_value=fake_root):
+            bundle_dir = T._build_runtime_bundle(d, "test-bundle")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn(".github/copilot-instructions.md", content)
+        self.assertIn("bundle/instructions.md", content)
+
+    def test_context_packet_summarizes_recall_pack(self):
+        d = self._make()
+        pack = {"tagged_entries": [{"id": 1, "category": "pattern", "title": "Use packet"}], "related_entries": []}
+        bundle_dir = T._build_runtime_bundle(d, "test-bundle", recall_pack_data=pack, recall_source_mode="task_json")
+        content = (bundle_dir / "context-packet.md").read_text(encoding="utf-8")
+        self.assertIn("Source mode: task_json", content)
+        self.assertIn("Tagged entries: 1", content)
+
+
+class TestRenderDispatchContext(unittest.TestCase):
+    """Tests for _render_dispatch_context updated to reference context-packet.md."""
+
+    def test_no_bundle_returns_raw_context(self):
+        result = T._render_dispatch_context("my context", {}, None)
+        self.assertEqual(result, "my context")
+
+    def test_with_bundle_references_context_packet_first(self):
+        bundle_dir = Path("/some/bundle/path")
+        result = T._render_dispatch_context("ctx", {}, bundle_dir)
+        self.assertIn("context-packet.md", result)
+        lines = result.splitlines()
+        # context-packet.md should come before manifest.json in the read-first list
+        packet_idx = next(i for i, l in enumerate(lines) if "context-packet.md" in l)
+        manifest_idx = next(i for i, l in enumerate(lines) if "manifest.json" in l)
+        self.assertLess(packet_idx, manifest_idx)
+
+    def test_with_bundle_still_lean(self):
+        bundle_dir = Path("/some/bundle")
+        result = T._render_dispatch_context("large " * 500, {"scope": ["a.py"]}, bundle_dir)
+        self.assertIn("Runtime bundle is authoritative", result)
+        self.assertLess(len(result), 2000)
 
 
 class TestCmdBundle(unittest.TestCase):
@@ -1753,7 +1945,9 @@ class TestSwarmBundleFlag(unittest.TestCase):
         idx = output.find("{")
         data, _ = decoder.raw_decode(output, idx)
         self.assertIn("bundle_path", data)
+        self.assertIn("context_packet_path", data)
         self.assertTrue(Path(data["bundle_path"]).exists())
+        self.assertTrue(Path(data["context_packet_path"]).exists())
 
     def test_swarm_bundle_creates_bundle_dir(self):
         d = make_tentacle("sw-test2", self.base)
@@ -1853,7 +2047,9 @@ class TestSwarmBundleFlag(unittest.TestCase):
         idx = out.find("{")
         data, _ = decoder.raw_decode(out, idx)
         self.assertIn("bundle_path", data)
+        self.assertIn("context_packet_path", data)
         self.assertIn("context_bundle", data["execution_guidance"])
+        self.assertIn("context-packet.md", data["execution_guidance"]["context_bundle"])
         recall = json.loads((d / "bundle" / "recall-pack.json").read_text(encoding="utf-8"))
         self.assertEqual(recall["source_mode"], "task_json")
         self.assertEqual(recall["tagged_entries"][0]["title"], "Use runtime bundle")


### PR DESCRIPTION
## Summary
- add bundle\context-packet.md with optional .github\context-packet-template.md overrides
- feed goal context and prior handoffs into dispatch-created bundles without duplicating those sections in the packet
- update prompt and JSON dispatch guidance to point workers at the context packet first

## Testing
- python -m py_compile tentacle.py tests/test_tentacle_runtime.py tests/test_tentacle_goal.py
- python -m ruff check tentacle.py tests/test_tentacle_runtime.py tests/test_tentacle_goal.py
- python -m ruff format --check tentacle.py tests/test_tentacle_runtime.py tests/test_tentacle_goal.py
- python tests/test_tentacle_runtime.py
- python tests/test_tentacle_goal.py
- python tests/test_sk_cli.py
- python test_fixes.py
- python test_security.py

Closes #111