### PR TITLE
feat(skills): add handoff chains

### DIFF
--- a/hooks/lint-skills.py
+++ b/hooks/lint-skills.py
@@ -248,6 +248,7 @@ SKILL_VALID_FIELDS = {
     "allowed-tools",
     "user-invocable",
     "disable-model-invocation",
+    "handoffs",
     # Cross-platform fields (Claude Code / Kiro) — not used by Copilot CLI
     # but harmless and intentional for multi-platform compatibility:
     "aliases",

--- a/skill-catalog.py
+++ b/skill-catalog.py
@@ -66,18 +66,24 @@ def _parse_skill_yml(text: str) -> dict:
       hooks:           (optional)
         before_plan: <str>
         after_implement: <str>
+      handoffs:        (optional)
+        - label: <str>
+          skill: <str>
+          prompt: <str>
+          send: <bool>
     """
-    result: dict = {}
     lines = text.splitlines()
-    i = 0
 
     def _strip_comment(s: str) -> str:
         # Remove inline YAML comments
-        in_q = False
+        in_double = False
+        in_single = False
         for idx, ch in enumerate(s):
-            if ch == '"':
-                in_q = not in_q
-            elif ch == "#" and not in_q:
+            if ch == '"' and not in_single:
+                in_double = not in_double
+            elif ch == "'" and not in_double:
+                in_single = not in_single
+            elif ch == "#" and not in_double and not in_single:
                 return s[:idx]
         return s
 
@@ -88,67 +94,102 @@ def _parse_skill_yml(text: str) -> dict:
             return s[1:-1]
         return s
 
-    while i < len(lines):
-        raw = lines[i]
-        stripped = raw.strip()
-        i += 1
+    def _parse_scalar(s: str):
+        s = _unquote(_strip_comment(s).strip())
+        low = s.lower()
+        if low == "true":
+            return True
+        if low == "false":
+            return False
+        try:
+            return int(s)
+        except ValueError:
+            return s
 
-        if not stripped or stripped.startswith("#"):
-            continue
+    def _parse_block(index: int, indent: int) -> tuple[object, int]:
+        mapping: dict[str, object] = {}
+        sequence: list[object] = []
+        mode: str | None = None
 
-        # Top-level key: value
-        if not raw.startswith(" ") and ":" in stripped:
-            key, _, val = stripped.partition(":")
+        while index < len(lines):
+            raw = lines[index]
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                index += 1
+                continue
+
+            current_indent = len(raw) - len(raw.lstrip(" "))
+            if current_indent < indent:
+                break
+            if current_indent > indent:
+                break
+
+            content = _strip_comment(raw[current_indent:]).strip()
+            if not content:
+                index += 1
+                continue
+
+            if content.startswith("- "):
+                if mode is None:
+                    mode = "sequence"
+                elif mode != "sequence":
+                    break
+
+                item_text = content[2:].strip()
+                index += 1
+
+                if not item_text:
+                    item, index = _parse_block(index, current_indent + 2)
+                    sequence.append(item)
+                    continue
+
+                if ":" in item_text:
+                    item_key, _, item_value = item_text.partition(":")
+                    item: dict[str, object] = {}
+                    item_key = item_key.strip()
+                    item_value = item_value.strip()
+                    if item_value:
+                        item[item_key] = _parse_scalar(item_value)
+                    else:
+                        child, index = _parse_block(index, current_indent + 4)
+                        item[item_key] = child
+
+                    extra, index = _parse_block(index, current_indent + 2)
+                    if isinstance(extra, dict):
+                        item.update(extra)
+                    sequence.append(item)
+                    continue
+
+                sequence.append(_parse_scalar(item_text))
+                continue
+
+            if ":" not in content:
+                index += 1
+                continue
+
+            if mode is None:
+                mode = "mapping"
+            elif mode != "mapping":
+                break
+
+            key, _, value = content.partition(":")
             key = key.strip()
-            val = _strip_comment(val).strip()
-            if val:
-                # Try int (unquoted)
-                try:
-                    result[key] = int(val)
-                except ValueError:
-                    result[key] = _unquote(val)
-            else:
-                # Block value — collect children
-                children: dict = {}
-                list_items: list = []
-                while i < len(lines):
-                    child_raw = lines[i]
-                    child_stripped = child_raw.strip()
-                    if not child_stripped or child_stripped.startswith("#"):
-                        i += 1
-                        continue
-                    indent = len(child_raw) - len(child_raw.lstrip())
-                    if indent == 0:
-                        break
-                    i += 1
-                    if child_stripped.startswith("- "):
-                        list_items.append(child_stripped[2:].strip())
-                    elif ":" in child_stripped:
-                        ck, _, cv = child_stripped.partition(":")
-                        cv = _strip_comment(cv).strip()
-                        # Sub-block (e.g. provides.commands)
-                        if not cv:
-                            sub_items: list = []
-                            while i < len(lines):
-                                sub_raw = lines[i]
-                                sub_stripped = sub_raw.strip()
-                                if not sub_stripped or sub_stripped.startswith("#"):
-                                    i += 1
-                                    continue
-                                sub_indent = len(sub_raw) - len(sub_raw.lstrip())
-                                if sub_indent <= indent:
-                                    break
-                                i += 1
-                                if sub_stripped.startswith("- "):
-                                    sub_items.append(sub_stripped[2:].strip())
-                            children[ck.strip()] = sub_items
-                        else:
-                            try:
-                                children[ck.strip()] = int(cv)
-                            except ValueError:
-                                children[ck.strip()] = _unquote(cv)
-                result[key] = children if children else (list_items if list_items else {})
-    return result
+            value = value.strip()
+            index += 1
+
+            if value:
+                mapping[key] = _parse_scalar(value)
+                continue
+
+            child, index = _parse_block(index, current_indent + 2)
+            mapping[key] = child
+
+        if mode == "sequence":
+            return sequence, index
+        return mapping, index
+
+    parsed, _ = _parse_block(0, 0)
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def _validate_skill_yml(data: dict) -> list[str]:
@@ -182,6 +223,28 @@ def _validate_skill_yml(data: dict) -> list[str]:
     hooks = data.get("hooks", {})
     if hooks and not isinstance(hooks, dict):
         errors.append("'hooks' must be a mapping")
+
+    handoffs = data.get("handoffs", [])
+    if handoffs:
+        if not isinstance(handoffs, list):
+            errors.append("'handoffs' must be a list")
+        else:
+            for idx, handoff in enumerate(handoffs):
+                prefix = f"handoffs[{idx}]"
+                if not isinstance(handoff, dict):
+                    errors.append(f"{prefix} must be a mapping")
+                    continue
+
+                for field in ("label", "skill", "prompt", "send"):
+                    if field not in handoff:
+                        errors.append(f"{prefix}.{field} is required")
+
+                for field in ("label", "skill", "prompt"):
+                    if field in handoff and (not isinstance(handoff[field], str) or not handoff[field].strip()):
+                        errors.append(f"{prefix}.{field} must be a non-empty string")
+
+                if "send" in handoff and not isinstance(handoff["send"], bool):
+                    errors.append(f"{prefix}.send must be a boolean")
 
     return errors
 
@@ -273,6 +336,9 @@ def _list_official_skills() -> list[dict]:
                 data = _parse_skill_yml(skill_yml.read_text(encoding="utf-8"))
                 entry["commands"] = data.get("provides", {}).get("commands", [])
                 entry["sk_version"] = data.get("requires", {}).get("sk_version", "")
+                handoffs = data.get("handoffs", [])
+                if isinstance(handoffs, list) and handoffs:
+                    entry["handoffs"] = handoffs
             except Exception:
                 pass
         # Parse description from SKILL.md front-matter
@@ -283,6 +349,27 @@ def _list_official_skills() -> list[dict]:
                 break
         skills.append(entry)
     return skills
+
+
+def _format_handoff_brief(handoff: dict) -> str:
+    label = str(handoff.get("label") or handoff.get("skill") or "next-step")
+    skill = str(handoff.get("skill") or "unknown-skill")
+    mode = "auto" if handoff.get("send") else "suggest"
+    return f"{label} -> {skill} [{mode}]"
+
+
+def _print_handoff_suggestions(handoffs: list[dict]) -> None:
+    if not handoffs:
+        return
+    print("  Next skills:")
+    for handoff in handoffs:
+        label = str(handoff.get("label") or handoff.get("skill") or "Next step")
+        skill = str(handoff.get("skill") or "unknown-skill")
+        prompt = str(handoff.get("prompt") or "").strip()
+        mode = "auto" if handoff.get("send") else "suggest"
+        print(f"    - {label} -> {skill} ({mode})")
+        if prompt:
+            print(f"      {prompt}")
 
 
 # ---------------------------------------------------------------------------
@@ -366,6 +453,10 @@ def cmd_catalog(args: argparse.Namespace) -> int:
         cmds = ", ".join(s.get("commands", []))
         suffix = f"  [{cmds}]" if cmds else ""
         print(f"  [{marker}] {s['name']:<30} {desc[:60]}{suffix}")
+        handoffs = s.get("handoffs", [])
+        if handoffs:
+            summary = "; ".join(_format_handoff_brief(h) for h in handoffs)
+            print(f"      handoffs: {summary}")
 
     if installed:
         # Show community-installed skills not in official list
@@ -422,11 +513,15 @@ def _add_official(args: argparse.Namespace, project_root: Path, registry: dict, 
 
     # Validate skill.yml if present
     skill_yml_path = dest / "skill.yml"
+    handoffs: list[dict] = []
     if skill_yml_path.exists():
         data = _parse_skill_yml(skill_yml_path.read_text(encoding="utf-8"))
         errs = _validate_skill_yml(data)
         if errs:
             print(f"  ⚠  skill.yml validation warnings: {'; '.join(errs)}")
+        parsed_handoffs = data.get("handoffs", [])
+        if isinstance(parsed_handoffs, list):
+            handoffs = parsed_handoffs
 
     digest = _sha256_dir(dest)
     registry["skills"][name] = {
@@ -436,6 +531,7 @@ def _add_official(args: argparse.Namespace, project_root: Path, registry: dict, 
     }
     _save_registry(project_root, registry)
     print(f"  ✓ Installed '{name}' (digest: {digest[:16]}...)")
+    _print_handoff_suggestions(handoffs)
     return 0
 
 
@@ -540,6 +636,9 @@ def _add_community(args: argparse.Namespace, project_root: Path, registry: dict,
     }
     _save_registry(project_root, registry)
     print(f"  ✓ Installed community skill '{skill_name}' (digest: {digest[:16]}...)")
+    handoffs = yml_data.get("handoffs", [])
+    if isinstance(handoffs, list):
+        _print_handoff_suggestions(handoffs)
     return 0
 
 

--- a/skills/agent-creator/SKILL.md
+++ b/skills/agent-creator/SKILL.md
@@ -6,6 +6,15 @@ description: >
   the user mentions "create agents", "setup copilot agents", "generate .agent.md",
   or wants specialized AI agents for their development workflow. Also triggers when
   tentacle-creator needs default agents for a project that has none.
+handoffs:
+  - label: "Add quality hooks"
+    skill: hook-creator
+    prompt: "Generate project-specific hooks that enforce the workflow the new agents describe."
+    send: false
+  - label: "Review generated agents"
+    skill: code-reviewer
+    prompt: "Review the generated .agent.md files for correctness gaps before the team relies on them."
+    send: false
 ---
 
 # Agent Creator

--- a/skills/agent-creator/skill.yml
+++ b/skills/agent-creator/skill.yml
@@ -7,3 +7,12 @@ requires:
 hooks:
   before_plan: "review existing .agent.md files if present"
   after_implement: "validate generated .agent.md against project conventions"
+handoffs:
+  - label: "Add quality hooks"
+    skill: hook-creator
+    prompt: "Generate project-specific hooks that enforce the workflow the new agents describe."
+    send: false
+  - label: "Review generated agents"
+    skill: code-reviewer
+    prompt: "Review the generated .agent.md files for correctness gaps before the team relies on them."
+    send: false

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -6,6 +6,11 @@ description: >
   diff, or agent-produced code before merging. Trigger phrases: "review this code",
   "review my PR", "code review", "check for bugs", "security review", "audit the diff",
   "look for issues", "is this safe to merge".
+handoffs:
+  - label: "Backfill missing guardrails"
+    skill: hook-creator
+    prompt: "If the review uncovered missing safety rails or workflow enforcement, generate hooks to close those gaps."
+    send: false
 ---
 
 # Code Reviewer

--- a/skills/code-reviewer/skill.yml
+++ b/skills/code-reviewer/skill.yml
@@ -4,3 +4,8 @@ provides:
     - code-reviewer
 requires:
   sk_version: ">=1.0.0"
+handoffs:
+  - label: "Backfill missing guardrails"
+    skill: hook-creator
+    prompt: "If the review uncovered missing safety rails or workflow enforcement, generate hooks to close those gaps."
+    send: false

--- a/skills/hook-creator/SKILL.md
+++ b/skills/hook-creator/SKILL.md
@@ -7,6 +7,11 @@ description: >
   "postToolUse", or wants automated safety rails for AI coding sessions. Also use when
   the user wants to enforce coding standards, block dangerous commands, protect secrets,
   gate commits, enforce TDD pipelines, or add any form of automated guardrails.
+handoffs:
+  - label: "Audit generated hooks"
+    skill: code-reviewer
+    prompt: "Review the generated hook scripts for safety gaps, broken assumptions, and enforcement holes."
+    send: true
 ---
 
 # Hook Creator

--- a/skills/hook-creator/skill.yml
+++ b/skills/hook-creator/skill.yml
@@ -4,3 +4,8 @@ provides:
     - hook-creator
 requires:
   sk_version: ">=1.0.0"
+handoffs:
+  - label: "Audit generated hooks"
+    skill: code-reviewer
+    prompt: "Review the generated hook scripts for safety gaps, broken assumptions, and enforcement holes."
+    send: true

--- a/tests/test_lint_skills.py
+++ b/tests/test_lint_skills.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+test_lint_skills.py — Focused tests for hooks/lint-skills.py.
+
+Covers:
+  - SKILL.md frontmatter accepts `handoffs`
+  - Nested handoff blocks do not trigger SK-007 unknown-field warnings
+  - Existing skill/schema-confusion checks still fire alongside handoffs
+
+Run: python3 tests/test_lint_skills.py
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+PASS = 0
+FAIL = 0
+REPO = Path(__file__).parent.parent
+SCRIPT = REPO / "hooks" / "lint-skills.py"
+
+
+def _test(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  ✅ {name}")
+    else:
+        FAIL += 1
+        print(f"  ❌ {name}" + (f" — {detail}" if detail else ""))
+
+
+def _load_module(path: Path, mod_name: str):
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    saved_argv = sys.argv[:]
+    sys.argv = [str(path)]
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.argv = saved_argv
+    return mod
+
+
+lint = _load_module(SCRIPT, "_lint_skills")
+
+
+print("\n🧭 skill handoffs")
+
+skill_with_handoffs = """\
+---
+name: sample-skill
+description: >
+  Use when you need a guided follow-up. Triggers on skill chaining and next-step suggestions.
+handoffs:
+  - label: Review generated output
+    skill: code-reviewer
+    prompt: Review the generated output for correctness.
+    send: true
+  - label: Tighten generated hooks
+    skill: hook-creator
+    prompt: Tighten the generated hooks after review.
+    send: false
+---
+"""
+
+fields, _ = lint.parse_frontmatter(skill_with_handoffs)
+issues = lint.lint_skill_file(Path("skills/sample-skill/SKILL.md"), skill_with_handoffs)
+
+_test("parse_frontmatter captures handoffs field", "handoffs" in fields)
+_test(
+    "handoffs are allowed on skills",
+    not any(issue.code == "SK-007" and "handoffs" in issue.message for issue in issues),
+)
+_test(
+    "nested handoff keys do not trigger unknown-field warnings",
+    not any(issue.code == "SK-007" and "skill" in issue.message.lower() for issue in issues),
+)
+
+
+print("\n🧱 existing checks still apply")
+
+skill_with_tools_and_handoffs = """\
+---
+name: sample-skill
+description: >
+  Use when you need a guided follow-up. Triggers on skill chaining and next-step suggestions.
+tools: [bash]
+handoffs:
+  - label: Review generated output
+    skill: code-reviewer
+    prompt: Review the generated output for correctness.
+    send: true
+---
+"""
+
+issues_with_tools = lint.lint_skill_file(
+    Path("skills/sample-skill/SKILL.md"),
+    skill_with_tools_and_handoffs,
+)
+_test(
+    "tools still errors on skills",
+    any(issue.code == "SK-008" for issue in issues_with_tools),
+)
+_test(
+    "handoffs do not suppress tools error",
+    any(issue.code == "SK-008" for issue in issues_with_tools)
+    and not any(issue.code == "SK-007" and "handoffs" in issue.message for issue in issues_with_tools),
+)
+
+
+print(f"\n{'=' * 50}")
+print(f"Results: {PASS} passed, {FAIL} failed")
+if FAIL > 0:
+    sys.exit(1)

--- a/tests/test_skill_catalog.py
+++ b/tests/test_skill_catalog.py
@@ -94,8 +94,17 @@ def _make_official_skills_dir(base: Path) -> Path:
             f"---\nname: {name}\ndescription: Fake skill {name}\n---\n# {name}\n",
             encoding="utf-8",
         )
+        handoffs = ""
+        if name == "alpha-skill":
+            handoffs = (
+                "handoffs:\n"
+                '  - label: "Review generated output"\n'
+                "    skill: code-reviewer\n"
+                '    prompt: "Review the generated output for correctness."\n'
+                "    send: true\n"
+            )
         (sd / "skill.yml").write_text(
-            f'schema_version: 1\nprovides:\n  commands:\n    - {name}\nrequires:\n  sk_version: ">=1.0.0"\n',
+            f'schema_version: 1\nprovides:\n  commands:\n    - {name}\nrequires:\n  sk_version: ">=1.0.0"\n{handoffs}',
             encoding="utf-8",
         )
     refs = skills / "references"
@@ -119,6 +128,15 @@ requires:
 hooks:
   before_plan: do something
   after_implement: check output
+handoffs:
+  - label: Review output
+    skill: code-reviewer
+    prompt: Review the generated output
+    send: true
+  - label: Patch skill
+    skill: skill-patch
+    prompt: Patch the generated skill after review
+    send: false
 """
 
 parsed = sc._parse_skill_yml(yml_text)
@@ -127,6 +145,24 @@ _test("provides.commands parsed", parsed.get("provides", {}).get("commands") == 
 _test("requires.sk_version parsed", parsed.get("requires", {}).get("sk_version") == ">=1.0.0")
 _test("hooks.before_plan parsed", parsed.get("hooks", {}).get("before_plan") == "do something")
 _test("hooks.after_implement parsed", parsed.get("hooks", {}).get("after_implement") == "check output")
+_test(
+    "handoffs parsed as list of mappings",
+    parsed.get("handoffs")
+    == [
+        {
+            "label": "Review output",
+            "skill": "code-reviewer",
+            "prompt": "Review the generated output",
+            "send": True,
+        },
+        {
+            "label": "Patch skill",
+            "skill": "skill-patch",
+            "prompt": "Patch the generated skill after review",
+            "send": False,
+        },
+    ],
+)
 
 # ── 2. _validate_skill_yml ────────────────────────────────────────────────
 
@@ -136,6 +172,14 @@ valid_data = {
     "schema_version": 1,
     "provides": {"commands": ["my-cmd"]},
     "requires": {"sk_version": ">=1.0.0"},
+    "handoffs": [
+        {
+            "label": "Review output",
+            "skill": "code-reviewer",
+            "prompt": "Review the generated output",
+            "send": True,
+        }
+    ],
 }
 errs = sc._validate_skill_yml(valid_data)
 _test("valid manifest → no errors", errs == [], f"errors: {errs}")
@@ -160,6 +204,28 @@ _test("empty provides.commands → error", any("commands" in e for e in errs))
 missing_sk_version = {"schema_version": 1, "provides": {"commands": ["x"]}, "requires": {}}
 errs = sc._validate_skill_yml(missing_sk_version)
 _test("missing requires.sk_version → error", any("sk_version" in e for e in errs))
+
+bad_handoffs_type = dict(valid_data)
+bad_handoffs_type["handoffs"] = {"label": "bad"}
+errs = sc._validate_skill_yml(bad_handoffs_type)
+_test("handoffs must be a list", any("'handoffs' must be a list" in e for e in errs))
+
+bad_handoff_missing_field = dict(valid_data)
+bad_handoff_missing_field["handoffs"] = [{"label": "Review output", "skill": "code-reviewer", "send": True}]
+errs = sc._validate_skill_yml(bad_handoff_missing_field)
+_test("handoff missing prompt → error", any("handoffs[0].prompt" in e for e in errs))
+
+bad_handoff_send_type = dict(valid_data)
+bad_handoff_send_type["handoffs"] = [
+    {
+        "label": "Review output",
+        "skill": "code-reviewer",
+        "prompt": "Review the generated output",
+        "send": "yes",
+    }
+]
+errs = sc._validate_skill_yml(bad_handoff_send_type)
+_test("handoff send must be boolean", any("handoffs[0].send must be a boolean" in e for e in errs))
 
 # ── 3. cmd_catalog ────────────────────────────────────────────────────────
 
@@ -186,6 +252,7 @@ try:
     _test("catalog --json contains 'alpha-skill'", "alpha-skill" in captured)
     _test("catalog --json contains 'beta-skill'", "beta-skill" in captured)
     _test("catalog --json omits non-skill references dir", "references" not in captured)
+    _test("catalog --json includes handoffs", "Review generated output" in captured and "code-reviewer" in captured)
 
     # Text output
     ns_text = argparse.Namespace(json=False)
@@ -217,14 +284,18 @@ try:
 
     ns_add = argparse.Namespace(name="alpha-skill", **{"from": None}, force=False)
     with patch.object(sc, "_find_project_root", return_value=_add_project):
-        with patch("builtins.print"):
+        with patch("builtins.print") as mock_print:
             rc = sc.cmd_add(ns_add)
+    out_add = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
 
     _test("add official skill exits 0", rc == 0)
     dest = _add_project / ".copilot" / "skills" / "alpha-skill"
     _test("skill directory created", dest.exists())
     _test("SKILL.md present", (dest / "SKILL.md").exists())
     _test("skill.yml present", (dest / "skill.yml").exists())
+    _test(
+        "add output includes handoff suggestions", "Review generated output" in out_add and "code-reviewer" in out_add
+    )
 
     reg = sc._load_registry(_add_project)
     _test("registry entry created", "alpha-skill" in reg.get("skills", {}))


### PR DESCRIPTION
## Summary
- define `handoffs` in `skill.yml` and surface parsed next-step suggestions in `sk skill catalog` and `sk skill add`
- allow `handoffs` in skill frontmatter and wire bundled handoff chains across the official skills
- add parser, catalog, and lint regression coverage for handoff manifests

## Testing
- `python tests/test_skill_catalog.py`
- `python tests/test_lint_skills.py`
- `python tests/test_validate_skill.py`
- `python test_fixes.py`
- `python test_security.py`

Closes #100
