### PR TITLE
feat: manage context blocks in project instruction files

### DIFF
--- a/context-blocks.py
+++ b/context-blocks.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+context-blocks.py - Manage safe, marker-bounded context blocks in agent config files.
+
+Usage:
+    python context-blocks.py upsert --agent copilot "content"
+    python context-blocks.py upsert --agent copilot --block-id "AWS, Docker" "content"
+    python context-blocks.py remove --agent copilot
+    python context-blocks.py remove --agent copilot --block-id "AWS, Docker"
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+from host_manifest import COPILOT_DIR, HOST_INSTRUCTION_FILES  # noqa: E402
+
+DEFAULT_BLOCK_ID = "SESSION-KNOWLEDGE"
+REGISTRY_PATH = COPILOT_DIR / "session-state" / "tools-managed-projects.json"
+_AGENT_ALIASES = {
+    "copilot": "Copilot CLI",
+    "copilot-cli": "Copilot CLI",
+    "github-copilot": "Copilot CLI",
+    "claude": "Claude Code",
+    "claude-code": "Claude Code",
+    "agents": "All agents",
+    "all": "All agents",
+    "all-agents": "All agents",
+}
+
+
+def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_bytes(content.encode(encoding))
+        os.replace(str(tmp), str(path))
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+
+def _load_project_registry() -> list[str]:
+    try:
+        if REGISTRY_PATH.exists():
+            data = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+            paths: list[str] = []
+            for entry in data.get("projects", []):
+                if isinstance(entry, str):
+                    paths.append(entry)
+                elif isinstance(entry, dict):
+                    value = entry.get("path", "")
+                    if isinstance(value, str) and value:
+                        paths.append(value)
+            return paths
+    except Exception:
+        pass
+    return []
+
+
+def _register_project(project_root: Path) -> None:
+    try:
+        key = str(project_root.resolve())
+        raw: list = []
+        if REGISTRY_PATH.exists():
+            try:
+                raw = json.loads(REGISTRY_PATH.read_text(encoding="utf-8")).get("projects", [])
+            except Exception:
+                raw = []
+        existing = set()
+        for entry in raw:
+            if isinstance(entry, str):
+                existing.add(entry)
+            elif isinstance(entry, dict):
+                value = entry.get("path", "")
+                if value:
+                    existing.add(value)
+        if key not in existing:
+            raw.append(key)
+            REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write_text(REGISTRY_PATH, json.dumps({"projects": raw}, indent=2))
+    except Exception:
+        pass
+
+
+def _find_git_root(start: Path | None = None) -> Path:
+    current = (start or Path.cwd()).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def _normalize_agent(agent: str) -> str:
+    key = (agent or "").strip().lower()
+    if key not in _AGENT_ALIASES:
+        allowed = ", ".join(sorted(_AGENT_ALIASES))
+        raise ValueError(f"Unknown --agent '{agent}'. Choose from: {allowed}")
+    return _AGENT_ALIASES[key]
+
+
+def _validate_block_id(block_id: str) -> str:
+    value = (block_id or "").strip()
+    if not value:
+        raise ValueError("--block-id must not be empty")
+    if "<!--" in value or "-->" in value or "\n" in value or "\r" in value:
+        raise ValueError("--block-id cannot contain comment delimiters or newlines")
+    return value
+
+
+def _resolve_target(repo_root: Path, agent: str) -> Path:
+    host_name = _normalize_agent(agent)
+    rel = HOST_INSTRUCTION_FILES[host_name]
+    return repo_root / rel
+
+
+def _detect_newline(text: str) -> str:
+    if "\r\n" in text:
+        return "\r\n"
+    return "\n"
+
+
+def _marker_pair(block_id: str) -> tuple[str, str]:
+    normalized = _validate_block_id(block_id)
+    return f"<!-- {normalized} SK START -->", f"<!-- {normalized} SK END -->"
+
+
+def _line_without_newline(line: str) -> str:
+    return line.rstrip("\r\n")
+
+
+def _find_block_span(lines: list[str], start_marker: str, end_marker: str) -> tuple[int, int] | None:
+    start_indexes = [idx for idx, line in enumerate(lines) if _line_without_newline(line) == start_marker]
+    end_indexes = [idx for idx, line in enumerate(lines) if _line_without_newline(line) == end_marker]
+    if not start_indexes and not end_indexes:
+        return None
+    if len(start_indexes) != 1 or len(end_indexes) != 1:
+        raise ValueError("Managed block markers are duplicated or incomplete")
+    start_idx = start_indexes[0]
+    end_idx = end_indexes[0]
+    if end_idx < start_idx:
+        raise ValueError("Managed block end marker appears before start marker")
+    return start_idx, end_idx
+
+
+def _build_block_lines(content: str, start_marker: str, end_marker: str, newline: str) -> list[str]:
+    normalized = content.replace("\r\n", "\n").replace("\r", "\n")
+    payload = normalized.split("\n")
+    if payload and payload[-1] == "":
+        payload = payload[:-1]
+    block = [start_marker + newline]
+    block.extend(line + newline for line in payload)
+    block.append(end_marker + newline)
+    return block
+
+
+def _upsert_block_text(text: str, content: str, start_marker: str, end_marker: str) -> str:
+    newline = _detect_newline(text)
+    lines = text.splitlines(keepends=True)
+    block_lines = _build_block_lines(content, start_marker, end_marker, newline)
+    span = _find_block_span(lines, start_marker, end_marker)
+    if span is not None:
+        start_idx, end_idx = span
+        lines[start_idx : end_idx + 1] = block_lines
+        return "".join(lines)
+
+    if lines and not lines[-1].endswith(("\n", "\r")):
+        lines[-1] = lines[-1] + newline
+    if lines and _line_without_newline(lines[-1]).strip():
+        lines.append(newline)
+    lines.extend(block_lines)
+    return "".join(lines) if lines else "".join(block_lines)
+
+
+def _remove_block_text(text: str, start_marker: str, end_marker: str) -> tuple[str, bool]:
+    lines = text.splitlines(keepends=True)
+    span = _find_block_span(lines, start_marker, end_marker)
+    if span is None:
+        return text, False
+    start_idx, end_idx = span
+    before = lines[:start_idx]
+    after = lines[end_idx + 1 :]
+
+    if (
+        before
+        and after
+        and not _line_without_newline(before[-1]).strip()
+        and not _line_without_newline(after[0]).strip()
+    ):
+        after = after[1:]
+    if not before:
+        while after and not _line_without_newline(after[0]).strip():
+            after = after[1:]
+    if not after:
+        while before and not _line_without_newline(before[-1]).strip():
+            before = before[:-1]
+
+    return "".join(before + after), True
+
+
+def _upsert_file(target: Path, block_id: str, content: str) -> str:
+    start_marker, end_marker = _marker_pair(block_id)
+    existing = target.read_text(encoding="utf-8") if target.exists() else ""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_text(target, _upsert_block_text(existing, content, start_marker, end_marker))
+    return "updated" if existing else "created"
+
+
+def _remove_file_block(target: Path, block_id: str) -> tuple[str, bool]:
+    if not target.exists():
+        return "missing", False
+    start_marker, end_marker = _marker_pair(block_id)
+    existing = target.read_text(encoding="utf-8")
+    updated, changed = _remove_block_text(existing, start_marker, end_marker)
+    if changed:
+        _atomic_write_text(target, updated)
+        return "removed", True
+    return "absent", False
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="context-blocks",
+        description="Manage safe, marker-bounded content blocks inside project agent config files.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    upsert = sub.add_parser("upsert", help="Create or update a managed block")
+    upsert.add_argument("--agent", required=True, help="Target agent config file (copilot, claude, agents)")
+    upsert.add_argument("--block-id", default=DEFAULT_BLOCK_ID, help="Managed block label shown in markers")
+    upsert.add_argument("--repo", type=Path, default=None, help="Project root (defaults to git root or cwd)")
+    upsert.add_argument("content", help="Managed block content")
+
+    remove = sub.add_parser("remove", help="Remove a managed block only")
+    remove.add_argument("--agent", required=True, help="Target agent config file (copilot, claude, agents)")
+    remove.add_argument("--block-id", default=DEFAULT_BLOCK_ID, help="Managed block label shown in markers")
+    remove.add_argument("--repo", type=Path, default=None, help="Project root (defaults to git root or cwd)")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        repo_root = _find_git_root(args.repo) if args.repo is not None else _find_git_root()
+        target = _resolve_target(repo_root, args.agent)
+        block_id = _validate_block_id(args.block_id)
+    except ValueError as exc:
+        print(f"context-blocks: {exc}", file=sys.stderr)
+        return 2
+
+    if args.command == "upsert":
+        action = _upsert_file(target, block_id, args.content)
+        _register_project(repo_root)
+        print(f"{action}: {target.relative_to(repo_root)} [{block_id}]")
+        return 0
+
+    if args.command == "remove":
+        action, changed = _remove_file_block(target, block_id)
+        if action == "missing":
+            print(f"missing: {target.relative_to(repo_root)}")
+        elif changed:
+            print(f"removed: {target.relative_to(repo_root)} [{block_id}]")
+        else:
+            print(f"absent: {target.relative_to(repo_root)} [{block_id}]")
+        return 0
+
+    print(f"context-blocks: unsupported command '{args.command}'", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/install.py
+++ b/install.py
@@ -36,6 +36,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import re
 import shutil
 import sqlite3
 import subprocess
@@ -99,6 +100,7 @@ def _real_home():
 from host_manifest import (  # noqa: E402
     CLAUDE_DIR,
     COPILOT_DIR,
+    HOST_INSTRUCTION_FILES,
     HOST_SKILL_SUBPATHS,
 )
 from host_manifest import (
@@ -192,6 +194,7 @@ TOOL_FILES = [
     "learn.py",
     "embed.py",
     "claude-adapter.py",
+    "context-blocks.py",
     "sync-knowledge.py",
     "sync-config.py",
     "sync-daemon.py",
@@ -213,6 +216,7 @@ SUPPORT_FILES = [
 SK_LAUNCHER_DIR = HOME / ".copilot" / "bin"
 _SK_PATH_MARKER_START = "# >>> session-knowledge sk launcher >>>"
 _SK_PATH_MARKER_END = "# <<< session-knowledge sk launcher <<<"
+_CONTEXT_START_RE = re.compile(r"^\s*<!--\s*(?P<block>[^\r\n<>]+?)\s+SK START\s*-->\s*$")
 
 # ---------------------------------------------------------------------------
 # Markers
@@ -455,6 +459,83 @@ def _partition_manifest_removals(paths: list[Path]) -> tuple[list[Path], list[Pa
         else:
             modified.append(path)
     return removable, modified, untracked
+
+
+def _remove_managed_context_blocks_from_text(text: str) -> tuple[str, int]:
+    """Remove all managed `<!-- ... SK START -->` blocks from text."""
+    lines = text.splitlines(keepends=True)
+    if not lines:
+        return text, 0
+    output: list[str] = []
+    removed = 0
+    idx = 0
+    while idx < len(lines):
+        match = _CONTEXT_START_RE.match(lines[idx].rstrip("\r\n"))
+        if not match:
+            output.append(lines[idx])
+            idx += 1
+            continue
+        block_id = match.group("block")
+        end_marker = f"<!-- {block_id} SK END -->"
+        end_idx = None
+        for probe in range(idx + 1, len(lines)):
+            if lines[probe].rstrip("\r\n") == end_marker:
+                end_idx = probe
+                break
+        if end_idx is None:
+            output.append(lines[idx])
+            idx += 1
+            continue
+        removed += 1
+        idx = end_idx + 1
+        if output and idx < len(lines) and not output[-1].strip() and not lines[idx].strip():
+            idx += 1
+        if not output:
+            while idx < len(lines) and not lines[idx].strip():
+                idx += 1
+    if removed and output and all(not line.strip() for line in output):
+        output = []
+    return "".join(output), removed
+
+
+def _remove_managed_context_blocks_from_file(path: Path, *, quiet: bool = False) -> bool:
+    """Strip all managed context blocks from a single instruction file."""
+    if not path.is_file():
+        return False
+    original = path.read_text(encoding="utf-8")
+    updated, removed = _remove_managed_context_blocks_from_text(original)
+    if removed <= 0 or updated == original:
+        return False
+    _atomic_write_text(path, updated)
+    if not quiet:
+        print(f"  {OK} Removed {removed} managed context block(s) from {_tilde(path)}")
+    return True
+
+
+def _managed_context_targets(project_root: Path) -> list[Path]:
+    """Return unique project instruction-file targets that may hold managed blocks."""
+    targets: list[Path] = []
+    seen: set[str] = set()
+    for rel in HOST_INSTRUCTION_FILES.values():
+        key = str(rel)
+        if key in seen:
+            continue
+        seen.add(key)
+        targets.append(project_root / rel)
+    return targets
+
+
+def _remove_registered_project_context_blocks(*, quiet: bool = False) -> int:
+    """Remove managed context blocks from every registered project instruction file."""
+    changed = 0
+    for raw_root in _load_project_registry():
+        project_root = Path(raw_root).expanduser()
+        if not project_root.is_dir():
+            continue
+        for target in _managed_context_targets(project_root):
+            if _remove_managed_context_blocks_from_file(target, quiet=quiet):
+                changed += 1
+    return changed
 
 
 def _file_url_to_path(url: str) -> Path | None:
@@ -1451,6 +1532,9 @@ def uninstall() -> int:
     # Remove managed sk launcher files and PATH injections
     launcher_removed = uninstall_sk_launcher(quiet=False)
     removed += launcher_removed
+
+    context_removed = _remove_registered_project_context_blocks(quiet=False)
+    removed += context_removed
 
     print(f"\n  Uninstall complete \u2014 removed {removed} item(s).")
     print(f"  Session data preserved at {_tilde(SESSION_STATE)}")

--- a/sk.py
+++ b/sk.py
@@ -37,7 +37,7 @@ Usage:
     sk sync   run|config|status|gateway|merge [<args>...]
     sk checkpoint save|restore|diff [<args>...]
     sk profile build|import|export [<args>...]
-    sk context project|map [<args>...]
+    sk context project|map|upsert|remove [<args>...]
     sk scout  run|config|status [<args>...]
     sk project add|remove|list [<args>...]
 
@@ -124,6 +124,8 @@ _GROUPS: dict[str, dict[str, str]] = {
     "context": {
         "project": "project-context.py",
         "map": "codebase-map.py",
+        "upsert": "context-blocks.py",
+        "remove": "context-blocks.py",
     },
     "scout": {
         "run": "trend-scout.py",
@@ -298,6 +300,8 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 2
+        if cmd == "context" and sub in ("upsert", "remove"):
+            return _run(_GROUPS[cmd][sub], [sub] + sub_rest)
         return _run(_GROUPS[cmd][sub], sub_rest)
 
     # Unknown

--- a/tests/test_context_blocks.py
+++ b/tests/test_context_blocks.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+test_context_blocks.py - Focused tests for context-blocks.py.
+
+Run: python tests/test_context_blocks.py
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+TOOLS_DIR = Path(__file__).parent.parent
+SCRIPT_PATH = TOOLS_DIR / "context-blocks.py"
+
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("context_blocks", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cb = _load_module()
+
+
+class TempRepoMixin:
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="context-blocks-")
+        self.repo_root = Path(self._tmpdir) / "repo"
+        self.repo_root.mkdir(parents=True, exist_ok=True)
+        (self.repo_root / ".git").mkdir()
+        self.registry_path = Path(self._tmpdir) / "tools-managed-projects.json"
+        self.original_registry = cb.REGISTRY_PATH
+        cb.REGISTRY_PATH = self.registry_path
+
+    def tearDown(self):
+        cb.REGISTRY_PATH = self.original_registry
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def target(self) -> Path:
+        return self.repo_root / ".github" / "copilot-instructions.md"
+
+
+class TestScriptExists(unittest.TestCase):
+    def test_script_exists(self):
+        self.assertTrue(SCRIPT_PATH.exists(), f"context-blocks.py not found at {SCRIPT_PATH}")
+
+
+class TestHelpers(TempRepoMixin, unittest.TestCase):
+    def test_normalize_agent(self):
+        self.assertEqual(cb._normalize_agent("copilot"), "Copilot CLI")
+        self.assertEqual(cb._normalize_agent("claude-code"), "Claude Code")
+        self.assertEqual(cb._normalize_agent("agents"), "All agents")
+
+    def test_block_id_validation_rejects_marker_injection(self):
+        with self.assertRaises(ValueError):
+            cb._validate_block_id("bad --> marker")
+
+    def test_register_project_preserves_string_registry(self):
+        cb._register_project(self.repo_root)
+        data = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        self.assertIn(str(self.repo_root.resolve()), data["projects"])
+
+
+class TestUpsertRemove(TempRepoMixin, unittest.TestCase):
+    def test_upsert_creates_missing_file(self):
+        rc = cb.main(["upsert", "--repo", str(self.repo_root), "--agent", "copilot", "managed content"])
+        self.assertEqual(rc, 0)
+        content = self.target().read_text(encoding="utf-8")
+        self.assertIn("<!-- SESSION-KNOWLEDGE SK START -->", content)
+        self.assertIn("managed content", content)
+        self.assertIn("<!-- SESSION-KNOWLEDGE SK END -->", content)
+
+    def test_upsert_updates_only_managed_block(self):
+        target = self.target()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            "User header\n\n"
+            "<!-- SESSION-KNOWLEDGE SK START -->\n"
+            "old content\n"
+            "<!-- SESSION-KNOWLEDGE SK END -->\n\n"
+            "User footer\n",
+            encoding="utf-8",
+        )
+        rc = cb.main(["upsert", "--repo", str(self.repo_root), "--agent", "copilot", "new content"])
+        self.assertEqual(rc, 0)
+        content = target.read_text(encoding="utf-8")
+        self.assertIn("User header", content)
+        self.assertIn("User footer", content)
+        self.assertIn("new content", content)
+        self.assertNotIn("old content", content)
+
+    def test_multiple_blocks_supported(self):
+        target = self.target()
+        rc1 = cb.main(
+            [
+                "upsert",
+                "--repo",
+                str(self.repo_root),
+                "--agent",
+                "copilot",
+                "--block-id",
+                "AWS, Docker",
+                "aws docker content",
+            ]
+        )
+        rc2 = cb.main(
+            [
+                "upsert",
+                "--repo",
+                str(self.repo_root),
+                "--agent",
+                "copilot",
+                "--block-id",
+                "Python",
+                "python content",
+            ]
+        )
+        self.assertEqual(rc1, 0)
+        self.assertEqual(rc2, 0)
+        content = target.read_text(encoding="utf-8")
+        self.assertIn("<!-- AWS, Docker SK START -->", content)
+        self.assertIn("<!-- Python SK START -->", content)
+
+        rc3 = cb.main(["remove", "--repo", str(self.repo_root), "--agent", "copilot", "--block-id", "Python"])
+        self.assertEqual(rc3, 0)
+        updated = target.read_text(encoding="utf-8")
+        self.assertIn("<!-- AWS, Docker SK START -->", updated)
+        self.assertNotIn("<!-- Python SK START -->", updated)
+        self.assertIn("aws docker content", updated)
+
+    def test_remove_preserves_user_content(self):
+        target = self.target()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            "before\n\n"
+            "<!-- SESSION-KNOWLEDGE SK START -->\n"
+            "managed content\n"
+            "<!-- SESSION-KNOWLEDGE SK END -->\n\n"
+            "after\n",
+            encoding="utf-8",
+        )
+        rc = cb.main(["remove", "--repo", str(self.repo_root), "--agent", "copilot"])
+        self.assertEqual(rc, 0)
+        content = target.read_text(encoding="utf-8")
+        self.assertEqual(content, "before\n\nafter\n")
+
+    def test_remove_absent_block_is_safe(self):
+        target = self.target()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("user content only\n", encoding="utf-8")
+        rc = cb.main(["remove", "--repo", str(self.repo_root), "--agent", "copilot"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(target.read_text(encoding="utf-8"), "user content only\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_helpers.py
+++ b/tests/test_install_helpers.py
@@ -305,6 +305,7 @@ test("TOOL_FILES contains briefing.py", "briefing.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains watch-sessions.py", "watch-sessions.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains install.py", "install.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains sk.py", "sk.py" in _install.TOOL_FILES)
+test("TOOL_FILES contains context-blocks.py", "context-blocks.py" in _install.TOOL_FILES)
 test("SUPPORT_FILES contains pyproject.toml", "pyproject.toml" in _install.SUPPORT_FILES)
 
 # MINIMAL_SKILL_MD sanity
@@ -314,6 +315,48 @@ test("MINIMAL_SKILL_MD contains name field", "name: session-knowledge" in skill_
 test("MINIMAL_SKILL_MD contains description", "description:" in skill_md)
 test("MINIMAL_SKILL_MD contains H1 title", "# Session Knowledge" in skill_md)
 test("MINIMAL_SKILL_MD mentions briefing.py", "briefing.py" in skill_md)
+
+
+# ── 8b. Managed context cleanup helpers (issue #102) ─────────────────────────
+
+print("\n🧩 Managed context cleanup helpers")
+
+cleaned_text, removed_blocks = _install._remove_managed_context_blocks_from_text(
+    "before\n\n<!-- SESSION-KNOWLEDGE SK START -->\nmanaged content\n<!-- SESSION-KNOWLEDGE SK END -->\n\nafter\n"
+)
+test("managed context block removed from text", removed_blocks == 1)
+test("managed context cleanup preserves surrounding content", cleaned_text == "before\n\nafter\n")
+
+original_registry_context = _install.REGISTRY_PATH
+_install.REGISTRY_PATH = SCRATCH / "context-cleanup-registry.json"
+if _install.REGISTRY_PATH.exists():
+    _install.REGISTRY_PATH.unlink()
+
+context_project = SCRATCH / "context-cleanup-project"
+(context_project / ".github").mkdir(parents=True, exist_ok=True)
+copilot_instructions = context_project / ".github" / "copilot-instructions.md"
+copilot_instructions.write_text(
+    "header\n\n<!-- SESSION-KNOWLEDGE SK START -->\nmanaged content\n<!-- SESSION-KNOWLEDGE SK END -->\n\nfooter\n",
+    encoding="utf-8",
+)
+(context_project / "CLAUDE.md").write_text("claude user content\n", encoding="utf-8")
+_install._atomic_write_text(
+    _install.REGISTRY_PATH,
+    json.dumps({"projects": [str(context_project.resolve())]}, indent=2),
+)
+
+removed_files = _install._remove_registered_project_context_blocks(quiet=True)
+test("registered project cleanup removes managed context file blocks", removed_files == 1)
+test(
+    "registered project cleanup preserves non-managed file content",
+    copilot_instructions.read_text(encoding="utf-8") == "header\n\nfooter\n",
+)
+test(
+    "registered project cleanup leaves unrelated files untouched",
+    (context_project / "CLAUDE.md").read_text(encoding="utf-8") == "claude user content\n",
+)
+
+_install.REGISTRY_PATH = original_registry_context
 
 
 # ── 9. Editable install uninstall guard ───────────────────────────────────────

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -486,6 +486,24 @@ class TestSkGroupedCommands(unittest.TestCase):
     def test_context_map(self):
         self._assert_group_routes("context", "map", "codebase-map.py")
 
+    def test_context_upsert(self):
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main(["context", "upsert", "--agent", "copilot", "managed content"])
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with(
+            "context-blocks.py",
+            ["upsert", "--agent", "copilot", "managed content"],
+        )
+
+    def test_context_remove(self):
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main(["context", "remove", "--agent", "copilot", "--block-id", "AWS, Docker"])
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with(
+            "context-blocks.py",
+            ["remove", "--agent", "copilot", "--block-id", "AWS, Docker"],
+        )
+
     # scout group
     def test_scout_run(self):
         self._assert_group_routes("scout", "run", "trend-scout.py")


### PR DESCRIPTION
## Summary
- add `sk context upsert/remove` for marker-bounded managed blocks in project agent instruction files
- register touched projects and scrub managed blocks from registered instruction files during uninstall
- cover the new CLI routing, block operations, and uninstall cleanup with focused Python tests

Closes #102