### PR TITLE
feat(cron): add scheduled task templates

### DIFF
--- a/cron-tasks.py
+++ b/cron-tasks.py
@@ -246,7 +246,7 @@ def _build_reflection_artifact(task: dict, now: datetime) -> str:
         f"Task Name: {task['name']}\n"
         f"Generated: {now.isoformat()}\n\n"
         "Suggested command:\n"
-        "claude -p \"Review the last week of session activity, summarize recurring mistakes and successful patterns, and propose three concrete improvements for next week.\"\n\n"
+        'claude -p "Review the last week of session activity, summarize recurring mistakes and successful patterns, and propose three concrete improvements for next week."\n\n'
         "Context snapshot:\n"
         f"- Session state path: {SESSION_STATE}\n"
         f"- Knowledge DB size: {_knowledge_db_size()}\n"

--- a/cron-tasks.py
+++ b/cron-tasks.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""
+cron-tasks.py - Manage scheduled cron task templates for session knowledge.
+
+Commands:
+    add <reflection|cleanup>     Add a scheduled task
+    remove <task-id-or-name>     Remove a scheduled task
+    list                         List configured tasks
+    run                          Execute due tasks once or in a loop
+"""
+
+from __future__ import annotations
+
+import argparse
+import calendar
+import json
+import os
+import sys
+import time
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from host_manifest import SESSION_STATE
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+CONFIG_PATH = SESSION_STATE / "cron-config.json"
+LOG_PATH = SESSION_STATE / "cron-executions.jsonl"
+ARTIFACTS_DIR = SESSION_STATE / "cron-artifacts"
+DEFAULT_LOOP_INTERVAL = 60
+DAY_NAMES = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")
+DAY_TO_INDEX = {name: idx for idx, name in enumerate(DAY_NAMES)}
+TEMPLATE_DEFINITIONS = {
+    "reflection": {
+        "description": "Generate a weekly AI reflection prompt artifact.",
+        "default_schedule": {"kind": "weekly", "day": "sunday", "time": "03:00"},
+    },
+    "cleanup": {
+        "description": "Generate a weekly cleanup task artifact.",
+        "default_schedule": {"kind": "weekly", "day": "sunday", "time": "02:00"},
+    },
+}
+
+
+def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_bytes(content.encode(encoding))
+        os.replace(str(tmp), str(path))
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+
+def _ensure_session_state() -> None:
+    SESSION_STATE.mkdir(parents=True, exist_ok=True)
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _now_local() -> datetime:
+    return datetime.now().astimezone()
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized)
+
+
+def _format_iso(value: datetime | None) -> str | None:
+    return None if value is None else value.isoformat()
+
+
+def _load_config() -> dict:
+    if CONFIG_PATH.exists():
+        try:
+            data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+            tasks = data.get("tasks", [])
+            if isinstance(tasks, list):
+                return {"tasks": tasks}
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {"tasks": []}
+
+
+def _save_config(config: dict) -> None:
+    _ensure_session_state()
+    _atomic_write_text(CONFIG_PATH, json.dumps(config, indent=2))
+
+
+def _append_log(entry: dict) -> None:
+    _ensure_session_state()
+    with open(LOG_PATH, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry) + "\n")
+
+
+def _parse_time_of_day(value: str) -> str:
+    try:
+        hour_text, minute_text = value.split(":", 1)
+        hour = int(hour_text)
+        minute = int(minute_text)
+    except ValueError as exc:
+        raise ValueError("--at must be in HH:MM format") from exc
+    if hour < 0 or hour > 23 or minute < 0 or minute > 59:
+        raise ValueError("--at must be in HH:MM format")
+    return f"{hour:02d}:{minute:02d}"
+
+
+def _last_day_of_month(year: int, month: int) -> int:
+    return calendar.monthrange(year, month)[1]
+
+
+def _previous_month(year: int, month: int) -> tuple[int, int]:
+    if month == 1:
+        return year - 1, 12
+    return year, month - 1
+
+
+def _schedule_to_text(schedule: dict) -> str:
+    kind = schedule["kind"]
+    if kind == "interval":
+        minutes = int(schedule["minutes"])
+        return f"every {minutes} minute(s)"
+    if kind == "daily":
+        return f"daily at {schedule['time']}"
+    if kind == "weekly":
+        return f"weekly on {schedule['day']} at {schedule['time']}"
+    if kind == "monthly":
+        return f"monthly on day {schedule['day_of_month']} at {schedule['time']}"
+    return kind
+
+
+def _default_task_name(template: str) -> str:
+    return f"{template}-{uuid.uuid4().hex[:8]}"
+
+
+def _resolve_schedule(template: str, args: argparse.Namespace) -> dict:
+    if args.every_minutes is not None:
+        if args.every_minutes <= 0:
+            raise ValueError("--every-minutes must be greater than zero")
+        return {"kind": "interval", "minutes": int(args.every_minutes)}
+
+    base = dict(TEMPLATE_DEFINITIONS[template]["default_schedule"])
+    kind = args.schedule or base["kind"]
+    schedule = {"kind": kind}
+    if kind == "daily":
+        schedule["time"] = _parse_time_of_day(args.at or base.get("time", "02:00"))
+    elif kind == "weekly":
+        day = (args.day or base.get("day", "monday")).lower()
+        if day not in DAY_TO_INDEX:
+            raise ValueError(f"--day must be one of: {', '.join(DAY_NAMES)}")
+        schedule["day"] = day
+        schedule["time"] = _parse_time_of_day(args.at or base.get("time", "03:00"))
+    elif kind == "monthly":
+        day_of_month = args.day_of_month or int(base.get("day_of_month", 1))
+        if day_of_month < 1 or day_of_month > 31:
+            raise ValueError("--day-of-month must be between 1 and 31")
+        schedule["day_of_month"] = int(day_of_month)
+        schedule["time"] = _parse_time_of_day(args.at or base.get("time", "04:00"))
+    else:
+        raise ValueError("--schedule must be one of: daily, weekly, monthly")
+    return schedule
+
+
+def _scheduled_slot(now: datetime, schedule: dict) -> datetime:
+    hour, minute = (int(part) for part in schedule["time"].split(":", 1))
+    if schedule["kind"] == "daily":
+        candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if candidate > now:
+            candidate -= timedelta(days=1)
+        return candidate
+
+    if schedule["kind"] == "weekly":
+        target_day = DAY_TO_INDEX[schedule["day"]]
+        candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        days_back = (candidate.weekday() - target_day) % 7
+        candidate -= timedelta(days=days_back)
+        if candidate > now:
+            candidate -= timedelta(days=7)
+        return candidate
+
+    year = now.year
+    month = now.month
+    day = min(int(schedule["day_of_month"]), _last_day_of_month(year, month))
+    candidate = now.replace(day=day, hour=hour, minute=minute, second=0, microsecond=0)
+    if candidate > now:
+        year, month = _previous_month(year, month)
+        day = min(int(schedule["day_of_month"]), _last_day_of_month(year, month))
+        candidate = candidate.replace(year=year, month=month, day=day)
+    return candidate
+
+
+def _task_is_due(task: dict, now: datetime) -> bool:
+    if not task.get("enabled", True):
+        return False
+
+    schedule = task["schedule"]
+    last_run_at = _parse_iso(task.get("last_run_at"))
+    if schedule["kind"] == "interval":
+        if last_run_at is None:
+            return True
+        return now >= last_run_at + timedelta(minutes=int(schedule["minutes"]))
+
+    slot = _scheduled_slot(now, schedule)
+    if last_run_at is None:
+        return slot <= now
+    return last_run_at < slot <= now
+
+
+def _knowledge_db_size() -> str:
+    db_path = SESSION_STATE / "knowledge.db"
+    if not db_path.exists():
+        return "missing"
+    return f"{db_path.stat().st_size} bytes"
+
+
+def _session_dir_count() -> int:
+    if not SESSION_STATE.exists():
+        return 0
+    return len([entry for entry in SESSION_STATE.iterdir() if entry.is_dir() and not entry.name.startswith(".")])
+
+
+def _stale_artifact_count(cutoff: datetime) -> int:
+    if not ARTIFACTS_DIR.exists():
+        return 0
+    count = 0
+    for artifact in ARTIFACTS_DIR.glob("*.md"):
+        modified = datetime.fromtimestamp(artifact.stat().st_mtime, tz=cutoff.tzinfo)
+        if modified < cutoff:
+            count += 1
+    return count
+
+
+def _build_reflection_artifact(task: dict, now: datetime) -> str:
+    return (
+        "# AI Reflection Task Template\n\n"
+        f"Task ID: {task['id']}\n"
+        f"Task Name: {task['name']}\n"
+        f"Generated: {now.isoformat()}\n\n"
+        "Suggested command:\n"
+        "claude -p \"Review the last week of session activity, summarize recurring mistakes and successful patterns, and propose three concrete improvements for next week.\"\n\n"
+        "Context snapshot:\n"
+        f"- Session state path: {SESSION_STATE}\n"
+        f"- Knowledge DB size: {_knowledge_db_size()}\n"
+        f"- Session directory count: {_session_dir_count()}\n"
+        f"- Execution log: {LOG_PATH}\n"
+    )
+
+
+def _build_cleanup_artifact(task: dict, now: datetime) -> str:
+    retention_days = int(task.get("retention_days", 90))
+    cutoff = now - timedelta(days=retention_days)
+    stale_artifacts = _stale_artifact_count(cutoff)
+    return (
+        "# Cleanup Task Template\n\n"
+        f"Task ID: {task['id']}\n"
+        f"Task Name: {task['name']}\n"
+        f"Generated: {now.isoformat()}\n"
+        f"Retention window: {retention_days} day(s)\n"
+        f"Cutoff: {cutoff.isoformat()}\n\n"
+        "Suggested cleanup checklist:\n"
+        "- Review stale cron artifacts older than the cutoff.\n"
+        "- Review stale session knowledge entries before any destructive pruning.\n"
+        "- Record the cleanup result in the execution log.\n\n"
+        f"Current stale artifact count: {stale_artifacts}\n"
+        f"Execution log: {LOG_PATH}\n"
+    )
+
+
+def _write_artifact(task: dict, now: datetime, content: str) -> Path:
+    _ensure_session_state()
+    stamp = now.strftime("%Y%m%d-%H%M%S")
+    path = ARTIFACTS_DIR / f"{stamp}-{task['id']}-{task['template']}.md"
+    _atomic_write_text(path, content)
+    return path
+
+
+def _execute_task(task: dict, now: datetime) -> dict:
+    if task["template"] == "reflection":
+        artifact_content = _build_reflection_artifact(task, now)
+    elif task["template"] == "cleanup":
+        artifact_content = _build_cleanup_artifact(task, now)
+    else:
+        raise ValueError(f"Unknown task template: {task['template']}")
+
+    artifact_path = _write_artifact(task, now, artifact_content)
+    return {
+        "task_id": task["id"],
+        "task_name": task["name"],
+        "template": task["template"],
+        "executed_at": now.isoformat(),
+        "status": "generated",
+        "artifact_path": str(artifact_path),
+        "schedule": task["schedule"],
+    }
+
+
+def _run_due_tasks(config: dict, now: datetime | None = None) -> int:
+    current = now or _now_local()
+    executed = 0
+    for task in config["tasks"]:
+        if not _task_is_due(task, current):
+            continue
+        log_entry = _execute_task(task, current)
+        _append_log(log_entry)
+        task["last_run_at"] = current.isoformat()
+        task["last_status"] = log_entry["status"]
+        _save_config(config)
+        executed += 1
+        print(f"executed: {task['id']} -> {log_entry['artifact_path']}")
+    return executed
+
+
+def cmd_add(args: argparse.Namespace) -> int:
+    try:
+        schedule = _resolve_schedule(args.template, args)
+    except ValueError as exc:
+        print(f"sk cron add: {exc}", file=sys.stderr)
+        return 1
+
+    config = _load_config()
+    task = {
+        "id": uuid.uuid4().hex[:12],
+        "name": args.name or _default_task_name(args.template),
+        "template": args.template,
+        "schedule": schedule,
+        "retention_days": int(args.retention_days),
+        "created_at": _now_local().isoformat(),
+        "last_run_at": None,
+        "last_status": None,
+        "enabled": True,
+    }
+    config["tasks"].append(task)
+    _save_config(config)
+    print(f"added: {task['id']} [{task['template']}] {_schedule_to_text(task['schedule'])}")
+    return 0
+
+
+def cmd_remove(identifier: str) -> int:
+    config = _load_config()
+    remaining = [task for task in config["tasks"] if task["id"] != identifier and task["name"] != identifier]
+    if len(remaining) == len(config["tasks"]):
+        print(f"not configured: {identifier}")
+        return 0
+    config["tasks"] = remaining
+    _save_config(config)
+    print(f"removed: {identifier}")
+    return 0
+
+
+def cmd_list(json_output: bool = False) -> int:
+    config = _load_config()
+    tasks = config["tasks"]
+    if json_output:
+        print(json.dumps(tasks, indent=2))
+        return 0
+    if not tasks:
+        print("no cron tasks configured")
+        return 0
+    for task in tasks:
+        last_run = task.get("last_run_at") or "never"
+        print(
+            f"{task['id']:<12} {task['template']:<10} {task['name']:<24} "
+            f"[{_schedule_to_text(task['schedule'])}] last-run={last_run}"
+        )
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    if args.once:
+        try:
+            executed = _run_due_tasks(_load_config())
+        except (OSError, ValueError, KeyError) as exc:
+            print(f"sk cron run: {exc}", file=sys.stderr)
+            return 1
+        print(f"completed: {executed} task(s) executed")
+        return 0
+
+    print(f"cron runner started (interval={args.interval}s)")
+    while True:
+        try:
+            config = _load_config()
+            _run_due_tasks(config)
+            time.sleep(args.interval)
+        except KeyboardInterrupt:
+            print("cron runner stopped")
+            return 0
+        except (OSError, ValueError, KeyError) as exc:
+            print(f"cron runner error: {exc}", file=sys.stderr)
+            try:
+                time.sleep(args.interval)
+            except KeyboardInterrupt:
+                print("cron runner stopped")
+                return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sk cron",
+        description="Manage scheduled cron task templates for session knowledge.",
+    )
+    sub = parser.add_subparsers(dest="subcommand", metavar="<subcommand>")
+
+    add_p = sub.add_parser("add", help="Add a scheduled cron task")
+    add_p.add_argument("template", choices=sorted(TEMPLATE_DEFINITIONS), help="Task template")
+    add_p.add_argument("--name", default=None, help="Optional task name")
+    add_p.add_argument("--schedule", choices=("daily", "weekly", "monthly"), default=None)
+    add_p.add_argument("--every-minutes", type=int, default=None, help="Run at a fixed minute interval")
+    add_p.add_argument("--at", default=None, help="Time of day in HH:MM for daily/weekly/monthly schedules")
+    add_p.add_argument("--day", default=None, help="Weekday for weekly schedules")
+    add_p.add_argument("--day-of-month", type=int, default=None, help="Day of month for monthly schedules")
+    add_p.add_argument("--retention-days", type=int, default=90, help="Retention window for cleanup templates")
+
+    remove_p = sub.add_parser("remove", help="Remove a configured cron task")
+    remove_p.add_argument("identifier", help="Task ID or task name")
+
+    list_p = sub.add_parser("list", help="List configured cron tasks")
+    list_p.add_argument("--json", action="store_true", dest="json_output", help="Emit JSON")
+
+    run_p = sub.add_parser("run", help="Execute due cron tasks")
+    run_p.add_argument("--once", action="store_true", help="Run due tasks once and exit")
+    run_p.add_argument("--interval", type=int, default=DEFAULT_LOOP_INTERVAL, help="Loop interval in seconds")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.subcommand == "add":
+        return cmd_add(args)
+    if args.subcommand == "remove":
+        return cmd_remove(args.identifier)
+    if args.subcommand == "list":
+        return cmd_list(json_output=args.json_output)
+    if args.subcommand == "run":
+        return cmd_run(args)
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/install.py
+++ b/install.py
@@ -200,6 +200,7 @@ TOOL_FILES = [
     "agent_adapters.py",
     "claude-adapter.py",
     "context-blocks.py",
+    "cron-tasks.py",
     "sync-knowledge.py",
     "sync-config.py",
     "sync-daemon.py",

--- a/sk.py
+++ b/sk.py
@@ -48,6 +48,7 @@ Usage:
     sk preset  add|remove|list [<args>...]
     sk context project|map|upsert|remove [<args>...]
     sk scout  run|config|status [<args>...]
+    sk cron   add|remove|list|run [<args>...]
     sk project add|remove|list [<args>...]
     sk events append|status|replay|tail [<args>...]
 
@@ -172,6 +173,12 @@ _GROUPS: dict[str, dict[str, str]] = {
         "run": "trend-scout.py",
         "config": "scout-config.py",
         "status": "scout-status.py",
+    },
+    "cron": {
+        "add": "cron-tasks.py",
+        "remove": "cron-tasks.py",
+        "list": "cron-tasks.py",
+        "run": "cron-tasks.py",
     },
     "project": {
         "add": "project-registry.py",
@@ -447,6 +454,24 @@ def _run_events(extra_args: list[str]) -> int:
     return _run("events.py", extra_args)
 
 
+def _run_cron(extra_args: list[str]) -> int:
+    """Dispatch ``sk cron ...`` to cron-tasks.py."""
+    if not extra_args or extra_args[0] in ("-h", "--help"):
+        subs = list(_GROUPS["cron"].keys())
+        print(f"sk cron: available subcommands: {', '.join(subs)}")
+        print(f"Usage: sk cron <{'|'.join(subs)}> [args...]")
+        return 0
+    sub = extra_args[0]
+    if sub not in _GROUPS["cron"]:
+        subs = list(_GROUPS["cron"].keys())
+        print(
+            f"sk cron: unknown subcommand '{sub}'. Choose from: {', '.join(subs)}",
+            file=sys.stderr,
+        )
+        return 2
+    return _run("cron-tasks.py", extra_args)
+
+
 def _print_help() -> None:
     direct_list = "  " + "\n  ".join(f"sk {cmd:<12} → {script}" for cmd, script in _DIRECT.items())
     print(
@@ -483,6 +508,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_constitution(rest)
     if cmd == "skill":
         return _run_skill(rest)
+    if cmd == "cron":
+        return _run_cron(rest)
     if cmd == "events":
         return _run_events(rest)
     if cmd in {"plan", "tasks"}:

--- a/tentacle.py
+++ b/tentacle.py
@@ -681,9 +681,7 @@ def _normalize_agent_profile_id(profile_id: str) -> str:
     elif slug.endswith(".md"):
         slug = slug[: -len(".md")]
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", slug or ""):
-        raise ValueError(
-            "Agent profile id must be a slug containing only letters, numbers, underscores, and hyphens."
-        )
+        raise ValueError("Agent profile id must be a slug containing only letters, numbers, underscores, and hyphens.")
     return slug
 
 
@@ -920,7 +918,9 @@ def _render_agent_profile_section(profile: dict | None, *, prompt: bool = False)
     lines.extend(_render_profile_list("Escalation Rules", _profile_list(profile, "escalation_rules"), limit=list_limit))
     lines.extend(_render_profile_list("Anti-patterns", _profile_list(profile, "anti_patterns"), limit=list_limit))
     lines.extend(
-        _render_profile_list("Evidence Required in Handoff", _profile_list(profile, "evidence_required"), limit=list_limit)
+        _render_profile_list(
+            "Evidence Required in Handoff", _profile_list(profile, "evidence_required"), limit=list_limit
+        )
     )
     lines.extend(_render_profile_list("Tools Denied", _profile_list(profile, "tools_denied"), limit=list_limit))
     return "\n" + "\n".join(lines).rstrip() + "\n"
@@ -9859,7 +9859,9 @@ def main():
         default=None,
         help="Agent type for workers (default: profile agent_type, then general-purpose)",
     )
-    p_swarm.add_argument("--model", default=None, help="Model for workers (default: profile model, then claude-sonnet-4.6)")
+    p_swarm.add_argument(
+        "--model", default=None, help="Model for workers (default: profile model, then claude-sonnet-4.6)"
+    )
     p_swarm.add_argument(
         "--output",
         choices=["prompt", "parallel", "json"],
@@ -9893,7 +9895,9 @@ def main():
     # dispatch (alias for swarm --output prompt)
     p_dispatch = sub.add_parser("dispatch", help="Generate single-agent dispatch prompt")
     p_dispatch.add_argument("name", help="Tentacle name")
-    p_dispatch.add_argument("--agent-type", default=None, help="Agent type (default: profile agent_type, then general-purpose)")
+    p_dispatch.add_argument(
+        "--agent-type", default=None, help="Agent type (default: profile agent_type, then general-purpose)"
+    )
     p_dispatch.add_argument("--model", default=None, help="Model (default: profile model, then claude-sonnet-4.6)")
     p_dispatch.add_argument(
         "--briefing",

--- a/tests/test_cron_tasks.py
+++ b/tests/test_cron_tasks.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+test_cron_tasks.py - Focused tests for cron-tasks.py.
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+TOOLS_DIR = Path(__file__).parent.parent
+SCRIPT_PATH = TOOLS_DIR / "cron-tasks.py"
+
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("cron_tasks", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cron_tasks = _load_module()
+
+
+class CronPathsMixin:
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="cron-tasks-")
+        self.session_state = Path(self._tmpdir) / "session-state"
+        self.config_path = self.session_state / "cron-config.json"
+        self.log_path = self.session_state / "cron-executions.jsonl"
+        self.artifacts_dir = self.session_state / "cron-artifacts"
+        self.original_session_state = cron_tasks.SESSION_STATE
+        self.original_config_path = cron_tasks.CONFIG_PATH
+        self.original_log_path = cron_tasks.LOG_PATH
+        self.original_artifacts_dir = cron_tasks.ARTIFACTS_DIR
+        cron_tasks.SESSION_STATE = self.session_state
+        cron_tasks.CONFIG_PATH = self.config_path
+        cron_tasks.LOG_PATH = self.log_path
+        cron_tasks.ARTIFACTS_DIR = self.artifacts_dir
+
+    def tearDown(self):
+        cron_tasks.SESSION_STATE = self.original_session_state
+        cron_tasks.CONFIG_PATH = self.original_config_path
+        cron_tasks.LOG_PATH = self.original_log_path
+        cron_tasks.ARTIFACTS_DIR = self.original_artifacts_dir
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+
+class TestCronTasksCli(CronPathsMixin, unittest.TestCase):
+    def test_add_list_remove_roundtrip(self):
+        rc = cron_tasks.main(["add", "reflection", "--name", "weekly-review", "--every-minutes", "60"])
+        self.assertEqual(rc, 0)
+
+        config = json.loads(self.config_path.read_text(encoding="utf-8"))
+        self.assertEqual(len(config["tasks"]), 1)
+        task = config["tasks"][0]
+        self.assertEqual(task["template"], "reflection")
+        self.assertEqual(task["name"], "weekly-review")
+        self.assertEqual(task["schedule"], {"kind": "interval", "minutes": 60})
+
+        with patch("builtins.print") as mock_print:
+            rc = cron_tasks.main(["list", "--json"])
+        self.assertEqual(rc, 0)
+        output = " ".join(str(part) for call in mock_print.call_args_list for part in call[0])
+        self.assertIn("weekly-review", output)
+
+        rc = cron_tasks.main(["remove", task["id"]])
+        self.assertEqual(rc, 0)
+        updated = json.loads(self.config_path.read_text(encoding="utf-8"))
+        self.assertEqual(updated["tasks"], [])
+
+    def test_run_once_generates_log_and_artifact(self):
+        rc = cron_tasks.main(["add", "cleanup", "--name", "cleanup-weekly", "--every-minutes", "15", "--retention-days", "30"])
+        self.assertEqual(rc, 0)
+
+        rc = cron_tasks.main(["run", "--once"])
+        self.assertEqual(rc, 0)
+
+        self.assertTrue(self.log_path.exists())
+        log_entries = [json.loads(line) for line in self.log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        self.assertEqual(len(log_entries), 1)
+        entry = log_entries[0]
+        self.assertEqual(entry["template"], "cleanup")
+        artifact_path = Path(entry["artifact_path"])
+        self.assertTrue(artifact_path.exists())
+        artifact_text = artifact_path.read_text(encoding="utf-8")
+        self.assertIn("Cleanup Task Template", artifact_text)
+        self.assertIn("Retention window: 30 day(s)", artifact_text)
+
+        rc = cron_tasks.main(["run", "--once"])
+        self.assertEqual(rc, 0)
+        log_entries_again = [json.loads(line) for line in self.log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        self.assertEqual(len(log_entries_again), 1)
+
+    def test_run_once_returns_nonzero_on_execution_error(self):
+        cron_tasks.main(["add", "cleanup", "--name", "cleanup-weekly", "--every-minutes", "15"])
+        with patch.object(cron_tasks, "_write_artifact", side_effect=OSError("disk full")), patch(
+            "builtins.print"
+        ) as mock_print:
+            rc = cron_tasks.main(["run", "--once"])
+        self.assertEqual(rc, 1)
+        printed = " ".join(str(part) for call in mock_print.call_args_list for part in call[0])
+        self.assertIn("sk cron run: disk full", printed)
+
+
+class TestCronScheduling(CronPathsMixin, unittest.TestCase):
+    def test_weekly_schedule_runs_once_per_slot(self):
+        now = datetime(2026, 5, 17, 3, 30, tzinfo=timezone.utc)
+        task = {
+            "id": "reflect-1",
+            "name": "reflect-1",
+            "template": "reflection",
+            "enabled": True,
+            "schedule": {"kind": "weekly", "day": "sunday", "time": "03:00"},
+            "last_run_at": None,
+        }
+
+        self.assertTrue(cron_tasks._task_is_due(task, now))
+
+        task["last_run_at"] = now.replace(hour=3, minute=5).isoformat()
+        self.assertFalse(cron_tasks._task_is_due(task, now))
+
+        task["last_run_at"] = (now - timedelta(days=8)).isoformat()
+        self.assertTrue(cron_tasks._task_is_due(task, now))
+
+    def test_reflection_artifact_includes_template_command(self):
+        now = datetime(2026, 5, 17, 4, 0, tzinfo=timezone.utc)
+        task = {
+            "id": "reflect-2",
+            "name": "reflect-2",
+            "template": "reflection",
+            "enabled": True,
+            "schedule": {"kind": "interval", "minutes": 60},
+            "last_run_at": None,
+            "retention_days": 90,
+        }
+        artifact = cron_tasks._build_reflection_artifact(task, now)
+        self.assertIn("AI Reflection Task Template", artifact)
+        self.assertIn("claude -p", artifact)
+        self.assertIn(str(cron_tasks.LOG_PATH), artifact)
+
+    def test_run_loop_surfaces_errors_and_stops_cleanly(self):
+        args = cron_tasks.build_parser().parse_args(["run", "--interval", "1"])
+        with patch.object(cron_tasks, "_load_config", return_value={"tasks": []}), patch.object(
+            cron_tasks,
+            "_run_due_tasks",
+            side_effect=[OSError("disk full"), 0],
+        ), patch("time.sleep", side_effect=[None, KeyboardInterrupt]), patch(
+            "builtins.print"
+        ) as mock_print:
+            rc = cron_tasks.cmd_run(args)
+        self.assertEqual(rc, 0)
+        printed = " ".join(str(part) for call in mock_print.call_args_list for part in call[0])
+        self.assertIn("cron runner started", printed)
+        self.assertIn("cron runner stopped", printed)
+
+    def test_run_loop_stops_cleanly_during_recovery_sleep(self):
+        args = cron_tasks.build_parser().parse_args(["run", "--interval", "1"])
+        with patch.object(cron_tasks, "_load_config", return_value={"tasks": []}), patch.object(
+            cron_tasks,
+            "_run_due_tasks",
+            side_effect=OSError("disk full"),
+        ), patch("time.sleep", side_effect=KeyboardInterrupt), patch("builtins.print") as mock_print:
+            rc = cron_tasks.cmd_run(args)
+        self.assertEqual(rc, 0)
+        printed = " ".join(str(part) for call in mock_print.call_args_list for part in call[0])
+        self.assertIn("cron runner started", printed)
+        self.assertIn("cron runner stopped", printed)
+
+    def test_run_due_tasks_persists_success_before_later_failure(self):
+        now = datetime(2026, 5, 17, 4, 0, tzinfo=timezone.utc)
+        config = {
+            "tasks": [
+                {
+                    "id": "cleanup-1",
+                    "name": "cleanup-1",
+                    "template": "cleanup",
+                    "enabled": True,
+                    "schedule": {"kind": "interval", "minutes": 60},
+                    "last_run_at": None,
+                    "last_status": None,
+                },
+                {
+                    "id": "reflect-1",
+                    "name": "reflect-1",
+                    "template": "reflection",
+                    "enabled": True,
+                    "schedule": {"kind": "interval", "minutes": 60},
+                    "last_run_at": None,
+                    "last_status": None,
+                },
+            ]
+        }
+        first_entry = {
+            "task_id": "cleanup-1",
+            "task_name": "cleanup-1",
+            "template": "cleanup",
+            "executed_at": now.isoformat(),
+            "status": "generated",
+            "artifact_path": str(self.artifacts_dir / "cleanup.md"),
+            "schedule": {"kind": "interval", "minutes": 60},
+        }
+        with patch.object(cron_tasks, "_execute_task", side_effect=[first_entry, OSError("disk full")]):
+            with self.assertRaises(OSError):
+                cron_tasks._run_due_tasks(config, now)
+
+        persisted = json.loads(self.config_path.read_text(encoding="utf-8"))
+        self.assertEqual(persisted["tasks"][0]["last_run_at"], now.isoformat())
+        self.assertEqual(persisted["tasks"][0]["last_status"], "generated")
+        self.assertIsNone(persisted["tasks"][1]["last_run_at"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cron_tasks.py
+++ b/tests/test_cron_tasks.py
@@ -84,14 +84,18 @@ class TestCronTasksCli(CronPathsMixin, unittest.TestCase):
         self.assertEqual(updated["tasks"], [])
 
     def test_run_once_generates_log_and_artifact(self):
-        rc = cron_tasks.main(["add", "cleanup", "--name", "cleanup-weekly", "--every-minutes", "15", "--retention-days", "30"])
+        rc = cron_tasks.main(
+            ["add", "cleanup", "--name", "cleanup-weekly", "--every-minutes", "15", "--retention-days", "30"]
+        )
         self.assertEqual(rc, 0)
 
         rc = cron_tasks.main(["run", "--once"])
         self.assertEqual(rc, 0)
 
         self.assertTrue(self.log_path.exists())
-        log_entries = [json.loads(line) for line in self.log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        log_entries = [
+            json.loads(line) for line in self.log_path.read_text(encoding="utf-8").splitlines() if line.strip()
+        ]
         self.assertEqual(len(log_entries), 1)
         entry = log_entries[0]
         self.assertEqual(entry["template"], "cleanup")
@@ -103,14 +107,17 @@ class TestCronTasksCli(CronPathsMixin, unittest.TestCase):
 
         rc = cron_tasks.main(["run", "--once"])
         self.assertEqual(rc, 0)
-        log_entries_again = [json.loads(line) for line in self.log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        log_entries_again = [
+            json.loads(line) for line in self.log_path.read_text(encoding="utf-8").splitlines() if line.strip()
+        ]
         self.assertEqual(len(log_entries_again), 1)
 
     def test_run_once_returns_nonzero_on_execution_error(self):
         cron_tasks.main(["add", "cleanup", "--name", "cleanup-weekly", "--every-minutes", "15"])
-        with patch.object(cron_tasks, "_write_artifact", side_effect=OSError("disk full")), patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch.object(cron_tasks, "_write_artifact", side_effect=OSError("disk full")),
+            patch("builtins.print") as mock_print,
+        ):
             rc = cron_tasks.main(["run", "--once"])
         self.assertEqual(rc, 1)
         printed = " ".join(str(part) for call in mock_print.call_args_list for part in call[0])
@@ -155,13 +162,16 @@ class TestCronScheduling(CronPathsMixin, unittest.TestCase):
 
     def test_run_loop_surfaces_errors_and_stops_cleanly(self):
         args = cron_tasks.build_parser().parse_args(["run", "--interval", "1"])
-        with patch.object(cron_tasks, "_load_config", return_value={"tasks": []}), patch.object(
-            cron_tasks,
-            "_run_due_tasks",
-            side_effect=[OSError("disk full"), 0],
-        ), patch("time.sleep", side_effect=[None, KeyboardInterrupt]), patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch.object(cron_tasks, "_load_config", return_value={"tasks": []}),
+            patch.object(
+                cron_tasks,
+                "_run_due_tasks",
+                side_effect=[OSError("disk full"), 0],
+            ),
+            patch("time.sleep", side_effect=[None, KeyboardInterrupt]),
+            patch("builtins.print") as mock_print,
+        ):
             rc = cron_tasks.cmd_run(args)
         self.assertEqual(rc, 0)
         printed = " ".join(str(part) for call in mock_print.call_args_list for part in call[0])
@@ -170,11 +180,16 @@ class TestCronScheduling(CronPathsMixin, unittest.TestCase):
 
     def test_run_loop_stops_cleanly_during_recovery_sleep(self):
         args = cron_tasks.build_parser().parse_args(["run", "--interval", "1"])
-        with patch.object(cron_tasks, "_load_config", return_value={"tasks": []}), patch.object(
-            cron_tasks,
-            "_run_due_tasks",
-            side_effect=OSError("disk full"),
-        ), patch("time.sleep", side_effect=KeyboardInterrupt), patch("builtins.print") as mock_print:
+        with (
+            patch.object(cron_tasks, "_load_config", return_value={"tasks": []}),
+            patch.object(
+                cron_tasks,
+                "_run_due_tasks",
+                side_effect=OSError("disk full"),
+            ),
+            patch("time.sleep", side_effect=KeyboardInterrupt),
+            patch("builtins.print") as mock_print,
+        ):
             rc = cron_tasks.cmd_run(args)
         self.assertEqual(rc, 0)
         printed = " ".join(str(part) for call in mock_print.call_args_list for part in call[0])

--- a/tests/test_install_helpers.py
+++ b/tests/test_install_helpers.py
@@ -816,9 +816,7 @@ try:
     _install._current_path_has_launcher_dir = lambda path_value=None, delimiter=None: False
     _install._read_windows_user_path = lambda: (str(_doctor_launcher.parent), None)
     _install._which_command = lambda name: (
-        r"C:\Users\tester\AppData\Local\Microsoft\WindowsApps\python3.exe"
-        if name == "python3"
-        else None
+        r"C:\Users\tester\AppData\Local\Microsoft\WindowsApps\python3.exe" if name == "python3" else None
     )
 
     _doctor_buf = io.StringIO()

--- a/tests/test_install_helpers.py
+++ b/tests/test_install_helpers.py
@@ -331,6 +331,7 @@ test("TOOL_FILES contains specify.py", "specify.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains task.py", "task.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains context-blocks.py", "context-blocks.py" in _install.TOOL_FILES)
 test("TOOL_FILES contains agent_adapters.py", "agent_adapters.py" in _install.TOOL_FILES)
+test("TOOL_FILES contains cron-tasks.py", "cron-tasks.py" in _install.TOOL_FILES)
 test("SUPPORT_FILES contains pyproject.toml", "pyproject.toml" in _install.SUPPORT_FILES)
 test("SUPPORT_DIRS contains skills", "skills" in _install.SUPPORT_DIRS)
 

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -560,6 +560,41 @@ class TestSkGroupedCommands(unittest.TestCase):
         self._assert_group_routes("scout", "status", "scout-status.py")
 
 
+class TestSkCronNamespace(unittest.TestCase):
+    """Verify that sk cron subcommands route to cron-tasks.py."""
+
+    def _assert_cron_routes(self, extra: list[str], expected: list[str]):
+        with patch.object(sk, "_run", return_value=0) as mock_run:
+            rc = sk.main(["cron"] + extra)
+        self.assertEqual(rc, 0)
+        mock_run.assert_called_once_with("cron-tasks.py", expected)
+
+    def test_cron_add(self):
+        self._assert_cron_routes(["add", "reflection", "--every-minutes", "60"], ["add", "reflection", "--every-minutes", "60"])
+
+    def test_cron_remove(self):
+        self._assert_cron_routes(["remove", "reflection-123"], ["remove", "reflection-123"])
+
+    def test_cron_list(self):
+        self._assert_cron_routes(["list", "--json"], ["list", "--json"])
+
+    def test_cron_run(self):
+        self._assert_cron_routes(["run", "--once"], ["run", "--once"])
+
+    def test_cron_help_flag(self):
+        with patch("builtins.print") as mock_print:
+            rc = sk.main(["cron", "--help"])
+        self.assertEqual(rc, 0)
+        output = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
+        self.assertIn("sk cron", output)
+        self.assertIn("add", output)
+
+    def test_cron_unknown_sub_returns_2(self):
+        with patch("builtins.print"):
+            rc = sk.main(["cron", "pause"])
+        self.assertEqual(rc, 2)
+
+
 class TestSkProjectNamespace(unittest.TestCase):
     """Verify that sk project add/remove/list route to project-registry.py."""
 

--- a/tests/test_sk_cli.py
+++ b/tests/test_sk_cli.py
@@ -570,7 +570,9 @@ class TestSkCronNamespace(unittest.TestCase):
         mock_run.assert_called_once_with("cron-tasks.py", expected)
 
     def test_cron_add(self):
-        self._assert_cron_routes(["add", "reflection", "--every-minutes", "60"], ["add", "reflection", "--every-minutes", "60"])
+        self._assert_cron_routes(
+            ["add", "reflection", "--every-minutes", "60"], ["add", "reflection", "--every-minutes", "60"]
+        )
 
     def test_cron_remove(self):
         self._assert_cron_routes(["remove", "reflection-123"], ["remove", "reflection-123"])


### PR DESCRIPTION
## Summary
- add a new `sk cron` namespace backed by `cron-tasks.py`
- support interval, daily, weekly, and monthly scheduled reflection/cleanup templates with artifact + execution-log persistence
- cover daemon shutdown, error handling, CLI routing, and installer packaging in focused tests

## Testing
- python -m py_compile cron-tasks.py sk.py install.py tests\test_cron_tasks.py tests\test_sk_cli.py tests\test_install_helpers.py
- python -m ruff check cron-tasks.py sk.py install.py tests\test_cron_tasks.py tests\test_sk_cli.py tests\test_install_helpers.py
- python tests\test_cron_tasks.py
- python tests\test_sk_cli.py
- python tests\test_install_helpers.py
- python test_fixes.py
- python test_security.py

Closes #92
