### PR TITLE
feat(skills): add extension catalog

### DIFF
--- a/install.py
+++ b/install.py
@@ -206,6 +206,7 @@ TOOL_FILES = [
     "sync-gateway.py",
     "generate-summary.py",
     "sk.py",
+    "skill-catalog.py",
     "install.py",
 ]
 
@@ -214,6 +215,10 @@ SUPPORT_FILES = [
     "KNOWLEDGE.md",
     "embedding-config.json",
     "pyproject.toml",
+]
+
+SUPPORT_DIRS = [
+    "skills",
 ]
 
 # Managed sk launcher directory (cross-platform: ~/.copilot/bin/)
@@ -249,6 +254,51 @@ def _count_scripts(d: Path) -> int:
     if not d.is_dir():
         return 0
     return sum(1 for f in d.iterdir() if f.suffix == ".py")
+
+
+def _support_dir_files(base_dir: Path) -> list[Path]:
+    """Return managed files under support directories."""
+    files: list[Path] = []
+    for rel_dir in SUPPORT_DIRS:
+        root = base_dir / rel_dir
+        if not root.is_dir():
+            continue
+        files.extend(sorted(p for p in root.rglob("*") if p.is_file()))
+    return files
+
+
+def _prune_empty_dir(root: Path) -> None:
+    """Remove an empty directory tree from the bottom up."""
+    if not root.is_dir():
+        return
+    for child in sorted((p for p in root.rglob("*") if p.is_dir()), key=lambda p: len(p.parts), reverse=True):
+        try:
+            child.rmdir()
+        except OSError:
+            pass
+    try:
+        root.rmdir()
+    except OSError:
+        pass
+
+
+def _replace_support_dir(src_dir: Path, dst_dir: Path) -> None:
+    """Refresh a bundled support directory via staged same-volume renames."""
+    staging_dir = dst_dir.with_name(dst_dir.name + ".new")
+    backup_dir = dst_dir.with_name(dst_dir.name + ".old")
+    shutil.rmtree(staging_dir, ignore_errors=True)
+    shutil.rmtree(backup_dir, ignore_errors=True)
+    shutil.copytree(str(src_dir), str(staging_dir))
+    try:
+        if dst_dir.exists():
+            os.replace(str(dst_dir), str(backup_dir))
+        os.replace(str(staging_dir), str(dst_dir))
+    except Exception:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        if backup_dir.exists() and not dst_dir.exists():
+            os.replace(str(backup_dir), str(dst_dir))
+        raise
+    shutil.rmtree(backup_dir, ignore_errors=True)
 
 
 MANAGED_MANIFEST_VERSION = "1.0.0"
@@ -1444,6 +1494,7 @@ def uninstall() -> int:
         p = TOOLS_DIR / f
         if p.is_file():
             managed_files.append(p)
+    managed_files.extend(_support_dir_files(TOOLS_DIR))
 
     removable, preserved_modified, preserved_untracked = _partition_manifest_removals(managed_files)
     runtime_removable: list[Path] = []
@@ -1523,6 +1574,8 @@ def uninstall() -> int:
 
     if removable:
         _forget_managed_paths(removable)
+    for rel_dir in SUPPORT_DIRS:
+        _prune_empty_dir(TOOLS_DIR / rel_dir)
 
     if TOOLS_DIR.is_dir():
         remaining = list(TOOLS_DIR.iterdir())
@@ -1569,10 +1622,22 @@ def install():
                 shutil.copy2(str(src), str(dst))
                 managed_paths.append(dst)
                 copied += 1
+        copied_support_dirs = 0
+        for rel_dir in SUPPORT_DIRS:
+            src_dir = source_dir / rel_dir
+            dst_dir = TOOLS_DIR / rel_dir
+            if not src_dir.is_dir():
+                continue
+            _replace_support_dir(src_dir, dst_dir)
+            copied_support_dirs += 1
         print(f"  {OK} Copied {copied} files")
+        if copied_support_dirs:
+            noun = "directory" if copied_support_dirs == 1 else "directories"
+            print(f"  {OK} Copied {copied_support_dirs} support {noun}")
     else:
         managed_paths.extend([TOOLS_DIR / f for f in TOOL_FILES + SUPPORT_FILES if (TOOLS_DIR / f).is_file()])
         print(f"  {OK} Scripts already in place")
+    managed_paths.extend(_support_dir_files(TOOLS_DIR))
 
     print("\n  Building knowledge index...")
     if SESSION_STATE.is_dir():

--- a/sk.py
+++ b/sk.py
@@ -34,6 +34,7 @@ Usage:
     sk skill-suggest [<args>...]      Run skill-suggest.py
     sk skill-patch  [<args>...]       Run skill-patch.py
     sk skill-curator [<args>...]      Run skill-curator.py
+    sk skill catalog|add|remove [<args>...]  Run skill-catalog.py
     sk hooks        run|list|<event>  Run hooks/hook_runner.py
     sk audit-hooks  [<args>...]       Run audit-hooks.py
     sk audit-instructions [<args>...] Run audit-instructions.py
@@ -152,6 +153,11 @@ _GROUPS: dict[str, dict[str, str]] = {
         "add": "project-registry.py",
         "remove": "project-registry.py",
         "list": "project-registry.py",
+    },
+    "skill": {
+        "catalog": "skill-catalog.py",
+        "add": "skill-catalog.py",
+        "remove": "skill-catalog.py",
     },
 }
 
@@ -278,6 +284,29 @@ def _run_constitution(extra_args: list[str]) -> int:
     return _run("constitution.py", extra_args)
 
 
+def _run_skill(extra_args: list[str]) -> int:
+    """Dispatch ``sk skill ...`` to skill-catalog.py.
+
+    All subcommands (catalog / add / remove) are forwarded as the first positional
+    argument so skill-catalog.py's argparse sub-parser can route them correctly.
+    """
+    if not extra_args or extra_args[0] in ("-h", "--help"):
+        subs = list(_GROUPS["skill"].keys())
+        print(f"sk skill: available subcommands: {', '.join(subs)}")
+        print(f"Usage: sk skill <{'|'.join(subs)}> [args...]")
+        return 0
+    sub = extra_args[0]
+    if sub not in _GROUPS["skill"]:
+        subs = list(_GROUPS["skill"].keys())
+        print(
+            f"sk skill: unknown subcommand '{sub}'. Choose from: {', '.join(subs)}",
+            file=sys.stderr,
+        )
+        return 2
+    # Forward ALL args including the subcommand to skill-catalog.py
+    return _run("skill-catalog.py", extra_args)
+
+
 def _run_spec_phase(phase: str, extra_args: list[str]) -> int:
     """Dispatch ``sk plan`` / ``sk tasks`` through specify.py."""
     return _run("specify.py", [phase] + extra_args)
@@ -317,6 +346,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_project(rest)
     if cmd == "constitution":
         return _run_constitution(rest)
+    if cmd == "skill":
+        return _run_skill(rest)
     if cmd in {"plan", "tasks"}:
         return _run_spec_phase(cmd, rest)
     if cmd == "doctor":

--- a/skill-catalog.py
+++ b/skill-catalog.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+"""skill-catalog.py — Extension Catalog for skills (sk skill catalog/add/remove).
+
+Manages installation and removal of skills from:
+  - Official catalog: bundled skills/ directory in this repo
+  - Community catalog: ZIP packages from HTTPS URLs (--from <url>)
+
+Registry: <repo>/.copilot/skills/.registry  (JSON, SHA-256 tracking)
+
+Usage:
+    python skill-catalog.py catalog               List official skills
+    python skill-catalog.py catalog --json        Output as JSON
+    python skill-catalog.py add <name>            Install official skill
+    python skill-catalog.py add --from <url>      Install community skill (HTTPS only)
+    python skill-catalog.py remove <name>         Remove installed skill (checks digest)
+    python skill-catalog.py remove <name> --force Force removal even if digest mismatch
+    python skill-catalog.py --help                Show this help
+"""
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import sys
+import zipfile
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+if os.name == "nt":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+_TOOLS_DIR = Path(__file__).parent.resolve()
+_OFFICIAL_SKILLS_DIR = _TOOLS_DIR / "skills"
+
+_SKILL_YML_SCHEMA_VERSION = 1
+_REGISTRY_FILENAME = ".registry"
+
+# Minimum required fields in skill.yml
+_SKILL_YML_REQUIRED = ("schema_version", "provides", "requires")
+
+# ---------------------------------------------------------------------------
+# skill.yml parsing / validation (pure stdlib — no YAML library)
+# ---------------------------------------------------------------------------
+
+
+def _parse_skill_yml(text: str) -> dict:
+    """Parse a minimal skill.yml using a hand-rolled parser (no PyYAML dependency).
+
+    Supports the subset needed by this spec:
+      schema_version: <int>
+      provides:
+        commands:
+          - <str>
+          ...
+      requires:
+        sk_version: <str>
+      hooks:           (optional)
+        before_plan: <str>
+        after_implement: <str>
+    """
+    result: dict = {}
+    lines = text.splitlines()
+    i = 0
+
+    def _strip_comment(s: str) -> str:
+        # Remove inline YAML comments
+        in_q = False
+        for idx, ch in enumerate(s):
+            if ch == '"':
+                in_q = not in_q
+            elif ch == "#" and not in_q:
+                return s[:idx]
+        return s
+
+    def _unquote(s: str) -> str:
+        """Strip surrounding YAML quotes from a scalar value."""
+        s = s.strip()
+        if len(s) >= 2 and ((s[0] == '"' and s[-1] == '"') or (s[0] == "'" and s[-1] == "'")):
+            return s[1:-1]
+        return s
+
+    while i < len(lines):
+        raw = lines[i]
+        stripped = raw.strip()
+        i += 1
+
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        # Top-level key: value
+        if not raw.startswith(" ") and ":" in stripped:
+            key, _, val = stripped.partition(":")
+            key = key.strip()
+            val = _strip_comment(val).strip()
+            if val:
+                # Try int (unquoted)
+                try:
+                    result[key] = int(val)
+                except ValueError:
+                    result[key] = _unquote(val)
+            else:
+                # Block value — collect children
+                children: dict = {}
+                list_items: list = []
+                while i < len(lines):
+                    child_raw = lines[i]
+                    child_stripped = child_raw.strip()
+                    if not child_stripped or child_stripped.startswith("#"):
+                        i += 1
+                        continue
+                    indent = len(child_raw) - len(child_raw.lstrip())
+                    if indent == 0:
+                        break
+                    i += 1
+                    if child_stripped.startswith("- "):
+                        list_items.append(child_stripped[2:].strip())
+                    elif ":" in child_stripped:
+                        ck, _, cv = child_stripped.partition(":")
+                        cv = _strip_comment(cv).strip()
+                        # Sub-block (e.g. provides.commands)
+                        if not cv:
+                            sub_items: list = []
+                            while i < len(lines):
+                                sub_raw = lines[i]
+                                sub_stripped = sub_raw.strip()
+                                if not sub_stripped or sub_stripped.startswith("#"):
+                                    i += 1
+                                    continue
+                                sub_indent = len(sub_raw) - len(sub_raw.lstrip())
+                                if sub_indent <= indent:
+                                    break
+                                i += 1
+                                if sub_stripped.startswith("- "):
+                                    sub_items.append(sub_stripped[2:].strip())
+                            children[ck.strip()] = sub_items
+                        else:
+                            try:
+                                children[ck.strip()] = int(cv)
+                            except ValueError:
+                                children[ck.strip()] = _unquote(cv)
+                result[key] = children if children else (list_items if list_items else {})
+    return result
+
+
+def _validate_skill_yml(data: dict) -> list[str]:
+    """Return list of validation error strings (empty = valid)."""
+    errors: list[str] = []
+
+    if "schema_version" not in data:
+        errors.append("missing 'schema_version'")
+    elif not isinstance(data["schema_version"], int):
+        errors.append("'schema_version' must be an integer")
+    elif data["schema_version"] != _SKILL_YML_SCHEMA_VERSION:
+        errors.append(f"'schema_version' must be {_SKILL_YML_SCHEMA_VERSION} (got {data['schema_version']})")
+
+    provides = data.get("provides", {})
+    if not isinstance(provides, dict):
+        errors.append("'provides' must be a mapping")
+    else:
+        cmds = provides.get("commands")
+        if cmds is None:
+            errors.append("'provides.commands' is required")
+        elif not isinstance(cmds, list) or len(cmds) == 0:
+            errors.append("'provides.commands' must be a non-empty list")
+
+    requires = data.get("requires", {})
+    if not isinstance(requires, dict):
+        errors.append("'requires' must be a mapping")
+    else:
+        if "sk_version" not in requires:
+            errors.append("'requires.sk_version' is required")
+
+    hooks = data.get("hooks", {})
+    if hooks and not isinstance(hooks, dict):
+        errors.append("'hooks' must be a mapping")
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Registry helpers
+# ---------------------------------------------------------------------------
+
+
+def _registry_path(project_root: Path) -> Path:
+    return project_root / ".copilot" / "skills" / _REGISTRY_FILENAME
+
+
+def _load_registry(project_root: Path) -> dict:
+    rp = _registry_path(project_root)
+    if not rp.exists():
+        return {"skills": {}}
+    try:
+        data = json.loads(rp.read_text(encoding="utf-8"))
+        if "skills" not in data:
+            data["skills"] = {}
+        return data
+    except (json.JSONDecodeError, OSError):
+        return {"skills": {}}
+
+
+def _save_registry(project_root: Path, registry: dict) -> None:
+    rp = _registry_path(project_root)
+    rp.parent.mkdir(parents=True, exist_ok=True)
+    tmp = rp.with_suffix(".tmp")
+    try:
+        tmp.write_bytes(json.dumps(registry, indent=2, sort_keys=True).encode("utf-8"))
+        os.replace(str(tmp), str(rp))
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# SHA-256 helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha256_dir(directory: Path) -> str:
+    """Return a stable SHA-256 digest over all files in a directory (sorted)."""
+    digest = hashlib.sha256()
+    for p in sorted(directory.rglob("*")):
+        if p.is_file():
+            rel = p.relative_to(directory).as_posix()
+            digest.update(rel.encode("utf-8"))
+            digest.update(b"\x00")
+            with p.open("rb") as fh:
+                for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                    digest.update(chunk)
+    return digest.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Official catalog helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_official_skills() -> list[dict]:
+    """Return list of official skill info dicts from the bundled skills/ dir."""
+    skills = []
+    if not _OFFICIAL_SKILLS_DIR.exists():
+        return skills
+    for skill_dir in sorted(_OFFICIAL_SKILLS_DIR.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skill_md = skill_dir / "SKILL.md"
+        skill_yml = skill_dir / "skill.yml"
+        if not skill_md.exists():
+            continue
+        entry: dict = {"name": skill_dir.name, "source": "official", "path": str(skill_dir)}
+        if skill_yml.exists():
+            try:
+                data = _parse_skill_yml(skill_yml.read_text(encoding="utf-8"))
+                entry["commands"] = data.get("provides", {}).get("commands", [])
+                entry["sk_version"] = data.get("requires", {}).get("sk_version", "")
+            except Exception:
+                pass
+        # Parse description from SKILL.md front-matter
+        lines = skill_md.read_text(encoding="utf-8").splitlines()
+        for line in lines:
+            if line.strip().startswith("description:"):
+                entry["description"] = line.split(":", 1)[1].strip().strip('"').strip("'")
+                break
+        skills.append(entry)
+    return skills
+
+
+# ---------------------------------------------------------------------------
+# Install / uninstall helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_project_root(cwd: Path | None = None) -> Path:
+    """Walk up from cwd looking for a .git directory or .copilot directory."""
+    start = cwd or Path.cwd()
+    for candidate in [start, *start.parents]:
+        if (candidate / ".git").exists() or (candidate / ".copilot").exists():
+            return candidate
+    # Fallback: cwd
+    return start
+
+
+def _skill_install_dir(project_root: Path, name: str) -> Path:
+    return project_root / ".copilot" / "skills" / name
+
+
+def _copy_official_skill(name: str, dest: Path) -> None:
+    """Copy official skill directory into dest."""
+    src = _OFFICIAL_SKILLS_DIR / name
+    if not src.exists():
+        raise FileNotFoundError(f"Official skill '{name}' not found in {_OFFICIAL_SKILLS_DIR}")
+    if dest.exists():
+        import shutil
+
+        shutil.rmtree(dest)
+    import shutil
+
+    shutil.copytree(str(src), str(dest))
+
+
+def _download_https_zip(url: str, timeout: int = 30) -> bytes:
+    """Download a ZIP from an HTTPS URL. Raises on non-HTTPS or HTTP errors."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise ValueError(f"Only HTTPS community sources are allowed (got: {url!r})")
+    with urlopen(url, timeout=timeout) as resp:  # noqa: S310 — HTTPS enforced above
+        return resp.read()
+
+
+def _find_skill_root_in_zip(zf: zipfile.ZipFile) -> str | None:
+    """Return the common prefix path (or '') where skill.yml lives in the ZIP."""
+    names = zf.namelist()
+    for name in names:
+        if name.endswith("skill.yml") and not name.startswith("__"):
+            prefix = name[: name.rfind("skill.yml")]
+            return prefix
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: catalog
+# ---------------------------------------------------------------------------
+
+
+def cmd_catalog(args: argparse.Namespace) -> int:
+    project_root = _find_project_root()
+    registry = _load_registry(project_root)
+    installed = registry.get("skills", {})
+
+    skills = _list_official_skills()
+
+    if args.json:
+        for s in skills:
+            s["installed"] = s["name"] in installed
+        print(json.dumps({"official": skills, "installed": list(installed.keys())}, indent=2))
+        return 0
+
+    if not skills:
+        print("No official skills found.")
+        return 0
+
+    print(f"Official skills ({len(skills)}):")
+    for s in skills:
+        marker = "✓" if s["name"] in installed else " "
+        desc = s.get("description", "")
+        cmds = ", ".join(s.get("commands", []))
+        suffix = f"  [{cmds}]" if cmds else ""
+        print(f"  [{marker}] {s['name']:<30} {desc[:60]}{suffix}")
+
+    if installed:
+        # Show community-installed skills not in official list
+        official_names = {s["name"] for s in skills}
+        community = {k: v for k, v in installed.items() if k not in official_names}
+        if community:
+            print(f"\nCommunity-installed skills ({len(community)}):")
+            for name, meta in community.items():
+                src = meta.get("source_url", "<local>")
+                print(f"  [✓] {name:<30} from {src}")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: add
+# ---------------------------------------------------------------------------
+
+
+def cmd_add(args: argparse.Namespace) -> int:
+    project_root = _find_project_root()
+    registry = _load_registry(project_root)
+
+    from_url: str | None = getattr(args, "from", None)
+
+    if from_url:
+        # Community install
+        return _add_community(args, project_root, registry, from_url)
+    else:
+        # Official install
+        if not args.name:
+            print("skill-catalog add: provide a skill name or --from <url>", file=sys.stderr)
+            return 2
+        return _add_official(args, project_root, registry, args.name)
+
+
+def _add_official(args: argparse.Namespace, project_root: Path, registry: dict, name: str) -> int:
+    # Validate exists in official catalog
+    official = {s["name"] for s in _list_official_skills()}
+    if name not in official:
+        print(f"skill-catalog add: official skill '{name}' not found.", file=sys.stderr)
+        print(f"  Available: {', '.join(sorted(official))}", file=sys.stderr)
+        return 1
+
+    dest = _skill_install_dir(project_root, name)
+
+    if dest.exists() and not getattr(args, "force", False):
+        print(f"Skill '{name}' is already installed at {dest}")
+        print("Use --force to reinstall.")
+        return 0
+
+    print(f"Installing official skill '{name}' → {dest} ...")
+    _copy_official_skill(name, dest)
+
+    # Validate skill.yml if present
+    skill_yml_path = dest / "skill.yml"
+    if skill_yml_path.exists():
+        data = _parse_skill_yml(skill_yml_path.read_text(encoding="utf-8"))
+        errs = _validate_skill_yml(data)
+        if errs:
+            print(f"  ⚠  skill.yml validation warnings: {'; '.join(errs)}")
+
+    digest = _sha256_dir(dest)
+    registry["skills"][name] = {
+        "source": "official",
+        "installed_at": _now_iso(),
+        "digest": digest,
+    }
+    _save_registry(project_root, registry)
+    print(f"  ✓ Installed '{name}' (digest: {digest[:16]}...)")
+    return 0
+
+
+def _add_community(args: argparse.Namespace, project_root: Path, registry: dict, url: str) -> int:
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        print("skill-catalog add: only HTTPS community sources are allowed.", file=sys.stderr)
+        return 1
+
+    print(f"Downloading community skill from {url} ...")
+    try:
+        data = _download_https_zip(url)
+    except Exception as exc:
+        print(f"skill-catalog add: download failed: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile as exc:
+        print(f"skill-catalog add: not a valid ZIP: {exc}", file=sys.stderr)
+        return 1
+
+    prefix = _find_skill_root_in_zip(zf)
+    if prefix is None:
+        print("skill-catalog add: no skill.yml found in ZIP.", file=sys.stderr)
+        return 1
+    if prefix + "SKILL.md" not in zf.namelist():
+        print("skill-catalog add: SKILL.md is required in ZIP.", file=sys.stderr)
+        return 1
+
+    # Read and validate skill.yml from the ZIP before extracting
+    yml_bytes = zf.read(prefix + "skill.yml")
+    try:
+        yml_data = _parse_skill_yml(yml_bytes.decode("utf-8"))
+    except Exception as exc:
+        print(f"skill-catalog add: failed to parse skill.yml: {exc}", file=sys.stderr)
+        return 1
+
+    errs = _validate_skill_yml(yml_data)
+    if errs:
+        print("skill-catalog add: skill.yml validation failed:", file=sys.stderr)
+        for e in errs:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    # Determine skill name from skill.yml or URL
+    skill_name: str | None = None
+    if isinstance(yml_data.get("provides"), dict):
+        cmds = yml_data["provides"].get("commands", [])
+        if cmds:
+            skill_name = cmds[0].replace(" ", "-").lower()
+    if not skill_name:
+        skill_name = parsed.path.rstrip("/").rsplit("/", 1)[-1].replace(".zip", "")
+
+    if not skill_name:
+        print("skill-catalog add: cannot determine skill name.", file=sys.stderr)
+        return 1
+
+    dest = _skill_install_dir(project_root, skill_name)
+    if dest.exists() and not getattr(args, "force", False):
+        print(f"Skill '{skill_name}' is already installed at {dest}")
+        print("Use --force to reinstall.")
+        return 0
+
+    import shutil
+
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+
+    # Extract with Zip Slip protection, stripping the prefix
+    for member in zf.infolist():
+        if not member.filename.startswith(prefix):
+            continue
+        rel = member.filename[len(prefix) :]
+        if not rel:
+            continue
+        out_path = (dest / rel).resolve()
+        # Zip Slip check
+        try:
+            out_path.relative_to(dest.resolve())
+        except ValueError:
+            print(
+                f"skill-catalog add: Zip Slip detected for '{member.filename}' — aborting.",
+                file=sys.stderr,
+            )
+            shutil.rmtree(dest, ignore_errors=True)
+            return 1
+        if member.is_dir():
+            out_path.mkdir(parents=True, exist_ok=True)
+        else:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(member) as src, out_path.open("wb") as dst:
+                dst.write(src.read())
+
+    digest = _sha256_dir(dest)
+    registry["skills"][skill_name] = {
+        "source": "community",
+        "source_url": url,
+        "installed_at": _now_iso(),
+        "digest": digest,
+    }
+    _save_registry(project_root, registry)
+    print(f"  ✓ Installed community skill '{skill_name}' (digest: {digest[:16]}...)")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: remove
+# ---------------------------------------------------------------------------
+
+
+def cmd_remove(args: argparse.Namespace) -> int:
+    project_root = _find_project_root()
+    registry = _load_registry(project_root)
+    name: str = args.name
+
+    if name not in registry.get("skills", {}):
+        print(f"Skill '{name}' is not installed (not in registry).", file=sys.stderr)
+        return 1
+
+    dest = _skill_install_dir(project_root, name)
+    entry = registry["skills"][name]
+
+    if dest.exists():
+        current_digest = _sha256_dir(dest)
+        registered_digest = entry.get("digest", "")
+        if current_digest != registered_digest and not getattr(args, "force", False):
+            print(
+                f"skill-catalog remove: digest mismatch for '{name}'.",
+                file=sys.stderr,
+            )
+            print(
+                f"  registered: {registered_digest[:32]}...",
+                file=sys.stderr,
+            )
+            print(
+                f"  on-disk:    {current_digest[:32]}...",
+                file=sys.stderr,
+            )
+            print(
+                "Skill files may have been modified. Use --force to remove anyway.",
+                file=sys.stderr,
+            )
+            return 1
+
+    import shutil
+
+    if dest.exists():
+        shutil.rmtree(dest)
+
+    del registry["skills"][name]
+    _save_registry(project_root, registry)
+    print(f"  ✓ Removed skill '{name}'")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="skill-catalog",
+        description="Extension catalog for copilot-session-knowledge skills.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  python skill-catalog.py catalog\n"
+            "  python skill-catalog.py catalog --json\n"
+            "  python skill-catalog.py add agent-creator\n"
+            "  python skill-catalog.py add --from https://example.com/my-skill.zip\n"
+            "  python skill-catalog.py remove agent-creator\n"
+            "  python skill-catalog.py remove agent-creator --force\n"
+        ),
+    )
+    sub = parser.add_subparsers(dest="subcommand", metavar="subcommand")
+
+    # catalog
+    p_catalog = sub.add_parser("catalog", help="List available skills")
+    p_catalog.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # add
+    p_add = sub.add_parser("add", help="Install a skill")
+    p_add.add_argument("name", nargs="?", help="Official skill name")
+    p_add.add_argument(
+        "--from",
+        dest="from",
+        metavar="URL",
+        help="Install community skill from HTTPS ZIP URL",
+    )
+    p_add.add_argument("--force", action="store_true", help="Reinstall if already installed")
+
+    # remove
+    p_remove = sub.add_parser("remove", help="Uninstall a skill")
+    p_remove.add_argument("name", help="Skill name to remove")
+    p_remove.add_argument("--force", action="store_true", help="Remove even if digest mismatch")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.subcommand == "catalog":
+        return cmd_catalog(args)
+    elif args.subcommand == "add":
+        return cmd_add(args)
+    elif args.subcommand == "remove":
+        return cmd_remove(args)
+    else:
+        parser.print_help()
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/agent-creator/skill.yml
+++ b/skills/agent-creator/skill.yml
@@ -1,0 +1,9 @@
+schema_version: 1
+provides:
+  commands:
+    - agent-creator
+requires:
+  sk_version: ">=1.0.0"
+hooks:
+  before_plan: "review existing .agent.md files if present"
+  after_implement: "validate generated .agent.md against project conventions"

--- a/skills/code-reviewer/skill.yml
+++ b/skills/code-reviewer/skill.yml
@@ -1,0 +1,6 @@
+schema_version: 1
+provides:
+  commands:
+    - code-reviewer
+requires:
+  sk_version: ">=1.0.0"

--- a/skills/hook-creator/skill.yml
+++ b/skills/hook-creator/skill.yml
@@ -1,0 +1,6 @@
+schema_version: 1
+provides:
+  commands:
+    - hook-creator
+requires:
+  sk_version: ">=1.0.0"

--- a/tests/test_install_helpers.py
+++ b/tests/test_install_helpers.py
@@ -237,6 +237,24 @@ test("empty dir returns 0", _install._count_scripts(empty_dir) == 0)
 test("non-existent dir returns 0", _install._count_scripts(SCRATCH / "no-such-dir") == 0)
 
 
+# ── 4b. _replace_support_dir ─────────────────────────────────────────────────
+
+print("\n📁 _replace_support_dir")
+
+support_src = SCRATCH / "support-src" / "skills"
+support_dst = SCRATCH / "support-dst" / "skills"
+(support_src / "agent-creator").mkdir(parents=True, exist_ok=True)
+(support_dst / "stale").mkdir(parents=True, exist_ok=True)
+(support_src / "agent-creator" / "SKILL.md").write_text("# New skill\n", encoding="utf-8")
+(support_dst / "stale" / "old.txt").write_text("old", encoding="utf-8")
+
+_install._replace_support_dir(support_src, support_dst)
+test("replace_support_dir copies new support tree", (support_dst / "agent-creator" / "SKILL.md").is_file())
+test("replace_support_dir removes stale support content", not (support_dst / "stale").exists())
+test("replace_support_dir removes staging dir", not (support_dst.parent / "skills.new").exists())
+test("replace_support_dir removes backup dir", not (support_dst.parent / "skills.old").exists())
+
+
 # ── 5. _tilde ────────────────────────────────────────────────────────────────
 
 print("\n🏠 _tilde")
@@ -305,12 +323,14 @@ test("TOOL_FILES contains briefing.py", "briefing.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains watch-sessions.py", "watch-sessions.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains install.py", "install.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains sk.py", "sk.py" in _install.TOOL_FILES)
+test("TOOL_FILES contains skill-catalog.py", "skill-catalog.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains clarify.py", "clarify.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains constitution.py", "constitution.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains specify.py", "specify.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains task.py", "task.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains context-blocks.py", "context-blocks.py" in _install.TOOL_FILES)
 test("SUPPORT_FILES contains pyproject.toml", "pyproject.toml" in _install.SUPPORT_FILES)
+test("SUPPORT_DIRS contains skills", "skills" in _install.SUPPORT_DIRS)
 
 # MINIMAL_SKILL_MD sanity
 skill_md = _install.MINIMAL_SKILL_MD

--- a/tests/test_skill_catalog.py
+++ b/tests/test_skill_catalog.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""test_skill_catalog.py — Tests for skill-catalog.py.
+
+Covers:
+  - _parse_skill_yml: basic field parsing
+  - _validate_skill_yml: valid + invalid manifests
+  - cmd_catalog: lists official skills, marks installed ones
+  - cmd_add (official): copies files, writes registry entry with digest
+  - cmd_add (already installed): no-op unless --force
+  - cmd_add (community, non-https): rejected
+  - cmd_add (community, ZIP with Zip Slip): rejected
+  - cmd_remove: removes files + registry, checks digest
+  - cmd_remove (digest mismatch without --force): rejected
+  - cmd_remove (digest mismatch with --force): succeeds
+  - sk skill namespace: routes to skill-catalog.py subcommands
+
+Run: python3 tests/test_skill_catalog.py
+"""
+
+import importlib.util
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+TOOLS_DIR = Path(__file__).parent.parent
+CATALOG_SCRIPT = TOOLS_DIR / "skill-catalog.py"
+SK_SCRIPT = TOOLS_DIR / "sk.py"
+
+PASS = 0
+FAIL = 0
+
+
+def _test(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  ✅ {name}")
+    else:
+        FAIL += 1
+        print(f"  ❌ {name}" + (f" — {detail}" if detail else ""))
+
+
+def _load_module(path: Path, mod_name: str):
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    saved_argv = sys.argv[:]
+    sys.argv = [str(path)]
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.argv = saved_argv
+    return mod
+
+
+sc = _load_module(CATALOG_SCRIPT, "_skill_catalog")
+sk = _load_module(SK_SCRIPT, "_sk")
+
+# ---------------------------------------------------------------------------
+# Scratch directory
+# ---------------------------------------------------------------------------
+SCRATCH = TOOLS_DIR / ".test-scratch" / "skill-catalog-tests"
+SCRATCH.mkdir(parents=True, exist_ok=True)
+
+
+def _make_fake_project(base: Path) -> Path:
+    """Create a minimal fake project root with a .git dir."""
+    proj = base / "fake-project"
+    if proj.exists():
+        shutil.rmtree(proj)
+    proj.mkdir(parents=True)
+    (proj / ".git").mkdir()
+    return proj
+
+
+def _make_official_skills_dir(base: Path) -> Path:
+    """Create a minimal skills/ directory with two fake official skills."""
+    skills = base / "skills"
+    for name in ("alpha-skill", "beta-skill"):
+        sd = skills / name
+        sd.mkdir(parents=True, exist_ok=True)
+        (sd / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: Fake skill {name}\n---\n# {name}\n",
+            encoding="utf-8",
+        )
+        (sd / "skill.yml").write_text(
+            f'schema_version: 1\nprovides:\n  commands:\n    - {name}\nrequires:\n  sk_version: ">=1.0.0"\n',
+            encoding="utf-8",
+        )
+    refs = skills / "references"
+    refs.mkdir(parents=True, exist_ok=True)
+    (refs / "skill-standards.md").write_text("not a skill", encoding="utf-8")
+    return skills
+
+
+# ── 1. _parse_skill_yml ────────────────────────────────────────────────────
+
+print("\n📄 _parse_skill_yml")
+
+yml_text = """\
+schema_version: 1
+provides:
+  commands:
+    - my-command
+    - other-cmd
+requires:
+  sk_version: ">=1.0.0"
+hooks:
+  before_plan: do something
+  after_implement: check output
+"""
+
+parsed = sc._parse_skill_yml(yml_text)
+_test("schema_version parsed as int", parsed.get("schema_version") == 1)
+_test("provides.commands parsed", parsed.get("provides", {}).get("commands") == ["my-command", "other-cmd"])
+_test("requires.sk_version parsed", parsed.get("requires", {}).get("sk_version") == ">=1.0.0")
+_test("hooks.before_plan parsed", parsed.get("hooks", {}).get("before_plan") == "do something")
+_test("hooks.after_implement parsed", parsed.get("hooks", {}).get("after_implement") == "check output")
+
+# ── 2. _validate_skill_yml ────────────────────────────────────────────────
+
+print("\n✅ _validate_skill_yml")
+
+valid_data = {
+    "schema_version": 1,
+    "provides": {"commands": ["my-cmd"]},
+    "requires": {"sk_version": ">=1.0.0"},
+}
+errs = sc._validate_skill_yml(valid_data)
+_test("valid manifest → no errors", errs == [], f"errors: {errs}")
+
+bad_schema = dict(valid_data)
+bad_schema["schema_version"] = 2
+errs = sc._validate_skill_yml(bad_schema)
+_test("unsupported schema_version → error", any("schema_version" in e for e in errs))
+
+missing_schema = {k: v for k, v in valid_data.items() if k != "schema_version"}
+errs = sc._validate_skill_yml(missing_schema)
+_test("missing schema_version → error", any("schema_version" in e for e in errs))
+
+missing_commands = {"schema_version": 1, "provides": {}, "requires": {"sk_version": ">=1.0.0"}}
+errs = sc._validate_skill_yml(missing_commands)
+_test("missing provides.commands → error", any("commands" in e for e in errs))
+
+empty_commands = {"schema_version": 1, "provides": {"commands": []}, "requires": {"sk_version": ">=1.0.0"}}
+errs = sc._validate_skill_yml(empty_commands)
+_test("empty provides.commands → error", any("commands" in e for e in errs))
+
+missing_sk_version = {"schema_version": 1, "provides": {"commands": ["x"]}, "requires": {}}
+errs = sc._validate_skill_yml(missing_sk_version)
+_test("missing requires.sk_version → error", any("sk_version" in e for e in errs))
+
+# ── 3. cmd_catalog ────────────────────────────────────────────────────────
+
+print("\n📋 cmd_catalog")
+
+_catalog_scratch = SCRATCH / "catalog_test"
+_catalog_scratch.mkdir(parents=True, exist_ok=True)
+_fake_skills = _make_official_skills_dir(_catalog_scratch)
+_fake_project = _make_fake_project(_catalog_scratch)
+
+# Monkey-patch the official skills dir
+original_skills_dir = sc._OFFICIAL_SKILLS_DIR
+sc._OFFICIAL_SKILLS_DIR = _fake_skills
+
+try:
+    # JSON output
+    import argparse
+
+    ns = argparse.Namespace(json=True)
+    with patch("builtins.print") as mock_print:
+        rc = sc.cmd_catalog(ns)
+    captured = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+    _test("catalog --json exits 0", rc == 0)
+    _test("catalog --json contains 'alpha-skill'", "alpha-skill" in captured)
+    _test("catalog --json contains 'beta-skill'", "beta-skill" in captured)
+    _test("catalog --json omits non-skill references dir", "references" not in captured)
+
+    # Text output
+    ns_text = argparse.Namespace(json=False)
+    # Patch _find_project_root to avoid depending on real CWD
+    with patch.object(sc, "_find_project_root", return_value=_fake_project):
+        with patch("builtins.print") as mock_print:
+            rc2 = sc.cmd_catalog(ns_text)
+    captured2 = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+    _test("catalog text exits 0", rc2 == 0)
+    _test("catalog text lists skills", "alpha-skill" in captured2 or "beta-skill" in captured2)
+    _test("catalog text omits non-skill references dir", "references" not in captured2)
+
+finally:
+    sc._OFFICIAL_SKILLS_DIR = original_skills_dir
+
+# ── 4. cmd_add (official) ─────────────────────────────────────────────────
+
+print("\n📦 cmd_add (official)")
+
+_add_scratch = SCRATCH / "add_test"
+_add_scratch.mkdir(parents=True, exist_ok=True)
+_add_skills = _make_official_skills_dir(_add_scratch)
+_add_project = _make_fake_project(_add_scratch)
+
+sc._OFFICIAL_SKILLS_DIR = _add_skills
+
+try:
+    import argparse
+
+    ns_add = argparse.Namespace(name="alpha-skill", **{"from": None}, force=False)
+    with patch.object(sc, "_find_project_root", return_value=_add_project):
+        with patch("builtins.print"):
+            rc = sc.cmd_add(ns_add)
+
+    _test("add official skill exits 0", rc == 0)
+    dest = _add_project / ".copilot" / "skills" / "alpha-skill"
+    _test("skill directory created", dest.exists())
+    _test("SKILL.md present", (dest / "SKILL.md").exists())
+    _test("skill.yml present", (dest / "skill.yml").exists())
+
+    reg = sc._load_registry(_add_project)
+    _test("registry entry created", "alpha-skill" in reg.get("skills", {}))
+    entry = reg["skills"]["alpha-skill"]
+    _test("registry has digest", bool(entry.get("digest")))
+    _test("registry source is official", entry.get("source") == "official")
+
+    # Idempotent (no-op if already installed)
+    with patch.object(sc, "_find_project_root", return_value=_add_project):
+        with patch("builtins.print") as mock_print2:
+            rc2 = sc.cmd_add(ns_add)
+    out2 = " ".join(str(c) for call in mock_print2.call_args_list for c in call[0])
+    _test("re-add no-op exits 0", rc2 == 0)
+    _test("re-add prints already installed", "already installed" in out2.lower())
+
+    # Unknown skill
+    ns_bad = argparse.Namespace(name="nonexistent-skill", **{"from": None}, force=False)
+    with patch.object(sc, "_find_project_root", return_value=_add_project):
+        rc_bad = sc.cmd_add(ns_bad)
+    _test("add unknown skill exits 1", rc_bad == 1)
+
+finally:
+    sc._OFFICIAL_SKILLS_DIR = original_skills_dir
+
+# ── 5. cmd_add (community – non-HTTPS rejected) ────────────────────────────
+
+print("\n🔒 cmd_add community (HTTPS enforcement)")
+
+_https_scratch = SCRATCH / "https_test"
+_https_scratch.mkdir(parents=True, exist_ok=True)
+_https_project = _make_fake_project(_https_scratch)
+
+ns_http = argparse.Namespace(name=None, **{"from": "http://example.com/skill.zip"}, force=False)
+with patch.object(sc, "_find_project_root", return_value=_https_project):
+    rc_http = sc.cmd_add(ns_http)
+_test("HTTP (non-HTTPS) community URL rejected with rc=1", rc_http == 1)
+
+ns_ftp = argparse.Namespace(name=None, **{"from": "ftp://example.com/skill.zip"}, force=False)
+with patch.object(sc, "_find_project_root", return_value=_https_project):
+    rc_ftp = sc.cmd_add(ns_ftp)
+_test("FTP community URL rejected with rc=1", rc_ftp == 1)
+
+# ── 6. cmd_add (community – valid ZIP) ────────────────────────────────────
+
+print("\n📦 cmd_add community (valid ZIP)")
+
+_comm_scratch = SCRATCH / "comm_test"
+_comm_scratch.mkdir(parents=True, exist_ok=True)
+_comm_project = _make_fake_project(_comm_scratch)
+
+
+def _make_valid_zip() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(
+            "my-community-skill/skill.yml",
+            'schema_version: 1\nprovides:\n  commands:\n    - comm-cmd\nrequires:\n  sk_version: ">=1.0.0"\n',
+        )
+        zf.writestr("my-community-skill/SKILL.md", "# Community Skill\n")
+    return buf.getvalue()
+
+
+valid_zip_bytes = _make_valid_zip()
+
+ns_comm = argparse.Namespace(name=None, **{"from": "https://example.com/comm.zip"}, force=False)
+with patch.object(sc, "_find_project_root", return_value=_comm_project):
+    with patch.object(sc, "_download_https_zip", return_value=valid_zip_bytes):
+        with patch("builtins.print"):
+            rc_comm = sc.cmd_add(ns_comm)
+
+_test("community add from valid ZIP exits 0", rc_comm == 0)
+dest_comm = _comm_project / ".copilot" / "skills" / "comm-cmd"
+_test("community skill dir created", dest_comm.exists())
+reg_comm = sc._load_registry(_comm_project)
+_test("community registry entry created", "comm-cmd" in reg_comm.get("skills", {}))
+entry_comm = reg_comm["skills"]["comm-cmd"]
+_test("community entry source is 'community'", entry_comm.get("source") == "community")
+_test("community entry has source_url", bool(entry_comm.get("source_url")))
+_test("community entry has digest", bool(entry_comm.get("digest")))
+
+# ── 7. Zip Slip protection ─────────────────────────────────────────────────
+
+print("\n🛡️  Zip Slip protection")
+
+_slip_scratch = SCRATCH / "zipslip_test"
+_slip_scratch.mkdir(parents=True, exist_ok=True)
+_slip_project = _make_fake_project(_slip_scratch)
+
+
+def _make_slip_zip() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(
+            "evil-skill/skill.yml",
+            'schema_version: 1\nprovides:\n  commands:\n    - evil\nrequires:\n  sk_version: ">=1.0.0"\n',
+        )
+        zf.writestr("evil-skill/../../escaped.txt", "pwned")
+    return buf.getvalue()
+
+
+slip_zip_bytes = _make_slip_zip()
+
+ns_slip = argparse.Namespace(name=None, **{"from": "https://evil.example.com/slip.zip"}, force=False)
+with patch.object(sc, "_find_project_root", return_value=_slip_project):
+    with patch.object(sc, "_download_https_zip", return_value=slip_zip_bytes):
+        rc_slip = sc.cmd_add(ns_slip)
+_test("Zip Slip ZIP rejected (rc=1)", rc_slip == 1)
+
+# ── 8. cmd_add (community – missing SKILL.md) ───────────────────────────────
+
+print("\n📄 cmd_add community (missing SKILL.md)")
+
+_missing_skill_md_scratch = SCRATCH / "missing_skill_md_test"
+_missing_skill_md_scratch.mkdir(parents=True, exist_ok=True)
+_missing_skill_md_project = _make_fake_project(_missing_skill_md_scratch)
+
+
+def _make_missing_skill_md_zip() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(
+            "broken-skill/skill.yml",
+            'schema_version: 1\nprovides:\n  commands:\n    - broken\nrequires:\n  sk_version: ">=1.0.0"\n',
+        )
+    return buf.getvalue()
+
+
+missing_skill_md_zip = _make_missing_skill_md_zip()
+
+ns_missing_skill_md = argparse.Namespace(
+    name=None,
+    **{"from": "https://example.com/broken.zip"},
+    force=False,
+)
+with patch.object(sc, "_find_project_root", return_value=_missing_skill_md_project):
+    with patch.object(sc, "_download_https_zip", return_value=missing_skill_md_zip):
+        rc_missing_skill_md = sc.cmd_add(ns_missing_skill_md)
+_test("community ZIP without SKILL.md rejected (rc=1)", rc_missing_skill_md == 1)
+
+# ── 9. cmd_remove ─────────────────────────────────────────────────────────
+
+print("\n🗑️  cmd_remove")
+
+_rem_scratch = SCRATCH / "remove_test"
+_rem_scratch.mkdir(parents=True, exist_ok=True)
+_rem_skills = _make_official_skills_dir(_rem_scratch)
+_rem_project = _make_fake_project(_rem_scratch)
+
+sc._OFFICIAL_SKILLS_DIR = _rem_skills
+
+try:
+    # Install first
+    ns_install = argparse.Namespace(name="beta-skill", **{"from": None}, force=False)
+    with patch.object(sc, "_find_project_root", return_value=_rem_project):
+        with patch("builtins.print"):
+            sc.cmd_add(ns_install)
+
+    # Verify installed
+    dest_rem = _rem_project / ".copilot" / "skills" / "beta-skill"
+    _test("setup: skill was installed", dest_rem.exists())
+
+    # Remove
+    ns_rem = argparse.Namespace(name="beta-skill", force=False)
+    with patch.object(sc, "_find_project_root", return_value=_rem_project):
+        with patch("builtins.print"):
+            rc_rem = sc.cmd_remove(ns_rem)
+
+    _test("remove exits 0", rc_rem == 0)
+    _test("skill directory removed", not dest_rem.exists())
+    reg_rem = sc._load_registry(_rem_project)
+    _test("registry entry removed", "beta-skill" not in reg_rem.get("skills", {}))
+
+    # Remove non-installed
+    ns_missing = argparse.Namespace(name="nonexistent", force=False)
+    with patch.object(sc, "_find_project_root", return_value=_rem_project):
+        rc_missing = sc.cmd_remove(ns_missing)
+    _test("remove non-installed skill exits 1", rc_missing == 1)
+
+finally:
+    sc._OFFICIAL_SKILLS_DIR = original_skills_dir
+
+# ── 10. cmd_remove (digest mismatch) ──────────────────────────────────────
+
+print("\n🔐 cmd_remove digest mismatch")
+
+_digest_scratch = SCRATCH / "digest_test"
+_digest_scratch.mkdir(parents=True, exist_ok=True)
+_digest_skills = _make_official_skills_dir(_digest_scratch)
+_digest_project = _make_fake_project(_digest_scratch)
+
+sc._OFFICIAL_SKILLS_DIR = _digest_skills
+
+try:
+    # Install alpha-skill
+    ns_install2 = argparse.Namespace(name="alpha-skill", **{"from": None}, force=False)
+    with patch.object(sc, "_find_project_root", return_value=_digest_project):
+        with patch("builtins.print"):
+            sc.cmd_add(ns_install2)
+
+    # Tamper with installed file
+    skill_dest = _digest_project / ".copilot" / "skills" / "alpha-skill"
+    (skill_dest / "tampered.txt").write_text("modified", encoding="utf-8")
+
+    # Remove without --force → should fail
+    ns_rem2 = argparse.Namespace(name="alpha-skill", force=False)
+    with patch.object(sc, "_find_project_root", return_value=_digest_project):
+        rc_mismatch = sc.cmd_remove(ns_rem2)
+    _test("digest mismatch without --force → rc=1", rc_mismatch == 1)
+
+    # Remove with --force → should succeed
+    ns_rem2_force = argparse.Namespace(name="alpha-skill", force=True)
+    with patch.object(sc, "_find_project_root", return_value=_digest_project):
+        with patch("builtins.print"):
+            rc_force = sc.cmd_remove(ns_rem2_force)
+    _test("digest mismatch with --force → rc=0", rc_force == 0)
+
+finally:
+    sc._OFFICIAL_SKILLS_DIR = original_skills_dir
+
+# ── 11. sk skill namespace routing ────────────────────────────────────────
+
+print("\n🔀 sk skill namespace routing")
+
+
+def _mock_run(script, extra_args):
+    """Track calls without actually running subprocess."""
+    return (script, extra_args)
+
+
+with patch.object(sk, "_run", side_effect=lambda s, a: 0):
+    # sk skill catalog
+    rc_sk_cat = sk.main(["skill", "catalog"])
+    _test("sk skill catalog routes (rc=0)", rc_sk_cat == 0)
+
+    # sk skill add agent-creator
+    rc_sk_add = sk.main(["skill", "add", "agent-creator"])
+    _test("sk skill add routes (rc=0)", rc_sk_add == 0)
+
+    # sk skill remove agent-creator
+    rc_sk_rem = sk.main(["skill", "remove", "agent-creator"])
+    _test("sk skill remove routes (rc=0)", rc_sk_rem == 0)
+
+# sk skill unknown subcommand
+import io as _io
+
+captured_err = _io.StringIO()
+with patch.object(sys, "stderr", captured_err):
+    rc_sk_unk = sk.main(["skill", "unknown-sub"])
+_test("sk skill unknown subcommand → rc=2", rc_sk_unk == 2)
+
+# sk skill (no subcommand) → help
+with patch("builtins.print"):
+    rc_sk_help = sk.main(["skill"])
+_test("sk skill (no subcommand) → rc=0 (help)", rc_sk_help == 0)
+
+# Ensure old direct commands still work
+with patch.object(sk, "_run", return_value=0):
+    rc_suggest = sk.main(["skill-suggest"])
+    _test("sk skill-suggest direct command still works", rc_suggest == 0)
+
+    rc_patch = sk.main(["skill-patch"])
+    _test("sk skill-patch direct command still works", rc_patch == 0)
+
+    rc_curator = sk.main(["skill-curator"])
+    _test("sk skill-curator direct command still works", rc_curator == 0)
+
+# ── 12. _sha256_dir stability ─────────────────────────────────────────────
+
+print("\n🔑 _sha256_dir")
+
+_sha_dir = SCRATCH / "sha256_test"
+_sha_dir.mkdir(parents=True, exist_ok=True)
+(_sha_dir / "a.txt").write_text("hello", encoding="utf-8")
+(_sha_dir / "b.txt").write_text("world", encoding="utf-8")
+
+d1 = sc._sha256_dir(_sha_dir)
+d2 = sc._sha256_dir(_sha_dir)
+_test("_sha256_dir is stable (same result twice)", d1 == d2)
+
+# Modifying a file changes the digest
+(_sha_dir / "a.txt").write_text("modified", encoding="utf-8")
+d3 = sc._sha256_dir(_sha_dir)
+_test("_sha256_dir changes after file modification", d1 != d3)
+
+# ── Cleanup ────────────────────────────────────────────────────────────────
+
+try:
+    shutil.rmtree(SCRATCH)
+except Exception:
+    pass
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+print(f"\n{'=' * 50}")
+print(f"Results: {PASS} passed, {FAIL} failed")
+if FAIL > 0:
+    sys.exit(1)


### PR DESCRIPTION
## Summary
- add sk skill catalog|add|remove via a new standalone skill-catalog.py
- install official and community skills into project-local .copilot/skills/ with SHA-256 registry tracking and safe removal checks
- bundle official skill assets in installer output and cover the new flows with focused tests

Closes #96