### PR TITLE
feat(spec-kit): add multi-agent adapter registry

### DIFF
--- a/agent_adapters.py
+++ b/agent_adapters.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+agent_adapters.py — Adapter registry for project-level AI instruction files.
+
+This module intentionally covers project config/instruction surfaces only.
+Runtime/session host support remains grounded elsewhere (see host_manifest.py).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+DEFAULT_BLOCK_ID = "SESSION-KNOWLEDGE"
+
+AGENTS_BLOCK_CONTENT = """## Session Knowledge
+
+- Run `sk briefing --auto --compact` before starting work.
+- Use `sk query "<topic>"` to recall prior project decisions and patterns.
+- Record durable lessons with `sk learn --pattern ...` or `sk learn --mistake ...` after meaningful changes.
+"""
+
+COPILOT_BLOCK_CONTENT = """## Session Knowledge
+
+- Keep `.github/instructions/session-knowledge.instructions.md` installed for the full workflow policy.
+- Keep `.github/skills/session-knowledge/SKILL.md` available so Copilot can discover briefing, query, and learn commands.
+"""
+
+IMPORT_AGENTS_CONTENT = "@AGENTS.md"
+
+
+def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_bytes(content.encode(encoding))
+        os.replace(str(tmp), str(path))
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+
+def validate_block_id(block_id: str) -> str:
+    value = (block_id or "").strip()
+    if not value:
+        raise ValueError("--block-id must not be empty")
+    if "<!--" in value or "-->" in value or "\n" in value or "\r" in value:
+        raise ValueError("--block-id cannot contain comment delimiters or newlines")
+    return value
+
+
+def _detect_newline(text: str) -> str:
+    return "\r\n" if "\r\n" in text else "\n"
+
+
+def _line_without_newline(line: str) -> str:
+    return line.rstrip("\r\n")
+
+
+def _marker_pair(block_id: str) -> tuple[str, str]:
+    normalized = validate_block_id(block_id)
+    return f"<!-- {normalized} SK START -->", f"<!-- {normalized} SK END -->"
+
+
+def _find_block_span(lines: list[str], start_marker: str, end_marker: str) -> tuple[int, int] | None:
+    start_indexes = [idx for idx, line in enumerate(lines) if _line_without_newline(line) == start_marker]
+    end_indexes = [idx for idx, line in enumerate(lines) if _line_without_newline(line) == end_marker]
+    if not start_indexes and not end_indexes:
+        return None
+    if len(start_indexes) != 1 or len(end_indexes) != 1:
+        raise ValueError("Managed block markers are duplicated or incomplete")
+    start_idx = start_indexes[0]
+    end_idx = end_indexes[0]
+    if end_idx < start_idx:
+        raise ValueError("Managed block end marker appears before start marker")
+    return start_idx, end_idx
+
+
+def _build_block_lines(content: str, start_marker: str, end_marker: str, newline: str) -> list[str]:
+    normalized = content.replace("\r\n", "\n").replace("\r", "\n")
+    payload = normalized.split("\n")
+    if payload and payload[-1] == "":
+        payload = payload[:-1]
+    block = [start_marker + newline]
+    block.extend(line + newline for line in payload)
+    block.append(end_marker + newline)
+    return block
+
+
+def _upsert_block_text(text: str, content: str, start_marker: str, end_marker: str) -> str:
+    newline = _detect_newline(text)
+    lines = text.splitlines(keepends=True)
+    block_lines = _build_block_lines(content, start_marker, end_marker, newline)
+    span = _find_block_span(lines, start_marker, end_marker)
+    if span is not None:
+        start_idx, end_idx = span
+        lines[start_idx : end_idx + 1] = block_lines
+        return "".join(lines)
+
+    if lines and not lines[-1].endswith(("\n", "\r")):
+        lines[-1] = lines[-1] + newline
+    if lines and _line_without_newline(lines[-1]).strip():
+        lines.append(newline)
+    lines.extend(block_lines)
+    return "".join(lines) if lines else "".join(block_lines)
+
+
+def _remove_block_text(text: str, start_marker: str, end_marker: str) -> tuple[str, bool]:
+    lines = text.splitlines(keepends=True)
+    span = _find_block_span(lines, start_marker, end_marker)
+    if span is None:
+        return text, False
+    start_idx, end_idx = span
+    before = lines[:start_idx]
+    after = lines[end_idx + 1 :]
+
+    if (
+        before
+        and after
+        and not _line_without_newline(before[-1]).strip()
+        and not _line_without_newline(after[0]).strip()
+    ):
+        after = after[1:]
+    if not before:
+        while after and not _line_without_newline(after[0]).strip():
+            after = after[1:]
+    if not after:
+        while before and not _line_without_newline(before[-1]).strip():
+            before = before[:-1]
+
+    return "".join(before + after), True
+
+
+@dataclass(frozen=True)
+class AgentAdapter:
+    key: str
+    name: str
+    context_file: str
+    aliases: tuple[str, ...]
+    detect_paths: tuple[str, ...]
+    default_content: str
+    bootstrap_agents: tuple[str, ...] = ()
+    public: bool = True
+
+    def target_path(self, repo_root: Path) -> Path:
+        return repo_root / self.context_file
+
+    def detect(self, repo_root: Path) -> bool:
+        return any((repo_root / rel).exists() for rel in self.detect_paths)
+
+    def upsert_context(
+        self,
+        repo_root: Path,
+        content: str | None = None,
+        *,
+        block_id: str = DEFAULT_BLOCK_ID,
+        dry_run: bool = False,
+    ) -> str:
+        target = self.target_path(repo_root)
+        payload = self.default_content if content is None else content
+        start_marker, end_marker = _marker_pair(block_id)
+        existed = target.exists()
+        existing = target.read_text(encoding="utf-8") if existed else ""
+        updated = _upsert_block_text(existing, payload, start_marker, end_marker)
+        if updated == existing:
+            return "unchanged"
+        if not dry_run:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write_text(target, updated)
+        return "updated" if existed else "created"
+
+    def remove_context(
+        self,
+        repo_root: Path,
+        *,
+        block_id: str = DEFAULT_BLOCK_ID,
+        dry_run: bool = False,
+    ) -> tuple[str, bool]:
+        target = self.target_path(repo_root)
+        if not target.exists():
+            return "missing", False
+        start_marker, end_marker = _marker_pair(block_id)
+        existing = target.read_text(encoding="utf-8")
+        updated, changed = _remove_block_text(existing, start_marker, end_marker)
+        if changed and not dry_run:
+            _atomic_write_text(target, updated)
+            return "removed", True
+        if changed:
+            return "removed", True
+        return "absent", False
+
+
+_REGISTRY: tuple[AgentAdapter, ...] = (
+    AgentAdapter(
+        key="copilot",
+        name="Copilot CLI",
+        context_file=".github/copilot-instructions.md",
+        aliases=("copilot", "copilot-cli", "github-copilot"),
+        detect_paths=(".github/copilot-instructions.md",),
+        default_content=COPILOT_BLOCK_CONTENT,
+    ),
+    AgentAdapter(
+        key="claude",
+        name="Claude Code",
+        context_file="CLAUDE.md",
+        aliases=("claude", "claude-code"),
+        detect_paths=("CLAUDE.md", ".claude"),
+        default_content=IMPORT_AGENTS_CONTENT,
+        bootstrap_agents=("agents",),
+    ),
+    AgentAdapter(
+        key="codex",
+        name="Codex",
+        context_file="AGENTS.md",
+        aliases=("codex",),
+        detect_paths=(".codex",),
+        default_content=AGENTS_BLOCK_CONTENT,
+    ),
+    AgentAdapter(
+        key="cursor",
+        name="Cursor",
+        context_file="AGENTS.md",
+        aliases=("cursor",),
+        detect_paths=(".cursor",),
+        default_content=AGENTS_BLOCK_CONTENT,
+    ),
+    AgentAdapter(
+        key="windsurf",
+        name="Windsurf",
+        context_file="AGENTS.md",
+        aliases=("windsurf",),
+        detect_paths=(".windsurf",),
+        default_content=AGENTS_BLOCK_CONTENT,
+    ),
+    AgentAdapter(
+        key="gemini",
+        name="Gemini CLI",
+        context_file="GEMINI.md",
+        aliases=("gemini", "gemini-cli"),
+        detect_paths=("GEMINI.md", ".gemini"),
+        default_content=IMPORT_AGENTS_CONTENT,
+        bootstrap_agents=("agents",),
+    ),
+    AgentAdapter(
+        key="agents",
+        name="All agents",
+        context_file="AGENTS.md",
+        aliases=("agents", "all", "all-agents"),
+        detect_paths=("AGENTS.md",),
+        default_content=AGENTS_BLOCK_CONTENT,
+        public=False,
+    ),
+)
+
+AGENT_ADAPTERS: dict[str, AgentAdapter] = {adapter.key: adapter for adapter in _REGISTRY}
+_ALIAS_TO_KEY: dict[str, str] = {
+    alias: adapter.key for adapter in _REGISTRY for alias in adapter.aliases
+}
+PUBLIC_AGENT_KEYS: tuple[str, ...] = tuple(adapter.key for adapter in _REGISTRY if adapter.public)
+CLI_AGENT_KEYS: tuple[str, ...] = tuple(adapter.key for adapter in _REGISTRY)
+
+
+def resolve_agent_key(agent: str) -> str:
+    key = (agent or "").strip().lower()
+    if key not in _ALIAS_TO_KEY:
+        allowed = ", ".join(CLI_AGENT_KEYS)
+        raise ValueError(f"Unknown --agent '{agent}'. Choose from: {allowed}")
+    return _ALIAS_TO_KEY[key]
+
+
+def get_adapter(agent: str) -> AgentAdapter:
+    return AGENT_ADAPTERS[resolve_agent_key(agent)]
+
+
+def detect_agents(repo_root: Path) -> list[str]:
+    detected: list[str] = []
+    for key in PUBLIC_AGENT_KEYS:
+        if AGENT_ADAPTERS[key].detect(repo_root):
+            detected.append(key)
+    if not detected and AGENT_ADAPTERS["agents"].detect(repo_root):
+        detected.append("agents")
+    return detected
+
+
+def expand_init_agents(agent_keys: list[str]) -> list[str]:
+    expanded: list[str] = []
+
+    def add(key: str) -> None:
+        normalized = resolve_agent_key(key)
+        if normalized not in expanded:
+            expanded.append(normalized)
+
+    for raw in agent_keys:
+        adapter = get_adapter(raw)
+        for dep in adapter.bootstrap_agents:
+            add(dep)
+        add(adapter.key)
+    return expanded
+
+
+def unique_target_adapters(adapters: list[AgentAdapter]) -> list[AgentAdapter]:
+    seen: set[str] = set()
+    unique: list[AgentAdapter] = []
+    for adapter in adapters:
+        if adapter.context_file in seen:
+            continue
+        seen.add(adapter.context_file)
+        unique.append(adapter)
+    return unique

--- a/context-blocks.py
+++ b/context-blocks.py
@@ -20,20 +20,10 @@ if os.name == "nt":
         if hasattr(_stream, "reconfigure"):
             _stream.reconfigure(encoding="utf-8", errors="replace")
 
-from host_manifest import COPILOT_DIR, HOST_INSTRUCTION_FILES  # noqa: E402
+from agent_adapters import DEFAULT_BLOCK_ID, get_adapter, validate_block_id  # noqa: E402
+from host_manifest import COPILOT_DIR  # noqa: E402
 
-DEFAULT_BLOCK_ID = "SESSION-KNOWLEDGE"
 REGISTRY_PATH = COPILOT_DIR / "session-state" / "tools-managed-projects.json"
-_AGENT_ALIASES = {
-    "copilot": "Copilot CLI",
-    "copilot-cli": "Copilot CLI",
-    "github-copilot": "Copilot CLI",
-    "claude": "Claude Code",
-    "claude-code": "Claude Code",
-    "agents": "All agents",
-    "all": "All agents",
-    "all-agents": "All agents",
-}
 
 
 def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
@@ -101,26 +91,15 @@ def _find_git_root(start: Path | None = None) -> Path:
 
 
 def _normalize_agent(agent: str) -> str:
-    key = (agent or "").strip().lower()
-    if key not in _AGENT_ALIASES:
-        allowed = ", ".join(sorted(_AGENT_ALIASES))
-        raise ValueError(f"Unknown --agent '{agent}'. Choose from: {allowed}")
-    return _AGENT_ALIASES[key]
+    return get_adapter(agent).name
 
 
 def _validate_block_id(block_id: str) -> str:
-    value = (block_id or "").strip()
-    if not value:
-        raise ValueError("--block-id must not be empty")
-    if "<!--" in value or "-->" in value or "\n" in value or "\r" in value:
-        raise ValueError("--block-id cannot contain comment delimiters or newlines")
-    return value
+    return validate_block_id(block_id)
 
 
 def _resolve_target(repo_root: Path, agent: str) -> Path:
-    host_name = _normalize_agent(agent)
-    rel = HOST_INSTRUCTION_FILES[host_name]
-    return repo_root / rel
+    return get_adapter(agent).target_path(repo_root)
 
 
 def _detect_newline(text: str) -> str:
@@ -235,13 +214,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     sub = parser.add_subparsers(dest="command", required=True)
 
     upsert = sub.add_parser("upsert", help="Create or update a managed block")
-    upsert.add_argument("--agent", required=True, help="Target agent config file (copilot, claude, agents)")
+    upsert.add_argument("--agent", required=True, help="Target adapter config file")
     upsert.add_argument("--block-id", default=DEFAULT_BLOCK_ID, help="Managed block label shown in markers")
     upsert.add_argument("--repo", type=Path, default=None, help="Project root (defaults to git root or cwd)")
     upsert.add_argument("content", help="Managed block content")
 
     remove = sub.add_parser("remove", help="Remove a managed block only")
-    remove.add_argument("--agent", required=True, help="Target agent config file (copilot, claude, agents)")
+    remove.add_argument("--agent", required=True, help="Target adapter config file")
     remove.add_argument("--block-id", default=DEFAULT_BLOCK_ID, help="Managed block label shown in markers")
     remove.add_argument("--repo", type=Path, default=None, help="Project root (defaults to git root or cwd)")
     return parser.parse_args(argv)
@@ -251,7 +230,8 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     try:
         repo_root = _find_git_root(args.repo) if args.repo is not None else _find_git_root()
-        target = _resolve_target(repo_root, args.agent)
+        adapter = get_adapter(args.agent)
+        target = adapter.target_path(repo_root)
         block_id = _validate_block_id(args.block_id)
     except ValueError as exc:
         print(f"context-blocks: {exc}", file=sys.stderr)

--- a/install.py
+++ b/install.py
@@ -197,6 +197,7 @@ TOOL_FILES = [
     "watch-sessions.py",
     "learn.py",
     "embed.py",
+    "agent_adapters.py",
     "claude-adapter.py",
     "context-blocks.py",
     "sync-knowledge.py",

--- a/setup-project.py
+++ b/setup-project.py
@@ -22,6 +22,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+from agent_adapters import detect_agents, expand_init_agents, get_adapter, unique_target_adapters
+from host_manifest import HOST_INSTRUCTION_FILES as KNOWN_HOSTS_INSTRUCTION_FILES  # noqa: E402
+from host_manifest import HOST_SKILL_SUBPATHS  # noqa: E402
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 TEMPLATES_DIR = SCRIPT_DIR / "templates"
 SKILLS_DIR = SCRIPT_DIR / "skills"
@@ -46,8 +50,6 @@ def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> Non
 
 # Host metadata is centralised in host_manifest.py — import canonical constants.
 # Do NOT add new hosts here; update host_manifest.py through the review process.
-from host_manifest import HOST_INSTRUCTION_FILES as KNOWN_HOSTS_INSTRUCTION_FILES  # noqa: E402
-from host_manifest import HOST_SKILL_SUBPATHS  # noqa: E402
 if os.name == "nt":
     for _s in (sys.stdout, sys.stderr):
         if hasattr(_s, "reconfigure"):
@@ -467,6 +469,39 @@ def patch_agents_md(project_root: Path, dry_run: bool) -> bool:
     return True
 
 
+def _select_init_adapters(
+    project_root: Path, requested_agents: list[str] | None, *, init_mode: bool
+) -> tuple[list, list[str]]:
+    selected = list(requested_agents or [])
+    if not selected and init_mode:
+        selected = detect_agents(project_root)
+        if not selected:
+            selected = ["copilot"]
+    if not selected:
+        return [], []
+    adapters = [get_adapter(key) for key in expand_init_agents(selected)]
+    return unique_target_adapters(adapters), selected
+
+
+def apply_init_adapters(project_root: Path, adapters: list, dry_run: bool) -> int:
+    changes = 0
+    for adapter in adapters:
+        rel = adapter.target_path(project_root).relative_to(project_root)
+        try:
+            status = adapter.upsert_context(project_root, dry_run=dry_run)
+        except ValueError as exc:
+            raise ValueError(f"{adapter.name} context at {rel} is invalid: {exc}") from exc
+        if status == "unchanged":
+            print(f"  ⏭ {adapter.name} already up to date ({rel})")
+            continue
+        changes += 1
+        if dry_run:
+            print(f"  [dry-run] Would {status}: {rel} ({adapter.name})")
+        else:
+            print(f"  ✓ {status.capitalize()}: {rel} ({adapter.name})")
+    return changes
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Integrate session-knowledge + tentacle orchestration into a project",
@@ -524,6 +559,15 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
              "(default: none; choices: default, python, typescript, mobile, fullstack)"
     )
     parser.add_argument(
+        "--agent",
+        dest="agents",
+        action="append",
+        default=None,
+        metavar="AGENT",
+        help="Initialize adapter-specific context files; repeat to target multiple adapters",
+    )
+    parser.add_argument("--init-mode", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument(
         "--dry-run", action="store_true",
         help="Show what would be done without making changes"
     )
@@ -549,6 +593,13 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
         print("   (dry-run mode)")
     print()
 
+    try:
+        init_adapters, requested_init = _select_init_adapters(
+            project_root, args.agents, init_mode=args.init_mode
+        )
+    except ValueError as exc:
+        print(f"✗ {exc}")
+        sys.exit(1)
     changes = 0
 
     # 1. Install session-knowledge skill + instructions
@@ -567,12 +618,25 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
     # 4. Patch config files
     if not args.skill_only:
         print("\n📝 Config Files:")
-        if patch_claude_md(project_root, args.dry_run):
-            changes += 1
-        if patch_copilot_instructions(project_root, args.dry_run):
-            changes += 1
-        if patch_agents_md(project_root, args.dry_run):
-            changes += 1
+        if init_adapters:
+            if args.agents:
+                requested_text = ", ".join(requested_init)
+                print(f"  Initializing adapter contexts for: {requested_text}")
+            elif args.init_mode:
+                detected_text = ", ".join(requested_init)
+                print(f"  Using detected adapters: {detected_text}")
+            try:
+                changes += apply_init_adapters(project_root, init_adapters, args.dry_run)
+            except ValueError as exc:
+                print(f"✗ {exc}")
+                sys.exit(1)
+        else:
+            if patch_claude_md(project_root, args.dry_run):
+                changes += 1
+            if patch_copilot_instructions(project_root, args.dry_run):
+                changes += 1
+            if patch_agents_md(project_root, args.dry_run):
+                changes += 1
 
     # 5. Install workflow profile hook bundle (optional, only when --profile is given)
     if args.profile:

--- a/sk.py
+++ b/sk.py
@@ -18,6 +18,7 @@ Usage:
     sk tentacle [<args>...]       Run tentacle.py
     sk install  [<args>...]       Run install.py
     sk setup    [<args>...]       Run setup-project.py
+    sk init     [<args>...]       Run setup-project.py --init-mode
     sk update   [<args>...]       Run auto-update-tools.py
     sk browse   [<args>...]       Run browse.py
     sk benchmark [<args>...]      Run benchmark.py
@@ -488,6 +489,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_spec_phase(cmd, rest)
     if cmd == "doctor":
         return _run("install.py", ["--doctor"] + rest)
+    if cmd == "init":
+        return _run("setup-project.py", ["--init-mode"] + rest)
     if cmd in _DIRECT:
         return _run(_DIRECT[cmd], rest)
 

--- a/tests/test_agent_adapters.py
+++ b/tests/test_agent_adapters.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+test_agent_adapters.py - Focused tests for the multi-agent adapter registry.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+TOOLS_DIR = Path(__file__).parent.parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+import agent_adapters as adapters
+
+
+class TempRepoMixin:
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="agent-adapters-")
+        self.repo_root = Path(self._tmpdir) / "repo"
+        self.repo_root.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+
+class TestRegistry(TempRepoMixin, unittest.TestCase):
+    def test_public_adapter_keys_cover_expected_agents(self):
+        self.assertEqual(
+            adapters.PUBLIC_AGENT_KEYS,
+            ("copilot", "claude", "codex", "cursor", "windsurf", "gemini"),
+        )
+
+    def test_detect_agents_reads_project_markers(self):
+        (self.repo_root / ".github").mkdir(parents=True, exist_ok=True)
+        (self.repo_root / ".github" / "copilot-instructions.md").write_text("existing", encoding="utf-8")
+        (self.repo_root / ".claude").mkdir()
+        (self.repo_root / ".cursor").mkdir()
+        (self.repo_root / "GEMINI.md").write_text("@AGENTS.md\n", encoding="utf-8")
+
+        self.assertEqual(adapters.detect_agents(self.repo_root), ["copilot", "claude", "cursor", "gemini"])
+
+    def test_expand_init_agents_bootstraps_shared_agents_for_import_stubs(self):
+        self.assertEqual(adapters.expand_init_agents(["claude", "gemini"]), ["agents", "claude", "gemini"])
+
+    def test_unique_target_adapters_collapses_shared_agents(self):
+        expanded = adapters.expand_init_agents(["claude", "cursor"])
+        selected = [adapters.get_adapter(key) for key in expanded]
+        unique = adapters.unique_target_adapters(selected)
+        self.assertEqual([adapter.context_file for adapter in unique], ["AGENTS.md", "CLAUDE.md"])
+
+
+class TestAdapterBehavior(TempRepoMixin, unittest.TestCase):
+    def test_upsert_and_remove_context_are_idempotent(self):
+        adapter = adapters.get_adapter("cursor")
+
+        first = adapter.upsert_context(self.repo_root)
+        second = adapter.upsert_context(self.repo_root)
+        self.assertEqual(first, "created")
+        self.assertEqual(second, "unchanged")
+
+        agents_md = self.repo_root / "AGENTS.md"
+        content = agents_md.read_text(encoding="utf-8")
+        self.assertIn("<!-- SESSION-KNOWLEDGE SK START -->", content)
+        self.assertIn("sk briefing --auto --compact", content)
+
+        removed, changed = adapter.remove_context(self.repo_root)
+        absent, changed_again = adapter.remove_context(self.repo_root)
+        self.assertEqual((removed, changed), ("removed", True))
+        self.assertEqual((absent, changed_again), ("absent", False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_context_blocks.py
+++ b/tests/test_context_blocks.py
@@ -63,6 +63,9 @@ class TestHelpers(TempRepoMixin, unittest.TestCase):
     def test_normalize_agent(self):
         self.assertEqual(cb._normalize_agent("copilot"), "Copilot CLI")
         self.assertEqual(cb._normalize_agent("claude-code"), "Claude Code")
+        self.assertEqual(cb._normalize_agent("codex"), "Codex")
+        self.assertEqual(cb._normalize_agent("cursor"), "Cursor")
+        self.assertEqual(cb._normalize_agent("gemini"), "Gemini CLI")
         self.assertEqual(cb._normalize_agent("agents"), "All agents")
 
     def test_block_id_validation_rejects_marker_injection(self):
@@ -73,6 +76,12 @@ class TestHelpers(TempRepoMixin, unittest.TestCase):
         cb._register_project(self.repo_root)
         data = json.loads(self.registry_path.read_text(encoding="utf-8"))
         self.assertIn(str(self.repo_root.resolve()), data["projects"])
+
+    def test_resolve_targets_for_multi_agent_registry(self):
+        self.assertEqual(cb._resolve_target(self.repo_root, "copilot"), self.repo_root / ".github" / "copilot-instructions.md")
+        self.assertEqual(cb._resolve_target(self.repo_root, "claude"), self.repo_root / "CLAUDE.md")
+        self.assertEqual(cb._resolve_target(self.repo_root, "gemini"), self.repo_root / "GEMINI.md")
+        self.assertEqual(cb._resolve_target(self.repo_root, "cursor"), self.repo_root / "AGENTS.md")
 
 
 class TestUpsertRemove(TempRepoMixin, unittest.TestCase):

--- a/tests/test_install_helpers.py
+++ b/tests/test_install_helpers.py
@@ -330,6 +330,7 @@ test("TOOL_FILES contains constitution.py", "constitution.py" in _install.TOOL_F
 test("TOOL_FILES contains specify.py", "specify.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains task.py", "task.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains context-blocks.py", "context-blocks.py" in _install.TOOL_FILES)
+test("TOOL_FILES contains agent_adapters.py", "agent_adapters.py" in _install.TOOL_FILES)
 test("SUPPORT_FILES contains pyproject.toml", "pyproject.toml" in _install.SUPPORT_FILES)
 test("SUPPORT_DIRS contains skills", "skills" in _install.SUPPORT_DIRS)
 

--- a/tests/test_setup_project_init.py
+++ b/tests/test_setup_project_init.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+test_setup_project_init.py - Focused tests for adapter-aware setup-project init mode.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+TOOLS_DIR = Path(__file__).parent.parent
+SCRIPT_PATH = TOOLS_DIR / "setup-project.py"
+
+
+class TempProjectMixin:
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="setup-project-init-")
+        self.project_root = Path(self._tmpdir) / "repo"
+        self.project_root.mkdir(parents=True, exist_ok=True)
+        self.home_root = Path(self._tmpdir) / "home"
+        self.home_root.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def run_setup(self, *extra: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["HOME"] = str(self.home_root)
+        env["USERPROFILE"] = str(self.home_root)
+        env["PYTHONUTF8"] = "1"
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), str(self.project_root), *extra],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=str(self.project_root),
+            env=env,
+            timeout=120,
+        )
+
+
+class TestSetupProjectInitMode(TempProjectMixin, unittest.TestCase):
+    def test_explicit_claude_init_creates_agents_and_import_stub(self):
+        result = self.run_setup("--init-mode", "--agent", "claude", "--no-tentacle")
+        self.assertEqual(result.returncode, 0, msg=result.stderr or result.stdout)
+        self.assertIn("Initializing adapter contexts for: claude", result.stdout)
+
+        agents_md = self.project_root / "AGENTS.md"
+        claude_md = self.project_root / "CLAUDE.md"
+        self.assertTrue(agents_md.exists())
+        self.assertTrue(claude_md.exists())
+        self.assertIn("<!-- SESSION-KNOWLEDGE SK START -->", agents_md.read_text(encoding="utf-8"))
+        self.assertIn("@AGENTS.md", claude_md.read_text(encoding="utf-8"))
+
+    def test_auto_detect_cursor_uses_shared_agents_file(self):
+        (self.project_root / ".cursor").mkdir()
+
+        result = self.run_setup("--init-mode", "--no-tentacle")
+        self.assertEqual(result.returncode, 0, msg=result.stderr or result.stdout)
+        self.assertIn("Using detected adapters: cursor", result.stdout)
+
+        agents_md = self.project_root / "AGENTS.md"
+        self.assertTrue(agents_md.exists())
+        self.assertFalse((self.project_root / "CLAUDE.md").exists())
+        self.assertIn("sk query", agents_md.read_text(encoding="utf-8"))
+
+    def test_duplicate_markers_fail_with_clean_error(self):
+        (self.project_root / "CLAUDE.md").write_text(
+            "<!-- SESSION-KNOWLEDGE SK START -->\nold one\n<!-- SESSION-KNOWLEDGE SK END -->\n"
+            "<!-- SESSION-KNOWLEDGE SK START -->\nold two\n<!-- SESSION-KNOWLEDGE SK END -->\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_setup("--init-mode", "--agent", "claude", "--no-tentacle")
+        combined = (result.stdout or "") + (result.stderr or "")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Claude Code context at CLAUDE.md is invalid", combined)
+        self.assertNotIn("Traceback", combined)
+
+    def test_invalid_agent_fails_without_traceback(self):
+        result = self.run_setup("--init-mode", "--agent", "unknown-agent", "--no-tentacle")
+        combined = (result.stdout or "") + (result.stderr or "")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Unknown --agent 'unknown-agent'", combined)
+        self.assertNotIn("Traceback", combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -132,6 +132,12 @@ class TestSkDirectCommands(unittest.TestCase):
     def test_setup(self):
         self._assert_routes("setup", "setup-project.py")
 
+    def test_init_routes_setup_project_with_init_mode(self):
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main(["init", "--agent", "claude"])
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with("setup-project.py", ["--init-mode", "--agent", "claude"])
+
     def test_update(self):
         self._assert_routes("update", "auto-update-tools.py")
 


### PR DESCRIPTION
## Summary
- add a shared AgentAdapter registry for Copilot, Claude, Codex, Cursor, Windsurf, and Gemini project-file integrations
- add adapter-aware sk init / setup-project.py --init-mode flows with safe marker management and shared AGENTS deduplication
- add focused coverage for adapter behavior, setup-project init flows, installer packaging, and CLI routing while keeping runtime host support scoped to Copilot CLI + Claude Code

## Testing
- python tests\\test_agent_adapters.py
- python tests\\test_setup_project_init.py
- python tests\\test_context_blocks.py
- python tests\\test_sk_cli.py
- python tests\\test_host_symmetry.py
- python tests\\test_karpathy_skill_rollout.py
- python tests\\test_install_helpers.py
- python test_fixes.py
- python test_security.py

Closes #97