### PR TITLE
feat: add structured clarify gate

### DIFF
--- a/briefing.py
+++ b/briefing.py
@@ -59,6 +59,7 @@ if os.name == "nt":
 TOOLS_DIR = Path(__file__).parent
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
 DB_PATH = SESSION_STATE / "knowledge.db"
+_CLARIFY_STORE_PATH = SESSION_STATE / "clarifications.json"
 
 # Read-side filter: suppress Wave-style progress/status-note entries that were
 # mistakenly stored as knowledge (WaveN verification, rust-wave tentacle reports).
@@ -929,6 +930,92 @@ def _normalize_feedback_query(query: str) -> str:
     return normalized[:500]
 
 
+def _clarify_query_tokens(query: str) -> set[str]:
+    """Tokenize a clarification query for approximate matching."""
+    return {
+        match.group(0).lower() for match in re.finditer(r"[A-Za-z0-9_.:/-]+", query or "") if len(match.group(0)) >= 3
+    }
+
+
+def _load_clarification_entries(path: Path | None = None) -> list[dict]:
+    """Load stored clarification results from session-state JSON."""
+    target = path or _CLARIFY_STORE_PATH
+    try:
+        if not target.exists():
+            return []
+        data = json.loads(target.read_text(encoding="utf-8"))
+        entries = data.get("entries", [])
+        return [entry for entry in entries if isinstance(entry, dict)]
+    except Exception:
+        return []
+
+
+def _clarification_match_score(query: str, repo_root: str, entry: dict) -> float:
+    """Score a stored clarification entry against the current briefing query."""
+    entry_repo_root = str(entry.get("repo_root", "") or "")
+    if repo_root and entry_repo_root and entry_repo_root != repo_root:
+        return -1.0
+
+    query_norm = _normalize_feedback_query(query)
+    entry_norm = _normalize_feedback_query(str(entry.get("normalized_query") or entry.get("raw_query") or ""))
+    if not query_norm or not entry_norm:
+        return -1.0
+    if query_norm == entry_norm:
+        return 3.0
+    if query_norm in entry_norm or entry_norm in query_norm:
+        return 2.0
+
+    query_tokens = _clarify_query_tokens(query_norm)
+    entry_tokens = set(entry.get("tokens", [])) or _clarify_query_tokens(entry_norm)
+    if not query_tokens or not entry_tokens:
+        return -1.0
+    overlap = len(query_tokens & entry_tokens)
+    if overlap <= 0:
+        return -1.0
+    return overlap / max(1, min(len(query_tokens), len(entry_tokens)))
+
+
+def _load_matching_clarification(query: str, repo_root: str = "", path: Path | None = None) -> dict | None:
+    """Return the best matching stored clarification for the current repo/query."""
+    best_entry = None
+    best_score = -1.0
+    best_created_at = ""
+    for entry in _load_clarification_entries(path):
+        score = _clarification_match_score(query, repo_root, entry)
+        created_at = str(entry.get("created_at", "") or "")
+        if score > best_score or (score == best_score and created_at > best_created_at):
+            best_entry = entry
+            best_score = score
+            best_created_at = created_at
+    return best_entry if best_score > 0 else None
+
+
+def _serialize_clarification(entry: dict | None) -> dict | None:
+    """Return the stable public shape for a stored clarification entry."""
+    if not entry:
+        return None
+    return {
+        "raw_query": entry.get("raw_query", ""),
+        "clarified_task": entry.get("clarified_task", ""),
+        "questions": [
+            {
+                "category": question.get("category", ""),
+                "question": question.get("question", ""),
+                "options": list(question.get("options", [])),
+            }
+            for question in entry.get("questions", [])[:5]
+            if isinstance(question, dict)
+        ],
+        "taxonomy_categories": list(entry.get("taxonomy_categories", [])),
+        "created_at": entry.get("created_at", ""),
+    }
+
+
+def _xml_escape(text: str) -> str:
+    """Escape a string for XML-like compact briefing output."""
+    return str(text or "").replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
+
+
 def _compute_snippet_freshness(row: dict) -> str:
     """Read-time snippet freshness state: fresh|drifted|missing|unknown."""
     source_file = (_row_value(row, "source_file") or "").strip()
@@ -1771,6 +1858,14 @@ def generate_subagent_context(
     _, categories, per_cat_limit = _mode_category_config(limit, mode, query, infer_auto=infer_auto_mode)
     labels = {"mistake": "AVOID", "pattern": "USE", "decision": "NOTE", "tool": "CONFIG"}
     half_life = _get_briefing_half_life(db)
+    clarify_entry = _load_matching_clarification(query, repo_root=_current_repo_root())
+
+    if clarify_entry:
+        lines.append(f"  [CLARIFY] {_word_trim(clarify_entry.get('clarified_task', ''), 140)}")
+        for question in clarify_entry.get("questions", [])[:3]:
+            category = question.get("category", "?")
+            prompt = _word_trim(question.get("question", ""), 100)
+            lines.append(f"  [QUESTION] {category}: {prompt}")
 
     for cat in categories:
         label = labels.get(cat, cat.upper())
@@ -1945,6 +2040,7 @@ def generate_briefing(
     # File annotations (fail-open when table absent; scoped to current repo)
     _repo_root = _current_repo_root()
     file_annotations = query_file_annotations(db, query=rewritten_query, repo_root=_repo_root, limit=6)
+    clarify_entry = _load_matching_clarification(query, repo_root=_repo_root)
 
     # Pack-only machine surface extras
     task_matches = []
@@ -1992,6 +2088,7 @@ def generate_briefing(
                     "query": query,
                     "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
                     "sections": {},
+                    "clarify": _serialize_clarification(clarify_entry),
                     "message": "No relevant past experience found.",
                 },
                 indent=2,
@@ -2007,14 +2104,29 @@ def generate_briefing(
                 "file_matches": file_matches,
                 "past_work": [],
                 "next_open": next_open,
+                "clarify": _serialize_clarification(clarify_entry),
             }
             output = json.dumps(pack, indent=2, ensure_ascii=False)
         else:
-            output = f"No relevant past experience found for: {query}\n"
+            if clarify_entry:
+                if fmt == "compact":
+                    output = _format_compact(
+                        query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+                    )
+                elif full:
+                    output = _format_markdown(
+                        query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+                    )
+                else:
+                    output = _format_default(
+                        query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+                    )
+            else:
+                output = f"No relevant past experience found for: {query}\n"
     else:
         # Format output
         if fmt == "json":
-            output = _format_json(query, briefing_data, past_work, categories, blast)
+            output = _format_json(query, briefing_data, past_work, categories, blast, clarify_entry)
         elif fmt == "pack":
             pack_entries = {
                 k: [_serialize_pack_entry(e) for e in briefing_data.get(k, [])]
@@ -2048,14 +2160,21 @@ def generate_briefing(
                     for w in past_work
                 ],
                 "next_open": next_open,
+                "clarify": _serialize_clarification(clarify_entry),
             }
             output = json.dumps(pack, indent=2, ensure_ascii=False)
         elif fmt == "compact":
-            output = _format_compact(query, briefing_data, past_work, categories, blast, file_annotations)
+            output = _format_compact(
+                query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+            )
         elif full:
-            output = _format_markdown(query, briefing_data, past_work, categories, blast, file_annotations)
+            output = _format_markdown(
+                query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+            )
         else:
-            output = _format_default(query, briefing_data, past_work, categories, blast, file_annotations)
+            output = _format_default(
+                query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+            )
 
     # Append event-level skill usage section (non-pack formats only; fail-open).
     if fmt not in ("json", "pack"):
@@ -2082,12 +2201,20 @@ def generate_briefing(
 
 
 def _format_default(
-    query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None
+    query: str,
+    data: dict,
+    past_work: list,
+    categories: dict,
+    blast: list = None,
+    file_annotations: list | None = None,
+    clarify_entry: dict | None = None,
 ) -> str:
     """Compact default format: titles + 1-line summaries (~500 tokens)."""
     lines = []
     lines.append(f"📋 Briefing: {query}")
     lines.append("")
+
+    lines.extend(_format_clarification_default_block(clarify_entry))
 
     for cat, meta in categories.items():
         entries = data.get(cat, [])
@@ -2167,7 +2294,13 @@ def _format_default(
 
 
 def _format_markdown(
-    query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None
+    query: str,
+    data: dict,
+    past_work: list,
+    categories: dict,
+    blast: list = None,
+    file_annotations: list | None = None,
+    clarify_entry: dict | None = None,
 ) -> str:
     """Format briefing as Markdown."""
     lines = []
@@ -2178,6 +2311,8 @@ def _format_markdown(
     lines.append("")
     lines.append("---")
     lines.append("")
+
+    lines.extend(_format_clarification_markdown_block(clarify_entry))
 
     for cat, meta in categories.items():
         entries = data.get(cat, [])
@@ -2257,9 +2392,18 @@ def _format_markdown(
     return "\n".join(lines)
 
 
-def _format_json(query: str, data: dict, past_work: list, categories: dict, blast: list = None) -> str:
+def _format_json(
+    query: str, data: dict, past_work: list, categories: dict, blast: list = None, clarify_entry: dict | None = None
+) -> str:
     """Format briefing as JSON."""
     output = {"query": query, "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S"), "sections": {}}
+
+    clarify = _serialize_clarification(clarify_entry)
+    if clarify:
+        output["sections"]["clarify"] = {
+            "title": "Clarify Gate",
+            "entry": clarify,
+        }
 
     for cat, meta in categories.items():
         entries = data.get(cat, [])
@@ -2321,8 +2465,71 @@ def _word_trim(s: str, limit: int = 80) -> str:
     return s
 
 
+def _format_clarification_default_block(entry: dict | None) -> list[str]:
+    """Render a plain-text clarification block for briefing output."""
+    clarify = _serialize_clarification(entry)
+    if not clarify:
+        return []
+    lines = ["❓ Clarify Gate"]
+    task = _word_trim(clarify.get("clarified_task", ""), 180)
+    if task:
+        lines.append(f"  Ready brief: {task}")
+    for index, question in enumerate(clarify.get("questions", [])[:5], 1):
+        q_text = _word_trim(question.get("question", ""), 120)
+        category = question.get("category", "?")
+        lines.append(f"  {index}. [{category}] {q_text}")
+        options = " | ".join(question.get("options", [])[:4])
+        if options:
+            lines.append(f"     {options}")
+    lines.append("")
+    return lines
+
+
+def _format_clarification_markdown_block(entry: dict | None) -> list[str]:
+    """Render a Markdown clarification block for full briefing output."""
+    clarify = _serialize_clarification(entry)
+    if not clarify:
+        return []
+    lines = ["## ❓ Clarify Gate", ""]
+    task = clarify.get("clarified_task", "")
+    if task:
+        lines.append(f"**Ready brief:** {task}")
+        lines.append("")
+    for index, question in enumerate(clarify.get("questions", [])[:5], 1):
+        category = question.get("category", "?")
+        lines.append(f"{index}. **{category}** — {question.get('question', '')}")
+        options = question.get("options", [])
+        if options:
+            lines.append(f"   Options: {' | '.join(options[:4])}")
+        lines.append("")
+    return lines
+
+
+def _format_clarification_compact_block(entry: dict | None) -> list[str]:
+    """Render an XML-like compact clarification block."""
+    clarify = _serialize_clarification(entry)
+    if not clarify:
+        return []
+    lines = ["<clarify>"]
+    task = _word_trim(clarify.get("clarified_task", ""), 180)
+    if task:
+        lines.append(f"  <task>{_xml_escape(task)}</task>")
+    for question in clarify.get("questions", [])[:5]:
+        category = _xml_escape(question.get("category", "?"))
+        prompt = _xml_escape(_word_trim(question.get("question", ""), 120))
+        lines.append(f'  <question category="{category}">{prompt}</question>')
+    lines.append("</clarify>")
+    return lines
+
+
 def _format_compact(
-    query: str, data: dict, past_work: list, categories: dict, blast: list = None, file_annotations: list | None = None
+    query: str,
+    data: dict,
+    past_work: list,
+    categories: dict,
+    blast: list = None,
+    file_annotations: list | None = None,
+    clarify_entry: dict | None = None,
 ) -> str:
     """Compact format optimized for AI agent context injection.
 
@@ -2333,6 +2540,7 @@ def _format_compact(
     lines = []
     safe_query = query[:100].replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
     lines.append(f'<briefing task="{safe_query}">\n')
+    lines.extend(_format_clarification_compact_block(clarify_entry))
 
     def _cat_block(cat: str) -> None:
         """Append one XML-style category block to *lines*.

--- a/clarify.py
+++ b/clarify.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""
+clarify.py - Generate bounded clarification questions for underspecified tasks.
+
+Usage:
+    python clarify.py "implement auth flow"
+    python clarify.py "implement auth flow" --json
+    python clarify.py "implement auth flow" --no-store
+    python clarify.py "implement auth flow" --repo C:\\path\\to\\repo
+"""
+
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+SESSION_STATE = Path.home() / ".copilot" / "session-state"
+STORE_PATH = SESSION_STATE / "clarifications.json"
+MAX_QUESTIONS = 5
+STORE_LIMIT = 50
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_.:/-]+")
+_NUMBER_RE = re.compile(r"\b\d+(?:\.\d+)?\b")
+_PATH_RE = re.compile(r"[\\/]|`[^`]+`|[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")
+_VAGUE_TERMS = {
+    "add",
+    "change",
+    "clean",
+    "create",
+    "enhance",
+    "fix",
+    "handle",
+    "improve",
+    "manage",
+    "optimize",
+    "refactor",
+    "support",
+    "update",
+}
+_DOMAIN_MARKERS = {
+    "agent",
+    "api",
+    "auth",
+    "backend",
+    "briefing",
+    "browser",
+    "cli",
+    "config",
+    "context",
+    "copilot",
+    "database",
+    "db",
+    "frontend",
+    "hook",
+    "knowledge",
+    "skill",
+    "sync",
+    "ui",
+    "watcher",
+}
+_CATEGORY_DEFAULTS = {
+    "Functional Scope": 0.9,
+    "Domain": 0.4,
+    "UX": 0.2,
+    "Security": 0.3,
+    "Performance": 0.2,
+    "Integration": 0.5,
+    "Error Handling": 0.5,
+    "Testing": 0.8,
+    "Deployment": 0.2,
+    "Business Rules": 0.4,
+}
+
+TAXONOMY = [
+    {
+        "name": "Functional Scope",
+        "keywords": ["add", "build", "change", "create", "fix", "implement", "refactor", "support", "update"],
+        "specificity": ["only", "minimal", "mvp", "single", "full", "end-to-end", "all", "just"],
+        "question": "What exact functional boundary should this task cover?",
+        "options": [
+            "A. Minimal happy-path only",
+            "B. Full user-facing flow",
+            "C. End-to-end plus edge cases",
+            "Custom",
+        ],
+    },
+    {
+        "name": "Domain",
+        "keywords": ["agent", "api", "auth", "backend", "briefing", "browser", "cli", "config", "database", "ui"],
+        "specificity": ["file", "module", "repo", "script", "service", "workflow"],
+        "question": "Which concrete repo area, module, or system boundary is in scope?",
+        "options": [
+            "A. One known file/module",
+            "B. One subsystem across a few files",
+            "C. Cross-cutting change across multiple systems",
+            "Custom",
+        ],
+    },
+    {
+        "name": "UX",
+        "keywords": ["copy", "prompt", "screen", "settings", "ui", "ux", "user", "workflow"],
+        "specificity": ["accessibility", "layout", "message", "screen", "text", "tone"],
+        "question": "What user-facing behavior or interaction should this feel like?",
+        "options": [
+            "A. Keep current UX unchanged",
+            "B. Small UX improvement only",
+            "C. New user flow or prompt shape",
+            "Custom",
+        ],
+    },
+    {
+        "name": "Security",
+        "keywords": ["auth", "credential", "permission", "secret", "security", "token"],
+        "specificity": ["encrypt", "least-privilege", "sanitize", "validate", "verify"],
+        "question": "Are there security or trust boundaries that this task must preserve?",
+        "options": [
+            "A. No new security-sensitive surface",
+            "B. Existing auth/trust rules must stay unchanged",
+            "C. New validation / auth / secret-handling is required",
+            "Custom",
+        ],
+    },
+    {
+        "name": "Performance",
+        "keywords": ["fast", "latency", "optimize", "performance", "perf", "slow"],
+        "specificity": ["budget", "ms", "seconds", "throughput", "target"],
+        "question": "Is there a performance budget or latency target for this work?",
+        "options": [
+            "A. Correctness only; no explicit perf target",
+            "B. Keep current performance envelope",
+            "C. Hit a specific performance target",
+            "Custom",
+        ],
+    },
+    {
+        "name": "Integration",
+        "keywords": ["api", "bridge", "briefing", "hook", "import", "integrate", "merge", "surface", "sync"],
+        "specificity": ["consumer", "producer", "upstream", "downstream", "read", "write"],
+        "question": "What other command, file, or subsystem must consume or produce this result?",
+        "options": [
+            "A. Standalone behavior only",
+            "B. One downstream integration",
+            "C. Multiple integrations must stay in sync",
+            "Custom",
+        ],
+    },
+    {
+        "name": "Error Handling",
+        "keywords": ["error", "fail", "guard", "invalid", "retry", "validation"],
+        "specificity": ["message", "raise", "return", "warning", "exit"],
+        "question": "How should invalid input or failure conditions be surfaced?",
+        "options": [
+            "A. Fail loudly with explicit error",
+            "B. Return structured validation feedback",
+            "C. Retry/recover with user-visible guidance",
+            "Custom",
+        ],
+    },
+    {
+        "name": "Testing",
+        "keywords": ["acceptance", "assert", "coverage", "pytest", "test", "tests", "verification"],
+        "specificity": ["fixture", "integration", "regression", "unit"],
+        "question": "What test evidence is required before this is considered done?",
+        "options": [
+            "A. Focused unit tests only",
+            "B. Focused plus existing regression suites",
+            "C. Full end-to-end / operator verification",
+            "Custom",
+        ],
+    },
+    {
+        "name": "Deployment",
+        "keywords": ["ci", "deploy", "install", "launcher", "release", "ship"],
+        "specificity": ["migration", "rollout", "windows", "linux", "macos", "version"],
+        "question": "Does this change need install, rollout, or environment-specific handling?",
+        "options": [
+            "A. No deployment/install impact",
+            "B. Update one install/runtime path",
+            "C. Multi-environment rollout considerations",
+            "Custom",
+        ],
+    },
+    {
+        "name": "Business Rules",
+        "keywords": ["budget", "policy", "priority", "quota", "rule", "rules", "validation"],
+        "specificity": ["allow", "deny", "must", "never", "only", "threshold"],
+        "question": "What non-technical rule or policy determines the correct behavior?",
+        "options": [
+            "A. Follow current behavior unchanged",
+            "B. Add one explicit rule/constraint",
+            "C. Introduce a new policy matrix or thresholds",
+            "Custom",
+        ],
+    },
+]
+
+
+def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_bytes(content.encode(encoding))
+        os.replace(str(tmp), str(path))
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+
+def _find_git_root(start: Path | None = None) -> Path:
+    current = (start or Path.cwd()).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def _normalize_query(query: str) -> str:
+    normalized = (query or "").lower().strip()
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized[:500]
+
+
+def _query_tokens(query: str) -> set[str]:
+    return {match.group(0).lower() for match in _TOKEN_RE.finditer(query or "") if len(match.group(0)) >= 3}
+
+
+def _contains_any(tokens: set[str], values: list[str]) -> bool:
+    return any(value in tokens for value in values)
+
+
+def _category_score(category: dict, query: str, tokens: set[str]) -> float:
+    name = category["name"]
+    score = _CATEGORY_DEFAULTS.get(name, 0.0)
+    relevant = _contains_any(tokens, category["keywords"])
+    specific = any(spec in query for spec in category["specificity"])
+
+    if len(tokens) < 10:
+        score += 0.2
+    if tokens & _VAGUE_TERMS:
+        score += 0.25
+    if _NUMBER_RE.search(query):
+        score -= 0.15
+    if _PATH_RE.search(query):
+        score -= 0.1
+
+    if name == "Functional Scope":
+        if relevant:
+            score += 0.35
+        if not specific:
+            score += 0.45
+    elif name == "Domain":
+        if not (tokens & _DOMAIN_MARKERS):
+            score += 0.8
+        elif not specific:
+            score += 0.2
+    elif name == "UX":
+        if relevant and not specific:
+            score += 0.7
+        elif relevant:
+            score += 0.2
+        else:
+            score -= 0.2
+    elif name == "Security":
+        if relevant and not specific:
+            score += 0.8
+        elif relevant:
+            score += 0.3
+        else:
+            score -= 0.15
+    elif name == "Performance":
+        if relevant and not (_NUMBER_RE.search(query) or specific):
+            score += 0.8
+        elif relevant:
+            score += 0.15
+        else:
+            score -= 0.25
+    elif name == "Integration":
+        if relevant and not specific:
+            score += 0.75
+        elif relevant:
+            score += 0.25
+    elif name == "Error Handling":
+        if relevant and not specific:
+            score += 0.7
+        elif not relevant:
+            score += 0.15
+    elif name == "Testing":
+        if not _contains_any(tokens, category["keywords"]):
+            score += 0.9
+        elif not specific:
+            score += 0.25
+    elif name == "Deployment":
+        if relevant and not specific:
+            score += 0.65
+        elif not relevant:
+            score -= 0.1
+    elif name == "Business Rules":
+        if relevant and not specific:
+            score += 0.7
+        elif not relevant:
+            score += 0.15
+
+    return score
+
+
+def _build_questions(query: str, max_questions: int = MAX_QUESTIONS) -> list[dict]:
+    normalized = _normalize_query(query)
+    tokens = _query_tokens(normalized)
+    ranked = []
+    for category in TAXONOMY:
+        score = _category_score(category, normalized, tokens)
+        ranked.append(
+            {
+                "category": category["name"],
+                "question": category["question"],
+                "options": list(category["options"]),
+                "score": round(score, 3),
+            }
+        )
+    ranked.sort(key=lambda item: (-item["score"], item["category"]))
+    return [
+        {k: v for k, v in item.items() if k != "score"} for item in ranked[: max(1, min(MAX_QUESTIONS, max_questions))]
+    ]
+
+
+def _build_clarified_task(query: str, questions: list[dict]) -> str:
+    task = " ".join((query or "").split())
+    if not questions:
+        return (
+            f"Implement {task} using existing repo conventions and validate the change with the existing focused gates."
+        )
+    categories = ", ".join(question["category"] for question in questions[:3])
+    return (
+        f"Implement {task} with explicit confirmation of the key open areas before coding. "
+        f"Resolve clarification around {categories} so the work stays bounded and verifiable."
+    )
+
+
+def _load_store(path: Path | None = None) -> dict:
+    target = path or STORE_PATH
+    try:
+        if target.exists():
+            data = json.loads(target.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(data.get("entries", []), list):
+                return data
+    except Exception:
+        pass
+    return {"entries": []}
+
+
+def _store_entry(entry: dict, path: Path | None = None) -> None:
+    target = path or STORE_PATH
+    payload = _load_store(target)
+    entries = [item for item in payload.get("entries", []) if isinstance(item, dict) and item.get("id") != entry["id"]]
+    entries.insert(0, entry)
+    payload["entries"] = entries[:STORE_LIMIT]
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_text(target, json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def _entry_id(repo_root: str, normalized_query: str) -> str:
+    digest = hashlib.sha1(f"{repo_root}\n{normalized_query}".encode()).hexdigest()
+    return digest[:16]
+
+
+def _serialize_result(query: str, repo_root: str, questions: list[dict]) -> dict:
+    normalized = _normalize_query(query)
+    tokens = sorted(_query_tokens(normalized))
+    entry = {
+        "id": _entry_id(repo_root, normalized),
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "repo_root": repo_root,
+        "raw_query": query,
+        "normalized_query": normalized,
+        "tokens": tokens,
+        "taxonomy_categories": [category["name"] for category in TAXONOMY],
+        "questions": questions[:MAX_QUESTIONS],
+        "clarified_task": _build_clarified_task(query, questions),
+    }
+    return entry
+
+
+def _format_text(result: dict, store_path: Path, stored: bool) -> str:
+    lines = [
+        f"❓ Clarify Gate: {result['raw_query']}",
+        "",
+        "Clarified task",
+        f"  {result['clarified_task']}",
+        "",
+        f"Questions ({len(result['questions'])}/{len(result['taxonomy_categories'])} categories scanned)",
+    ]
+    for index, question in enumerate(result["questions"], 1):
+        lines.append(f"  {index}. [{question['category']}] {question['question']}")
+        lines.append("     " + " | ".join(question["options"]))
+    if stored:
+        lines.extend(["", f"Stored: {store_path}"])
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if not args or "--help" in args or "-h" in args:
+        print(__doc__)
+        return 0
+
+    emit_json = "--json" in args
+    store = "--no-store" not in args
+    repo_root = None
+    if "--repo" in args:
+        idx = args.index("--repo")
+        if idx + 1 >= len(args):
+            print("clarify: --repo requires a path", file=sys.stderr)
+            return 2
+        repo_root = _find_git_root(Path(args[idx + 1]))
+
+    consumed = set()
+    for flag in ("--json", "--no-store"):
+        if flag in args:
+            consumed.add(args.index(flag))
+    if "--repo" in args:
+        idx = args.index("--repo")
+        consumed.update({idx, idx + 1})
+
+    query_parts = [part for index, part in enumerate(args) if index not in consumed and not part.startswith("--")]
+    query = " ".join(query_parts).strip()
+    if not query:
+        print("clarify: provide a task description", file=sys.stderr)
+        return 2
+
+    root = (repo_root or _find_git_root()).resolve().as_posix()
+    questions = _build_questions(query, max_questions=MAX_QUESTIONS)
+    result = _serialize_result(query, root, questions)
+    if store:
+        _store_entry(result)
+
+    if emit_json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        print(_format_text(result, STORE_PATH, stored=store))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/install.py
+++ b/install.py
@@ -190,6 +190,7 @@ TOOL_FILES = [
     "extract-knowledge.py",
     "query-session.py",
     "briefing.py",
+    "clarify.py",
     "watch-sessions.py",
     "learn.py",
     "embed.py",

--- a/sk.py
+++ b/sk.py
@@ -9,6 +9,7 @@ Usage:
     sk briefing [<args>...]       Run briefing.py
     sk query    [<args>...]       Run query-session.py
     sk learn    [<args>...]       Run learn.py
+    sk clarify  [<args>...]       Run clarify.py
     sk tentacle [<args>...]       Run tentacle.py
     sk install  [<args>...]       Run install.py
     sk setup    [<args>...]       Run setup-project.py
@@ -69,6 +70,7 @@ _DIRECT: dict[str, str] = {
     "briefing": "briefing.py",
     "query": "query-session.py",
     "learn": "learn.py",
+    "clarify": "clarify.py",
     "tentacle": "tentacle.py",
     "install": "install.py",
     "setup": "setup-project.py",

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -918,7 +918,10 @@ test("16a: _parse_skill_frontmatter folded desc has no embedded newline", "\n" n
 # 16b. _parse_skill_frontmatter — inline description
 _fm_inline = "---\nname: another-skill\ndescription: Short inline description.\n---\n"
 _meta_i = _b._parse_skill_frontmatter(_fm_inline)
-test("16b: _parse_skill_frontmatter extracts inline description", _meta_i.get("description") == "Short inline description.")
+test(
+    "16b: _parse_skill_frontmatter extracts inline description",
+    _meta_i.get("description") == "Short inline description.",
+)
 
 # 16c. _parse_skill_frontmatter — missing frontmatter returns empty
 _meta_no = _b._parse_skill_frontmatter("# No frontmatter\nJust body content")
@@ -1078,17 +1081,32 @@ _pos_mistake = _fc_out.find("MISTAKE_ENTRY")
 _pos_pattern = _fc_out.find("PATTERN_ENTRY")
 _pos_decision = _fc_out.find("DECISION_ENTRY")
 _pos_tool = _fc_out.find("TOOL_ENTRY")
-test("17e: mistakes appear before patterns in compact output", _pos_mistake < _pos_pattern, f"mistake@{_pos_mistake} pattern@{_pos_pattern}")
-test("17e: mistakes appear before decisions", _pos_mistake < _pos_decision, f"mistake@{_pos_mistake} decision@{_pos_decision}")
+test(
+    "17e: mistakes appear before patterns in compact output",
+    _pos_mistake < _pos_pattern,
+    f"mistake@{_pos_mistake} pattern@{_pos_pattern}",
+)
+test(
+    "17e: mistakes appear before decisions",
+    _pos_mistake < _pos_decision,
+    f"mistake@{_pos_mistake} decision@{_pos_decision}",
+)
 test("17e: mistakes appear before tools", _pos_mistake < _pos_tool, f"mistake@{_pos_mistake} tool@{_pos_tool}")
-test("17e: patterns appear before decisions", _pos_pattern < _pos_decision, f"pattern@{_pos_pattern} decision@{_pos_decision}")
+test(
+    "17e: patterns appear before decisions",
+    _pos_pattern < _pos_decision,
+    f"pattern@{_pos_pattern} decision@{_pos_decision}",
+)
 
 # 17f. Graceful degradation: explicit budget — structured outputs (json/pack) are not truncated
 # Simulate a budget scenario: if output is a JSON string that exceeds budget, it must not be
 # truncated (the budget enforcement in main() has fmt not in ("json","pack") guard).
 # We verify this guard is present in the source code (structural safety guarantee).
 _br_src_125 = (REPO / "briefing.py").read_text(encoding="utf-8")
-test("17f: source guards json/pack from truncation (fmt not in json/pack check)", 'fmt not in ("json", "pack")' in _br_src_125)
+test(
+    "17f: source guards json/pack from truncation (fmt not in json/pack check)",
+    'fmt not in ("json", "pack")' in _br_src_125,
+)
 test("17f: source uses _compute_dynamic_budget", "_compute_dynamic_budget" in _br_src_125)
 test("17f: source has --available-tokens flag handling", "--available-tokens" in _br_src_125)
 
@@ -1108,14 +1126,19 @@ test("17h: avail=2000 → 100 (old floor was 500, new formula 5% = 100)", _b._co
 _br_src_125_full = (REPO / "briefing.py").read_text(encoding="utf-8")
 test("17i: source uses injected_tokens in footer comment", "injected_tokens" in _br_src_125_full)
 test("17i: source uses budget_tokens in footer comment", "budget_tokens" in _br_src_125_full)
-test("17i: dead-locals pattern removed (no _ = (injected_tokens, budget_tokens))", "_ = (injected_tokens, budget_tokens)" not in _br_src_125_full)
+test(
+    "17i: dead-locals pattern removed (no _ = (injected_tokens, budget_tokens))",
+    "_ = (injected_tokens, budget_tokens)" not in _br_src_125_full,
+)
 
 # 17j. --task path uses progressive reduction (not just hard truncation)
 # Verify the source has the loop for --task path as well as the main path
 test("17j: --task path has progressive-limit loop", "task_injected_tokens" in _br_src_125_full)
 test("17j: --task path has graceful degradation footer", "task_budget_tokens" in _br_src_125_full)
-test("17j: --task path does not hard-truncate immediately (has reduce loop before fallback)",
-     "for reduced_limit in range" in _br_src_125_full)
+test(
+    "17j: --task path does not hard-truncate immediately (has reduce loop before fallback)",
+    "for reduced_limit in range" in _br_src_125_full,
+)
 
 # 17k. Tight-context bug: available_tokens < 20 must NOT return 0 (which would disable cap)
 print("\n🔒 17k: tight-context _compute_dynamic_budget fix (PR review finding #2)")
@@ -1134,13 +1157,19 @@ test("17k: avail=0 → 0 (no-cap preserved when no context given)", _b._compute_
 # 17l. Footer-budget safety: final emitted output must not exceed the enforced cap
 print("\n📏 17l: footer-budget safety (PR review finding #1)")
 # Verify source uses footer-length-aware truncation (reserves room before adding footer)
-test("17l: main path reserves footer length before truncating (avail = budget - len(footer))",
-     "avail = budget - len(footer)" in _br_src_125_full)
-test("17l: --task path reserves footer length before truncating",
-     # The task path uses the same pattern
-     _br_src_125_full.count("avail = budget - len(footer)") >= 2)
-test("17l: entry-reduction footer only added when it fits (len check)",
-     "len(output) + len(footer) <= budget" in _br_src_125_full)
+test(
+    "17l: main path reserves footer length before truncating (avail = budget - len(footer))",
+    "avail = budget - len(footer)" in _br_src_125_full,
+)
+test(
+    "17l: --task path reserves footer length before truncating",
+    # The task path uses the same pattern
+    _br_src_125_full.count("avail = budget - len(footer)") >= 2,
+)
+test(
+    "17l: entry-reduction footer only added when it fits (len check)",
+    "len(output) + len(footer) <= budget" in _br_src_125_full,
+)
 
 # 17m. --task --available-tokens behavioral CLI test (end-to-end through main()/CLI parsing)
 # Root cause of CI-only failure: get_db() calls sys.exit(1) when knowledge.db is absent,
@@ -1167,8 +1196,7 @@ try:
         " code_language TEXT, code_snippet TEXT)"
     )
     _17m_conn.execute(
-        "CREATE TABLE documents ("
-        "id INTEGER PRIMARY KEY, doc_type TEXT, title TEXT, file_path TEXT, seq INTEGER)"
+        "CREATE TABLE documents (id INTEGER PRIMARY KEY, doc_type TEXT, title TEXT, file_path TEXT, seq INTEGER)"
     )
     _17m_conn.commit()
     _17m_conn.close()
@@ -1179,10 +1207,14 @@ try:
 
     # Tight budget: available_tokens=400 → budget = max(1, min(2000, int(400*0.05))) = 20 chars
     _task_budget_result = _sp.run(
-        [sys.executable, str(_briefing_py), "--task", "nonexistent-test-task-id-17m",
-         "--available-tokens", "400"],
-        capture_output=True, text=True, encoding="utf-8", errors="replace",
-        timeout=30, cwd=str(REPO), env=_17m_env,
+        [sys.executable, str(_briefing_py), "--task", "nonexistent-test-task-id-17m", "--available-tokens", "400"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+        cwd=str(REPO),
+        env=_17m_env,
     )
     test(
         "17m: --task --available-tokens exits 0 (fixture DB present, deterministic on CI)",
@@ -1194,18 +1226,20 @@ try:
     # Budget is 20 chars; any output must respect that cap or be empty.
     test(
         "17m: --task --available-tokens output ≤ 20 chars OR empty (budget enforced)",
-        len(_task_budget_output.strip()) == 0
-        or len(_task_budget_output) <= 20
-        or "[BUDGET" in _task_budget_output,
+        len(_task_budget_output.strip()) == 0 or len(_task_budget_output) <= 20 or "[BUDGET" in _task_budget_output,
         f"len={len(_task_budget_output)} out={_task_budget_output[:100]}",
     )
 
     # Large budget: available_tokens=40000 → budget = min(2000, 2000) = 2000 chars
     _task_large_result = _sp.run(
-        [sys.executable, str(_briefing_py), "--task", "nonexistent-test-task-id-17m",
-         "--available-tokens", "40000"],
-        capture_output=True, text=True, encoding="utf-8", errors="replace",
-        timeout=30, cwd=str(REPO), env=_17m_env,
+        [sys.executable, str(_briefing_py), "--task", "nonexistent-test-task-id-17m", "--available-tokens", "40000"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+        cwd=str(REPO),
+        env=_17m_env,
     )
     test(
         "17m: --task --available-tokens 40000 exits 0",
@@ -1221,6 +1255,59 @@ try:
     )
 finally:
     _shutil.rmtree(str(_17m_home), ignore_errors=True)
+
+
+# ── 18. Clarify result matching + rendering (issue #101) ───────────────────────
+
+print("\n❓ Clarify result matching + rendering  (issue #101)")
+
+_clarify_tmpdir = tempfile.TemporaryDirectory()
+try:
+    _clarify_store = Path(_clarify_tmpdir.name) / "clarifications.json"
+    _clarify_entry = {
+        "id": "clarify-test",
+        "created_at": "2026-05-16T08:00:00Z",
+        "repo_root": "C:/repo",
+        "raw_query": "implement auth flow",
+        "normalized_query": "implement auth flow",
+        "tokens": ["implement", "auth", "flow"],
+        "clarified_task": "Implement auth flow with explicit confirmation of scope and test evidence.",
+        "taxonomy_categories": ["Functional Scope", "Testing"],
+        "questions": [
+            {
+                "category": "Functional Scope",
+                "question": "What exact functional boundary should this task cover?",
+                "options": [
+                    "A. Minimal happy-path only",
+                    "B. Full user-facing flow",
+                    "C. End-to-end plus edge cases",
+                    "Custom",
+                ],
+            }
+        ],
+    }
+    _clarify_store.write_text(_json.dumps({"entries": [_clarify_entry]}, indent=2), encoding="utf-8")
+
+    _matched = _b._load_matching_clarification("implement auth flow", repo_root="C:/repo", path=_clarify_store)
+    test(
+        "clarify loader matches exact repo/query entry",
+        isinstance(_matched, dict) and _matched.get("id") == "clarify-test",
+    )
+
+    _mismatch = _b._load_matching_clarification("implement auth flow", repo_root="C:/other", path=_clarify_store)
+    test("clarify loader rejects repo mismatch", _mismatch is None)
+
+    _default = _b._format_default("implement auth flow", {}, [], {}, clarify_entry=_matched)
+    test("default briefing includes clarify section", "Clarify Gate" in _default and "Ready brief:" in _default)
+
+    _compact = _b._format_compact("implement auth flow", {}, [], {}, clarify_entry=_matched)
+    test("compact briefing includes clarify block", "<clarify>" in _compact and "<question" in _compact)
+
+    _json_out = _b._format_json("implement auth flow", {}, [], {}, clarify_entry=_matched)
+    _json_data = _json.loads(_json_out)
+    test("json briefing includes clarify section", "clarify" in _json_data.get("sections", {}))
+finally:
+    _clarify_tmpdir.cleanup()
 
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/tests/test_clarify.py
+++ b/tests/test_clarify.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+test_clarify.py - Focused tests for clarify.py.
+
+Run: python tests/test_clarify.py
+"""
+
+import importlib.util
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).parent.parent
+SCRIPT_PATH = REPO / "clarify.py"
+
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("clarify", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+clarify = _load_module()
+
+
+class TestClarify(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="clarify-")
+        self.repo_root = Path(self._tmpdir) / "repo"
+        self.repo_root.mkdir(parents=True, exist_ok=True)
+        (self.repo_root / ".git").mkdir()
+        self.store_path = Path(self._tmpdir) / "clarifications.json"
+        self.original_store_path = clarify.STORE_PATH
+        clarify.STORE_PATH = self.store_path
+
+    def tearDown(self):
+        clarify.STORE_PATH = self.original_store_path
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_taxonomy_has_expected_categories(self):
+        self.assertEqual(len(clarify.TAXONOMY), 10)
+        self.assertIn("Functional Scope", [entry["name"] for entry in clarify.TAXONOMY])
+        self.assertIn("Testing", [entry["name"] for entry in clarify.TAXONOMY])
+
+    def test_build_questions_caps_at_five(self):
+        questions = clarify._build_questions("fix auth flow and make it better")
+        self.assertLessEqual(len(questions), 5)
+        self.assertGreater(len(questions), 0)
+
+    def test_main_json_stores_result(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = clarify.main(["implement auth flow", "--json", "--repo", str(self.repo_root)])
+        self.assertEqual(rc, 0)
+        payload = json.loads(buf.getvalue())
+        self.assertEqual(payload["raw_query"], "implement auth flow")
+        self.assertLessEqual(len(payload["questions"]), 5)
+        stored = json.loads(self.store_path.read_text(encoding="utf-8"))
+        self.assertEqual(len(stored["entries"]), 1)
+        self.assertEqual(stored["entries"][0]["normalized_query"], "implement auth flow")
+
+    def test_no_store_skips_file_write(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = clarify.main(["implement auth flow", "--no-store", "--repo", str(self.repo_root)])
+        self.assertEqual(rc, 0)
+        self.assertFalse(self.store_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_helpers.py
+++ b/tests/test_install_helpers.py
@@ -305,6 +305,7 @@ test("TOOL_FILES contains briefing.py", "briefing.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains watch-sessions.py", "watch-sessions.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains install.py", "install.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains sk.py", "sk.py" in _install.TOOL_FILES)
+test("TOOL_FILES contains clarify.py", "clarify.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains context-blocks.py", "context-blocks.py" in _install.TOOL_FILES)
 test("SUPPORT_FILES contains pyproject.toml", "pyproject.toml" in _install.SUPPORT_FILES)
 

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -100,6 +100,9 @@ class TestSkDirectCommands(unittest.TestCase):
     def test_learn(self):
         self._assert_routes("learn", "learn.py")
 
+    def test_clarify(self):
+        self._assert_routes("clarify", "clarify.py", ["implement auth flow"])
+
     def test_tentacle(self):
         self._assert_routes("tentacle", "tentacle.py", ["list"])
 


### PR DESCRIPTION
## Summary
- add a standalone `sk clarify` command that scans 10 taxonomy categories and emits at most 5 structured clarification questions
- store clarification results in session-state JSON and surface the best matching clarify block inside later `briefing.py` outputs
- cover the new command, installer distribution, CLI routing, and briefing surfacing with focused Python tests

Closes #101