### PR TITLE
feat(constitution): add governance workflow

### DIFF
--- a/briefing.py
+++ b/briefing.py
@@ -60,6 +60,8 @@ TOOLS_DIR = Path(__file__).parent
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
 DB_PATH = SESSION_STATE / "knowledge.db"
 _CLARIFY_STORE_PATH = SESSION_STATE / "clarifications.json"
+_CONSTITUTION_RELATIVE_PATH = Path(".copilot") / "constitution.md"
+_CONSTITUTION_RULE_RE = re.compile(r"\s*\[rule:[a-z0-9-]+\]\s*", re.IGNORECASE)
 
 # Read-side filter: suppress Wave-style progress/status-note entries that were
 # mistakenly stored as knowledge (WaveN verification, rust-wave tentacle reports).
@@ -1008,6 +1010,79 @@ def _serialize_clarification(entry: dict | None) -> dict | None:
         ],
         "taxonomy_categories": list(entry.get("taxonomy_categories", [])),
         "created_at": entry.get("created_at", ""),
+    }
+
+
+def _strip_constitution_rule_tags(text: str) -> str:
+    cleaned = _CONSTITUTION_RULE_RE.sub("", str(text or ""))
+    return re.sub(r"\s{2,}", " ", cleaned).strip()
+
+
+def _load_constitution(repo_root: str = "") -> dict | None:
+    root = Path(repo_root).resolve() if repo_root else _current_repo_root()
+    constitution_path = root / _CONSTITUTION_RELATIVE_PATH
+    if not constitution_path.is_file():
+        return None
+    sections = {
+        "Principles": [],
+        "Quality Gates": [],
+        "Governance": [],
+        "Changelog": [],
+    }
+    current_section = None
+    title = "Project Constitution"
+    version = ""
+    last_amended = ""
+    try:
+        for raw_line in (
+            constitution_path.read_text(encoding="utf-8").replace("\r\n", "\n").replace("\r", "\n").split("\n")
+        ):
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            if stripped.startswith("# ") and title == "Project Constitution":
+                title = stripped[2:].strip() or title
+                continue
+            lowered = stripped.lower()
+            if lowered.startswith("version:"):
+                version = stripped.split(":", 1)[1].strip()
+                continue
+            if lowered.startswith("last amended:"):
+                last_amended = stripped.split(":", 1)[1].strip()
+                continue
+            if stripped.startswith("## "):
+                section_name = stripped[3:].strip()
+                current_section = section_name if section_name in sections else None
+                continue
+            if current_section and stripped.startswith("- "):
+                sections[current_section].append(stripped[2:].strip())
+    except OSError:
+        return None
+
+    return {
+        "path": str(constitution_path),
+        "title": title,
+        "version": version,
+        "last_amended": last_amended,
+        "principles": sections["Principles"],
+        "quality_gates": sections["Quality Gates"],
+        "governance": sections["Governance"],
+        "changelog": sections["Changelog"],
+    }
+
+
+def _serialize_constitution(entry: dict | None) -> dict | None:
+    if not entry:
+        return None
+    return {
+        "path": entry.get("path", ""),
+        "title": entry.get("title", ""),
+        "version": entry.get("version", ""),
+        "last_amended": entry.get("last_amended", ""),
+        "principles": [_strip_constitution_rule_tags(item) for item in entry.get("principles", [])[:5]],
+        "quality_gates": [_strip_constitution_rule_tags(item) for item in entry.get("quality_gates", [])[:5]],
+        "governance": [_strip_constitution_rule_tags(item) for item in entry.get("governance", [])[:5]],
+        "changelog": list(entry.get("changelog", [])[:5]),
     }
 
 
@@ -2040,6 +2115,7 @@ def generate_briefing(
     # File annotations (fail-open when table absent; scoped to current repo)
     _repo_root = _current_repo_root()
     file_annotations = query_file_annotations(db, query=rewritten_query, repo_root=_repo_root, limit=6)
+    constitution_entry = _load_constitution(_repo_root)
     clarify_entry = _load_matching_clarification(query, repo_root=_repo_root)
 
     # Pack-only machine surface extras
@@ -2079,7 +2155,7 @@ def generate_briefing(
     db.close()
 
     # Check if we have anything
-    total_entries = sum(len(v) for v in briefing_data.values()) + len(past_work)
+    total_entries = sum(len(v) for v in briefing_data.values()) + len(past_work) + (1 if constitution_entry else 0)
     output = ""
     if total_entries == 0:
         if fmt == "json":
@@ -2088,6 +2164,7 @@ def generate_briefing(
                     "query": query,
                     "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
                     "sections": {},
+                    "constitution": _serialize_constitution(constitution_entry),
                     "clarify": _serialize_clarification(clarify_entry),
                     "message": "No relevant past experience found.",
                 },
@@ -2104,29 +2181,51 @@ def generate_briefing(
                 "file_matches": file_matches,
                 "past_work": [],
                 "next_open": next_open,
+                "constitution": _serialize_constitution(constitution_entry),
                 "clarify": _serialize_clarification(clarify_entry),
             }
             output = json.dumps(pack, indent=2, ensure_ascii=False)
         else:
-            if clarify_entry:
+            if constitution_entry or clarify_entry:
                 if fmt == "compact":
                     output = _format_compact(
-                        query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+                        query,
+                        briefing_data,
+                        past_work,
+                        categories,
+                        blast,
+                        file_annotations,
+                        constitution_entry,
+                        clarify_entry,
                     )
                 elif full:
                     output = _format_markdown(
-                        query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+                        query,
+                        briefing_data,
+                        past_work,
+                        categories,
+                        blast,
+                        file_annotations,
+                        constitution_entry,
+                        clarify_entry,
                     )
                 else:
                     output = _format_default(
-                        query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+                        query,
+                        briefing_data,
+                        past_work,
+                        categories,
+                        blast,
+                        file_annotations,
+                        constitution_entry,
+                        clarify_entry,
                     )
             else:
                 output = f"No relevant past experience found for: {query}\n"
     else:
         # Format output
         if fmt == "json":
-            output = _format_json(query, briefing_data, past_work, categories, blast, clarify_entry)
+            output = _format_json(query, briefing_data, past_work, categories, blast, constitution_entry, clarify_entry)
         elif fmt == "pack":
             pack_entries = {
                 k: [_serialize_pack_entry(e) for e in briefing_data.get(k, [])]
@@ -2160,20 +2259,21 @@ def generate_briefing(
                     for w in past_work
                 ],
                 "next_open": next_open,
+                "constitution": _serialize_constitution(constitution_entry),
                 "clarify": _serialize_clarification(clarify_entry),
             }
             output = json.dumps(pack, indent=2, ensure_ascii=False)
         elif fmt == "compact":
             output = _format_compact(
-                query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+                query, briefing_data, past_work, categories, blast, file_annotations, constitution_entry, clarify_entry
             )
         elif full:
             output = _format_markdown(
-                query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+                query, briefing_data, past_work, categories, blast, file_annotations, constitution_entry, clarify_entry
             )
         else:
             output = _format_default(
-                query, briefing_data, past_work, categories, blast, file_annotations, clarify_entry
+                query, briefing_data, past_work, categories, blast, file_annotations, constitution_entry, clarify_entry
             )
 
     # Append event-level skill usage section (non-pack formats only; fail-open).
@@ -2207,6 +2307,7 @@ def _format_default(
     categories: dict,
     blast: list = None,
     file_annotations: list | None = None,
+    constitution_entry: dict | None = None,
     clarify_entry: dict | None = None,
 ) -> str:
     """Compact default format: titles + 1-line summaries (~500 tokens)."""
@@ -2214,6 +2315,7 @@ def _format_default(
     lines.append(f"📋 Briefing: {query}")
     lines.append("")
 
+    lines.extend(_format_constitution_default_block(constitution_entry))
     lines.extend(_format_clarification_default_block(clarify_entry))
 
     for cat, meta in categories.items():
@@ -2285,7 +2387,7 @@ def _format_default(
             lines.append(fa_block)
             lines.append("")
 
-    total = sum(len(v) for v in data.values()) + len(past_work)
+    total = sum(len(v) for v in data.values()) + len(past_work) + (1 if constitution_entry else 0)
     lines.append(
         f"({total} entries) Use --full for complete content, or query-session.py --detail <id> for specific entry"
     )
@@ -2300,6 +2402,7 @@ def _format_markdown(
     categories: dict,
     blast: list = None,
     file_annotations: list | None = None,
+    constitution_entry: dict | None = None,
     clarify_entry: dict | None = None,
 ) -> str:
     """Format briefing as Markdown."""
@@ -2312,6 +2415,7 @@ def _format_markdown(
     lines.append("---")
     lines.append("")
 
+    lines.extend(_format_constitution_markdown_block(constitution_entry))
     lines.extend(_format_clarification_markdown_block(clarify_entry))
 
     for cat, meta in categories.items():
@@ -2386,17 +2490,30 @@ def _format_markdown(
 
     lines.append("---")
     lines.append(
-        f"_Briefing from knowledge.db — {sum(len(v) for v in data.values())} entries + {len(past_work)} past work refs_"
+        f"_Briefing from knowledge.db — {sum(len(v) for v in data.values()) + (1 if constitution_entry else 0)} entries + {len(past_work)} past work refs_"
     )
 
     return "\n".join(lines)
 
 
 def _format_json(
-    query: str, data: dict, past_work: list, categories: dict, blast: list = None, clarify_entry: dict | None = None
+    query: str,
+    data: dict,
+    past_work: list,
+    categories: dict,
+    blast: list = None,
+    constitution_entry: dict | None = None,
+    clarify_entry: dict | None = None,
 ) -> str:
     """Format briefing as JSON."""
     output = {"query": query, "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S"), "sections": {}}
+
+    constitution = _serialize_constitution(constitution_entry)
+    if constitution:
+        output["sections"]["constitution"] = {
+            "title": "Constitution",
+            "entry": constitution,
+        }
 
     clarify = _serialize_clarification(clarify_entry)
     if clarify:
@@ -2485,6 +2602,27 @@ def _format_clarification_default_block(entry: dict | None) -> list[str]:
     return lines
 
 
+def _format_constitution_default_block(entry: dict | None) -> list[str]:
+    constitution = _serialize_constitution(entry)
+    if not constitution:
+        return []
+    lines = ["🏛️ Constitution"]
+    version = constitution.get("version", "")
+    amended = constitution.get("last_amended", "")
+    meta = " | ".join(part for part in [f"Version {version}" if version else "", amended] if part)
+    if meta:
+        lines.append(f"  {meta}")
+    for principle in constitution.get("principles", [])[:3]:
+        lines.append(f"  Principle: {_word_trim(principle, 120)}")
+    for gate in constitution.get("quality_gates", [])[:2]:
+        lines.append(f"  Gate: {_word_trim(gate, 120)}")
+    governance = constitution.get("governance", [])
+    if governance:
+        lines.append(f"  Governance: {_word_trim(governance[0], 120)}")
+    lines.append("")
+    return lines
+
+
 def _format_clarification_markdown_block(entry: dict | None) -> list[str]:
     """Render a Markdown clarification block for full briefing output."""
     clarify = _serialize_clarification(entry)
@@ -2505,6 +2643,29 @@ def _format_clarification_markdown_block(entry: dict | None) -> list[str]:
     return lines
 
 
+def _format_constitution_markdown_block(entry: dict | None) -> list[str]:
+    constitution = _serialize_constitution(entry)
+    if not constitution:
+        return []
+    lines = ["## 🏛️ Constitution", ""]
+    version = constitution.get("version", "")
+    amended = constitution.get("last_amended", "")
+    if version:
+        lines.append(f"**Version:** {version}")
+    if amended:
+        lines.append(f"**Last Amended:** {amended}")
+    if version or amended:
+        lines.append("")
+    for principle in constitution.get("principles", [])[:3]:
+        lines.append(f"- **Principle:** {principle}")
+    for gate in constitution.get("quality_gates", [])[:2]:
+        lines.append(f"- **Quality Gate:** {gate}")
+    for item in constitution.get("governance", [])[:1]:
+        lines.append(f"- **Governance:** {item}")
+    lines.append("")
+    return lines
+
+
 def _format_clarification_compact_block(entry: dict | None) -> list[str]:
     """Render an XML-like compact clarification block."""
     clarify = _serialize_clarification(entry)
@@ -2522,6 +2683,23 @@ def _format_clarification_compact_block(entry: dict | None) -> list[str]:
     return lines
 
 
+def _format_constitution_compact_block(entry: dict | None) -> list[str]:
+    constitution = _serialize_constitution(entry)
+    if not constitution:
+        return []
+    version = _xml_escape(constitution.get("version", ""))
+    amended = _xml_escape(constitution.get("last_amended", ""))
+    lines = [f'<constitution version="{version}" amended="{amended}">']
+    for principle in constitution.get("principles", [])[:3]:
+        lines.append(f"  <principle>{_xml_escape(_word_trim(principle, 120))}</principle>")
+    for gate in constitution.get("quality_gates", [])[:2]:
+        lines.append(f"  <gate>{_xml_escape(_word_trim(gate, 120))}</gate>")
+    for item in constitution.get("governance", [])[:1]:
+        lines.append(f"  <governance>{_xml_escape(_word_trim(item, 120))}</governance>")
+    lines.append("</constitution>")
+    return lines
+
+
 def _format_compact(
     query: str,
     data: dict,
@@ -2529,6 +2707,7 @@ def _format_compact(
     categories: dict,
     blast: list = None,
     file_annotations: list | None = None,
+    constitution_entry: dict | None = None,
     clarify_entry: dict | None = None,
 ) -> str:
     """Compact format optimized for AI agent context injection.
@@ -2540,6 +2719,7 @@ def _format_compact(
     lines = []
     safe_query = query[:100].replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
     lines.append(f'<briefing task="{safe_query}">\n')
+    lines.extend(_format_constitution_compact_block(constitution_entry))
     lines.extend(_format_clarification_compact_block(clarify_entry))
 
     def _cat_block(cat: str) -> None:

--- a/constitution.py
+++ b/constitution.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""
+constitution.py - Manage project-local constitution governance.
+
+Usage:
+    python constitution.py init
+    python constitution.py check
+    python constitution.py amend --summary "Add release approval gate" --bump minor
+    python constitution.py amend --summary "Clarify worktree policy" --principle "Use isolated worktrees. [rule:no-destructive-git]"
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+DEFAULT_CONSTITUTION_PATH = Path(".copilot") / "constitution.md"
+SECTION_ORDER = ("Principles", "Quality Gates", "Governance", "Changelog")
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+RULE_TAG_RE = re.compile(r"\[rule:(?P<rule>[a-z0-9-]+)\]", re.IGNORECASE)
+KNOWN_RULE_IDS = {
+    "no-destructive-git",
+    "no-force-push",
+}
+
+
+class ConstitutionUsageError(Exception):
+    """Raised for CLI usage issues without exiting the interpreter."""
+
+
+class _ConstitutionArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:  # pragma: no cover - exercised via main()
+        raise ConstitutionUsageError(message)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _today_iso() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_bytes(content.encode(encoding))
+        os.replace(str(tmp), str(path))
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+
+def _find_git_root(start: Path | None = None) -> Path:
+    current = (start or Path.cwd()).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def _resolve_repo_root(repo: str | None) -> Path:
+    if repo:
+        return Path(repo).expanduser().resolve()
+    return _find_git_root()
+
+
+def _constitution_path(repo_root: Path) -> Path:
+    return repo_root / DEFAULT_CONSTITUTION_PATH
+
+
+def _empty_document() -> dict:
+    return {
+        "title": "Project Constitution",
+        "version": "",
+        "last_amended": "",
+        "sections": {section: [] for section in SECTION_ORDER},
+    }
+
+
+def _default_document() -> dict:
+    doc = _empty_document()
+    now = _now_iso()
+    today = _today_iso()
+    doc["version"] = "1.0.0"
+    doc["last_amended"] = now
+    doc["sections"]["Principles"] = [
+        "**Protect History** — Never use destructive git commands on tracked work. [rule:no-destructive-git]",
+        "**Push Safely** — Do not force-push shared branches. [rule:no-force-push]",
+        "**Verify Before Claims** — Back correctness claims with executed validation evidence.",
+    ]
+    doc["sections"]["Quality Gates"] = [
+        "Run the relevant focused tests before calling work complete.",
+        "Keep public CLI/help surfaces aligned with the commands you introduce.",
+        "Preserve fail-open or explicit-error behavior that matches existing repo patterns.",
+    ]
+    doc["sections"]["Governance"] = [
+        "MAJOR updates change or remove a governing principle.",
+        "MINOR updates add a new principle, quality gate, or enforcement rule.",
+        "PATCH updates clarify wording, examples, or operator guidance without changing intent.",
+    ]
+    doc["sections"]["Changelog"] = [
+        f"1.0.0 | {today} | Initialized constitution.",
+    ]
+    return doc
+
+
+def _strip_rule_tags(text: str) -> str:
+    cleaned = RULE_TAG_RE.sub("", str(text or ""))
+    return re.sub(r"\s{2,}", " ", cleaned).strip()
+
+
+def _extract_rule_tags(text: str) -> list[str]:
+    return [match.group("rule").lower() for match in RULE_TAG_RE.finditer(str(text or ""))]
+
+
+def _parse_document(text: str) -> dict:
+    doc = _empty_document()
+    current_section = None
+    for raw_line in text.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("# ") and doc["title"] == "Project Constitution":
+            doc["title"] = stripped[2:].strip() or doc["title"]
+            continue
+        lowered = stripped.lower()
+        if lowered.startswith("version:"):
+            doc["version"] = stripped.split(":", 1)[1].strip()
+            continue
+        if lowered.startswith("last amended:"):
+            doc["last_amended"] = stripped.split(":", 1)[1].strip()
+            continue
+        if stripped.startswith("## "):
+            section_name = stripped[3:].strip()
+            current_section = section_name if section_name in doc["sections"] else None
+            continue
+        if current_section and stripped.startswith("- "):
+            doc["sections"][current_section].append(stripped[2:].strip())
+    return doc
+
+
+def _render_document(doc: dict) -> str:
+    lines = [f"# {doc.get('title') or 'Project Constitution'}", ""]
+    lines.append(f"Version: {doc.get('version', '').strip()}")
+    lines.append(f"Last Amended: {doc.get('last_amended', '').strip()}")
+    lines.append("")
+    for section in SECTION_ORDER:
+        lines.append(f"## {section}")
+        for item in doc["sections"].get(section, []):
+            lines.append(f"- {item}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _load_document(path: Path) -> dict:
+    return _parse_document(path.read_text(encoding="utf-8"))
+
+
+def _bump_version(version: str, bump: str) -> str:
+    major, minor, patch = [int(part) for part in version.split(".")]
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def _validate_document(doc: dict) -> list[str]:
+    violations: list[str] = []
+    title = str(doc.get("title", "")).strip()
+    if not title:
+        violations.append("missing title")
+
+    version = str(doc.get("version", "")).strip()
+    if not version:
+        violations.append("missing version")
+    elif not VERSION_RE.match(version):
+        violations.append("version must follow MAJOR.MINOR.PATCH")
+
+    if not str(doc.get("last_amended", "")).strip():
+        violations.append("missing Last Amended metadata")
+
+    sections = doc.get("sections", {})
+    for section in SECTION_ORDER:
+        if not sections.get(section):
+            violations.append(f"missing {section} section content")
+
+    changelog = sections.get("Changelog", [])
+    if changelog and version and not changelog[0].startswith(version):
+        violations.append("latest changelog entry must start with the current version")
+
+    for principle in sections.get("Principles", []):
+        for rule_id in _extract_rule_tags(principle):
+            if rule_id not in KNOWN_RULE_IDS:
+                violations.append(f"unknown rule tag: {rule_id}")
+
+    return violations
+
+
+def _serialize_document(
+    doc: dict, path: Path, *, valid: bool | None = None, violations: list[str] | None = None
+) -> dict:
+    principles = list(doc["sections"].get("Principles", []))
+    return {
+        "path": str(path),
+        "title": doc.get("title", ""),
+        "version": doc.get("version", ""),
+        "last_amended": doc.get("last_amended", ""),
+        "principles": [_strip_rule_tags(item) for item in principles],
+        "quality_gates": [_strip_rule_tags(item) for item in doc["sections"].get("Quality Gates", [])],
+        "governance": [_strip_rule_tags(item) for item in doc["sections"].get("Governance", [])],
+        "changelog": list(doc["sections"].get("Changelog", [])),
+        "rule_tags": sorted({rule for item in principles for rule in _extract_rule_tags(item)}),
+        "valid": valid,
+        "violations": list(violations or []),
+    }
+
+
+def _print_json(payload: dict) -> None:
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def _build_parser() -> _ConstitutionArgumentParser:
+    parser = _ConstitutionArgumentParser(description="Manage project-local constitution governance.")
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    init_parser = subparsers.add_parser("init", help="Create a constitution template.")
+    init_parser.add_argument("--repo", help="Repo root to operate on (defaults to current git root).")
+    init_parser.add_argument("--force", action="store_true", help="Overwrite an existing constitution.")
+    init_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+
+    check_parser = subparsers.add_parser("check", help="Validate the constitution document.")
+    check_parser.add_argument("--repo", help="Repo root to operate on (defaults to current git root).")
+    check_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+
+    amend_parser = subparsers.add_parser("amend", help="Append amendments and bump the constitution version.")
+    amend_parser.add_argument("--repo", help="Repo root to operate on (defaults to current git root).")
+    amend_parser.add_argument("--bump", choices=["major", "minor", "patch"], default="patch")
+    amend_parser.add_argument("--summary", required=True, help="Changelog summary for this amendment.")
+    amend_parser.add_argument("--principle", action="append", default=[], help="Principle bullet to append.")
+    amend_parser.add_argument("--quality-gate", action="append", default=[], help="Quality gate bullet to append.")
+    amend_parser.add_argument("--governance", action="append", default=[], help="Governance bullet to append.")
+    amend_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(argv)
+        if not args.subcommand:
+            raise ConstitutionUsageError("a subcommand is required: init, check, or amend")
+
+        repo_root = _resolve_repo_root(getattr(args, "repo", None))
+        constitution_path = _constitution_path(repo_root)
+
+        if args.subcommand == "init":
+            if constitution_path.exists() and not args.force:
+                print(
+                    f"constitution: already exists at {constitution_path} (use --force to overwrite)",
+                    file=sys.stderr,
+                )
+                return 1
+            doc = _default_document()
+            constitution_path.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write_text(constitution_path, _render_document(doc))
+            payload = _serialize_document(doc, constitution_path, valid=True, violations=[])
+            if args.json:
+                _print_json(payload)
+            else:
+                print(f"Initialized constitution: {constitution_path}")
+                print(f"Version: {doc['version']}")
+            return 0
+
+        if not constitution_path.exists():
+            payload = {
+                "path": str(constitution_path),
+                "valid": False,
+                "violations": ["constitution file not found"],
+            }
+            if getattr(args, "json", False):
+                _print_json(payload)
+            else:
+                print(f"constitution: file not found at {constitution_path}", file=sys.stderr)
+            return 1
+
+        doc = _load_document(constitution_path)
+
+        if args.subcommand == "check":
+            violations = _validate_document(doc)
+            payload = _serialize_document(doc, constitution_path, valid=not violations, violations=violations)
+            if args.json:
+                _print_json(payload)
+            else:
+                print(f"Constitution: {constitution_path}")
+                print(f"Version: {doc.get('version', '') or '(missing)'}")
+                if violations:
+                    print("Violations:")
+                    for violation in violations:
+                        print(f"- {violation}")
+                else:
+                    print("Status: valid")
+            return 0 if not violations else 1
+
+        if args.subcommand == "amend":
+            violations = _validate_document(doc)
+            if violations:
+                if args.json:
+                    _print_json(_serialize_document(doc, constitution_path, valid=False, violations=violations))
+                else:
+                    print("constitution: cannot amend an invalid constitution:", file=sys.stderr)
+                    for violation in violations:
+                        print(f"- {violation}", file=sys.stderr)
+                return 1
+
+            doc["version"] = _bump_version(doc["version"], args.bump)
+            doc["last_amended"] = _now_iso()
+            doc["sections"]["Principles"].extend([item.strip() for item in args.principle if item.strip()])
+            doc["sections"]["Quality Gates"].extend([item.strip() for item in args.quality_gate if item.strip()])
+            doc["sections"]["Governance"].extend([item.strip() for item in args.governance if item.strip()])
+            doc["sections"]["Changelog"].insert(
+                0,
+                f"{doc['version']} | {_today_iso()} | {args.summary.strip()}",
+            )
+            post_mutation_violations = _validate_document(doc)
+            if post_mutation_violations:
+                if args.json:
+                    _print_json(
+                        _serialize_document(
+                            doc,
+                            constitution_path,
+                            valid=False,
+                            violations=post_mutation_violations,
+                        )
+                    )
+                else:
+                    print("constitution: amendment would make the constitution invalid:", file=sys.stderr)
+                    for violation in post_mutation_violations:
+                        print(f"- {violation}", file=sys.stderr)
+                return 1
+            _atomic_write_text(constitution_path, _render_document(doc))
+            payload = _serialize_document(doc, constitution_path, valid=True, violations=[])
+            if args.json:
+                _print_json(payload)
+            else:
+                print(f"Amended constitution: {constitution_path}")
+                print(f"Version: {doc['version']}")
+                print(f"Summary: {args.summary.strip()}")
+            return 0
+
+        raise ConstitutionUsageError(f"unknown subcommand: {args.subcommand}")
+    except ConstitutionUsageError as exc:
+        print(f"constitution: {exc}", file=sys.stderr)
+        print(parser.format_usage().strip(), file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"constitution: filesystem error: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"constitution: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -14,6 +14,7 @@ hooks/
     __init__.py           # Rule registry
     common.py             # Shared utilities (get_module, deny, info, etc.)
     briefing.py           # Auto-briefing + enforce-briefing
+    constitution_gate.py  # Constitution-aware command enforcement
     learn_gate.py         # Enforce learn.py before commit/task_complete
     learn_reminder.py     # Remind to record learnings
     read_tracker.py       # Warn on repeated view reads via shared session state
@@ -38,6 +39,7 @@ hooks/
 | `enforce-learn` | preToolUse | Blocks git commit AND task_complete without learn.py |
 | `tentacle-enforce` | preToolUse | Blocks (deny) edits once ≥3 files across ≥2 modules are reached without tentacle setup. **Session-state paths** (`~/.copilot/session-state/`) are always exempt — `/research` outputs and other session artifacts are never blocked. **Bash redirects** are only flagged when the destination is a real source file; redirects to `.txt`, `.log`, `/dev/null`, or session-state paths are allowed. The deny message contains convention-level guidance: if you are the **orchestrator**, follow the runtime-bundle workflow — `tentacle.py create <name> --scope "<paths>" --desc "<desc>" --briefing` → `tentacle.py todo <name> add "<task>"` → `tentacle.py swarm <name> --agent-type general-purpose --model claude-sonnet-4.6 --briefing` (bundle is default); if you are a **dispatched sub-agent**, read the bundle manifest first, stay within your declared scope, write any scope gaps to `handoff.md`, and by convention avoid `git commit`/`git push`. |
 | `subagent-git-guard` | preToolUse | **Defense-in-depth**: blocks `git commit`/`git push` bash commands when the `dispatched-subagent-active` marker is fresh. This is a secondary surface — **not** the primary enforcement path (see §Dispatched-Subagent Git Guard below). Whether `preToolUse` fires inside a delegated subagent context is not guaranteed by the platform. |
+| `constitution-gate` | preToolUse | Reads project-local `.copilot/constitution.md` rule tags and blocks matching violations for declared constitution principles. Current built-in rule tags: `no-destructive-git` (blocks `git reset --hard`, `git checkout --`, and destructive `git clean` variants) and `no-force-push` (blocks `git push --force` / `-f`, but allows `--force-with-lease`). |
 | `syntax-gate` | preToolUse | Blocks `edit`/`create` payloads that introduce Python syntax errors — applies the proposed change in memory and runs `py_compile`; fail-open on non-`.py` paths and missing files. Catches errors before they land on disk. |
 | `read-before-edit` | preToolUse + postToolUse | Tracks viewed files (postToolUse on `view`), warns on `edit`/`create` of files not yet read in session (fail-open). |
 | `read-tracker` | preToolUse | Warns on repeated `view` reads of the same file in a session, using shared per-session state populated by `token-tracker`; configurable ignores via `READ_TRACKER_IGNORE_SUFFIXES`; never blocks. |

--- a/hooks/rules/__init__.py
+++ b/hooks/rules/__init__.py
@@ -23,6 +23,7 @@ def get_rules_for_event(event):
     from .block_edit_dist import BlockEditDistRule
     from .block_unsafe_html import BlockUnsafeHtmlRule
     from .briefing import AutoBriefingRule, EnforceBriefingRule
+    from .constitution_gate import ConstitutionGateRule
     from .edit_tracker import TestReminderRule, TrackEditsRule
     from .error_kb import ErrorKBRule
     from .integrity import IntegrityRule
@@ -51,6 +52,7 @@ def get_rules_for_event(event):
         EnforceLearnRule(),
         TentacleEnforceRule(),
         SubagentGitGuardRule(),
+        ConstitutionGateRule(),
         SyntaxGateRule(),
         BlockEditDistRule(),
         PnpmLockfileGuardRule(),

--- a/hooks/rules/constitution_gate.py
+++ b/hooks/rules/constitution_gate.py
@@ -15,7 +15,7 @@ _NO_DESTRUCTIVE_GIT = (
     re.compile(r"\bgit\s+clean\b[^\n]*(?:-fd|-df|-xdf|-xfd)\b"),
 )
 _NO_FORCE_PUSH = (
-    re.compile(r"\bgit\s+push\b[^\n]*\s--force\b"),
+    re.compile(r"\bgit\s+push\b[^\n]*\s--force(?:\s|$)"),
     re.compile(r"\bgit\s+push\b[^\n]*\s-f(?:\s|$)"),
 )
 

--- a/hooks/rules/constitution_gate.py
+++ b/hooks/rules/constitution_gate.py
@@ -1,0 +1,75 @@
+"""ConstitutionGateRule — enforce constitution rule tags from .copilot/constitution.md."""
+
+import os
+import re
+from pathlib import Path
+
+from . import Rule
+from .common import deny
+
+_RULE_TAG_RE = re.compile(r"\[rule:(?P<rule>[a-z0-9-]+)\]", re.IGNORECASE)
+_CONSTITUTION_RELATIVE_PATH = Path(".copilot") / "constitution.md"
+_NO_DESTRUCTIVE_GIT = (
+    re.compile(r"\bgit\s+reset\s+--hard\b"),
+    re.compile(r"\bgit\s+checkout\s+--\b"),
+    re.compile(r"\bgit\s+clean\b[^\n]*(?:-fd|-df|-xdf|-xfd)\b"),
+)
+_NO_FORCE_PUSH = (
+    re.compile(r"\bgit\s+push\b[^\n]*\s--force\b"),
+    re.compile(r"\bgit\s+push\b[^\n]*\s-f(?:\s|$)"),
+)
+
+
+def _find_git_root(start: Path | None = None) -> Path:
+    current = (start or Path.cwd()).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def _load_declared_rules(repo_root: Path | None = None) -> set[str]:
+    root = _find_git_root(repo_root or Path.cwd())
+    constitution_path = root / _CONSTITUTION_RELATIVE_PATH
+    if not constitution_path.is_file():
+        return set()
+    try:
+        text = constitution_path.read_text(encoding="utf-8")
+    except Exception:
+        return set()
+    return {match.group("rule").lower() for match in _RULE_TAG_RE.finditer(text)}
+
+
+def _matches_any(command: str, patterns: tuple[re.Pattern, ...]) -> bool:
+    return any(pattern.search(command) for pattern in patterns)
+
+
+class ConstitutionGateRule(Rule):
+    """Block commands that violate declared constitution rule tags."""
+
+    name = "constitution-gate"
+    events = ["preToolUse"]
+    tools = ["bash"]
+
+    def evaluate(self, event, data):
+        del event
+        command = str((data.get("toolInput") or {}).get("command") or "")
+        if not command:
+            return None
+
+        cwd = (data.get("toolInput") or {}).get("cwd") or data.get("cwd") or os.getcwd()
+        declared_rules = _load_declared_rules(Path(cwd))
+        if not declared_rules:
+            return None
+
+        if "no-destructive-git" in declared_rules and _matches_any(command, _NO_DESTRUCTIVE_GIT):
+            return deny(
+                "Constitution violation: no-destructive-git forbids destructive git commands declared in .copilot/constitution.md"
+            )
+
+        if "no-force-push" in declared_rules and _matches_any(command, _NO_FORCE_PUSH):
+            return deny(
+                "Constitution violation: no-force-push forbids force pushes declared in .copilot/constitution.md"
+            )
+
+        return None

--- a/install.py
+++ b/install.py
@@ -191,6 +191,7 @@ TOOL_FILES = [
     "query-session.py",
     "briefing.py",
     "clarify.py",
+    "constitution.py",
     "task.py",
     "watch-sessions.py",
     "learn.py",

--- a/sk.py
+++ b/sk.py
@@ -10,6 +10,7 @@ Usage:
     sk query    [<args>...]       Run query-session.py
     sk learn    [<args>...]       Run learn.py
     sk clarify  [<args>...]       Run clarify.py
+    sk constitution init|check|amend [<args>...]  Run constitution.py
     sk task     [<args>...]       Run task.py
     sk tentacle [<args>...]       Run tentacle.py
     sk install  [<args>...]       Run install.py
@@ -119,6 +120,11 @@ _GROUPS: dict[str, dict[str, str]] = {
         "save": "checkpoint-save.py",
         "restore": "checkpoint-restore.py",
         "diff": "checkpoint-diff.py",
+    },
+    "constitution": {
+        "init": "constitution.py",
+        "check": "constitution.py",
+        "amend": "constitution.py",
     },
     "profile": {
         "build": "profile-builder.py",
@@ -251,6 +257,21 @@ def _run_project(extra_args: list[str]) -> int:
     return _run("project-registry.py", extra_args)
 
 
+def _run_constitution(extra_args: list[str]) -> int:
+    """Dispatch ``sk constitution ...`` to constitution.py."""
+    if not extra_args or extra_args[0] in ("-h", "--help"):
+        return _run("constitution.py", ["--help"])
+    sub = extra_args[0]
+    if sub not in _GROUPS["constitution"]:
+        subs = list(_GROUPS["constitution"].keys())
+        print(
+            f"sk constitution: unknown subcommand '{sub}'. Choose from: {', '.join(subs)}",
+            file=sys.stderr,
+        )
+        return 2
+    return _run("constitution.py", extra_args)
+
+
 def _print_help() -> None:
     direct_list = "  " + "\n  ".join(f"sk {cmd:<12} → {script}" for cmd, script in _DIRECT.items())
     print(
@@ -283,6 +304,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_hooks(rest)
     if cmd == "project":
         return _run_project(rest)
+    if cmd == "constitution":
+        return _run_constitution(rest)
     if cmd == "doctor":
         return _run("install.py", ["--doctor"] + rest)
     if cmd in _DIRECT:

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+test_constitution.py - Focused tests for constitution.py.
+
+Run: python tests/test_constitution.py
+"""
+
+import importlib.util
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).parent.parent
+SCRIPT_PATH = REPO / "constitution.py"
+
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("constitution", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+constitution = _load_module()
+
+
+class TestConstitution(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="constitution-")
+        self.repo_root = Path(self._tmpdir) / "repo"
+        self.repo_root.mkdir(parents=True, exist_ok=True)
+        (self.repo_root / ".git").mkdir()
+        self.constitution_path = self.repo_root / ".copilot" / "constitution.md"
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _run(self, *args: str):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = constitution.main(list(args))
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def test_init_creates_template_sections(self):
+        rc, stdout, stderr = self._run("init", "--json", "--repo", str(self.repo_root))
+        self.assertEqual(rc, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["version"], "1.0.0")
+        self.assertTrue(self.constitution_path.exists())
+        content = self.constitution_path.read_text(encoding="utf-8")
+        self.assertIn("## Principles", content)
+        self.assertIn("## Quality Gates", content)
+        self.assertIn("## Governance", content)
+        self.assertIn("## Changelog", content)
+        self.assertIn("[rule:no-destructive-git]", content)
+
+    def test_check_reports_valid_document(self):
+        self._run("init", "--repo", str(self.repo_root))
+        rc, stdout, stderr = self._run("check", "--json", "--repo", str(self.repo_root))
+        self.assertEqual(rc, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertTrue(payload["valid"])
+        self.assertEqual(payload["violations"], [])
+        self.assertIn("no-destructive-git", payload["rule_tags"])
+
+    def test_amend_bumps_version_and_updates_changelog(self):
+        self._run("init", "--repo", str(self.repo_root))
+        rc, stdout, stderr = self._run(
+            "amend",
+            "--repo",
+            str(self.repo_root),
+            "--bump",
+            "minor",
+            "--summary",
+            "Add release approval gate",
+            "--quality-gate",
+            "Require release smoke tests.",
+            "--governance",
+            "Record PR links for governance changes.",
+            "--json",
+        )
+        self.assertEqual(rc, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["version"], "1.1.0")
+        content = self.constitution_path.read_text(encoding="utf-8")
+        self.assertIn("1.1.0 |", content)
+        self.assertIn("Add release approval gate", content)
+        self.assertIn("Require release smoke tests.", content)
+        self.assertIn("Record PR links for governance changes.", content)
+
+    def test_check_rejects_unknown_rule_tag(self):
+        self.constitution_path.parent.mkdir(parents=True, exist_ok=True)
+        self.constitution_path.write_text(
+            "# Project Constitution\n\n"
+            "Version: 1.0.0\n"
+            "Last Amended: 2026-01-01T00:00:00+00:00\n\n"
+            "## Principles\n"
+            "- **Protect History** — Never rewrite history. [rule:not-a-real-rule]\n\n"
+            "## Quality Gates\n"
+            "- Run focused tests.\n\n"
+            "## Governance\n"
+            "- Patch updates clarify wording.\n\n"
+            "## Changelog\n"
+            "- 1.0.0 | 2026-01-01 | Initialized constitution.\n",
+            encoding="utf-8",
+        )
+        rc, stdout, stderr = self._run("check", "--json", "--repo", str(self.repo_root))
+        self.assertEqual(rc, 1, stderr)
+        payload = json.loads(stdout)
+        self.assertFalse(payload["valid"])
+        self.assertTrue(any("unknown rule tag" in violation for violation in payload["violations"]))
+
+    def test_amend_rejects_unknown_rule_tag(self):
+        self._run("init", "--repo", str(self.repo_root))
+        rc, stdout, stderr = self._run(
+            "amend",
+            "--repo",
+            str(self.repo_root),
+            "--summary",
+            "Introduce invalid rule tag",
+            "--principle",
+            "Never rewrite history. [rule:unknown-custom-rule]",
+            "--json",
+        )
+        self.assertEqual(rc, 1, stderr)
+        payload = json.loads(stdout)
+        self.assertFalse(payload["valid"])
+        self.assertTrue(any("unknown rule tag" in violation for violation in payload["violations"]))
+        content = self.constitution_path.read_text(encoding="utf-8")
+        self.assertNotIn("unknown-custom-rule", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_constitution_briefing.py
+++ b/tests/test_constitution_briefing.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+test_constitution_briefing.py - Focused tests for constitution briefing integration.
+
+Run: python tests/test_constitution_briefing.py
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).parent.parent
+SCRIPT_PATH = REPO / "briefing.py"
+
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("briefing", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+briefing = _load_module()
+
+
+class TestConstitutionBriefing(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="constitution-briefing-")
+        self.repo_root = Path(self._tmpdir) / "repo"
+        self.repo_root.mkdir(parents=True, exist_ok=True)
+        (self.repo_root / ".git").mkdir()
+        constitution_path = self.repo_root / ".copilot" / "constitution.md"
+        constitution_path.parent.mkdir(parents=True, exist_ok=True)
+        constitution_path.write_text(
+            "# Project Constitution\n\n"
+            "Version: 1.0.0\n"
+            "Last Amended: 2026-01-01T00:00:00+00:00\n\n"
+            "## Principles\n"
+            "- **Protect History** — Never use destructive git commands. [rule:no-destructive-git]\n"
+            "- **Push Safely** — Avoid force pushes. [rule:no-force-push]\n\n"
+            "## Quality Gates\n"
+            "- Run focused tests.\n\n"
+            "## Governance\n"
+            "- Minor updates add new quality gates.\n\n"
+            "## Changelog\n"
+            "- 1.0.0 | 2026-01-01 | Initialized constitution.\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_load_constitution_parses_sections(self):
+        entry = briefing._load_constitution(str(self.repo_root))
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["version"], "1.0.0")
+        self.assertEqual(len(entry["principles"]), 2)
+        self.assertEqual(entry["quality_gates"], ["Run focused tests."])
+
+    def test_formats_render_constitution_first(self):
+        entry = briefing._load_constitution(str(self.repo_root))
+        default_output = briefing._format_default(
+            "ship constitution workflow",
+            {},
+            [],
+            {},
+            constitution_entry=entry,
+        )
+        self.assertIn("🏛️ Constitution", default_output)
+        self.assertLess(default_output.index("🏛️ Constitution"), default_output.index("(1 entries)"))
+
+        markdown_output = briefing._format_markdown(
+            "ship constitution workflow",
+            {},
+            [],
+            {},
+            constitution_entry=entry,
+        )
+        self.assertIn("## 🏛️ Constitution", markdown_output)
+
+        compact_output = briefing._format_compact(
+            "ship constitution workflow",
+            {},
+            [],
+            {},
+            constitution_entry=entry,
+        )
+        self.assertIn('<constitution version="1.0.0"', compact_output)
+
+        json_output = json.loads(
+            briefing._format_json(
+                "ship constitution workflow",
+                {},
+                [],
+                {},
+                constitution_entry=entry,
+            )
+        )
+        self.assertIn("constitution", json_output["sections"])
+        self.assertEqual(json_output["sections"]["constitution"]["entry"]["version"], "1.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_constitution_gate.py
+++ b/tests/test_constitution_gate.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+test_constitution_gate.py - Focused tests for ConstitutionGateRule.
+
+Run: python tests/test_constitution_gate.py
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO / "hooks"))
+
+from rules.constitution_gate import ConstitutionGateRule  # noqa: E402
+
+
+class TestConstitutionGate(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="constitution-gate-")
+        self.repo_root = Path(self._tmpdir) / "repo"
+        self.repo_root.mkdir(parents=True, exist_ok=True)
+        (self.repo_root / ".git").mkdir()
+        constitution_path = self.repo_root / ".copilot" / "constitution.md"
+        constitution_path.parent.mkdir(parents=True, exist_ok=True)
+        self.rule = ConstitutionGateRule()
+        self.path = constitution_path
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _write_constitution(self, principle_lines: list[str]) -> None:
+        self.path.write_text(
+            "# Project Constitution\n\n"
+            "Version: 1.0.0\n"
+            "Last Amended: 2026-01-01T00:00:00+00:00\n\n"
+            "## Principles\n"
+            + "".join(f"- {line}\n" for line in principle_lines)
+            + "\n## Quality Gates\n- Run focused tests.\n\n## Governance\n- Patch updates clarify wording.\n\n## Changelog\n- 1.0.0 | 2026-01-01 | Initialized constitution.\n",
+            encoding="utf-8",
+        )
+
+    def test_no_constitution_allows_command(self):
+        result = self.rule.evaluate(
+            "preToolUse",
+            {"toolName": "bash", "toolInput": {"command": "git reset --hard HEAD~1", "cwd": str(self.repo_root)}},
+        )
+        self.assertIsNone(result)
+
+    def test_destructive_git_is_denied_when_rule_declared(self):
+        self._write_constitution(["**Protect History** — Never rewrite history. [rule:no-destructive-git]"])
+        result = self.rule.evaluate(
+            "preToolUse",
+            {"toolName": "bash", "toolInput": {"command": "git reset --hard HEAD~1", "cwd": str(self.repo_root)}},
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["permissionDecision"], "deny")
+        self.assertIn("no-destructive-git", result["permissionDecisionReason"])
+
+    def test_force_push_is_denied_when_rule_declared(self):
+        self._write_constitution(["**Push Safely** — Avoid force pushes. [rule:no-force-push]"])
+        result = self.rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "bash",
+                "toolInput": {"command": "git push --force origin main", "cwd": str(self.repo_root)},
+            },
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["permissionDecision"], "deny")
+        self.assertIn("no-force-push", result["permissionDecisionReason"])
+
+    def test_force_with_lease_is_allowed(self):
+        self._write_constitution(["**Push Safely** — Avoid force pushes. [rule:no-force-push]"])
+        result = self.rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "bash",
+                "toolInput": {"command": "git push --force-with-lease origin main", "cwd": str(self.repo_root)},
+            },
+        )
+        self.assertIsNone(result)
+
+    def test_unrelated_command_is_allowed(self):
+        self._write_constitution(["**Protect History** — Never rewrite history. [rule:no-destructive-git]"])
+        result = self.rule.evaluate(
+            "preToolUse",
+            {"toolName": "bash", "toolInput": {"command": "git status", "cwd": str(self.repo_root)}},
+        )
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -390,6 +390,7 @@ pre_names = [r.name for r in pre_tool_rules]
 test("preToolUse has enforce-briefing", "enforce-briefing" in pre_names)
 test("preToolUse has enforce-learn", "enforce-learn" in pre_names)
 test("preToolUse has tentacle-enforce", "tentacle-enforce" in pre_names)
+test("preToolUse has constitution-gate", "constitution-gate" in pre_names)
 test("preToolUse has verification-gate", "verification-gate" in pre_names)
 
 post_names = [r.name for r in post_tool_rules]
@@ -5478,6 +5479,7 @@ _dummy_exists27g.write_text("# placeholder\n", encoding="utf-8")
 
 try:
     from unittest.mock import patch as _mock_patch27g
+
     sys.path.insert(0, str(REPO / "hooks"))
     import rules.briefing as _rb27g
     from rules.briefing import AutoBriefingRule as _ABR27g
@@ -5502,19 +5504,35 @@ try:
     def _mock_run27g(*a, **kw):
         # Pass through fast commands (git, etc.); simulate timeout for briefing.py.
         args = a[0] if a else kw.get("args", [])
-        if isinstance(args, list) and len(args) >= 2 and str(args[-1]).endswith("briefing.py") or \
-           (isinstance(args, list) and "--session-start" in args):
+        if (
+            isinstance(args, list)
+            and len(args) >= 2
+            and str(args[-1]).endswith("briefing.py")
+            or (isinstance(args, list) and "--session-start" in args)
+        ):
             raise _te27g
-        return subprocess.run.__wrapped__(*a, **kw) if hasattr(subprocess.run, "__wrapped__") else _orig_sp_run27g(*a, **kw)
+        return (
+            subprocess.run.__wrapped__(*a, **kw)
+            if hasattr(subprocess.run, "__wrapped__")
+            else _orig_sp_run27g(*a, **kw)
+        )
 
     _orig_sp_run27g = _rb27g.subprocess.run
 
     try:
-        with _mock_patch27g.object(_rb27g.subprocess, "run", side_effect=lambda *a, **kw: (
-            (_ for _ in ()).throw(_te27g)
-            if (a and isinstance(a[0], list) and any("briefing.py" in str(x) or x == "--session-start" for x in a[0]))
-            else _orig_sp_run27g(*a, **kw)
-        )):
+        with _mock_patch27g.object(
+            _rb27g.subprocess,
+            "run",
+            side_effect=lambda *a, **kw: (
+                (_ for _ in ()).throw(_te27g)
+                if (
+                    a
+                    and isinstance(a[0], list)
+                    and any("briefing.py" in str(x) or x == "--session-start" for x in a[0])
+                )
+                else _orig_sp_run27g(*a, **kw)
+            ),
+        ):
             _result27g = _rule27g.evaluate("sessionStart", {})
     except Exception:
         # mock.patch.object doesn't work as context manager for side_effect on non-method
@@ -5559,13 +5577,12 @@ finally:
 _rust_rules_src_27h = (REPO / "sk-rust" / "src" / "hooks" / "rules.rs").read_text(encoding="utf-8")
 test(
     "27h: Rust AutoBriefingRule joins reader thread on timeout and appends partial output",
-    "timed_out" in _rust_rules_src_27h and "handle.join()" in _rust_rules_src_27h
+    "timed_out" in _rust_rules_src_27h
+    and "handle.join()" in _rust_rules_src_27h
     and "partial_out" in _rust_rules_src_27h
     and _rust_rules_src_27h.index("partial_out") < _rust_rules_src_27h.index("Briefing timed out"),
     "sk-rust AutoBriefingRule must join reader thread and append partial output before timeout notice",
 )
-
-
 
 
 # ── Section 29: SK_TOOLS_DIR parity guard (issue #118 follow-up) ──
@@ -5574,9 +5591,11 @@ print("\n── Section 29: SK_TOOLS_DIR existence guard (parity with Rust) ─�
 import importlib
 import types as _types
 
+
 def _reload_common_with_env(env_overrides: dict):
     """Import hooks.rules.common with a patched environment and return TOOLS_DIR."""
     import sys as _sys
+
     _saved = os.environ.copy()
     for k, v in env_overrides.items():
         if v is None:
@@ -5588,6 +5607,7 @@ def _reload_common_with_env(env_overrides: dict):
     if mod_name in _sys.modules:
         del _sys.modules[mod_name]
     import importlib as _il
+
     try:
         mod = _il.import_module(mod_name)
         return mod.TOOLS_DIR
@@ -5597,8 +5617,10 @@ def _reload_common_with_env(env_overrides: dict):
         if mod_name in _sys.modules:
             del _sys.modules[mod_name]
 
+
 try:
-    import tempfile, pathlib
+    import pathlib
+    import tempfile
 
     # 28a: SK_TOOLS_DIR unset → default path
     _td28_result = _reload_common_with_env({"SK_TOOLS_DIR": None})
@@ -5628,6 +5650,7 @@ try:
         )
     finally:
         import shutil as _sh28
+
         _sh28.rmtree(_tmpdir28, ignore_errors=True)
 
 except Exception as _e28:

--- a/tests/test_install_helpers.py
+++ b/tests/test_install_helpers.py
@@ -306,6 +306,7 @@ test("TOOL_FILES contains watch-sessions.py", "watch-sessions.py" in _install.TO
 test("TOOL_FILES contains install.py", "install.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains sk.py", "sk.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains clarify.py", "clarify.py" in _install.TOOL_FILES)
+test("TOOL_FILES contains constitution.py", "constitution.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains task.py", "task.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains context-blocks.py", "context-blocks.py" in _install.TOOL_FILES)
 test("SUPPORT_FILES contains pyproject.toml", "pyproject.toml" in _install.SUPPORT_FILES)

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -585,6 +585,53 @@ class TestSkProjectNamespace(unittest.TestCase):
         self.assertIn("project", output)
 
 
+class TestSkConstitutionNamespace(unittest.TestCase):
+    """Verify that sk constitution init/check/amend route to constitution.py."""
+
+    def _assert_constitution_routes(self, sub: str, extra: list[str] | None = None):
+        extra = extra or []
+        expected_args = [sub] + extra
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main(["constitution", sub] + extra)
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with("constitution.py", expected_args)
+
+    def test_constitution_init(self):
+        self._assert_constitution_routes("init")
+
+    def test_constitution_check(self):
+        self._assert_constitution_routes("check", ["--json"])
+
+    def test_constitution_amend(self):
+        self._assert_constitution_routes(
+            "amend",
+            ["--summary", "Add release approval gate", "--bump", "minor"],
+        )
+
+    def test_constitution_unknown_sub_returns_2(self):
+        with patch("builtins.print"):
+            rc = sk.main(["constitution", "publish"])
+        self.assertEqual(rc, 2)
+
+    def test_constitution_help_flag(self):
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main(["constitution", "--help"])
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with("constitution.py", ["--help"])
+
+    def test_constitution_no_args_shows_help(self):
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main(["constitution"])
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with("constitution.py", ["--help"])
+
+    def test_constitution_in_help_output(self):
+        with patch("builtins.print") as mock_print:
+            sk.main(["--help"])
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("constitution", output)
+
+
 class TestSkErrorCases(unittest.TestCase):
     """Generic CLI error and edge-case routing tests."""
 


### PR DESCRIPTION
## Summary
- add project-local constitution lifecycle commands with versioned changelog support
- load constitution content first in briefing output and expose constitution-aware hook enforcement
- add focused constitution, briefing, hook, CLI, and installer coverage

## Validation
- python tests/test_constitution.py
- python tests/test_constitution_briefing.py
- python tests/test_constitution_gate.py
- python tests/test_briefing.py
- python tests/test_sk_cli.py
- python tests/test_install_helpers.py
- python tests/test_hooks.py
- python test_fixes.py
- python test_security.py

Closes #94