### PR TITLE
feat(remote-terminal): add zero-config tunnel retries

### DIFF
--- a/remote-terminal/README.md
+++ b/remote-terminal/README.md
@@ -21,7 +21,17 @@ By default the server:
 1. listens on `0.0.0.0:2208`
 2. generates a random token
 3. prints a LAN QR code immediately
-4. starts a Cloudflare Quick Tunnel and prints a public QR code once the tunnel URL is ready
+4. starts a Cloudflare Quick Tunnel state machine with an `ora` progress spinner
+5. retries tunnel setup after disconnects / tunnel errors with exponential backoff
+6. prints a public QR code once the tunnel URL is verified
+
+## Tunnel states
+
+```text
+STOPPED → PREPARING → CONNECTING → TUNNELING → VERIFYING → READY
+   ↑                                                      │
+   └──────────── error / disconnect / verify fail ────────┘
+```
 
 ## Environment variables
 
@@ -39,4 +49,5 @@ By default the server:
 - Open the printed URL directly if you already have the token; the HTML page and the WebSocket both require the same token.
 - `Ctrl+C`, `Ctrl+D`, tab completion, and resize handling are delegated to the real PTY-backed shell, so shell behavior stays native instead of being emulated in JavaScript.
 - For LAN-only smoke tests, start with `REMOTE_TERMINAL_DISABLE_TUNNEL=1 npm start`.
+- `/health` exposes the tunnel state machine (`tunnelState`, `tunnelRetryDelayMs`, `tunnelError`) without leaking the access token.
 - If your local Windows environment has a custom `cmd.exe` / PATH setup that prevents npm lifecycle scripts from seeing `node`, run `npm --script-shell pwsh <command>` for local verification. That is an environment workaround, not a package requirement.

--- a/remote-terminal/package-lock.json
+++ b/remote-terminal/package-lock.json
@@ -13,6 +13,7 @@
         "cloudflared": "^0.7.1",
         "express": "^4.21.2",
         "node-pty": "^1.1.0",
+        "ora": "^9.4.0",
         "qrcode-terminal": "^0.12.0",
         "socket.io": "^4.8.3"
       },
@@ -82,6 +83,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/array-flatten": {
@@ -159,6 +172,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cloudflared": {
@@ -509,6 +561,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -629,6 +693,46 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -698,6 +802,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -760,6 +876,43 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
+      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.2",
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parseurl": {
@@ -835,6 +988,22 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safe-buffer": {
@@ -984,6 +1153,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/socket.io": {
@@ -1146,6 +1327,49 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1229,6 +1453,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/remote-terminal/package.json
+++ b/remote-terminal/package.json
@@ -16,6 +16,7 @@
     "cloudflared": "^0.7.1",
     "express": "^4.21.2",
     "node-pty": "^1.1.0",
+    "ora": "^9.4.0",
     "qrcode-terminal": "^0.12.0",
     "socket.io": "^4.8.3"
   },

--- a/remote-terminal/server.js
+++ b/remote-terminal/server.js
@@ -19,9 +19,21 @@ const DEFAULT_HOST = "0.0.0.0";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 40;
 const DEFAULT_TERM = "xterm-256color";
+const DEFAULT_TUNNEL_RETRY_BASE_MS = 1000;
+const DEFAULT_TUNNEL_RETRY_MAX_MS = 30000;
+const DEFAULT_TUNNEL_VERIFY_ATTEMPTS = 12;
+const DEFAULT_TUNNEL_VERIFY_DELAY_MS = 5000;
 const PUBLIC_DIR = path.join(__dirname, "public");
 const XTERM_DIR = path.dirname(require.resolve("@xterm/xterm/package.json"));
 const XTERM_ADDON_DIR = path.dirname(require.resolve("@xterm/addon-fit/package.json"));
+const TUNNEL_STATES = Object.freeze({
+  STOPPED: "STOPPED",
+  PREPARING: "PREPARING",
+  CONNECTING: "CONNECTING",
+  TUNNELING: "TUNNELING",
+  VERIFYING: "VERIFYING",
+  READY: "READY",
+});
 
 function parseBoolean(value) {
   if (value === undefined || value === null) {
@@ -130,38 +142,153 @@ function renderQrCode(url, { label, logger, qrWriter }) {
   });
 }
 
-function createTunnel(localTarget, token, { logger, qrWriter, setPublicUrl, setTunnelError, tunnelFactory }) {
+function createNoopSpinner() {
+  return {
+    isSpinning: false,
+    text: "",
+    start(text) {
+      this.isSpinning = true;
+      if (text) {
+        this.text = text;
+      }
+      return this;
+    },
+    stop() {
+      this.isSpinning = false;
+      return this;
+    },
+    succeed(text) {
+      this.isSpinning = false;
+      if (text) {
+        this.text = text;
+      }
+      return this;
+    },
+    warn(text) {
+      this.isSpinning = false;
+      if (text) {
+        this.text = text;
+      }
+      return this;
+    },
+    fail(text) {
+      this.isSpinning = false;
+      if (text) {
+        this.text = text;
+      }
+      return this;
+    },
+  };
+}
+
+async function createSpinner(spinnerFactory) {
+  if (spinnerFactory) {
+    return spinnerFactory();
+  }
+
+  const { default: ora } = await import("ora");
+  return ora({
+    discardStdin: false,
+    text: `[${TUNNEL_STATES.STOPPED}] Tunnel idle`,
+  });
+}
+
+function formatRetryDelay(delayMs) {
+  if (delayMs >= 1000) {
+    const seconds = delayMs / 1000;
+    return Number.isInteger(seconds) ? `${seconds}s` : `${seconds.toFixed(1)}s`;
+  }
+
+  return `${delayMs}ms`;
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function defaultVerifyTunnel(publicAccessUrl, options = {}) {
+  const attempts = options.attempts ?? DEFAULT_TUNNEL_VERIFY_ATTEMPTS;
+  const delayMs = options.delayMs ?? DEFAULT_TUNNEL_VERIFY_DELAY_MS;
+  const healthUrl = new URL("health", stripTokenFromUrl(publicAccessUrl)).toString();
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    if (options.onProgress) {
+      options.onProgress(attempt, attempts, healthUrl);
+    }
+
+    try {
+      const response = await fetch(healthUrl, { method: "GET" });
+      if (!response.ok) {
+        throw new Error(`health check returned HTTP ${response.status}`);
+      }
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        await sleep(delayMs);
+      }
+    }
+  }
+
+  throw lastError || new Error("Tunnel verification failed");
+}
+
+function createTunnel(
+  localTarget,
+  token,
+  { logger, qrWriter, setPublicUrl, setTunnelError, tunnelFactory, onConnected, onTunneling, onReadyRequested, onFailure },
+) {
   const tunnel = tunnelFactory(localTarget);
-  let published = false;
+  let connected = false;
+  let publicAccessUrl = null;
+  let failed = false;
+
+  function fail(message) {
+    if (failed) {
+      return;
+    }
+
+    failed = true;
+    setPublicUrl(null);
+    setTunnelError(message);
+    onFailure(message);
+  }
 
   tunnel.once("url", (url) => {
-    published = true;
     setTunnelError(null);
-    const publicUrl = buildAccessUrl(url, token);
-    setPublicUrl(publicUrl);
-    renderQrCode(publicUrl, {
+    publicAccessUrl = buildAccessUrl(url, token);
+    setPublicUrl(publicAccessUrl);
+    renderQrCode(publicAccessUrl, {
       label: "Quick tunnel QR",
       logger,
       qrWriter,
     });
+    onTunneling(publicAccessUrl);
+    if (connected) {
+      onReadyRequested(publicAccessUrl);
+    }
+  });
+
+  tunnel.once("connected", (connection) => {
+    connected = true;
+    onConnected(connection);
+    if (publicAccessUrl) {
+      onReadyRequested(publicAccessUrl);
+    }
+  });
+
+  tunnel.once("disconnected", (connection) => {
+    const location = connection && connection.location ? connection.location : "unknown";
+    fail(`cloudflared disconnected (${location})`);
   });
 
   tunnel.once("error", (error) => {
-    setPublicUrl(null);
-    setTunnelError(error.message);
-    logger(`Cloudflare Quick Tunnel failed: ${error.message}`);
+    fail(error.message);
   });
 
   tunnel.once("exit", (code, signal) => {
-    setPublicUrl(null);
-    if (!published) {
-      setTunnelError(`cloudflared exited before publishing a URL (code=${code ?? "null"}, signal=${signal ?? "none"})`);
-      logger(
-        `Cloudflare Quick Tunnel exited before publishing a URL (code=${code ?? "null"}, signal=${signal ?? "none"}).`,
-      );
-    } else {
-      setTunnelError(`cloudflared exited (code=${code ?? "null"}, signal=${signal ?? "none"})`);
-    }
+    fail(`cloudflared exited (code=${code ?? "null"}, signal=${signal ?? "none"})`);
   });
 
   return tunnel;
@@ -210,6 +337,11 @@ async function startRemoteTerminal(options = {}) {
   const tunnelEnabled = options.disableTunnel
     ? false
     : !parseBoolean(process.env.REMOTE_TERMINAL_DISABLE_TUNNEL);
+  const verifyTunnel = options.verifyTunnel || defaultVerifyTunnel;
+  const retryBaseMs = options.retryBaseMs ?? DEFAULT_TUNNEL_RETRY_BASE_MS;
+  const retryMaxMs = options.retryMaxMs ?? DEFAULT_TUNNEL_RETRY_MAX_MS;
+  const verifyAttempts = options.verifyAttempts ?? DEFAULT_TUNNEL_VERIFY_ATTEMPTS;
+  const verifyDelayMs = options.verifyDelayMs ?? DEFAULT_TUNNEL_VERIFY_DELAY_MS;
 
   const app = express();
   app.disable("x-powered-by");
@@ -221,6 +353,13 @@ async function startRemoteTerminal(options = {}) {
   let shellRunning = true;
   let shellExit = null;
   let tunnelError = null;
+  let tunnelState = TUNNEL_STATES.STOPPED;
+  let tunnelAttempt = 0;
+  let tunnelRetryDelayMs = null;
+  let retryTimer = null;
+  let verificationInFlight = false;
+  let pendingVerification = null;
+  let stopping = false;
   const closed = new Promise((resolve) => {
     closedResolve = resolve;
   });
@@ -242,6 +381,7 @@ async function startRemoteTerminal(options = {}) {
   const io = new Server(server, {
     serveClient: true,
   });
+  const spinner = tunnelEnabled ? await createSpinner(options.spinnerFactory) : createNoopSpinner();
 
   function setPublicUrl(url) {
     publicUrl = url;
@@ -251,14 +391,178 @@ async function startRemoteTerminal(options = {}) {
     tunnelError = message;
   }
 
+  function updateSpinner(text, terminalAction) {
+    if (!spinner) {
+      return;
+    }
+
+    if (terminalAction === "succeed" && typeof spinner.succeed === "function") {
+      if (!spinner.isSpinning && typeof spinner.start === "function") {
+        spinner.start(text);
+      }
+      spinner.succeed(text);
+      return;
+    }
+
+    if (terminalAction === "warn" && typeof spinner.warn === "function") {
+      if (!spinner.isSpinning && typeof spinner.start === "function") {
+        spinner.start(text);
+      }
+      spinner.warn(text);
+      return;
+    }
+
+    if (!spinner.isSpinning && typeof spinner.start === "function") {
+      spinner.start(text);
+      return;
+    }
+
+    spinner.text = text;
+  }
+
+  function setTunnelState(nextState, detail, terminalAction = null) {
+    tunnelState = nextState;
+    const text = `[${nextState}] ${detail}`;
+    logger(text);
+    updateSpinner(text, terminalAction);
+  }
+
+  function clearRetryTimer() {
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+    tunnelRetryDelayMs = null;
+  }
+
+  async function scheduleRetry(message) {
+    if (stopping || !tunnelEnabled) {
+      return;
+    }
+
+    clearRetryTimer();
+    pendingVerification = null;
+
+    if (tunnel) {
+      tunnel.stop();
+      tunnel = null;
+    }
+
+    const delayMs = Math.min(retryMaxMs, retryBaseMs * 2 ** Math.max(0, tunnelAttempt - 1));
+    tunnelRetryDelayMs = delayMs;
+    setTunnelState(TUNNEL_STATES.STOPPED, `${message}; retrying in ${formatRetryDelay(delayMs)}`, "warn");
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      tunnelRetryDelayMs = null;
+      void connectTunnel();
+    }, delayMs);
+  }
+
+  async function verifyAndMarkReady(publicAccessUrl, attemptNumber) {
+    if (stopping || publicAccessUrl !== publicUrl || attemptNumber !== tunnelAttempt) {
+      return;
+    }
+
+    if (verificationInFlight) {
+      pendingVerification = { publicAccessUrl, attemptNumber };
+      return;
+    }
+
+    verificationInFlight = true;
+    pendingVerification = null;
+    try {
+      await verifyTunnel(publicAccessUrl, {
+        attempts: verifyAttempts,
+        delayMs: verifyDelayMs,
+        onProgress: (attempt, total) => {
+          setTunnelState(TUNNEL_STATES.VERIFYING, `Verifying public URL (${attempt}/${total})`);
+        },
+      });
+
+      if (stopping || publicAccessUrl !== publicUrl || attemptNumber !== tunnelAttempt) {
+        return;
+      }
+
+      clearRetryTimer();
+      tunnelAttempt = 0;
+      setTunnelError(null);
+      setTunnelState(TUNNEL_STATES.READY, `Public URL ready: ${stripTokenFromUrl(publicAccessUrl)}`, "succeed");
+    } catch (error) {
+      if (stopping || publicAccessUrl !== publicUrl || attemptNumber !== tunnelAttempt) {
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      await scheduleRetry(`Tunnel verification failed: ${message}`);
+    } finally {
+      verificationInFlight = false;
+      const nextVerification = pendingVerification;
+      pendingVerification = null;
+      if (
+        !stopping &&
+        nextVerification &&
+        nextVerification.publicAccessUrl === publicUrl &&
+        nextVerification.attemptNumber === tunnelAttempt
+      ) {
+        void verifyAndMarkReady(nextVerification.publicAccessUrl, nextVerification.attemptNumber);
+      }
+    }
+  }
+
+  async function connectTunnel() {
+    if (stopping || !tunnelEnabled) {
+      return;
+    }
+
+    clearRetryTimer();
+    tunnelAttempt += 1;
+    const attemptNumber = tunnelAttempt;
+    const attemptLabel = `attempt ${tunnelAttempt}`;
+
+    try {
+      setTunnelState(TUNNEL_STATES.PREPARING, `Preparing Cloudflare Quick Tunnel (${attemptLabel})`);
+      if (!options.tunnelFactory) {
+        await ensureCloudflaredBinary(logger);
+      }
+
+      setTunnelState(TUNNEL_STATES.CONNECTING, `Starting Cloudflare Quick Tunnel (${attemptLabel})`);
+      tunnel = createTunnel(`http://127.0.0.1:${activePort}`, token, {
+        logger,
+        qrWriter,
+        setPublicUrl,
+        setTunnelError,
+        tunnelFactory: options.tunnelFactory || ((target) => Tunnel.quick(target)),
+        onConnected: (connection) => {
+          const location = connection && connection.location ? connection.location : "unknown";
+          setTunnelState(TUNNEL_STATES.TUNNELING, `Tunnel connected via ${location}`);
+        },
+        onTunneling: (publicAccessUrl) => {
+          setTunnelState(TUNNEL_STATES.TUNNELING, `Public URL issued: ${stripTokenFromUrl(publicAccessUrl)}`);
+        },
+        onReadyRequested: (publicAccessUrl) => {
+          void verifyAndMarkReady(publicAccessUrl, attemptNumber);
+        },
+        onFailure: (message) => {
+          void scheduleRetry(message);
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setTunnelError(message);
+      await scheduleRetry(`Cloudflare Quick Tunnel unavailable: ${message}`);
+    }
+  }
+
   async function stop() {
     if (stopPromise) {
       return stopPromise;
     }
 
     stopPromise = (async () => {
+      stopping = true;
+      clearRetryTimer();
       if (tunnel) {
         tunnel.stop();
+        tunnel = null;
       }
 
       if (shellRunning) {
@@ -270,6 +574,10 @@ async function startRemoteTerminal(options = {}) {
         new Promise((resolve) => io.close(() => resolve())),
         new Promise((resolve) => server.close(() => resolve())),
       ]);
+
+      if (spinner && typeof spinner.stop === "function") {
+        spinner.stop();
+      }
 
       closedResolve();
     })();
@@ -283,6 +591,9 @@ async function startRemoteTerminal(options = {}) {
       port: server.address().port,
       localOrigin: stripTokenFromUrl(buildAccessUrl(`http://${accessHost}:${server.address().port}/`, token)),
       publicOrigin: stripTokenFromUrl(publicUrl),
+      tunnelState,
+      tunnelAttempt,
+      tunnelRetryDelayMs,
       tunnelError,
       shell: shell.command,
       shellArgs: shell.args,
@@ -385,22 +696,7 @@ async function startRemoteTerminal(options = {}) {
   });
 
   if (tunnelEnabled) {
-    try {
-      if (!options.tunnelFactory) {
-        await ensureCloudflaredBinary(logger);
-      }
-      logger(`Starting Cloudflare Quick Tunnel for http://127.0.0.1:${activePort} ...`);
-      tunnel = createTunnel(`http://127.0.0.1:${activePort}`, token, {
-        logger,
-        qrWriter,
-        setPublicUrl,
-        setTunnelError,
-        tunnelFactory: options.tunnelFactory || ((target) => Tunnel.quick(target)),
-      });
-    } catch (error) {
-      tunnelError = error instanceof Error ? error.message : String(error);
-      logger(`Cloudflare Quick Tunnel unavailable: ${tunnelError}`);
-    }
+    await connectTunnel();
   }
 
   return {
@@ -411,6 +707,12 @@ async function startRemoteTerminal(options = {}) {
     localUrl,
     get publicUrl() {
       return publicUrl;
+    },
+    get tunnelState() {
+      return tunnelState;
+    },
+    get tunnelRetryDelayMs() {
+      return tunnelRetryDelayMs;
     },
     lastResize,
     closed,
@@ -435,7 +737,14 @@ async function main() {
 
 module.exports = {
   DEFAULT_PORT,
+  DEFAULT_TUNNEL_RETRY_BASE_MS,
+  DEFAULT_TUNNEL_RETRY_MAX_MS,
+  DEFAULT_TUNNEL_VERIFY_ATTEMPTS,
+  DEFAULT_TUNNEL_VERIFY_DELAY_MS,
+  TUNNEL_STATES,
   buildAccessUrl,
+  defaultVerifyTunnel,
+  formatRetryDelay,
   isValidToken,
   pickAccessHost,
   resolvePort,

--- a/remote-terminal/test/server.test.js
+++ b/remote-terminal/test/server.test.js
@@ -9,6 +9,7 @@ const { io } = require("socket.io-client");
 
 const {
   DEFAULT_PORT,
+  TUNNEL_STATES,
   buildAccessUrl,
   resolvePort,
   stripTokenFromUrl,
@@ -25,6 +26,49 @@ async function waitFor(check, message, timeout = 8000) {
   }
 
   throw new Error(message);
+}
+
+function createSpinnerRecorder(events = []) {
+  return {
+    isSpinning: false,
+    _text: "",
+    get text() {
+      return this._text;
+    },
+    set text(value) {
+      this._text = value;
+      events.push(`text:${value}`);
+    },
+    start(text) {
+      this.isSpinning = true;
+      if (text) {
+        this.text = text;
+      }
+      events.push(`start:${this.text}`);
+      return this;
+    },
+    stop() {
+      this.isSpinning = false;
+      events.push(`stop:${this.text}`);
+      return this;
+    },
+    succeed(text) {
+      this.isSpinning = false;
+      if (text) {
+        this.text = text;
+      }
+      events.push(`succeed:${this.text}`);
+      return this;
+    },
+    warn(text) {
+      this.isSpinning = false;
+      if (text) {
+        this.text = text;
+      }
+      events.push(`warn:${this.text}`);
+      return this;
+    },
+  };
 }
 
 async function connectClient(remoteTerminal, token) {
@@ -62,6 +106,7 @@ test("health endpoint is public but the terminal page stays token gated", async 
   assert.equal(payload.port, remoteTerminal.port);
   assert.equal(payload.localOrigin, stripTokenFromUrl(remoteTerminal.localUrl));
   assert.equal(payload.publicOrigin, null);
+  assert.equal(payload.tunnelState, TUNNEL_STATES.STOPPED);
   assert.equal(JSON.stringify(payload).includes("issue75-health-token"), false);
 
   const denied = await fetch(`http://127.0.0.1:${remoteTerminal.port}/`);
@@ -183,6 +228,7 @@ test("Cloudflare Quick Tunnel URLs become tokenized public access links", async 
     accessHost: "127.0.0.1",
     logger: () => {},
     qrWriter: (label, url) => qrCodes.push({ label, url }),
+    spinnerFactory: () => createSpinnerRecorder(),
     token: "issue75-tunnel-token",
     port: 0,
     tunnelFactory: () => tunnel,
@@ -207,6 +253,155 @@ test("Cloudflare Quick Tunnel URLs become tokenized public access links", async 
   assert.equal(stopCalls > 0, true);
 });
 
+test("tunnel state machine reaches READY and reports spinner progress", async (t) => {
+  const spinnerEvents = [];
+  const tunnel = new EventEmitter();
+  tunnel.stop = () => true;
+
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    logger: () => {},
+    spinnerFactory: () => createSpinnerRecorder(spinnerEvents),
+    token: "issue77-ready-token",
+    port: 0,
+    tunnelFactory: () => tunnel,
+    verifyTunnel: async (_url, options) => {
+      options.onProgress(1, 1);
+    },
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  tunnel.emit("connected", { location: "test-edge" });
+  tunnel.emit("url", "https://issue77.trycloudflare.com");
+
+  await waitFor(() => remoteTerminal.tunnelState === TUNNEL_STATES.READY, "tunnel never reached READY");
+
+  const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
+  const payload = await health.json();
+  assert.equal(payload.tunnelState, TUNNEL_STATES.READY);
+  assert.equal(payload.publicOrigin, stripTokenFromUrl(remoteTerminal.publicUrl));
+
+  const joined = spinnerEvents.join("\n");
+  assert.match(joined, /\[PREPARING\]/);
+  assert.match(joined, /\[CONNECTING\]/);
+  assert.match(joined, /\[TUNNELING\]/);
+  assert.match(joined, /\[VERIFYING\]/);
+  assert.match(joined, /\[READY\]/);
+});
+
+test("disconnects schedule an automatic tunnel retry", async (t) => {
+  const firstTunnel = new EventEmitter();
+  firstTunnel.stop = () => true;
+  const secondTunnel = new EventEmitter();
+  secondTunnel.stop = () => true;
+
+  const tunnels = [firstTunnel, secondTunnel];
+  let tunnelCalls = 0;
+
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    logger: () => {},
+    retryBaseMs: 50,
+    retryMaxMs: 50,
+    spinnerFactory: () => createSpinnerRecorder(),
+    token: "issue77-retry-token",
+    port: 0,
+    tunnelFactory: () => tunnels[tunnelCalls++],
+    verifyTunnel: async (_url, options) => {
+      options.onProgress(1, 1);
+    },
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  firstTunnel.emit("connected", { location: "retry-edge" });
+  firstTunnel.emit("url", "https://issue77-retry.trycloudflare.com");
+  await waitFor(() => remoteTerminal.tunnelState === TUNNEL_STATES.READY, "first tunnel never reached READY");
+
+  firstTunnel.emit("disconnected", { location: "retry-edge" });
+
+  const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
+  const payload = await health.json();
+  assert.equal(payload.tunnelState, TUNNEL_STATES.STOPPED);
+  assert.equal(payload.tunnelRetryDelayMs, 50);
+  assert.equal(payload.tunnelError, "cloudflared disconnected (retry-edge)");
+
+  await waitFor(() => tunnelCalls === 2, "retry did not start a new tunnel");
+});
+
+test("replacement tunnels re-queue verification without spawning extra retries", async (t) => {
+  const firstTunnel = new EventEmitter();
+  let firstStopCalls = 0;
+  firstTunnel.stop = () => {
+    firstStopCalls += 1;
+    return true;
+  };
+
+  const secondTunnel = new EventEmitter();
+  let secondStopCalls = 0;
+  secondTunnel.stop = () => {
+    secondStopCalls += 1;
+    return true;
+  };
+
+  const tunnels = [firstTunnel, secondTunnel];
+  const verifyCalls = [];
+  let tunnelCalls = 0;
+  let rejectFirstVerification;
+
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    logger: () => {},
+    retryBaseMs: 25,
+    retryMaxMs: 25,
+    spinnerFactory: () => createSpinnerRecorder(),
+    token: "issue77-overlap-token",
+    port: 0,
+    tunnelFactory: () => tunnels[tunnelCalls++],
+    verifyTunnel: async (publicAccessUrl, options) => {
+      verifyCalls.push(publicAccessUrl);
+      options.onProgress(1, 1);
+      if (verifyCalls.length === 1) {
+        await new Promise((_, reject) => {
+          rejectFirstVerification = reject;
+        });
+      }
+    },
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  firstTunnel.emit("connected", { location: "first-edge" });
+  firstTunnel.emit("url", "https://issue77-first.trycloudflare.com");
+  await waitFor(() => verifyCalls.length === 1, "first tunnel verification never started");
+
+  firstTunnel.emit("disconnected", { location: "first-edge" });
+  await waitFor(() => tunnelCalls === 2, "replacement tunnel was never started");
+
+  secondTunnel.emit("connected", { location: "second-edge" });
+  secondTunnel.emit("url", "https://issue77-second.trycloudflare.com");
+  rejectFirstVerification(new Error("stale verification failed"));
+
+  await waitFor(() => verifyCalls.length === 2, "replacement tunnel verification was not re-queued");
+  await waitFor(() => remoteTerminal.tunnelState === TUNNEL_STATES.READY, "replacement tunnel never reached READY");
+  await new Promise((resolve) => setTimeout(resolve, 80));
+
+  assert.equal(firstStopCalls > 0, true);
+  assert.equal(secondStopCalls, 0);
+  assert.equal(tunnelCalls, 2);
+
+  const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
+  const payload = await health.json();
+  assert.equal(payload.tunnelState, TUNNEL_STATES.READY);
+  assert.equal(payload.tunnelAttempt, 0);
+  assert.equal(payload.tunnelError, null);
+  assert.equal(payload.publicOrigin, stripTokenFromUrl(remoteTerminal.publicUrl));
+});
+
 test("async tunnel errors clear the public origin and surface in health", async (t) => {
   const tunnel = new EventEmitter();
   tunnel.stop = () => true;
@@ -214,6 +409,9 @@ test("async tunnel errors clear the public origin and surface in health", async 
   const remoteTerminal = await startRemoteTerminal({
     accessHost: "127.0.0.1",
     logger: () => {},
+    retryBaseMs: 60000,
+    retryMaxMs: 60000,
+    spinnerFactory: () => createSpinnerRecorder(),
     token: "issue75-async-tunnel-token",
     port: 0,
     tunnelFactory: () => tunnel,
@@ -231,6 +429,8 @@ test("async tunnel errors clear the public origin and surface in health", async 
   const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
   const payload = await health.json();
   assert.equal(payload.publicOrigin, null);
+  assert.equal(payload.tunnelState, TUNNEL_STATES.STOPPED);
+  assert.equal(payload.tunnelRetryDelayMs, 60000);
   assert.equal(payload.tunnelError, "async tunnel broke");
 });
 
@@ -239,6 +439,9 @@ test("tunnel bootstrap failures stay explicit without crashing the local server"
   const remoteTerminal = await startRemoteTerminal({
     accessHost: "127.0.0.1",
     logger: (message) => logs.push(message),
+    retryBaseMs: 60000,
+    retryMaxMs: 60000,
+    spinnerFactory: () => createSpinnerRecorder(),
     token: "issue75-tunnel-failure-token",
     port: 0,
     tunnelFactory: () => {
@@ -253,6 +456,8 @@ test("tunnel bootstrap failures stay explicit without crashing the local server"
   const payload = await health.json();
   assert.equal(payload.ok, true);
   assert.equal(payload.publicOrigin, null);
+  assert.equal(payload.tunnelState, TUNNEL_STATES.STOPPED);
+  assert.equal(payload.tunnelRetryDelayMs, 60000);
   assert.equal(payload.tunnelError, "fake tunnel bootstrap failure");
   assert.match(logs.join("\n"), /Cloudflare Quick Tunnel unavailable: fake tunnel bootstrap failure/);
 });


### PR DESCRIPTION
## Summary
- add a Cloudflare Quick Tunnel state machine with spinner progress and health-state reporting
- verify public tunnel readiness before marking READY and retry with exponential backoff on bootstrap, verify, disconnect, or exit failures
- add regression coverage for overlap between retry scheduling and in-flight verification

## Testing
- npm.cmd --script-shell pwsh test

Closes #77