### PR TITLE
feat: add remote terminal MVP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,30 @@ jobs:
       - name: Run tests
         run: python3 run_all_tests.py
 
+  remote-terminal:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: remote-terminal
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: remote-terminal/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
   browse-ui:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ browse-ui/tsconfig.tsbuildinfo
 browse-ui/.env.local
 browse-ui/.env*.local
 browse-ui/.turbo/
+remote-terminal/node_modules/
 
 publish.ps1
 

--- a/remote-terminal/README.md
+++ b/remote-terminal/README.md
@@ -1,0 +1,42 @@
+# Remote Terminal MVP
+
+This package adds a token-gated browser terminal backed by:
+
+- `node-pty` for the PTY session
+- `Socket.IO` for bidirectional streaming
+- `xterm.js` for the browser terminal
+- `cloudflared` for zero-config Cloudflare Quick Tunnel URLs
+- `qrcode-terminal` for scannable QR codes in the operator console
+
+## Usage
+
+```powershell
+cd remote-terminal
+npm install
+npm start
+```
+
+By default the server:
+
+1. listens on `0.0.0.0:2208`
+2. generates a random token
+3. prints a LAN QR code immediately
+4. starts a Cloudflare Quick Tunnel and prints a public QR code once the tunnel URL is ready
+
+## Environment variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `REMOTE_TERMINAL_PORT` | HTTP / Socket.IO port | `2208` |
+| `REMOTE_TERMINAL_HOST` | Bind host | `0.0.0.0` |
+| `REMOTE_TERMINAL_TOKEN` | Fixed access token instead of a random one | random 48-char hex |
+| `REMOTE_TERMINAL_ACCESS_HOST` | Override the QR code host/IP | first non-loopback IPv4 |
+| `REMOTE_TERMINAL_SHELL` | Override the spawned shell executable | `powershell.exe` on Windows, `$SHELL` or `/bin/bash` elsewhere |
+| `REMOTE_TERMINAL_DISABLE_TUNNEL` | Skip Cloudflare Quick Tunnel startup | unset / `false` |
+
+## Notes
+
+- Open the printed URL directly if you already have the token; the HTML page and the WebSocket both require the same token.
+- `Ctrl+C`, `Ctrl+D`, tab completion, and resize handling are delegated to the real PTY-backed shell, so shell behavior stays native instead of being emulated in JavaScript.
+- For LAN-only smoke tests, start with `REMOTE_TERMINAL_DISABLE_TUNNEL=1 npm start`.
+- If your local Windows environment has a custom `cmd.exe` / PATH setup that prevents npm lifecycle scripts from seeing `node`, run `npm --script-shell pwsh <command>` for local verification. That is an environment workaround, not a package requirement.

--- a/remote-terminal/package-lock.json
+++ b/remote-terminal/package-lock.json
@@ -1,0 +1,1235 @@
+{
+  "name": "remote-terminal",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "remote-terminal",
+      "version": "0.1.0",
+      "dependencies": {
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
+        "cloudflared": "^0.7.1",
+        "express": "^4.21.2",
+        "node-pty": "^1.1.0",
+        "qrcode-terminal": "^0.12.0",
+        "socket.io": "^4.8.3"
+      },
+      "devDependencies": {
+        "socket.io-client": "^4.8.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cloudflared": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cloudflared/-/cloudflared-0.7.1.tgz",
+      "integrity": "sha512-jJn1Gu9Tf4qnIu8tfiHZ25Hs8rNcRYSVf8zAd97wvYdOCzftm1CTs1S/RPhijjGi8gUT1p9yzfDi9zYlU/0RwA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "cloudflared": "lib/cloudflared.js"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.7.tgz",
+      "integrity": "sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/remote-terminal/package.json
+++ b/remote-terminal/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "remote-terminal",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MVP remote terminal powered by node-pty, Socket.IO, xterm.js, and Cloudflare Quick Tunnel.",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
+    "cloudflared": "^0.7.1",
+    "express": "^4.21.2",
+    "node-pty": "^1.1.0",
+    "qrcode-terminal": "^0.12.0",
+    "socket.io": "^4.8.3"
+  },
+  "devDependencies": {
+    "socket.io-client": "^4.8.3"
+  }
+}

--- a/remote-terminal/public/client.js
+++ b/remote-terminal/public/client.js
@@ -1,0 +1,67 @@
+(function bootstrapRemoteTerminal() {
+  const terminalNode = document.getElementById("terminal");
+  const statusNode = document.getElementById("status");
+  const search = new URLSearchParams(window.location.search);
+  const token = search.get("token");
+
+  if (!token) {
+    statusNode.textContent = "Missing token. Re-open the QR URL from the operator terminal.";
+    return;
+  }
+
+  const terminal = new window.Terminal({
+    cursorBlink: true,
+    convertEol: true,
+    scrollback: 5000,
+    theme: {
+      background: "#050816",
+      foreground: "#e2e8f0",
+      cursor: "#7dd3fc",
+    },
+  });
+  const fitAddon = new window.FitAddon.FitAddon();
+  terminal.loadAddon(fitAddon);
+  terminal.open(terminalNode);
+
+  const socket = window.io({
+    auth: { token },
+    transports: ["websocket"],
+  });
+
+  function syncSize() {
+    fitAddon.fit();
+    socket.emit("resize", {
+      cols: terminal.cols,
+      rows: terminal.rows,
+    });
+  }
+
+  socket.on("connect", function onConnect() {
+    statusNode.textContent = "Connected";
+    syncSize();
+    terminal.focus();
+  });
+
+  socket.on("disconnect", function onDisconnect(reason) {
+    statusNode.textContent = "Disconnected: " + reason;
+  });
+
+  socket.on("connect_error", function onConnectError(error) {
+    statusNode.textContent = "Connection failed: " + error.message;
+  });
+
+  socket.on("output", function onOutput(data) {
+    terminal.write(data);
+  });
+
+  socket.on("session-exit", function onSessionExit(payload) {
+    const code = payload && payload.exitCode !== null ? payload.exitCode : "null";
+    statusNode.textContent = "Shell exited (code=" + code + ")";
+  });
+
+  terminal.onData(function onInput(data) {
+    socket.emit("input", data);
+  });
+
+  window.addEventListener("resize", syncSize);
+})();

--- a/remote-terminal/public/index.html
+++ b/remote-terminal/public/index.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Remote Terminal</title>
+    <link rel="stylesheet" href="/vendor/xterm.css" />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family:
+          Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        background: #050816;
+        color: #e2e8f0;
+      }
+
+      header {
+        padding: 1rem 1.25rem 0.75rem;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        background: rgba(15, 23, 42, 0.92);
+        backdrop-filter: blur(12px);
+      }
+
+      h1 {
+        margin: 0 0 0.35rem;
+        font-size: 1.2rem;
+      }
+
+      p {
+        margin: 0;
+      }
+
+      #status {
+        margin-top: 0.5rem;
+        color: #7dd3fc;
+        font-size: 0.92rem;
+      }
+
+      #terminal {
+        flex: 1;
+        padding: 0.75rem;
+        min-height: 0;
+      }
+
+      footer {
+        padding: 0.7rem 1.25rem 1rem;
+        font-size: 0.9rem;
+        color: #94a3b8;
+      }
+
+      .xterm {
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Remote Terminal</h1>
+      <p>Token-authenticated terminal session powered by node-pty, Socket.IO, and xterm.js.</p>
+      <p id="status">Connecting…</p>
+    </header>
+    <main id="terminal" aria-label="Terminal session"></main>
+    <footer>Use the browser like a normal terminal: resize the window, press Ctrl+C, Ctrl+D, and use tab completion.</footer>
+    <script src="/socket.io/socket.io.js"></script>
+    <script src="/vendor/xterm.js"></script>
+    <script src="/vendor/xterm-addon-fit.js"></script>
+    <script src="/client.js"></script>
+  </body>
+</html>

--- a/remote-terminal/server.js
+++ b/remote-terminal/server.js
@@ -1,0 +1,451 @@
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+
+const express = require("express");
+const pty = require("node-pty");
+const qrcode = require("qrcode-terminal");
+const { Server } = require("socket.io");
+const {
+  Tunnel,
+  bin: cloudflaredBin,
+  install: installCloudflared,
+} = require("cloudflared");
+
+const DEFAULT_PORT = 2208;
+const DEFAULT_HOST = "0.0.0.0";
+const DEFAULT_COLS = 120;
+const DEFAULT_ROWS = 40;
+const DEFAULT_TERM = "xterm-256color";
+const PUBLIC_DIR = path.join(__dirname, "public");
+const XTERM_DIR = path.dirname(require.resolve("@xterm/xterm/package.json"));
+const XTERM_ADDON_DIR = path.dirname(require.resolve("@xterm/addon-fit/package.json"));
+
+function parseBoolean(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  return ["1", "true", "yes", "on"].includes(String(value).toLowerCase());
+}
+
+function resolvePort(value) {
+  const raw = value ?? process.env.REMOTE_TERMINAL_PORT ?? DEFAULT_PORT;
+  const parsed = Number.parseInt(String(raw), 10);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65535) {
+    throw new Error(`Invalid remote terminal port: ${raw}`);
+  }
+  return parsed;
+}
+
+function buildAccessUrl(baseUrl, token) {
+  const url = new URL(baseUrl);
+  url.searchParams.set("token", token);
+  return url.toString();
+}
+
+function stripTokenFromUrl(urlValue) {
+  if (!urlValue) {
+    return null;
+  }
+
+  const url = new URL(urlValue);
+  url.search = "";
+  return url.toString();
+}
+
+function pickAccessHost(explicitHost) {
+  if (explicitHost) {
+    return explicitHost;
+  }
+
+  const interfaces = os.networkInterfaces();
+  for (const entries of Object.values(interfaces)) {
+    for (const entry of entries ?? []) {
+      if (entry && entry.family === "IPv4" && !entry.internal) {
+        return entry.address;
+      }
+    }
+  }
+
+  return "127.0.0.1";
+}
+
+function resolveShell(command, args) {
+  if (command) {
+    return {
+      command,
+      args: Array.isArray(args) ? args : [],
+    };
+  }
+
+  const configuredShell = process.env.REMOTE_TERMINAL_SHELL;
+  if (configuredShell) {
+    return {
+      command: configuredShell,
+      args: (process.env.REMOTE_TERMINAL_SHELL_ARGS || "")
+        .split(/\s+/)
+        .filter(Boolean),
+    };
+  }
+
+  if (process.platform === "win32") {
+    return {
+      command: "powershell.exe",
+      args: ["-NoLogo"],
+    };
+  }
+
+  return {
+    command: process.env.SHELL || "/bin/bash",
+    args: ["-i"],
+  };
+}
+
+function createToken(explicitToken) {
+  return explicitToken || process.env.REMOTE_TERMINAL_TOKEN || crypto.randomBytes(24).toString("hex");
+}
+
+function isValidToken(expectedToken, candidate) {
+  if (typeof candidate !== "string") {
+    return false;
+  }
+
+  const expected = Buffer.from(expectedToken);
+  const actual = Buffer.from(candidate);
+  return expected.length === actual.length && crypto.timingSafeEqual(expected, actual);
+}
+
+function renderQrCode(url, { label, logger, qrWriter }) {
+  logger(`${label}: ${url}`);
+  if (qrWriter) {
+    qrWriter(label, url);
+    return;
+  }
+
+  qrcode.generate(url, { small: true }, (rendered) => {
+    logger(rendered.trimEnd());
+  });
+}
+
+function createTunnel(localTarget, token, { logger, qrWriter, setPublicUrl, setTunnelError, tunnelFactory }) {
+  const tunnel = tunnelFactory(localTarget);
+  let published = false;
+
+  tunnel.once("url", (url) => {
+    published = true;
+    setTunnelError(null);
+    const publicUrl = buildAccessUrl(url, token);
+    setPublicUrl(publicUrl);
+    renderQrCode(publicUrl, {
+      label: "Quick tunnel QR",
+      logger,
+      qrWriter,
+    });
+  });
+
+  tunnel.once("error", (error) => {
+    setPublicUrl(null);
+    setTunnelError(error.message);
+    logger(`Cloudflare Quick Tunnel failed: ${error.message}`);
+  });
+
+  tunnel.once("exit", (code, signal) => {
+    setPublicUrl(null);
+    if (!published) {
+      setTunnelError(`cloudflared exited before publishing a URL (code=${code ?? "null"}, signal=${signal ?? "none"})`);
+      logger(
+        `Cloudflare Quick Tunnel exited before publishing a URL (code=${code ?? "null"}, signal=${signal ?? "none"}).`,
+      );
+    } else {
+      setTunnelError(`cloudflared exited (code=${code ?? "null"}, signal=${signal ?? "none"})`);
+    }
+  });
+
+  return tunnel;
+}
+
+async function ensureCloudflaredBinary(logger) {
+  if (fs.existsSync(cloudflaredBin)) {
+    return;
+  }
+
+  logger(`Installing cloudflared binary at ${cloudflaredBin} ...`);
+  await installCloudflared(cloudflaredBin);
+}
+
+async function listen(server, port, host) {
+  await new Promise((resolve, reject) => {
+    const onError = (error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, host);
+  });
+}
+
+async function startRemoteTerminal(options = {}) {
+  const logger = options.logger || console.log;
+  const qrWriter = options.qrWriter;
+  const host = options.host || process.env.REMOTE_TERMINAL_HOST || DEFAULT_HOST;
+  const accessHost = pickAccessHost(options.accessHost || process.env.REMOTE_TERMINAL_ACCESS_HOST);
+  const port = resolvePort(options.port);
+  const token = createToken(options.token);
+  const shell = resolveShell(options.shellCommand, options.shellArgs);
+  const cwd = options.cwd || process.cwd();
+  const env = {
+    ...process.env,
+    TERM: DEFAULT_TERM,
+    ...(options.env || {}),
+  };
+  const tunnelEnabled = options.disableTunnel
+    ? false
+    : !parseBoolean(process.env.REMOTE_TERMINAL_DISABLE_TUNNEL);
+
+  const app = express();
+  app.disable("x-powered-by");
+
+  let publicUrl = null;
+  let tunnel = null;
+  let stopPromise = null;
+  let closedResolve;
+  let shellRunning = true;
+  let shellExit = null;
+  let tunnelError = null;
+  const closed = new Promise((resolve) => {
+    closedResolve = resolve;
+  });
+  const lastResize = {
+    cols: DEFAULT_COLS,
+    rows: DEFAULT_ROWS,
+  };
+
+  const ptyFactory = options.ptyFactory || pty.spawn;
+  const ptyProcess = ptyFactory(shell.command, shell.args, {
+    name: DEFAULT_TERM,
+    cols: DEFAULT_COLS,
+    rows: DEFAULT_ROWS,
+    cwd,
+    env,
+  });
+
+  const server = http.createServer(app);
+  const io = new Server(server, {
+    serveClient: true,
+  });
+
+  function setPublicUrl(url) {
+    publicUrl = url;
+  }
+
+  function setTunnelError(message) {
+    tunnelError = message;
+  }
+
+  async function stop() {
+    if (stopPromise) {
+      return stopPromise;
+    }
+
+    stopPromise = (async () => {
+      if (tunnel) {
+        tunnel.stop();
+      }
+
+      if (shellRunning) {
+        shellRunning = false;
+        ptyProcess.kill();
+      }
+
+      await Promise.allSettled([
+        new Promise((resolve) => io.close(() => resolve())),
+        new Promise((resolve) => server.close(() => resolve())),
+      ]);
+
+      closedResolve();
+    })();
+
+    return stopPromise;
+  }
+
+  app.get("/health", (_req, res) => {
+    res.json({
+      ok: true,
+      port: server.address().port,
+      localOrigin: stripTokenFromUrl(buildAccessUrl(`http://${accessHost}:${server.address().port}/`, token)),
+      publicOrigin: stripTokenFromUrl(publicUrl),
+      tunnelError,
+      shell: shell.command,
+      shellArgs: shell.args,
+      shellExit,
+      lastResize,
+      tunnelEnabled,
+    });
+  });
+
+  app.get("/", (req, res) => {
+    if (!isValidToken(token, req.query.token)) {
+      res.status(401).type("text/plain").send("missing or invalid token");
+      return;
+    }
+
+    res.sendFile(path.join(PUBLIC_DIR, "index.html"));
+  });
+
+  app.get("/client.js", (_req, res) => {
+    res.type("application/javascript").sendFile(path.join(PUBLIC_DIR, "client.js"));
+  });
+
+  app.get("/vendor/xterm.css", (_req, res) => {
+    res.type("text/css").sendFile(path.join(XTERM_DIR, "css", "xterm.css"));
+  });
+
+  app.get("/vendor/xterm.js", (_req, res) => {
+    res.type("application/javascript").sendFile(path.join(XTERM_DIR, "lib", "xterm.js"));
+  });
+
+  app.get("/vendor/xterm-addon-fit.js", (_req, res) => {
+    res.type("application/javascript").sendFile(path.join(XTERM_ADDON_DIR, "lib", "addon-fit.js"));
+  });
+
+  app.get("/favicon.ico", (_req, res) => {
+    res.status(204).end();
+  });
+
+  io.use((socket, next) => {
+    const providedToken = socket.handshake.auth.token || socket.handshake.query.token;
+    if (!isValidToken(token, Array.isArray(providedToken) ? providedToken[0] : providedToken)) {
+      next(new Error("unauthorized"));
+      return;
+    }
+
+    next();
+  });
+
+  io.on("connection", (socket) => {
+    socket.emit("output", "");
+    socket.on("input", (chunk) => {
+      if (typeof chunk === "string" && shellRunning) {
+        ptyProcess.write(chunk);
+      }
+    });
+
+    socket.on("resize", (payload) => {
+      const cols = Number.parseInt(String(payload?.cols), 10);
+      const rows = Number.parseInt(String(payload?.rows), 10);
+      if (Number.isInteger(cols) && Number.isInteger(rows) && cols > 0 && rows > 0) {
+        lastResize.cols = cols;
+        lastResize.rows = rows;
+        ptyProcess.resize(cols, rows);
+      }
+    });
+  });
+
+  ptyProcess.onData((data) => {
+    io.emit("output", data);
+  });
+
+  ptyProcess.onExit(({ exitCode, signal }) => {
+    shellRunning = false;
+    shellExit = {
+      exitCode,
+      signal,
+    };
+    io.emit("session-exit", shellExit);
+    logger(`Shell exited (code=${exitCode ?? "null"}, signal=${signal ?? "none"}).`);
+    void stop();
+  });
+
+  try {
+    await listen(server, port, host);
+  } catch (error) {
+    shellRunning = false;
+    ptyProcess.kill();
+    io.close();
+    throw error;
+  }
+
+  const activePort = server.address().port;
+  const localUrl = buildAccessUrl(`http://${accessHost}:${activePort}/`, token);
+  logger(`Remote terminal listening on http://${host}:${activePort}`);
+  logger(`Shell: ${shell.command}${shell.args.length ? ` ${shell.args.join(" ")}` : ""}`);
+  renderQrCode(localUrl, {
+    label: "Local access QR",
+    logger,
+    qrWriter,
+  });
+
+  if (tunnelEnabled) {
+    try {
+      if (!options.tunnelFactory) {
+        await ensureCloudflaredBinary(logger);
+      }
+      logger(`Starting Cloudflare Quick Tunnel for http://127.0.0.1:${activePort} ...`);
+      tunnel = createTunnel(`http://127.0.0.1:${activePort}`, token, {
+        logger,
+        qrWriter,
+        setPublicUrl,
+        setTunnelError,
+        tunnelFactory: options.tunnelFactory || ((target) => Tunnel.quick(target)),
+      });
+    } catch (error) {
+      tunnelError = error instanceof Error ? error.message : String(error);
+      logger(`Cloudflare Quick Tunnel unavailable: ${tunnelError}`);
+    }
+  }
+
+  return {
+    port: activePort,
+    host,
+    accessHost,
+    token,
+    localUrl,
+    get publicUrl() {
+      return publicUrl;
+    },
+    lastResize,
+    closed,
+    server,
+    io,
+    ptyProcess,
+    shell,
+    stop,
+  };
+}
+
+async function main() {
+  const remoteTerminal = await startRemoteTerminal();
+  const shutdown = async () => {
+    await remoteTerminal.stop();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+module.exports = {
+  DEFAULT_PORT,
+  buildAccessUrl,
+  isValidToken,
+  pickAccessHost,
+  resolvePort,
+  stripTokenFromUrl,
+  startRemoteTerminal,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.stack || error.message);
+    process.exit(1);
+  });
+}

--- a/remote-terminal/test/server.test.js
+++ b/remote-terminal/test/server.test.js
@@ -1,0 +1,361 @@
+const assert = require("node:assert/strict");
+const { EventEmitter, once } = require("node:events");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { io } = require("socket.io-client");
+
+const {
+  DEFAULT_PORT,
+  buildAccessUrl,
+  resolvePort,
+  stripTokenFromUrl,
+  startRemoteTerminal,
+} = require("../server.js");
+
+async function waitFor(check, message, timeout = 8000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeout) {
+    if (check()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error(message);
+}
+
+async function connectClient(remoteTerminal, token) {
+  const socket = io(`http://127.0.0.1:${remoteTerminal.port}`, {
+    auth: { token },
+    reconnection: false,
+    transports: ["websocket"],
+  });
+  await once(socket, "connect");
+  return socket;
+}
+
+test("resolvePort keeps the issue default", () => {
+  assert.equal(resolvePort(undefined), DEFAULT_PORT);
+});
+
+test("health endpoint is public but the terminal page stays token gated", async (t) => {
+  const qrCodes = [];
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    disableTunnel: true,
+    logger: () => {},
+    qrWriter: (label, url) => qrCodes.push({ label, url }),
+    token: "issue75-health-token",
+    port: 0,
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
+  assert.equal(health.status, 200);
+  const payload = await health.json();
+  assert.equal(payload.ok, true);
+  assert.equal(payload.port, remoteTerminal.port);
+  assert.equal(payload.localOrigin, stripTokenFromUrl(remoteTerminal.localUrl));
+  assert.equal(payload.publicOrigin, null);
+  assert.equal(JSON.stringify(payload).includes("issue75-health-token"), false);
+
+  const denied = await fetch(`http://127.0.0.1:${remoteTerminal.port}/`);
+  assert.equal(denied.status, 401);
+
+  const allowed = await fetch(remoteTerminal.localUrl);
+  assert.equal(allowed.status, 200);
+  assert.match(await allowed.text(), /Remote Terminal/);
+  assert.deepEqual(qrCodes, [{ label: "Local access QR", url: remoteTerminal.localUrl }]);
+});
+
+test("invalid socket auth is rejected", async (t) => {
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    disableTunnel: true,
+    logger: () => {},
+    token: "issue75-socket-token",
+    port: 0,
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  const socket = io(`http://127.0.0.1:${remoteTerminal.port}`, {
+    auth: { token: "wrong-token" },
+    reconnection: false,
+    transports: ["websocket"],
+  });
+  t.after(() => socket.close());
+
+  const [error] = await once(socket, "connect_error");
+  assert.match(error.message, /unauthorized/);
+});
+
+test("pty output streams through Socket.IO and resize reaches the PTY", async (t) => {
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    disableTunnel: true,
+    logger: () => {},
+    token: "issue75-io-token",
+    port: 0,
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  const socket = await connectClient(remoteTerminal, "issue75-io-token");
+  t.after(() => socket.close());
+
+  let output = "";
+  socket.on("output", (chunk) => {
+    output += chunk;
+  });
+
+  socket.emit("resize", { cols: 100, rows: 32 });
+  await waitFor(
+    () => remoteTerminal.lastResize.cols === 100 && remoteTerminal.lastResize.rows === 32,
+    "resize did not reach the PTY",
+  );
+
+  const echoCommand =
+    process.platform === "win32" ? "Write-Output 'ISSUE75_READY'" : "echo ISSUE75_READY";
+
+  socket.emit("input", `${echoCommand}\r`);
+  await waitFor(() => output.includes("ISSUE75_READY"), "did not receive PTY output");
+});
+
+test(
+  "Ctrl+C interrupts the active command on POSIX shells",
+  { skip: process.platform === "win32" ? "Ctrl+C proof runs in Linux CI with bash." : false },
+  async (t) => {
+    const remoteTerminal = await startRemoteTerminal({
+      accessHost: "127.0.0.1",
+      disableTunnel: true,
+      env: {
+        PATH: process.env.PATH,
+      },
+      logger: () => {},
+      token: "issue75-ctrlc-token",
+      port: 0,
+      shellCommand: "/bin/bash",
+      shellArgs: ["-i"],
+    });
+    t.after(async () => {
+      await remoteTerminal.stop();
+    });
+
+    const socket = await connectClient(remoteTerminal, "issue75-ctrlc-token");
+    t.after(() => socket.close());
+
+    let output = "";
+    socket.on("output", (chunk) => {
+      output += chunk;
+    });
+
+    socket.emit("input", "sleep 30\r");
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    socket.emit("input", "\u0003");
+    socket.emit("input", "echo ISSUE75_AFTER_CTRL_C\r");
+
+    await waitFor(
+      () => output.includes("ISSUE75_AFTER_CTRL_C"),
+      "Ctrl+C did not interrupt the active command quickly enough",
+      5000,
+    );
+  },
+);
+
+test("Cloudflare Quick Tunnel URLs become tokenized public access links", async (t) => {
+  const qrCodes = [];
+  const tunnel = new EventEmitter();
+  let stopCalls = 0;
+  tunnel.stop = () => {
+    stopCalls += 1;
+    return true;
+  };
+
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    logger: () => {},
+    qrWriter: (label, url) => qrCodes.push({ label, url }),
+    token: "issue75-tunnel-token",
+    port: 0,
+    tunnelFactory: () => tunnel,
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  tunnel.emit("url", "https://issue75.trycloudflare.com");
+
+  await waitFor(() => remoteTerminal.publicUrl !== null, "public Quick Tunnel URL never arrived");
+  assert.equal(
+    remoteTerminal.publicUrl,
+    buildAccessUrl("https://issue75.trycloudflare.com", "issue75-tunnel-token"),
+  );
+  assert.deepEqual(qrCodes[1], {
+    label: "Quick tunnel QR",
+    url: remoteTerminal.publicUrl,
+  });
+
+  await remoteTerminal.stop();
+  assert.equal(stopCalls > 0, true);
+});
+
+test("async tunnel errors clear the public origin and surface in health", async (t) => {
+  const tunnel = new EventEmitter();
+  tunnel.stop = () => true;
+
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    logger: () => {},
+    token: "issue75-async-tunnel-token",
+    port: 0,
+    tunnelFactory: () => tunnel,
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  tunnel.emit("url", "https://issue75.trycloudflare.com");
+  await waitFor(() => remoteTerminal.publicUrl !== null, "public Quick Tunnel URL never arrived");
+
+  tunnel.emit("error", new Error("async tunnel broke"));
+  await waitFor(() => remoteTerminal.publicUrl === null, "async tunnel error did not clear the public URL");
+
+  const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
+  const payload = await health.json();
+  assert.equal(payload.publicOrigin, null);
+  assert.equal(payload.tunnelError, "async tunnel broke");
+});
+
+test("tunnel bootstrap failures stay explicit without crashing the local server", async (t) => {
+  const logs = [];
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    logger: (message) => logs.push(message),
+    token: "issue75-tunnel-failure-token",
+    port: 0,
+    tunnelFactory: () => {
+      throw new Error("fake tunnel bootstrap failure");
+    },
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
+  const payload = await health.json();
+  assert.equal(payload.ok, true);
+  assert.equal(payload.publicOrigin, null);
+  assert.equal(payload.tunnelError, "fake tunnel bootstrap failure");
+  assert.match(logs.join("\n"), /Cloudflare Quick Tunnel unavailable: fake tunnel bootstrap failure/);
+});
+
+test("listen failures kill the spawned PTY before rethrowing", async (t) => {
+  const occupied = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    disableTunnel: true,
+    logger: () => {},
+    token: "issue75-port-owner",
+    port: 0,
+  });
+  t.after(async () => {
+    await occupied.stop();
+  });
+
+  let killed = false;
+  const fakePty = {
+    kill() {
+      killed = true;
+    },
+    onData() {},
+    onExit() {},
+    resize() {},
+    write() {},
+  };
+
+  await assert.rejects(
+    startRemoteTerminal({
+      accessHost: "127.0.0.1",
+      disableTunnel: true,
+      logger: () => {},
+      token: "issue75-port-collision",
+      port: occupied.port,
+      ptyFactory: () => fakePty,
+    }),
+    /EADDRINUSE|address already in use/,
+  );
+  assert.equal(killed, true);
+});
+
+test(
+  "Ctrl+D closes the PTY-backed session on POSIX shells",
+  { skip: process.platform === "win32" ? "Ctrl+D shell-exit proof is covered in Linux CI." : false },
+  async (t) => {
+    const remoteTerminal = await startRemoteTerminal({
+      accessHost: "127.0.0.1",
+      disableTunnel: true,
+      logger: () => {},
+      token: "issue75-eof-token",
+      port: 0,
+      shellCommand: "/bin/bash",
+      shellArgs: ["-i"],
+    });
+    t.after(async () => {
+      await remoteTerminal.stop();
+    });
+
+    const socket = await connectClient(remoteTerminal, "issue75-eof-token");
+    t.after(() => socket.close());
+
+    socket.emit("input", "\u0004");
+    await waitFor(() => remoteTerminal.server.listening === false, "Ctrl+D did not close the server session");
+  },
+);
+
+test(
+  "tab completion still works because the browser sends raw PTY input",
+  { skip: process.platform === "win32" ? "Tab-completion proof runs in Linux CI with bash." : false },
+  async (t) => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "issue75-tab-"));
+    const helperCommand = path.join(tempDir, "issue75-tab-target");
+    await fs.writeFile(helperCommand, "#!/bin/sh\necho ISSUE75_TAB_OK\n", { mode: 0o755 });
+    await fs.chmod(helperCommand, 0o755);
+    t.after(async () => {
+      await fs.rm(tempDir, { force: true, recursive: true });
+    });
+
+    const remoteTerminal = await startRemoteTerminal({
+      accessHost: "127.0.0.1",
+      disableTunnel: true,
+      env: {
+        PATH: `${tempDir}:${process.env.PATH}`,
+      },
+      logger: () => {},
+      token: "issue75-tab-token",
+      port: 0,
+      shellCommand: "/bin/bash",
+      shellArgs: ["-i"],
+    });
+    t.after(async () => {
+      await remoteTerminal.stop();
+    });
+
+    const socket = await connectClient(remoteTerminal, "issue75-tab-token");
+    t.after(() => socket.close());
+
+    let output = "";
+    socket.on("output", (chunk) => {
+      output += chunk;
+    });
+
+    socket.emit("input", "issue75-tab-ta\t\r");
+    await waitFor(() => output.includes("ISSUE75_TAB_OK"), "tab completion never executed the completed command");
+  },
+);

--- a/remote-terminal/test/server.test.js
+++ b/remote-terminal/test/server.test.js
@@ -295,7 +295,7 @@ test("listen failures kill the spawned PTY before rethrowing", async (t) => {
 });
 
 test(
-  "Ctrl+D closes the PTY-backed session on POSIX shells",
+  "Ctrl+D forwards EOF to the PTY process",
   { skip: process.platform === "win32" ? "Ctrl+D shell-exit proof is covered in Linux CI." : false },
   async (t) => {
     const remoteTerminal = await startRemoteTerminal({
@@ -304,8 +304,8 @@ test(
       logger: () => {},
       token: "issue75-eof-token",
       port: 0,
-      shellCommand: "/bin/bash",
-      shellArgs: ["-i"],
+      shellCommand: "/bin/cat",
+      shellArgs: [],
     });
     t.after(async () => {
       await remoteTerminal.stop();
@@ -314,6 +314,7 @@ test(
     const socket = await connectClient(remoteTerminal, "issue75-eof-token");
     t.after(() => socket.close());
 
+    socket.emit("input", "ISSUE75_EOF\r");
     socket.emit("input", "\u0004");
     await waitFor(() => remoteTerminal.server.listening === false, "Ctrl+D did not close the server session");
   },


### PR DESCRIPTION
## Summary
- add a self-contained `remote-terminal/` package with node-pty, Socket.IO, xterm.js, QR output, and optional Cloudflare Quick Tunnel bootstrap
- harden the runtime so health checks stay token-safe and tunnel/bootstrap failures stay explicit instead of crashing the local terminal
- add CI coverage plus Node tests for auth, PTY streaming, resize, tunnel failures, and Linux shell behaviors

## Testing
- `npm test` in `remote-terminal/` (via PowerShell script-shell on this Windows host)
- `npm start` smoke with `/health`, page fetch, served asset fetch, and a live Socket.IO PTY echo smoke
- `python run_all_tests.py` on this Windows host still reports pre-existing browse-related failures outside this change

Closes #75
