### PR TITLE
feat(projects): isolate knowledge db per project

### DIFF
--- a/anatomy-map.py
+++ b/anatomy-map.py
@@ -40,7 +40,7 @@ if os.name == "nt":
             _s.reconfigure(encoding="utf-8", errors="replace")
 
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
-DEFAULT_DB_PATH = SESSION_STATE / "knowledge.db"
+DEFAULT_DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 
 # ---------------------------------------------------------------------------
 # Static descriptions for common well-known filenames

--- a/briefing.py
+++ b/briefing.py
@@ -58,7 +58,7 @@ if os.name == "nt":
 
 TOOLS_DIR = Path(__file__).parent
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
-DB_PATH = SESSION_STATE / "knowledge.db"
+DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 _CLARIFY_STORE_PATH = SESSION_STATE / "clarifications.json"
 _CONSTITUTION_RELATIVE_PATH = Path(".copilot") / "constitution.md"
 _CONSTITUTION_RULE_RE = re.compile(r"\s*\[rule:[a-z0-9-]+\]\s*", re.IGNORECASE)

--- a/build-session-index.py
+++ b/build-session-index.py
@@ -33,7 +33,7 @@ if os.name == "nt":
         pass
 
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
-DB_PATH = SESSION_STATE / "knowledge.db"
+DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 
 CHECKPOINT_SECTIONS = ["overview", "history", "work_done", "technical_details", "important_files", "next_steps"]
 

--- a/embed.py
+++ b/embed.py
@@ -45,7 +45,7 @@ if os.name == "nt":
 # ── Paths ──────────────────────────────────────────────────────────────
 TOOLS_DIR = Path(__file__).resolve().parent
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
-DB_PATH = SESSION_STATE / "knowledge.db"
+DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 CONFIG_PATH = TOOLS_DIR / "embedding-config.json"
 
 # SSL verification — disable with --no-verify-ssl flag or COPILOT_NO_VERIFY_SSL=1

--- a/extract-knowledge.py
+++ b/extract-knowledge.py
@@ -37,7 +37,7 @@ if os.name == "nt":
         pass
 
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
-DB_PATH = SESSION_STATE / "knowledge.db"
+DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 
 
 def _emit_knowledge_event_fail_open(event_type: str, data: dict) -> None:

--- a/index-status.py
+++ b/index-status.py
@@ -28,7 +28,7 @@ if os.name == "nt":
         pass
 
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
-DB_PATH = SESSION_STATE / "knowledge.db"
+DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 STATUS_JSON_PATH = SESSION_STATE / "index-status.json"
 
 
@@ -54,9 +54,7 @@ def collect_status(db: sqlite3.Connection) -> dict:
     sessions_total = _safe_count(db, "SELECT COUNT(*) FROM sessions")
 
     # Phase 2: sessions with FTS complete (fts_indexed_at IS NOT NULL)
-    sessions_fts_done = _safe_count(
-        db, "SELECT COUNT(*) FROM sessions WHERE fts_indexed_at IS NOT NULL"
-    )
+    sessions_fts_done = _safe_count(db, "SELECT COUNT(*) FROM sessions WHERE fts_indexed_at IS NOT NULL")
 
     # event_offsets rows
     event_offsets_rows = _safe_count(db, "SELECT COUNT(*) FROM event_offsets")
@@ -67,18 +65,14 @@ def collect_status(db: sqlite3.Connection) -> dict:
     # last_indexed_at: most recent indexed_at_r from sessions (REAL timestamp)
     last_indexed_at = None
     try:
-        row = db.execute(
-            "SELECT MAX(indexed_at_r) FROM sessions WHERE indexed_at_r IS NOT NULL"
-        ).fetchone()
+        row = db.execute("SELECT MAX(indexed_at_r) FROM sessions WHERE indexed_at_r IS NOT NULL").fetchone()
         if row and row[0]:
             ts = float(row[0])
             last_indexed_at = datetime.fromtimestamp(ts).isoformat()
     except (sqlite3.OperationalError, TypeError, ValueError):
         # Fallback to text indexed_at column
         try:
-            row = db.execute(
-                "SELECT MAX(indexed_at) FROM sessions WHERE indexed_at IS NOT NULL"
-            ).fetchone()
+            row = db.execute("SELECT MAX(indexed_at) FROM sessions WHERE indexed_at IS NOT NULL").fetchone()
             last_indexed_at = row[0] if row else None
         except sqlite3.OperationalError:
             pass
@@ -113,7 +107,7 @@ def print_human(status: dict) -> None:
     if status["last_indexed_at"]:
         print(f"  Last indexed    : {status['last_indexed_at']}")
     else:
-        print(f"  Last indexed    : (never)")
+        print("  Last indexed    : (never)")
     db_kb = status["db_size_bytes"] / 1024
     print(f"  DB size         : {db_kb:.1f} KB")
     print("=" * 52)

--- a/knowledge-health.py
+++ b/knowledge-health.py
@@ -37,7 +37,7 @@ if os.name == "nt":
         pass
 
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
-DB_PATH = SESSION_STATE / "knowledge.db"
+DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 
 
 def _emit_knowledge_event_fail_open(event_type: str, data: dict) -> None:

--- a/learn.py
+++ b/learn.py
@@ -54,7 +54,7 @@ if os.name == "nt":
 
 TOOLS_DIR = Path(__file__).parent
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
-DB_PATH = SESSION_STATE / "knowledge.db"
+DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 
 
 def _emit_knowledge_event_fail_open(event_type: str, data: dict) -> None:

--- a/migrate.py
+++ b/migrate.py
@@ -371,13 +371,226 @@ def _repair_legacy_priority_collision(db: sqlite3.Connection):
     return repaired, renamed
 
 
+def _ensure_base_schema(db: sqlite3.Connection):
+    """Bootstrap the full base schema for a brand-new knowledge DB.
+
+    Fresh project-local DBs do not have an old migration history to upgrade from, so
+    they need the current base tables before the versioned ALTER/CREATE steps run.
+    Existing databases are unaffected because every statement is idempotent.
+    """
+    db.executescript("""
+        CREATE TABLE IF NOT EXISTS schema_version (
+            version INTEGER PRIMARY KEY,
+            migrated_at TEXT DEFAULT (datetime('now')),
+            name TEXT DEFAULT ''
+        );
+
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            path TEXT NOT NULL,
+            summary TEXT DEFAULT '',
+            total_checkpoints INTEGER DEFAULT 0,
+            total_research INTEGER DEFAULT 0,
+            total_files INTEGER DEFAULT 0,
+            has_plan INTEGER DEFAULT 0,
+            source TEXT DEFAULT 'copilot',
+            indexed_at TEXT,
+            file_mtime REAL,
+            indexed_at_r REAL,
+            fts_indexed_at REAL,
+            event_count_estimate INTEGER DEFAULT 0,
+            file_size_bytes INTEGER DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS documents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            doc_type TEXT NOT NULL,
+            seq INTEGER DEFAULT 0,
+            title TEXT NOT NULL,
+            stable_id TEXT,
+            file_path TEXT NOT NULL UNIQUE,
+            file_hash TEXT,
+            size_bytes INTEGER DEFAULT 0,
+            content_preview TEXT DEFAULT '',
+            source TEXT DEFAULT 'copilot',
+            indexed_at TEXT
+        );
+        CREATE TABLE IF NOT EXISTS sections (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            document_id INTEGER NOT NULL,
+            section_name TEXT NOT NULL,
+            stable_id TEXT,
+            content TEXT NOT NULL,
+            UNIQUE(document_id, section_name)
+        );
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_fts USING fts5(
+            title,
+            section_name,
+            content,
+            doc_type,
+            session_id UNINDEXED,
+            document_id UNINDEXED,
+            tokenize='unicode61 remove_diacritics 2'
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts USING fts5(
+            session_id UNINDEXED,
+            title,
+            user_messages,
+            assistant_messages,
+            tool_names,
+            tokenize='porter unicode61 remove_diacritics 2'
+        );
+        CREATE TABLE IF NOT EXISTS event_offsets (
+            session_id TEXT NOT NULL,
+            event_id INTEGER NOT NULL,
+            byte_offset INTEGER NOT NULL,
+            file_mtime REAL NOT NULL,
+            PRIMARY KEY (session_id, event_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS knowledge_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            document_id INTEGER,
+            category TEXT NOT NULL,
+            title TEXT NOT NULL,
+            stable_id TEXT,
+            content TEXT NOT NULL,
+            tags TEXT DEFAULT '',
+            confidence REAL DEFAULT 1.0,
+            occurrence_count INTEGER DEFAULT 1,
+            first_seen TEXT,
+            last_seen TEXT,
+            source TEXT DEFAULT 'copilot',
+            topic_key TEXT,
+            revision_count INTEGER DEFAULT 1,
+            content_hash TEXT,
+            wing TEXT DEFAULT '',
+            room TEXT DEFAULT '',
+            facts TEXT DEFAULT '[]',
+            est_tokens INTEGER DEFAULT 0,
+            task_id TEXT DEFAULT '',
+            affected_files TEXT DEFAULT '[]',
+            source_section TEXT DEFAULT '',
+            source_file TEXT DEFAULT '',
+            start_line INTEGER DEFAULT 0,
+            end_line INTEGER DEFAULT 0,
+            code_language TEXT DEFAULT '',
+            code_snippet TEXT DEFAULT '',
+            error_type TEXT DEFAULT '',
+            root_cause TEXT DEFAULT '',
+            severity TEXT DEFAULT 'medium',
+            is_resolved INTEGER DEFAULT 0,
+            fix_steps TEXT DEFAULT '',
+            prevention_hook TEXT DEFAULT '',
+            recurrence_after_briefing INTEGER DEFAULT 0,
+            valence TEXT DEFAULT '',
+            intensity REAL DEFAULT 0.5,
+            priority TEXT DEFAULT 'P2',
+            UNIQUE(category, title, session_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS knowledge_relations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_id INTEGER REFERENCES knowledge_entries(id),
+            target_id INTEGER REFERENCES knowledge_entries(id),
+            source_stable_id TEXT DEFAULT '',
+            target_stable_id TEXT DEFAULT '',
+            relation_type TEXT NOT NULL,
+            stable_id TEXT,
+            confidence REAL DEFAULT 0.8,
+            created_at TEXT,
+            UNIQUE(source_id, target_id, relation_type)
+        );
+
+        CREATE TABLE IF NOT EXISTS entity_relations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            subject TEXT NOT NULL,
+            predicate TEXT NOT NULL,
+            object TEXT NOT NULL,
+            stable_id TEXT,
+            noted_at TEXT DEFAULT (datetime('now')),
+            session_id TEXT DEFAULT '',
+            UNIQUE(subject, predicate, object)
+        );
+
+        CREATE TABLE IF NOT EXISTS search_feedback (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            query TEXT,
+            result_id TEXT,
+            result_kind TEXT,
+            verdict INTEGER NOT NULL CHECK(verdict IN (-1,0,1)),
+            comment TEXT,
+            user_agent TEXT,
+            created_at TEXT NOT NULL,
+            origin_replica_id TEXT DEFAULT 'local',
+            stable_id TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS wakeup_config (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            updated_at TEXT DEFAULT (datetime('now'))
+        );
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS ke_fts USING fts5(
+            title,
+            content,
+            tags,
+            category,
+            wing,
+            room,
+            facts,
+            error_type,
+            root_cause,
+            tokenize='unicode61 remove_diacritics 2'
+        );
+    """)
+
+    index_statements = [
+        "CREATE INDEX IF NOT EXISTS idx_documents_session ON documents(session_id)",
+        "CREATE INDEX IF NOT EXISTS idx_documents_type ON documents(doc_type)",
+        "CREATE INDEX IF NOT EXISTS idx_documents_source ON documents(source)",
+        "CREATE INDEX IF NOT EXISTS idx_documents_stable_id ON documents(stable_id)",
+        "CREATE INDEX IF NOT EXISTS idx_sections_doc ON sections(document_id)",
+        "CREATE INDEX IF NOT EXISTS idx_sections_stable_id ON sections(stable_id)",
+        "CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source)",
+        "CREATE INDEX IF NOT EXISTS idx_event_offsets_session ON event_offsets(session_id)",
+        "CREATE INDEX IF NOT EXISTS idx_ke_category ON knowledge_entries(category)",
+        "CREATE INDEX IF NOT EXISTS idx_ke_session ON knowledge_entries(session_id)",
+        "CREATE INDEX IF NOT EXISTS idx_ke_source ON knowledge_entries(source)",
+        "CREATE INDEX IF NOT EXISTS idx_ke_topic ON knowledge_entries(topic_key)",
+        "CREATE INDEX IF NOT EXISTS idx_ke_hash ON knowledge_entries(content_hash)",
+        "CREATE INDEX IF NOT EXISTS idx_ke_task ON knowledge_entries(task_id)",
+        "CREATE INDEX IF NOT EXISTS idx_ke_stable_id ON knowledge_entries(stable_id)",
+        "CREATE INDEX IF NOT EXISTS idx_ke_intensity ON knowledge_entries(intensity DESC)",
+        "CREATE INDEX IF NOT EXISTS idx_ke_priority ON knowledge_entries(priority)",
+        "CREATE INDEX IF NOT EXISTS idx_kr_source ON knowledge_relations(source_id)",
+        "CREATE INDEX IF NOT EXISTS idx_kr_target ON knowledge_relations(target_id)",
+        "CREATE INDEX IF NOT EXISTS idx_kr_source_stable ON knowledge_relations(source_stable_id)",
+        "CREATE INDEX IF NOT EXISTS idx_kr_target_stable ON knowledge_relations(target_stable_id)",
+        "CREATE INDEX IF NOT EXISTS idx_kr_stable_id ON knowledge_relations(stable_id)",
+        "CREATE INDEX IF NOT EXISTS idx_er_subject ON entity_relations(subject)",
+        "CREATE INDEX IF NOT EXISTS idx_er_object ON entity_relations(object)",
+        "CREATE INDEX IF NOT EXISTS idx_er_stable_id ON entity_relations(stable_id)",
+        "CREATE INDEX IF NOT EXISTS idx_sf_query ON search_feedback(query)",
+        "CREATE INDEX IF NOT EXISTS idx_sf_created ON search_feedback(created_at)",
+        "CREATE INDEX IF NOT EXISTS idx_sf_stable_id ON search_feedback(stable_id)",
+        "CREATE INDEX IF NOT EXISTS idx_sf_origin_replica ON search_feedback(origin_replica_id)",
+    ]
+    for sql in index_statements:
+        try:
+            db.execute(sql)
+        except sqlite3.OperationalError:
+            pass
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        sys.argv.append(os.path.expanduser("~/.copilot/session-state/knowledge.db"))
+        sys.argv.append(os.environ.get("SK_DB_PATH") or os.path.expanduser("~/.copilot/session-state/knowledge.db"))
     db = sqlite3.connect(sys.argv[1])
-    db.execute(
-        "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY, migrated_at TEXT DEFAULT (datetime('now')))"
-    )
+    _ensure_base_schema(db)
     try:
         db.execute("ALTER TABLE schema_version ADD COLUMN name TEXT DEFAULT ''")
     except sqlite3.OperationalError:

--- a/project-registry.py
+++ b/project-registry.py
@@ -11,7 +11,13 @@ Registry file: ~/.copilot/session-state/tools-managed-projects.json
 
 Schema (backward-compatible):
   Old entries: "/abs/path"                (plain string, written by install.py / setup-project.py)
-  New entries: {"name": "x", "path": ..., "created_at": "ISO8601"}   (written here)
+  New entries: {
+      "name": "x",
+      "path": ...,
+      "created_at": "ISO8601",
+      "session_state": ".../.copilot/session-state",
+      "db_path": ".../.copilot/session-state/knowledge.db"
+  }   (written here)
 
 Both formats co-exist.  All read paths normalize to the path string.
 """
@@ -32,9 +38,47 @@ if os.name == "nt":
 REGISTRY_PATH = Path.home() / ".copilot" / "session-state" / "tools-managed-projects.json"
 
 
+def _project_copilot_dir(project_root: Path) -> Path:
+    return project_root / ".copilot"
+
+
+def _project_session_state(project_root: Path) -> Path:
+    return _project_copilot_dir(project_root) / "session-state"
+
+
+def _project_db_path(project_root: Path) -> Path:
+    return _project_session_state(project_root) / "knowledge.db"
+
+
+def _normalize_entry(entry: object) -> dict:
+    path = _entry_path(entry)
+    created_at = entry.get("created_at") if isinstance(entry, dict) else None
+    name = entry.get("name") if isinstance(entry, dict) else None
+    session_state = entry.get("session_state") if isinstance(entry, dict) else None
+    db_path = entry.get("db_path") if isinstance(entry, dict) else None
+
+    root = Path(path) if path else None
+    if root is not None:
+        if not name:
+            name = root.name
+        if not session_state:
+            session_state = str(_project_session_state(root))
+        if not db_path:
+            db_path = str(_project_db_path(root))
+
+    return {
+        "name": name or "",
+        "path": path,
+        "created_at": created_at,
+        "session_state": session_state or "",
+        "db_path": db_path or "",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Atomic write (self-contained per architecture — no inter-script imports)
 # ---------------------------------------------------------------------------
+
 
 def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
     """Write *content* to *path* atomically via a sibling .tmp + os.replace."""
@@ -53,6 +97,7 @@ def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> Non
 # ---------------------------------------------------------------------------
 # Registry helpers — backward-compatible with string-only registries
 # ---------------------------------------------------------------------------
+
 
 def _entry_path(entry: object) -> str:
     """Return the path string from a registry entry (string or dict)."""
@@ -95,6 +140,7 @@ def _save_registry(entries: list) -> None:
 # ---------------------------------------------------------------------------
 # Auto-detection helpers
 # ---------------------------------------------------------------------------
+
 
 def _detect_project_root(start: Path | None = None) -> Path | None:
     """
@@ -146,6 +192,7 @@ def _detect_project_root(start: Path | None = None) -> Path | None:
 # Subcommand handlers
 # ---------------------------------------------------------------------------
 
+
 def cmd_add(path_arg: str | None, quiet: bool = False) -> int:
     """Register a project root in the registry."""
     if path_arg:
@@ -171,9 +218,16 @@ def cmd_add(path_arg: str | None, quiet: bool = False) -> int:
             print(f"already registered: {key}")
         return 0
 
-    name = root.name
     created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
-    raw.append({"name": name, "path": key, "created_at": created_at})
+    raw.append(
+        {
+            "name": root.name,
+            "path": key,
+            "created_at": created_at,
+            "session_state": str(_project_session_state(root)),
+            "db_path": str(_project_db_path(root)),
+        }
+    )
 
     try:
         _save_registry(raw)
@@ -244,31 +298,31 @@ def cmd_list(json_output: bool = False) -> int:
         return 0
 
     if json_output:
-        normalized = []
-        for entry in deduped:
-            if isinstance(entry, str):
-                normalized.append({"name": Path(entry).name, "path": entry, "created_at": None})
-            elif isinstance(entry, dict):
-                normalized.append(entry)
+        normalized = [_normalize_entry(entry) for entry in deduped]
         print(json.dumps(normalized, indent=2))
     else:
         for entry in deduped:
-            if isinstance(entry, str):
-                print(entry)
-            elif isinstance(entry, dict):
-                path = entry.get("path", "")
-                name = entry.get("name", Path(path).name if path else "")
-                added = entry.get("created_at", "")
-                if added:
-                    print(f"{path}  ({name}, added {added})")
-                else:
-                    print(f"{path}  ({name})")
+            normalized = _normalize_entry(entry)
+            path = normalized.get("path", "")
+            name = normalized.get("name", "")
+            added = normalized.get("created_at", "")
+            db_path = normalized.get("db_path", "")
+            details = [name] if name else []
+            if added:
+                details.append(f"added {added}")
+            if db_path:
+                details.append(f"db {db_path}")
+            if details:
+                print(f"{path}  ({', '.join(details)})")
+            else:
+                print(path)
     return 0
 
 
 # ---------------------------------------------------------------------------
 # Argument parsing and entry point
 # ---------------------------------------------------------------------------
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -277,7 +331,8 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
             "Registry: ~/.copilot/session-state/tools-managed-projects.json\n"
-            "Auto-detect: walks up from cwd for .copilot/, then falls back to git root."
+            "Auto-detect: walks up from cwd for .copilot/, then falls back to git root.\n"
+            "Each entry also records the project-local session-state and knowledge.db paths."
         ),
     )
     sub = parser.add_subparsers(dest="subcommand", metavar="<subcommand>")

--- a/query-session.py
+++ b/query-session.py
@@ -61,7 +61,7 @@ if os.name == "nt":
         pass
 
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
-DB_PATH = SESSION_STATE / "knowledge.db"
+DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 
 
 def _safe_int_list(values) -> list[int]:

--- a/sk.py
+++ b/sk.py
@@ -54,6 +54,7 @@ Usage:
     sk --version  Show version
 """
 
+import json
 import os
 import subprocess
 import sys
@@ -68,6 +69,21 @@ __version__ = "1.0.0"
 
 DEFAULT_TOOLS_DIR = Path(__file__).parent.resolve()
 CHECKOUT_MARKERS = ("briefing.py", "query-session.py", "install.py")
+PROJECT_REGISTRY_PATH = Path.home() / ".copilot" / "session-state" / "tools-managed-projects.json"
+_GLOBAL_COPILOT_DIR = (Path.home() / ".copilot").resolve()
+_PROJECT_DB_SCRIPTS = {
+    "anatomy-map.py",
+    "briefing.py",
+    "build-session-index.py",
+    "embed.py",
+    "extract-knowledge.py",
+    "index-status.py",
+    "knowledge-health.py",
+    "learn.py",
+    "migrate.py",
+    "query-session.py",
+    "watch-sessions.py",
+}
 
 # ---------------------------------------------------------------------------
 # Command → script mapping
@@ -213,6 +229,87 @@ def _print_missing_script_error(tools_dir: Path, script: str, *, from_env: bool)
     print(f"sk: script not found: {script_path}", file=sys.stderr)
 
 
+def _entry_path(entry: object) -> str:
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, dict):
+        path = entry.get("path", "")
+        return path if isinstance(path, str) else ""
+    return ""
+
+
+def _load_registered_projects() -> list[Path]:
+    try:
+        if PROJECT_REGISTRY_PATH.exists():
+            data = json.loads(PROJECT_REGISTRY_PATH.read_text(encoding="utf-8"))
+            projects = []
+            for entry in data.get("projects", []):
+                path = _entry_path(entry)
+                if path:
+                    projects.append(Path(path).expanduser().resolve())
+            return projects
+    except Exception:
+        pass
+    return []
+
+
+def _detect_project_root(start: Path | None = None) -> Path | None:
+    cwd = (start or Path.cwd()).resolve()
+    probe = cwd
+    for _ in range(32):
+        candidate = probe / ".copilot"
+        if candidate.is_dir() and candidate.resolve() != _GLOBAL_COPILOT_DIR:
+            return probe
+        parent = probe.parent
+        if parent == probe:
+            break
+        probe = parent
+    return None
+
+
+def _resolve_project_root_for_cwd(start: Path | None = None) -> Path | None:
+    cwd = (start or Path.cwd()).resolve()
+    detected = _detect_project_root(cwd)
+    if detected is not None:
+        return detected
+
+    matches = [root for root in _load_registered_projects() if cwd == root or root in cwd.parents]
+    if matches:
+        return max(matches, key=lambda root: len(root.parts))
+
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            timeout=5,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            return Path(proc.stdout.strip()).resolve()
+    except Exception:
+        pass
+    return None
+
+
+def _project_db_path(project_root: Path) -> Path:
+    return project_root / ".copilot" / "session-state" / "knowledge.db"
+
+
+def _project_env_for_script(script: str) -> dict[str, str] | None:
+    if Path(script).name not in _PROJECT_DB_SCRIPTS:
+        return None
+    project_root = _resolve_project_root_for_cwd()
+    if project_root is None:
+        return None
+    db_path = _project_db_path(project_root)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["SK_PROJECT_ROOT"] = str(project_root)
+    env["SK_DB_PATH"] = str(db_path)
+    return env
+
+
 def _run(script: str, extra_args: list[str]) -> int:
     """Delegate to a standalone script via subprocess."""
     tools_dir, from_env = _resolve_tools_dir()
@@ -221,7 +318,7 @@ def _run(script: str, extra_args: list[str]) -> int:
         _print_missing_script_error(tools_dir, script, from_env=from_env)
         return 2
     cmd = [sys.executable, str(script_path)] + extra_args
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, env=_project_env_for_script(script))
     return result.returncode
 
 

--- a/tests/test_project_registry.py
+++ b/tests/test_project_registry.py
@@ -160,6 +160,7 @@ class TestCmdAdd(unittest.TestCase):
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self._td, ignore_errors=True)
 
     def test_add_new_path(self):
@@ -185,6 +186,10 @@ class TestCmdAdd(unittest.TestCase):
         self.assertIn("name", entry)
         self.assertIn("path", entry)
         self.assertIn("created_at", entry)
+        self.assertIn("session_state", entry)
+        self.assertIn("db_path", entry)
+        self.assertTrue(entry["session_state"].endswith(str(Path(".copilot") / "session-state")))
+        self.assertTrue(entry["db_path"].endswith(str(Path(".copilot") / "session-state" / "knowledge.db")))
 
     def test_add_preserves_existing_string_entries(self):
         # Pre-populate with a legacy string entry using a real path
@@ -220,6 +225,7 @@ class TestCmdRemove(unittest.TestCase):
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self._td, ignore_errors=True)
 
     def _populate(self, entries):
@@ -235,10 +241,12 @@ class TestCmdRemove(unittest.TestCase):
         self.assertIn(self.keep_path, paths)
 
     def test_remove_dict_entry(self):
-        self._populate([
-            {"name": "keep", "path": self.keep_path, "created_at": "2025-01-01T00:00:00+00:00"},
-            {"name": "gone", "path": self.remove_path, "created_at": "2025-01-01T00:00:00+00:00"},
-        ])
+        self._populate(
+            [
+                {"name": "keep", "path": self.keep_path, "created_at": "2025-01-01T00:00:00+00:00"},
+                {"name": "gone", "path": self.remove_path, "created_at": "2025-01-01T00:00:00+00:00"},
+            ]
+        )
         rc = self.mod.cmd_remove(self.remove_path, quiet=True)
         self.assertEqual(rc, 0)
         data = json.loads(self.reg.read_text(encoding="utf-8"))
@@ -288,7 +296,10 @@ class TestCmdList(unittest.TestCase):
         output = "".join(str(c) for call in mock_print.call_args_list for c in call[0])
         parsed = json.loads(output)
         self.assertIsInstance(parsed, list)
-        self.assertTrue(any(item.get("path") == "/path/a" for item in parsed))
+        item = next((item for item in parsed if item.get("path") == "/path/a"), None)
+        self.assertIsNotNone(item)
+        self.assertIn("session_state", item)
+        self.assertIn("db_path", item)
 
     def test_list_json_empty(self):
         self.reg.write_text(json.dumps({"projects": []}), encoding="utf-8")
@@ -362,10 +373,12 @@ class TestDetectProjectRoot(unittest.TestCase):
             isolated.mkdir()
             # Patch Path.is_dir to return False for any path ending in .copilot
             orig_is_dir = Path.is_dir
+
             def _fake_is_dir(self_path):
                 if self_path.name == ".copilot":
                     return False
                 return orig_is_dir(self_path)
+
             with patch.object(Path, "is_dir", _fake_is_dir):
                 with patch.object(self.mod.subprocess, "run") as mock_run:
                     mock_run.return_value = MagicMock(returncode=1, stdout="")
@@ -379,10 +392,12 @@ class TestDetectProjectRoot(unittest.TestCase):
             isolated.mkdir()
             fake_root = str(isolated.resolve())
             orig_is_dir = Path.is_dir
+
             def _fake_is_dir(self_path):
                 if self_path.name == ".copilot":
                     return False
                 return orig_is_dir(self_path)
+
             with patch.object(Path, "is_dir", _fake_is_dir):
                 with patch.object(self.mod.subprocess, "run") as mock_run:
                     mock_run.return_value = MagicMock(returncode=0, stdout=fake_root + "\n")
@@ -405,6 +420,7 @@ class TestDetectProjectRoot(unittest.TestCase):
             subdir.mkdir(parents=True)
 
             orig_is_dir = Path.is_dir
+
             def _fake_is_dir(self_path):
                 if self_path.name == ".copilot":
                     return self_path.resolve() == fake_home_copilot
@@ -436,6 +452,7 @@ class TestDetectProjectRoot(unittest.TestCase):
             subdir.mkdir()
 
             orig_is_dir = Path.is_dir
+
             def _fake_is_dir(self_path):
                 if self_path.name == ".copilot":
                     # Both global and project-local exist; only project-local should win
@@ -468,6 +485,7 @@ class TestMainDispatch(unittest.TestCase):
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self._td, ignore_errors=True)
 
     def test_add_via_main(self):
@@ -520,6 +538,7 @@ class TestBackwardCompatibility(unittest.TestCase):
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self._td, ignore_errors=True)
 
     def test_mixed_registry_round_trip(self):

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -14,9 +14,11 @@ Run: python3 tests/test_sk_cli.py
 """
 
 import importlib.util
+import json
 import os
 import shutil
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -705,6 +707,62 @@ class TestSkErrorCases(unittest.TestCase):
         self.assertEqual(tools_dir, Path(tmpdir).resolve())
         self.assertTrue(from_env)
 
+    def test_resolve_project_root_detects_local_copilot_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "repo"
+            (project_root / ".copilot").mkdir(parents=True)
+            nested = project_root / "src" / "deep"
+            nested.mkdir(parents=True)
+            resolved = sk._resolve_project_root_for_cwd(nested)
+        self.assertEqual(resolved, project_root.resolve())
+
+    def test_resolve_project_root_falls_back_to_registry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "repo"
+            nested = project_root / "src"
+            nested.mkdir(parents=True)
+            registry = Path(tmpdir) / "registry.json"
+            registry.write_text(
+                json.dumps({"projects": [str(project_root.resolve())]}),
+                encoding="utf-8",
+            )
+            with patch.object(sk, "PROJECT_REGISTRY_PATH", registry):
+                resolved = sk._resolve_project_root_for_cwd(nested)
+        self.assertEqual(resolved, project_root.resolve())
+
+    def test_run_injects_project_db_env_for_core_scripts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tools_dir = Path(tmpdir) / "tools"
+            tools_dir.mkdir()
+            (tools_dir / "briefing.py").write_text("print('ok')\n", encoding="utf-8")
+            project_root = Path(tmpdir) / "repo"
+            project_root.mkdir()
+            expected_db = project_root / ".copilot" / "session-state" / "knowledge.db"
+            with patch.object(sk, "_resolve_tools_dir", return_value=(tools_dir, False)):
+                with patch.object(sk, "_resolve_project_root_for_cwd", return_value=project_root.resolve()):
+                    with patch("subprocess.run") as mock_run:
+                        mock_run.return_value = MagicMock(returncode=0)
+                        rc = sk._run("briefing.py", ["--auto"])
+                        self.assertEqual(rc, 0)
+                        self.assertTrue(expected_db.parent.is_dir())
+                        args, kwargs = mock_run.call_args
+                        self.assertEqual(args[0], [sys.executable, str(tools_dir / "briefing.py"), "--auto"])
+                        self.assertTrue(os.path.samefile(kwargs["env"]["SK_PROJECT_ROOT"], project_root.resolve()))
+                        self.assertEqual(Path(kwargs["env"]["SK_DB_PATH"]).name, "knowledge.db")
+                        self.assertTrue(os.path.samefile(Path(kwargs["env"]["SK_DB_PATH"]).parent, expected_db.parent))
+
+    def test_run_skips_project_db_env_for_non_db_scripts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tools_dir = Path(tmpdir) / "tools"
+            tools_dir.mkdir()
+            (tools_dir / "install.py").write_text("print('ok')\n", encoding="utf-8")
+            with patch.object(sk, "_resolve_tools_dir", return_value=(tools_dir, False)):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0)
+                    rc = sk._run("install.py", [])
+        self.assertEqual(rc, 0)
+        self.assertIsNone(mock_run.call_args.kwargs.get("env"))
+
     def test_missing_checkout_shows_editable_install_hint(self):
         temp_dir = Path(tempfile.mkdtemp(prefix="sk-missing-tools-"))
         try:
@@ -718,6 +776,80 @@ class TestSkErrorCases(unittest.TestCase):
         output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
         self.assertIn("pip install -e", output)
         self.assertIn("SK_TOOLS_DIR", output)
+
+
+class TestSkProjectDbRoutingSmoke(unittest.TestCase):
+    def _run_sk(self, args: list[str], cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SK_PATH)] + args,
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            env=env,
+            encoding="utf-8",
+            errors="replace",
+        )
+
+    def test_fresh_project_routes_index_and_knowledge_commands_to_project_db(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            home_dir = tmp / "home"
+            project = tmp / "project"
+            home_dir.mkdir()
+            (project / ".copilot").mkdir(parents=True)
+
+            env = os.environ.copy()
+            env["USERPROFILE"] = str(home_dir)
+            env["HOME"] = str(home_dir)
+
+            add_result = self._run_sk(["project", "add", str(project)], TOOLS_DIR, env)
+            self.assertEqual(
+                add_result.returncode,
+                0,
+                f"add failed: stdout={add_result.stdout!r} stderr={add_result.stderr!r}",
+            )
+
+            migrate_result = self._run_sk(["index", "migrate"], project, env)
+            self.assertEqual(
+                migrate_result.returncode,
+                0,
+                f"migrate failed: stdout={migrate_result.stdout!r} stderr={migrate_result.stderr!r}",
+            )
+
+            learn_result = self._run_sk(
+                [
+                    "learn",
+                    "--pattern",
+                    "Issue 91 smoke",
+                    "Project-local DB write via sk dispatcher",
+                    "--wing",
+                    "shared",
+                    "--room",
+                    "smoke",
+                    "--tags",
+                    "issue-91,smoke",
+                ],
+                project,
+                env,
+            )
+            self.assertEqual(
+                learn_result.returncode,
+                0,
+                f"learn failed: stdout={learn_result.stdout!r} stderr={learn_result.stderr!r}",
+            )
+
+            patterns_result = self._run_sk(["query", "--patterns"], project, env)
+            self.assertEqual(
+                patterns_result.returncode,
+                0,
+                f"query failed: stdout={patterns_result.stdout!r} stderr={patterns_result.stderr!r}",
+            )
+            self.assertIn("Issue 91 smoke", patterns_result.stdout)
+
+            project_db = project / ".copilot" / "session-state" / "knowledge.db"
+            global_db = home_dir / ".copilot" / "session-state" / "knowledge.db"
+            self.assertTrue(project_db.exists(), f"project db missing: {project_db}")
+            self.assertFalse(global_db.exists(), f"global db should stay absent: {global_db}")
 
 
 class TestSkHybridRoutingPreconditions(unittest.TestCase):

--- a/watch-sessions.py
+++ b/watch-sessions.py
@@ -17,26 +17,28 @@ Usage:
 Cross-platform: Windows, macOS, Linux. Pure Python stdlib.
 """
 
-import os
-import re
-import sys
-import time
-import signal
 import atexit
 import hashlib
+import os
+import re
+import signal
 import sqlite3
-from pathlib import Path
+import sys
+import time
 from datetime import datetime
+from pathlib import Path
 
 # Host metadata is centralised in host_manifest.py — import canonical constants.
 # Do NOT add new hosts here; update host_manifest.py through the review process.
 from host_manifest import (  # noqa: E402
-    SESSION_STATE,
     CLAUDE_PROJECTS,
+    SESSION_STATE,
+)
+from host_manifest import (
     HOST_SESSION_ROOTS as KNOWN_HOSTS,
 )
 
-DB_PATH = SESSION_STATE / "knowledge.db"
+DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 TOOLS_DIR = Path(__file__).parent
 STATE_FILE = SESSION_STATE / ".watch-state.json"
 LOCK_FILE = SESSION_STATE / ".watcher.lock"
@@ -46,7 +48,7 @@ DEFAULT_INTERVAL = 60  # seconds
 
 # Matches canonical UUID format (8-4-4-4-12 hex digits)
 _UUID_RE = re.compile(
-    r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,
 )
 
@@ -73,10 +75,9 @@ def _is_pid_running(pid: int) -> bool:
     """Check if a process with the given PID is still running."""
     if os.name == "nt":
         import ctypes
+
         PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-        handle = ctypes.windll.kernel32.OpenProcess(
-            PROCESS_QUERY_LIMITED_INFORMATION, False, pid
-        )
+        handle = ctypes.windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
         if handle:
             ctypes.windll.kernel32.CloseHandle(handle)
             return True
@@ -181,9 +182,7 @@ def _content_hash(path: Path) -> str:
         return ""
 
 
-def _extract_session_ids_from_paths(
-    paths: list, host_roots: list
-) -> list:
+def _extract_session_ids_from_paths(paths: list, host_roots: list) -> list:
     """Extract session IDs (UUIDs) from changed file paths.
 
     Supports two layouts:
@@ -220,6 +219,7 @@ def _extract_session_ids_from_paths(
 def load_state() -> dict:
     """Load previous watch state."""
     import json
+
     if STATE_FILE.exists():
         try:
             return json.loads(STATE_FILE.read_text(encoding="utf-8"))
@@ -230,7 +230,9 @@ def load_state() -> dict:
 
 def save_state(state: dict):
     """Save current watch state (atomic write — P0-10)."""
-    import json, os
+    import json
+    import os
+
     tmp = STATE_FILE.with_suffix(".tmp")
     try:
         tmp.write_text(json.dumps(state, default=str), encoding="utf-8")
@@ -245,6 +247,7 @@ def save_state(state: dict):
 def run_indexer(incremental: bool = True):
     """Run the build-session-index.py script."""
     import subprocess
+
     indexer = TOOLS_DIR / "build-session-index.py"
     if not indexer.exists():
         print(f"[watch] Error: indexer not found at {indexer}")
@@ -255,10 +258,7 @@ def run_indexer(incremental: bool = True):
         args.append("--incremental")
 
     try:
-        result = subprocess.run(
-            args, capture_output=True, text=True, timeout=120,
-            encoding="utf-8", errors="replace"
-        )
+        result = subprocess.run(args, capture_output=True, text=True, timeout=120, encoding="utf-8", errors="replace")
         if result.returncode == 0:
             # Only show output if something was indexed
             for line in result.stdout.splitlines():
@@ -282,6 +282,7 @@ def run_extractor(changed_files: list | None = None, session_ids: list | None = 
     Falls back to full extraction when session_ids is empty or not provided.
     """
     import subprocess
+
     extractor = TOOLS_DIR / "extract-knowledge.py"
     if not extractor.exists():
         return True  # Optional — skip if not installed
@@ -298,11 +299,7 @@ def run_extractor(changed_files: list | None = None, session_ids: list | None = 
         args += ["--sessions", ",".join(session_ids)]
 
     try:
-        result = subprocess.run(
-            args,
-            capture_output=True, text=True, timeout=120,
-            encoding="utf-8", errors="replace"
-        )
+        result = subprocess.run(args, capture_output=True, text=True, timeout=120, encoding="utf-8", errors="replace")
         if result.returncode == 0:
             for line in result.stdout.splitlines():
                 if "extracted" in line.lower():
@@ -316,8 +313,7 @@ def run_extractor(changed_files: list | None = None, session_ids: list | None = 
         return False
 
 
-def check_and_index(prev_sigs: dict, watch_dirs: list[Path],
-                    changed_only: bool = False) -> dict:
+def check_and_index(prev_sigs: dict, watch_dirs: list[Path], changed_only: bool = False) -> dict:
     """Compare current files with previous state, index if changed.
 
     Uses hybrid mtime+size fast-path followed by content-hash verification.
@@ -336,9 +332,9 @@ def check_and_index(prev_sigs: dict, watch_dirs: list[Path],
 
     # Files whose mtime or size changed — candidates for content check
     mtime_changed = {
-        f for f in current_mtime_sigs
-        if f in prev_sigs
-        and (current_mtime_sigs[f][0], current_mtime_sigs[f][1]) != (prev_sigs[f][0], prev_sigs[f][1])
+        f
+        for f in current_mtime_sigs
+        if f in prev_sigs and (current_mtime_sigs[f][0], current_mtime_sigs[f][1]) != (prev_sigs[f][0], prev_sigs[f][1])
     }
 
     # Build enriched sigs {fp: [mtime, size, hash]} and resolve true changes
@@ -381,9 +377,7 @@ def check_and_index(prev_sigs: dict, watch_dirs: list[Path],
         # Derive session IDs from changed paths so extraction is scoped to only the
         # sessions that actually changed.  Falls back to full extraction when the path
         # layout is unrecognised (empty list → no --sessions flag).
-        changed_session_ids = _extract_session_ids_from_paths(
-            all_changed, [root for _, root in KNOWN_HOSTS]
-        )
+        changed_session_ids = _extract_session_ids_from_paths(all_changed, [root for _, root in KNOWN_HOSTS])
         run_extractor(
             changed_files=all_changed if changed_only else None,
             session_ids=changed_session_ids or None,
@@ -398,8 +392,10 @@ def print_install_hint():
     pythonw = Path(sys.executable).parent / "pythonw.exe"
     if os.name == "nt":
         print("# Windows — Task Scheduler (hidden background, no terminal):")
-        print(f'schtasks /create /tn "CopilotSessionWatcher" '
-              f'/tr "\\"{pythonw}\\" \\"{script}\\" --service" /sc onlogon /f')
+        print(
+            f'schtasks /create /tn "CopilotSessionWatcher" '
+            f'/tr "\\"{pythonw}\\" \\"{script}\\" --service" /sc onlogon /f'
+        )
         print()
         print("# Start now:")
         print('schtasks /run /tn "CopilotSessionWatcher"')
@@ -414,7 +410,7 @@ def print_install_hint():
         print(f"@reboot python3 {script}")
         print()
         print("# Or create a systemd user service:")
-        print(f"# ~/.config/systemd/user/copilot-watcher.service")
+        print("# ~/.config/systemd/user/copilot-watcher.service")
         print("[Unit]")
         print("Description=Copilot Session Watcher")
         print("[Service]")
@@ -439,17 +435,14 @@ def _adaptive_poll_interval(file_signatures: dict) -> int:
         return 300  # idle tier — no files known
 
     # file_signatures values are [mtime, size, hash] or (mtime, size)
-    most_recent = max(
-        (v[0] if isinstance(v, (list, tuple)) else 0.0)
-        for v in file_signatures.values()
-    )
+    most_recent = max((v[0] if isinstance(v, (list, tuple)) else 0.0) for v in file_signatures.values())
     age = now - most_recent
 
-    if age <= 120:     # 2 minutes
+    if age <= 120:  # 2 minutes
         return 5
-    if age <= 3600:    # 1 hour
+    if age <= 3600:  # 1 hour
         return 30
-    return 300         # idle
+    return 300  # idle
 
 
 def main():
@@ -540,10 +533,12 @@ def main():
 
     # Graceful shutdown
     running = True
+
     def handle_signal(sig, frame):
         nonlocal running
         running = False
         print("\n[watch] Stopping...")
+
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)
 


### PR DESCRIPTION
## Summary
- route core knowledge scripts through sk into a detected project-local SK_DB_PATH
- enrich sk project list registry entries with project session-state and DB metadata
- bootstrap fresh project-local databases so sk index migrate, sk learn, and sk query work end-to-end

Closes #91