### PR TITLE
feat(remote-terminal): harden QR auth flow

### DIFF
--- a/remote-terminal/README.md
+++ b/remote-terminal/README.md
@@ -19,7 +19,7 @@ npm start
 By default the server:
 
 1. listens on `0.0.0.0:2208`
-2. generates a random token
+2. generates a one-time QR token that expires after 30 minutes
 3. prints a LAN QR code immediately
 4. starts a Cloudflare Quick Tunnel state machine with an `ora` progress spinner
 5. retries tunnel setup after disconnects / tunnel errors with exponential backoff
@@ -39,7 +39,7 @@ STOPPED → PREPARING → CONNECTING → TUNNELING → VERIFYING → READY
 | --- | --- | --- |
 | `REMOTE_TERMINAL_PORT` | HTTP / Socket.IO port | `2208` |
 | `REMOTE_TERMINAL_HOST` | Bind host | `0.0.0.0` |
-| `REMOTE_TERMINAL_TOKEN` | Fixed access token instead of a random one | random 48-char hex |
+| `REMOTE_TERMINAL_TOKEN` | Fixed trusted-device token that stays valid across restarts and does not auto-expire | random 48-char hex one-time token |
 | `REMOTE_TERMINAL_ACCESS_HOST` | Override the QR code host/IP | first non-loopback IPv4 |
 | `REMOTE_TERMINAL_SHELL` | Override the spawned shell executable | `powershell.exe` on Windows, `$SHELL` or `/bin/bash` elsewhere |
 | `REMOTE_TERMINAL_DISABLE_TUNNEL` | Skip Cloudflare Quick Tunnel startup | unset / `false` |
@@ -47,7 +47,11 @@ STOPPED → PREPARING → CONNECTING → TUNNELING → VERIFYING → READY
 ## Notes
 
 - Open the printed URL directly if you already have the token; the HTML page and the WebSocket both require the same token.
+- Generated QR tokens are one-time session keys: after 30 minutes they stop authorizing new page loads and new Socket.IO connections, but existing terminal sessions are left alone until they disconnect.
+- Failed HTTP and WebSocket auth attempts are rate limited to 5 tries per 60 seconds per client IP to make token guessing noisy and self-limiting.
+- When traffic is relayed through a local `cloudflared` process, the rate limiter prefers `CF-Connecting-IP` / `X-Forwarded-For` over the loopback relay address so different remote clients do not share one auth bucket.
+- `REMOTE_TERMINAL_TOKEN` is the supported trusted-device flow for operators who want a stable QR code or a bookmarkable fixed URL.
 - `Ctrl+C`, `Ctrl+D`, tab completion, and resize handling are delegated to the real PTY-backed shell, so shell behavior stays native instead of being emulated in JavaScript.
 - For LAN-only smoke tests, start with `REMOTE_TERMINAL_DISABLE_TUNNEL=1 npm start`.
-- `/health` exposes the tunnel state machine (`tunnelState`, `tunnelRetryDelayMs`, `tunnelError`) without leaking the access token.
+- `/health` exposes the tunnel state machine (`tunnelState`, `tunnelRetryDelayMs`, `tunnelError`) plus auth metadata (`persistentToken`, `tokenExpiresAt`) without leaking the access token.
 - If your local Windows environment has a custom `cmd.exe` / PATH setup that prevents npm lifecycle scripts from seeing `node`, run `npm --script-shell pwsh <command>` for local verification. That is an environment workaround, not a package requirement.

--- a/remote-terminal/server.js
+++ b/remote-terminal/server.js
@@ -23,6 +23,9 @@ const DEFAULT_TUNNEL_RETRY_BASE_MS = 1000;
 const DEFAULT_TUNNEL_RETRY_MAX_MS = 30000;
 const DEFAULT_TUNNEL_VERIFY_ATTEMPTS = 12;
 const DEFAULT_TUNNEL_VERIFY_DELAY_MS = 5000;
+const DEFAULT_AUTH_TOKEN_TTL_MS = 30 * 60 * 1000;
+const DEFAULT_AUTH_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const DEFAULT_AUTH_RATE_LIMIT_MAX_ATTEMPTS = 5;
 const PUBLIC_DIR = path.join(__dirname, "public");
 const XTERM_DIR = path.dirname(require.resolve("@xterm/xterm/package.json"));
 const XTERM_ADDON_DIR = path.dirname(require.resolve("@xterm/addon-fit/package.json"));
@@ -116,8 +119,14 @@ function resolveShell(command, args) {
   };
 }
 
-function createToken(explicitToken) {
-  return explicitToken || process.env.REMOTE_TERMINAL_TOKEN || crypto.randomBytes(24).toString("hex");
+function createAccessToken(explicitToken, options = {}) {
+  const configuredToken = explicitToken || process.env.REMOTE_TERMINAL_TOKEN || null;
+  const now = options.now || Date.now;
+  return {
+    value: configuredToken || crypto.randomBytes(24).toString("hex"),
+    persistent: Boolean(configuredToken),
+    expiresAt: configuredToken ? null : now() + (options.tokenTtlMs ?? DEFAULT_AUTH_TOKEN_TTL_MS),
+  };
 }
 
 function isValidToken(expectedToken, candidate) {
@@ -128,6 +137,116 @@ function isValidToken(expectedToken, candidate) {
   const expected = Buffer.from(expectedToken);
   const actual = Buffer.from(candidate);
   return expected.length === actual.length && crypto.timingSafeEqual(expected, actual);
+}
+
+function isTokenExpired(accessToken, now = Date.now) {
+  return accessToken.expiresAt !== null && now() >= accessToken.expiresAt;
+}
+
+function validateAccessToken(accessToken, candidate, now = Date.now) {
+  if (isTokenExpired(accessToken, now)) {
+    return {
+      ok: false,
+      message: "access token expired",
+      reason: "expired",
+    };
+  }
+
+  return isValidToken(accessToken.value, candidate)
+    ? { ok: true }
+    : {
+        ok: false,
+        message: "missing or invalid token",
+        reason: "invalid",
+      };
+}
+
+function isLoopbackAddress(address) {
+  return ["127.0.0.1", "::1", "::ffff:127.0.0.1"].includes(address);
+}
+
+function firstHeaderValue(value) {
+  if (Array.isArray(value)) {
+    return firstHeaderValue(value[0]);
+  }
+
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function getForwardedClientId(headers = {}) {
+  const cfConnectingIp = firstHeaderValue(headers["cf-connecting-ip"]);
+  if (cfConnectingIp) {
+    return cfConnectingIp;
+  }
+
+  const xForwardedFor = firstHeaderValue(headers["x-forwarded-for"]);
+  if (!xForwardedFor) {
+    return null;
+  }
+
+  const [firstClient] = xForwardedFor.split(",");
+  const clientId = firstClient ? firstClient.trim() : "";
+  return clientId || null;
+}
+
+function createAuthRateLimiter(options = {}) {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_AUTH_RATE_LIMIT_MAX_ATTEMPTS;
+  const windowMs = options.windowMs ?? DEFAULT_AUTH_RATE_LIMIT_WINDOW_MS;
+  const now = options.now || Date.now;
+  const attemptsByClient = new Map();
+
+  function getClientId(rawClientId) {
+    return rawClientId || "unknown";
+  }
+
+  function pruneExpiredEntries(currentTime) {
+    for (const [clientId, entry] of attemptsByClient.entries()) {
+      if (currentTime >= entry.resetAt) {
+        attemptsByClient.delete(clientId);
+      }
+    }
+  }
+
+  function getEntry(clientId) {
+    const entry = attemptsByClient.get(clientId);
+    return entry || null;
+  }
+
+  return {
+    check(rawClientId) {
+      const clientId = getClientId(rawClientId);
+      const currentTime = now();
+      pruneExpiredEntries(currentTime);
+      const entry = getEntry(clientId);
+      if (!entry || entry.count < maxAttempts) {
+        return {
+          limited: false,
+          retryAfterMs: 0,
+        };
+      }
+
+      return {
+        limited: true,
+        retryAfterMs: Math.max(0, entry.resetAt - currentTime),
+      };
+    },
+    recordFailure(rawClientId) {
+      const clientId = getClientId(rawClientId);
+      const currentTime = now();
+      pruneExpiredEntries(currentTime);
+      const existing = getEntry(clientId);
+      const entry = existing || {
+        count: 0,
+        resetAt: currentTime + windowMs,
+      };
+      entry.count += 1;
+      attemptsByClient.set(clientId, entry);
+      return entry.count;
+    },
+    reset(rawClientId) {
+      attemptsByClient.delete(getClientId(rawClientId));
+    },
+  };
 }
 
 function renderQrCode(url, { label, logger, qrWriter }) {
@@ -326,7 +445,12 @@ async function startRemoteTerminal(options = {}) {
   const host = options.host || process.env.REMOTE_TERMINAL_HOST || DEFAULT_HOST;
   const accessHost = pickAccessHost(options.accessHost || process.env.REMOTE_TERMINAL_ACCESS_HOST);
   const port = resolvePort(options.port);
-  const token = createToken(options.token);
+  const now = options.now || Date.now;
+  const accessToken = createAccessToken(options.token, {
+    now,
+    tokenTtlMs: options.tokenTtlMs,
+  });
+  const token = accessToken.value;
   const shell = resolveShell(options.shellCommand, options.shellArgs);
   const cwd = options.cwd || process.cwd();
   const env = {
@@ -342,6 +466,13 @@ async function startRemoteTerminal(options = {}) {
   const retryMaxMs = options.retryMaxMs ?? DEFAULT_TUNNEL_RETRY_MAX_MS;
   const verifyAttempts = options.verifyAttempts ?? DEFAULT_TUNNEL_VERIFY_ATTEMPTS;
   const verifyDelayMs = options.verifyDelayMs ?? DEFAULT_TUNNEL_VERIFY_DELAY_MS;
+  const authRateLimitWindowMs = options.authRateLimitWindowMs ?? DEFAULT_AUTH_RATE_LIMIT_WINDOW_MS;
+  const authRateLimitMaxAttempts = options.authRateLimitMaxAttempts ?? DEFAULT_AUTH_RATE_LIMIT_MAX_ATTEMPTS;
+  const authRateLimiter = createAuthRateLimiter({
+    maxAttempts: authRateLimitMaxAttempts,
+    now,
+    windowMs: authRateLimitWindowMs,
+  });
 
   const app = express();
   app.disable("x-powered-by");
@@ -433,6 +564,68 @@ async function startRemoteTerminal(options = {}) {
       retryTimer = null;
     }
     tunnelRetryDelayMs = null;
+  }
+
+  function getRequestClientId(req) {
+    const directAddress = req.socket && req.socket.remoteAddress;
+    if (isLoopbackAddress(directAddress)) {
+      const forwardedClientId = getForwardedClientId(req.headers);
+      if (forwardedClientId) {
+        return forwardedClientId;
+      }
+    }
+
+    return req.ip || directAddress || "unknown";
+  }
+
+  function getSocketClientId(socket) {
+    const directAddress =
+      (socket.request && socket.request.socket && socket.request.socket.remoteAddress) || socket.handshake.address;
+    if (isLoopbackAddress(directAddress)) {
+      const forwardedClientId = getForwardedClientId(socket.handshake.headers);
+      if (forwardedClientId) {
+        return forwardedClientId;
+      }
+    }
+
+    return socket.handshake.address || directAddress || "unknown";
+  }
+
+  function authenticateClient(clientId, candidateToken) {
+    const rateLimitState = authRateLimiter.check(clientId);
+    if (rateLimitState.limited) {
+      return {
+        ok: false,
+        message: "too many auth attempts",
+        retryAfterMs: rateLimitState.retryAfterMs,
+        status: 429,
+      };
+    }
+
+    const validation = validateAccessToken(accessToken, candidateToken, now);
+    if (!validation.ok) {
+      if (validation.reason === "invalid") {
+        authRateLimiter.recordFailure(clientId);
+      }
+      return {
+        ok: false,
+        message: validation.message,
+        status: 401,
+      };
+    }
+
+    authRateLimiter.reset(clientId);
+    return {
+      ok: true,
+    };
+  }
+
+  function sendAuthFailure(res, authResult) {
+    if (authResult.retryAfterMs) {
+      res.set("Retry-After", String(Math.max(1, Math.ceil(authResult.retryAfterMs / 1000))));
+    }
+
+    res.status(authResult.status).type("text/plain").send(authResult.message);
   }
 
   async function scheduleRetry(message) {
@@ -600,12 +793,18 @@ async function startRemoteTerminal(options = {}) {
       shellExit,
       lastResize,
       tunnelEnabled,
+      persistentToken: accessToken.persistent,
+      tokenExpiresAt: accessToken.expiresAt === null ? null : new Date(accessToken.expiresAt).toISOString(),
+      authRateLimitMaxAttempts,
+      authRateLimitWindowMs,
     });
   });
 
   app.get("/", (req, res) => {
-    if (!isValidToken(token, req.query.token)) {
-      res.status(401).type("text/plain").send("missing or invalid token");
+    const providedToken = Array.isArray(req.query.token) ? req.query.token[0] : req.query.token;
+    const authResult = authenticateClient(getRequestClientId(req), providedToken);
+    if (!authResult.ok) {
+      sendAuthFailure(res, authResult);
       return;
     }
 
@@ -634,8 +833,19 @@ async function startRemoteTerminal(options = {}) {
 
   io.use((socket, next) => {
     const providedToken = socket.handshake.auth.token || socket.handshake.query.token;
-    if (!isValidToken(token, Array.isArray(providedToken) ? providedToken[0] : providedToken)) {
-      next(new Error("unauthorized"));
+    const authResult = authenticateClient(getSocketClientId(socket), Array.isArray(providedToken) ? providedToken[0] : providedToken);
+    if (!authResult.ok) {
+      const error = new Error(
+        authResult.status === 401 && authResult.message === "missing or invalid token"
+          ? "unauthorized"
+          : authResult.message,
+      );
+      if (authResult.retryAfterMs) {
+        error.data = {
+          retryAfterMs: authResult.retryAfterMs,
+        };
+      }
+      next(error);
       return;
     }
 
@@ -689,6 +899,11 @@ async function startRemoteTerminal(options = {}) {
   const localUrl = buildAccessUrl(`http://${accessHost}:${activePort}/`, token);
   logger(`Remote terminal listening on http://${host}:${activePort}`);
   logger(`Shell: ${shell.command}${shell.args.length ? ` ${shell.args.join(" ")}` : ""}`);
+  if (accessToken.persistent) {
+    logger("Auth: persistent trusted-device token enabled");
+  } else {
+    logger(`Auth: one-time QR token expires at ${new Date(accessToken.expiresAt).toISOString()}`);
+  }
   renderQrCode(localUrl, {
     label: "Local access QR",
     logger,
@@ -707,6 +922,12 @@ async function startRemoteTerminal(options = {}) {
     localUrl,
     get publicUrl() {
       return publicUrl;
+    },
+    get persistentToken() {
+      return accessToken.persistent;
+    },
+    get tokenExpiresAt() {
+      return accessToken.expiresAt;
     },
     get tunnelState() {
       return tunnelState;
@@ -736,6 +957,9 @@ async function main() {
 }
 
 module.exports = {
+  DEFAULT_AUTH_RATE_LIMIT_MAX_ATTEMPTS,
+  DEFAULT_AUTH_RATE_LIMIT_WINDOW_MS,
+  DEFAULT_AUTH_TOKEN_TTL_MS,
   DEFAULT_PORT,
   DEFAULT_TUNNEL_RETRY_BASE_MS,
   DEFAULT_TUNNEL_RETRY_MAX_MS,

--- a/remote-terminal/test/server.test.js
+++ b/remote-terminal/test/server.test.js
@@ -8,6 +8,8 @@ const test = require("node:test");
 const { io } = require("socket.io-client");
 
 const {
+  DEFAULT_AUTH_RATE_LIMIT_MAX_ATTEMPTS,
+  DEFAULT_AUTH_TOKEN_TTL_MS,
   DEFAULT_PORT,
   TUNNEL_STATES,
   buildAccessUrl,
@@ -139,6 +141,170 @@ test("invalid socket auth is rejected", async (t) => {
 
   const [error] = await once(socket, "connect_error");
   assert.match(error.message, /unauthorized/);
+});
+
+test("generated QR tokens expire for new page and socket auth", async (t) => {
+  let nowValue = 1000;
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    disableTunnel: true,
+    logger: () => {},
+    now: () => nowValue,
+    port: 0,
+    tokenTtlMs: 200,
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  const validPage = await fetch(remoteTerminal.localUrl);
+  assert.equal(validPage.status, 200);
+
+  nowValue += 201;
+
+  const expiredPage = await fetch(remoteTerminal.localUrl);
+  assert.equal(expiredPage.status, 401);
+  assert.match(await expiredPage.text(), /expired/);
+
+  const socket = io(`http://127.0.0.1:${remoteTerminal.port}`, {
+    auth: { token: remoteTerminal.token },
+    reconnection: false,
+    transports: ["websocket"],
+  });
+  t.after(() => socket.close());
+
+  const [error] = await once(socket, "connect_error");
+  assert.match(error.message, /expired/);
+
+  const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
+  const payload = await health.json();
+  assert.equal(payload.persistentToken, false);
+  assert.equal(payload.tokenExpiresAt, new Date(remoteTerminal.tokenExpiresAt).toISOString());
+});
+
+test("expired tokens do not consume the auth rate-limit budget", async (t) => {
+  let nowValue = 1500;
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    authRateLimitMaxAttempts: 2,
+    authRateLimitWindowMs: 1000,
+    disableTunnel: true,
+    logger: () => {},
+    now: () => nowValue,
+    port: 0,
+    tokenTtlMs: 200,
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  nowValue += 201;
+
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const expiredPage = await fetch(remoteTerminal.localUrl);
+    assert.equal(expiredPage.status, 401);
+    assert.match(await expiredPage.text(), /expired/);
+  }
+});
+
+test("trusted-device tokens stay valid beyond the one-time QR TTL", async (t) => {
+  let nowValue = 2000;
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    disableTunnel: true,
+    logger: () => {},
+    now: () => nowValue,
+    port: 0,
+    token: "issue78-trusted-device-token",
+    tokenTtlMs: 200,
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  nowValue += 1000;
+
+  const allowed = await fetch(remoteTerminal.localUrl);
+  assert.equal(allowed.status, 200);
+  assert.equal(remoteTerminal.persistentToken, true);
+  assert.equal(remoteTerminal.tokenExpiresAt, null);
+
+  const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
+  const payload = await health.json();
+  assert.equal(payload.persistentToken, true);
+  assert.equal(payload.tokenExpiresAt, null);
+});
+
+test("invalid auth attempts are rate limited per client", async (t) => {
+  const authRateLimitWindowMs = 1000;
+  let nowValue = 3000;
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    authRateLimitMaxAttempts: DEFAULT_AUTH_RATE_LIMIT_MAX_ATTEMPTS,
+    authRateLimitWindowMs,
+    disableTunnel: true,
+    logger: () => {},
+    now: () => nowValue,
+    port: 0,
+    token: "issue78-rate-limit-token",
+    tokenTtlMs: DEFAULT_AUTH_TOKEN_TTL_MS,
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  for (let attempt = 0; attempt < DEFAULT_AUTH_RATE_LIMIT_MAX_ATTEMPTS; attempt += 1) {
+    const response = await fetch(`http://127.0.0.1:${remoteTerminal.port}/?token=wrong-token`);
+    assert.equal(response.status, 401);
+  }
+
+  const limited = await fetch(`http://127.0.0.1:${remoteTerminal.port}/?token=wrong-token`);
+  assert.equal(limited.status, 429);
+  assert.equal(limited.headers.get("retry-after"), String(Math.ceil(authRateLimitWindowMs / 1000)));
+  assert.match(await limited.text(), /too many auth attempts/);
+
+  nowValue += authRateLimitWindowMs + 1;
+
+  const recovered = await fetch(remoteTerminal.localUrl);
+  assert.equal(recovered.status, 200);
+});
+
+test("forwarded tunnel client IPs keep auth rate limiting scoped per client", async (t) => {
+  const authRateLimitWindowMs = 1000;
+  let nowValue = 4000;
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    authRateLimitMaxAttempts: DEFAULT_AUTH_RATE_LIMIT_MAX_ATTEMPTS,
+    authRateLimitWindowMs,
+    disableTunnel: true,
+    logger: () => {},
+    now: () => nowValue,
+    port: 0,
+    token: "issue78-forwarded-ip-token",
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  const blockedHeaders = { "CF-Connecting-IP": "198.51.100.10" };
+  const allowedHeaders = { "CF-Connecting-IP": "198.51.100.11" };
+
+  for (let attempt = 0; attempt < DEFAULT_AUTH_RATE_LIMIT_MAX_ATTEMPTS; attempt += 1) {
+    const response = await fetch(`http://127.0.0.1:${remoteTerminal.port}/?token=wrong-token`, {
+      headers: blockedHeaders,
+    });
+    assert.equal(response.status, 401);
+  }
+
+  const blockedClient = await fetch(`http://127.0.0.1:${remoteTerminal.port}/?token=wrong-token`, {
+    headers: blockedHeaders,
+  });
+  assert.equal(blockedClient.status, 429);
+
+  const differentForwardedClient = await fetch(`http://127.0.0.1:${remoteTerminal.port}/?token=wrong-token`, {
+    headers: allowedHeaders,
+  });
+  assert.equal(differentForwardedClient.status, 401);
 });
 
 test("pty output streams through Socket.IO and resize reaches the PTY", async (t) => {


### PR DESCRIPTION
## Summary
- add expiring one-time QR tokens plus persistent trusted-device token support for remote-terminal auth
- rate limit failed HTTP and Socket.IO auth attempts, including tunneled clients forwarded through the local cloudflared relay
- document the new auth behavior and cover expiry, persistence, rate limiting, and forwarded client IDs in tests

## Testing
- npm.cmd --script-shell pwsh test

Closes #78