### PR TITLE
feat(remote-terminal): add premium terminal UX

### DIFF
--- a/remote-terminal/README.md
+++ b/remote-terminal/README.md
@@ -6,6 +6,7 @@ This package adds a token-gated browser terminal backed by:
 - `node-pty` for the PTY session
 - `Socket.IO` for bidirectional streaming
 - `xterm.js` for the browser terminal
+- `systray2` for an optional native system tray menu without Electron
 - `cloudflared` for zero-config Cloudflare Quick Tunnel URLs
 - `qrcode-terminal` for scannable QR codes in the operator console
 
@@ -26,6 +27,9 @@ By default the server:
 5. retries tunnel setup after disconnects / tunnel errors with exponential backoff
 6. keeps the PTY session inside a detached daemon so active shells survive server restarts
 7. prints a public QR code once the tunnel URL is verified
+8. lets the browser switch between six terminal themes that persist in local storage
+9. exposes a touch-friendly on-screen keyboard for Ctrl / Alt / Shift, arrows, Tab, and F1-F12
+10. enables a desktop system tray menu when the host has a local GUI session
 
 ## Tunnel states
 
@@ -45,6 +49,8 @@ STOPPED → PREPARING → CONNECTING → TUNNELING → VERIFYING → READY
 | `REMOTE_TERMINAL_ACCESS_HOST` | Override the QR code host/IP | first non-loopback IPv4 |
 | `REMOTE_TERMINAL_SHELL` | Override the spawned shell executable | `powershell.exe` on Windows, `$SHELL` or `/bin/bash` elsewhere |
 | `REMOTE_TERMINAL_DISABLE_TUNNEL` | Skip Cloudflare Quick Tunnel startup | unset / `false` |
+| `REMOTE_TERMINAL_ENABLE_TRAY` | Force-enable the native tray integration even outside the default desktop detection | unset |
+| `REMOTE_TERMINAL_DISABLE_TRAY` | Force-disable the native tray integration | unset / `false` |
 
 ## PTY daemon IPC
 
@@ -69,13 +75,16 @@ The HTTP / Socket.IO server talks to `pty-daemon.js` over newline-delimited JSON
 ## Notes
 
 - Open the printed URL directly if you already have the token; the HTML page and the WebSocket both require the same token.
+- The browser UI ships with six themes: Default, Light, Dracula, Monokai, Solarized Dark, and Solarized Light. The selected theme persists in the current browser via `localStorage`.
+- Phones and tablets can toggle a touch keyboard that adds modifier keys, arrows, Tab, Enter, Backspace, and F1-F12 without stealing focus from the PTY session.
 - Generated QR tokens are one-time session keys: after 30 minutes they stop authorizing new page loads and new Socket.IO connections, but existing terminal sessions are left alone until they disconnect.
 - Failed HTTP and WebSocket auth attempts are rate limited to 5 tries per 60 seconds per client IP to make token guessing noisy and self-limiting.
 - When traffic is relayed through a local `cloudflared` process, the rate limiter prefers `CF-Connecting-IP` / `X-Forwarded-For` over the loopback relay address so different remote clients do not share one auth bucket.
 - `REMOTE_TERMINAL_TOKEN` is the supported trusted-device flow for operators who want a stable QR code or a bookmarkable fixed URL.
 - The PTY daemon is a detached subprocess: restarting the HTTP / Socket.IO server reattaches to the existing shell session instead of killing it.
 - If the PTY daemon crashes, the server respawns it after 1 second and reconnects over the same local IPC endpoint.
+- When the host has a desktop session, the operator gets a native `systray2` menu with live tunnel status, a copy-URL action, and a "Regenerate QR code" shortcut. macOS uses a template tray icon so the menu bar adapts to light/dark appearance automatically.
 - `Ctrl+C`, `Ctrl+D`, tab completion, and resize handling are delegated to the real PTY-backed shell, so shell behavior stays native instead of being emulated in JavaScript.
 - For LAN-only smoke tests, start with `REMOTE_TERMINAL_DISABLE_TUNNEL=1 npm start`.
-- `/health` exposes the tunnel state machine (`tunnelState`, `tunnelRetryDelayMs`, `tunnelError`), daemon state (`backendMode`, `daemonConnected`, `daemonEndpoint`, `daemonPid`), and auth metadata (`persistentToken`, `tokenExpiresAt`) without leaking the access token.
+- `/health` exposes the tunnel state machine (`tunnelState`, `tunnelRetryDelayMs`, `tunnelError`), daemon state (`backendMode`, `daemonConnected`, `daemonEndpoint`, `daemonPid`), tray state (`trayEnabled`, `trayReady`, `trayStatus`, `trayError`), and auth metadata (`persistentToken`, `tokenExpiresAt`) without leaking the access token.
 - If your local Windows environment has a custom `cmd.exe` / PATH setup that prevents npm lifecycle scripts from seeing `node`, run `npm --script-shell pwsh <command>` for local verification. That is an environment workaround, not a package requirement.

--- a/remote-terminal/package-lock.json
+++ b/remote-terminal/package-lock.json
@@ -15,7 +15,8 @@
         "node-pty": "^1.1.0",
         "ora": "^9.4.0",
         "qrcode-terminal": "^0.12.0",
-        "socket.io": "^4.8.3"
+        "socket.io": "^4.8.3",
+        "systray2": "^2.1.4"
       },
       "devDependencies": {
         "socket.io-client": "^4.8.3"
@@ -552,6 +553,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -621,6 +636,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -715,6 +736,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/log-symbols": {
@@ -1370,6 +1403,42 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/systray2": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/systray2/-/systray2-2.1.4.tgz",
+      "integrity": "sha512-ncviZ7m2fecb2tAAx7pl4nlbnwvSyL4GIKnRUvfiJXTsHysh3chSlxVxNk7Yj8jlfF2TsBn2CjLwCfhJQkR7/w==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.2",
+        "fs-extra": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/systray2/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/systray2/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1397,6 +1466,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/remote-terminal/package.json
+++ b/remote-terminal/package.json
@@ -18,7 +18,8 @@
     "node-pty": "^1.1.0",
     "ora": "^9.4.0",
     "qrcode-terminal": "^0.12.0",
-    "socket.io": "^4.8.3"
+    "socket.io": "^4.8.3",
+    "systray2": "^2.1.4"
   },
   "devDependencies": {
     "socket.io-client": "^4.8.3"

--- a/remote-terminal/public/client.js
+++ b/remote-terminal/public/client.js
@@ -1,67 +1,710 @@
-(function bootstrapRemoteTerminal() {
-  const terminalNode = document.getElementById("terminal");
-  const statusNode = document.getElementById("status");
-  const search = new URLSearchParams(window.location.search);
-  const token = search.get("token");
-
-  if (!token) {
-    statusNode.textContent = "Missing token. Re-open the QR URL from the operator terminal.";
-    return;
-  }
-
-  const terminal = new window.Terminal({
-    cursorBlink: true,
-    convertEol: true,
-    scrollback: 5000,
-    theme: {
-      background: "#050816",
-      foreground: "#e2e8f0",
-      cursor: "#7dd3fc",
+(function remoteTerminalClient(globalScope) {
+  const THEME_STORAGE_KEY = "remote-terminal-theme";
+  const KEYBOARD_VISIBILITY_STORAGE_KEY = "remote-terminal-keyboard-open";
+  const THEME_DEFINITIONS = Object.freeze({
+    default: {
+      colorScheme: "dark",
+      id: "default",
+      label: "Default",
+      ui: {
+        accent: "#7dd3fc",
+        appBg: "#050816",
+        buttonBg: "rgba(15, 23, 42, 0.92)",
+        buttonBorder: "rgba(125, 211, 252, 0.28)",
+        buttonText: "#e2e8f0",
+        danger: "#f87171",
+        keyboardBg: "rgba(15, 23, 42, 0.95)",
+        mutedText: "#94a3b8",
+        panelBg: "rgba(15, 23, 42, 0.92)",
+        panelBorder: "rgba(148, 163, 184, 0.18)",
+        shadow: "0 18px 40px rgba(2, 6, 23, 0.35)",
+        statusInfo: "#7dd3fc",
+        statusOffline: "#fda4af",
+        statusOnline: "#86efac",
+        statusWarning: "#facc15",
+        surfaceBg: "#020617",
+      },
+      xterm: {
+        background: "#050816",
+        black: "#0f172a",
+        blue: "#7dd3fc",
+        brightBlack: "#334155",
+        brightBlue: "#bae6fd",
+        brightCyan: "#67e8f9",
+        brightGreen: "#86efac",
+        brightMagenta: "#f9a8d4",
+        brightRed: "#fda4af",
+        brightWhite: "#f8fafc",
+        brightYellow: "#fde68a",
+        cursor: "#7dd3fc",
+        cursorAccent: "#020617",
+        cyan: "#22d3ee",
+        foreground: "#e2e8f0",
+        green: "#4ade80",
+        magenta: "#f472b6",
+        red: "#f87171",
+        selectionBackground: "#1e293b",
+        white: "#cbd5f5",
+        yellow: "#facc15",
+      },
+    },
+    light: {
+      colorScheme: "light",
+      id: "light",
+      label: "Light",
+      ui: {
+        accent: "#2563eb",
+        appBg: "#e2e8f0",
+        buttonBg: "rgba(255, 255, 255, 0.92)",
+        buttonBorder: "rgba(37, 99, 235, 0.2)",
+        buttonText: "#0f172a",
+        danger: "#dc2626",
+        keyboardBg: "rgba(255, 255, 255, 0.95)",
+        mutedText: "#475569",
+        panelBg: "rgba(255, 255, 255, 0.94)",
+        panelBorder: "rgba(148, 163, 184, 0.45)",
+        shadow: "0 16px 36px rgba(148, 163, 184, 0.3)",
+        statusInfo: "#2563eb",
+        statusOffline: "#dc2626",
+        statusOnline: "#15803d",
+        statusWarning: "#b45309",
+        surfaceBg: "#f8fafc",
+      },
+      xterm: {
+        background: "#ffffff",
+        black: "#1f2937",
+        blue: "#2563eb",
+        brightBlack: "#64748b",
+        brightBlue: "#1d4ed8",
+        brightCyan: "#0f766e",
+        brightGreen: "#15803d",
+        brightMagenta: "#a21caf",
+        brightRed: "#dc2626",
+        brightWhite: "#0f172a",
+        brightYellow: "#a16207",
+        cursor: "#2563eb",
+        cursorAccent: "#ffffff",
+        cyan: "#0f766e",
+        foreground: "#0f172a",
+        green: "#15803d",
+        magenta: "#a21caf",
+        red: "#dc2626",
+        selectionBackground: "#bfdbfe",
+        white: "#475569",
+        yellow: "#a16207",
+      },
+    },
+    dracula: {
+      colorScheme: "dark",
+      id: "dracula",
+      label: "Dracula",
+      ui: {
+        accent: "#bd93f9",
+        appBg: "#282a36",
+        buttonBg: "rgba(68, 71, 90, 0.92)",
+        buttonBorder: "rgba(189, 147, 249, 0.26)",
+        buttonText: "#f8f8f2",
+        danger: "#ff5555",
+        keyboardBg: "rgba(40, 42, 54, 0.96)",
+        mutedText: "#c0c4d6",
+        panelBg: "rgba(40, 42, 54, 0.94)",
+        panelBorder: "rgba(98, 114, 164, 0.55)",
+        shadow: "0 18px 42px rgba(22, 24, 33, 0.45)",
+        statusInfo: "#8be9fd",
+        statusOffline: "#ff5555",
+        statusOnline: "#50fa7b",
+        statusWarning: "#f1fa8c",
+        surfaceBg: "#1f2230",
+      },
+      xterm: {
+        background: "#282a36",
+        black: "#21222c",
+        blue: "#bd93f9",
+        brightBlack: "#6272a4",
+        brightBlue: "#d6acff",
+        brightCyan: "#a4ffff",
+        brightGreen: "#69ff94",
+        brightMagenta: "#ff92df",
+        brightRed: "#ff6e6e",
+        brightWhite: "#ffffff",
+        brightYellow: "#ffffa5",
+        cursor: "#ff79c6",
+        cursorAccent: "#282a36",
+        cyan: "#8be9fd",
+        foreground: "#f8f8f2",
+        green: "#50fa7b",
+        magenta: "#ff79c6",
+        red: "#ff5555",
+        selectionBackground: "#44475a",
+        white: "#f8f8f2",
+        yellow: "#f1fa8c",
+      },
+    },
+    monokai: {
+      colorScheme: "dark",
+      id: "monokai",
+      label: "Monokai",
+      ui: {
+        accent: "#a6e22e",
+        appBg: "#1f1f1b",
+        buttonBg: "rgba(39, 40, 34, 0.94)",
+        buttonBorder: "rgba(166, 226, 46, 0.2)",
+        buttonText: "#f8f8f2",
+        danger: "#f92672",
+        keyboardBg: "rgba(31, 31, 27, 0.97)",
+        mutedText: "#c7c7bd",
+        panelBg: "rgba(39, 40, 34, 0.95)",
+        panelBorder: "rgba(117, 113, 94, 0.46)",
+        shadow: "0 18px 42px rgba(9, 9, 6, 0.45)",
+        statusInfo: "#66d9ef",
+        statusOffline: "#f92672",
+        statusOnline: "#a6e22e",
+        statusWarning: "#fd971f",
+        surfaceBg: "#11110f",
+      },
+      xterm: {
+        background: "#272822",
+        black: "#272822",
+        blue: "#66d9ef",
+        brightBlack: "#75715e",
+        brightBlue: "#66d9ef",
+        brightCyan: "#a1efe4",
+        brightGreen: "#a6e22e",
+        brightMagenta: "#ae81ff",
+        brightRed: "#f92672",
+        brightWhite: "#f9f8f5",
+        brightYellow: "#fd971f",
+        cursor: "#f8f8f0",
+        cursorAccent: "#272822",
+        cyan: "#a1efe4",
+        foreground: "#f8f8f2",
+        green: "#a6e22e",
+        magenta: "#ae81ff",
+        red: "#f92672",
+        selectionBackground: "#49483e",
+        white: "#f8f8f2",
+        yellow: "#fd971f",
+      },
+    },
+    "solarized-dark": {
+      colorScheme: "dark",
+      id: "solarized-dark",
+      label: "Solarized Dark",
+      ui: {
+        accent: "#2aa198",
+        appBg: "#002b36",
+        buttonBg: "rgba(7, 54, 66, 0.94)",
+        buttonBorder: "rgba(42, 161, 152, 0.26)",
+        buttonText: "#eee8d5",
+        danger: "#dc322f",
+        keyboardBg: "rgba(0, 43, 54, 0.97)",
+        mutedText: "#93a1a1",
+        panelBg: "rgba(7, 54, 66, 0.95)",
+        panelBorder: "rgba(88, 110, 117, 0.5)",
+        shadow: "0 18px 40px rgba(0, 24, 31, 0.4)",
+        statusInfo: "#268bd2",
+        statusOffline: "#dc322f",
+        statusOnline: "#859900",
+        statusWarning: "#b58900",
+        surfaceBg: "#001f27",
+      },
+      xterm: {
+        background: "#002b36",
+        black: "#073642",
+        blue: "#268bd2",
+        brightBlack: "#586e75",
+        brightBlue: "#839496",
+        brightCyan: "#93a1a1",
+        brightGreen: "#586e75",
+        brightMagenta: "#6c71c4",
+        brightRed: "#cb4b16",
+        brightWhite: "#fdf6e3",
+        brightYellow: "#657b83",
+        cursor: "#2aa198",
+        cursorAccent: "#002b36",
+        cyan: "#2aa198",
+        foreground: "#eee8d5",
+        green: "#859900",
+        magenta: "#d33682",
+        red: "#dc322f",
+        selectionBackground: "#073642",
+        white: "#eee8d5",
+        yellow: "#b58900",
+      },
+    },
+    "solarized-light": {
+      colorScheme: "light",
+      id: "solarized-light",
+      label: "Solarized Light",
+      ui: {
+        accent: "#268bd2",
+        appBg: "#fdf6e3",
+        buttonBg: "rgba(255, 251, 235, 0.94)",
+        buttonBorder: "rgba(38, 139, 210, 0.2)",
+        buttonText: "#073642",
+        danger: "#dc322f",
+        keyboardBg: "rgba(253, 246, 227, 0.97)",
+        mutedText: "#586e75",
+        panelBg: "rgba(255, 251, 235, 0.95)",
+        panelBorder: "rgba(147, 161, 161, 0.42)",
+        shadow: "0 16px 36px rgba(147, 161, 161, 0.28)",
+        statusInfo: "#268bd2",
+        statusOffline: "#dc322f",
+        statusOnline: "#859900",
+        statusWarning: "#b58900",
+        surfaceBg: "#eee8d5",
+      },
+      xterm: {
+        background: "#fdf6e3",
+        black: "#073642",
+        blue: "#268bd2",
+        brightBlack: "#657b83",
+        brightBlue: "#268bd2",
+        brightCyan: "#2aa198",
+        brightGreen: "#859900",
+        brightMagenta: "#6c71c4",
+        brightRed: "#cb4b16",
+        brightWhite: "#002b36",
+        brightYellow: "#586e75",
+        cursor: "#268bd2",
+        cursorAccent: "#fdf6e3",
+        cyan: "#2aa198",
+        foreground: "#073642",
+        green: "#859900",
+        magenta: "#d33682",
+        red: "#dc322f",
+        selectionBackground: "#eee8d5",
+        white: "#586e75",
+        yellow: "#b58900",
+      },
     },
   });
-  const fitAddon = new window.FitAddon.FitAddon();
-  terminal.loadAddon(fitAddon);
-  terminal.open(terminalNode);
 
-  const socket = window.io({
-    auth: { token },
-    transports: ["websocket"],
+  const VIRTUAL_KEY_ROWS = Object.freeze([
+    Object.freeze([
+      { id: "ctrl", kind: "modifier", label: "Ctrl" },
+      { id: "alt", kind: "modifier", label: "Alt" },
+      { id: "shift", kind: "modifier", label: "Shift" },
+      { id: "esc", kind: "sequence", label: "Esc" },
+    ]),
+    Object.freeze([
+      { id: "tab", kind: "sequence", label: "Tab" },
+      { id: "left", kind: "sequence", label: "Left" },
+      { id: "up", kind: "sequence", label: "Up" },
+      { id: "down", kind: "sequence", label: "Down" },
+      { id: "right", kind: "sequence", label: "Right" },
+      { id: "enter", kind: "sequence", label: "Enter" },
+      { id: "backspace", kind: "sequence", label: "Bksp" },
+    ]),
+    Object.freeze([
+      { id: "f1", kind: "sequence", label: "F1" },
+      { id: "f2", kind: "sequence", label: "F2" },
+      { id: "f3", kind: "sequence", label: "F3" },
+      { id: "f4", kind: "sequence", label: "F4" },
+    ]),
+    Object.freeze([
+      { id: "f5", kind: "sequence", label: "F5" },
+      { id: "f6", kind: "sequence", label: "F6" },
+      { id: "f7", kind: "sequence", label: "F7" },
+      { id: "f8", kind: "sequence", label: "F8" },
+    ]),
+    Object.freeze([
+      { id: "f9", kind: "sequence", label: "F9" },
+      { id: "f10", kind: "sequence", label: "F10" },
+      { id: "f11", kind: "sequence", label: "F11" },
+      { id: "f12", kind: "sequence", label: "F12" },
+    ]),
+    Object.freeze([
+      { id: "a", kind: "character", label: "A" },
+      { id: "c", kind: "character", label: "C" },
+      { id: "d", kind: "character", label: "D" },
+      { id: "l", kind: "character", label: "L" },
+      { id: "u", kind: "character", label: "U" },
+      { id: "z", kind: "character", label: "Z" },
+    ]),
+  ]);
+
+  const FUNCTION_KEY_SEQUENCES = Object.freeze({
+    f1: "\u001bOP",
+    f2: "\u001bOQ",
+    f3: "\u001bOR",
+    f4: "\u001bOS",
+    f5: "\u001b[15~",
+    f6: "\u001b[17~",
+    f7: "\u001b[18~",
+    f8: "\u001b[19~",
+    f9: "\u001b[20~",
+    f10: "\u001b[21~",
+    f11: "\u001b[23~",
+    f12: "\u001b[24~",
   });
 
-  function syncSize() {
-    fitAddon.fit();
-    socket.emit("resize", {
-      cols: terminal.cols,
-      rows: terminal.rows,
+  const ARROW_SUFFIXES = Object.freeze({
+    down: "B",
+    left: "D",
+    right: "C",
+    up: "A",
+  });
+
+  function readStoredValue(key) {
+    try {
+      return globalScope.localStorage ? globalScope.localStorage.getItem(key) : null;
+    } catch (error) {
+      console.warn("remote-terminal storage read failed:", error.message);
+      return null;
+    }
+  }
+
+  function writeStoredValue(key, value) {
+    try {
+      if (globalScope.localStorage) {
+        globalScope.localStorage.setItem(key, value);
+      }
+    } catch (error) {
+      console.warn("remote-terminal storage write failed:", error.message);
+    }
+  }
+
+  function normalizeThemeName(themeName) {
+    return Object.prototype.hasOwnProperty.call(THEME_DEFINITIONS, themeName) ? themeName : "default";
+  }
+
+  function getThemeDefinition(themeName) {
+    return THEME_DEFINITIONS[normalizeThemeName(themeName)];
+  }
+
+  function getModifierCode(modifiers) {
+    const code =
+      1 + (modifiers.shift ? 1 : 0) + (modifiers.alt ? 2 : 0) + (modifiers.ctrl ? 4 : 0);
+    return code === 1 ? null : code;
+  }
+
+  function prefixAlt(sequence, modifiers) {
+    return modifiers.alt ? "\u001b" + sequence : sequence;
+  }
+
+  function encodeCharacter(value, modifiers) {
+    let character = modifiers.shift ? value.toUpperCase() : value.toLowerCase();
+    if (modifiers.ctrl) {
+      const controlCode = character.toUpperCase().charCodeAt(0) - 64;
+      if (controlCode > 0 && controlCode < 32) {
+        character = String.fromCharCode(controlCode);
+      }
+    }
+    return prefixAlt(character, modifiers);
+  }
+
+  function getVirtualKeySequence(keyId, modifiers) {
+    const normalizedModifiers = {
+      alt: Boolean(modifiers && modifiers.alt),
+      ctrl: Boolean(modifiers && modifiers.ctrl),
+      shift: Boolean(modifiers && modifiers.shift),
+    };
+
+    if (Object.prototype.hasOwnProperty.call(ARROW_SUFFIXES, keyId)) {
+      const modifierCode = getModifierCode(normalizedModifiers);
+      const sequence = modifierCode
+        ? "\u001b[1;" + modifierCode + ARROW_SUFFIXES[keyId]
+        : "\u001b[" + ARROW_SUFFIXES[keyId];
+      return sequence;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(FUNCTION_KEY_SEQUENCES, keyId)) {
+      return prefixAlt(FUNCTION_KEY_SEQUENCES[keyId], normalizedModifiers);
+    }
+
+    switch (keyId) {
+      case "tab":
+        return prefixAlt(normalizedModifiers.shift ? "\u001b[Z" : "\t", normalizedModifiers);
+      case "enter":
+        return prefixAlt("\r", normalizedModifiers);
+      case "backspace":
+        return prefixAlt("\u007f", normalizedModifiers);
+      case "esc":
+        return "\u001b";
+      default:
+        if (/^[a-z]$/i.test(keyId)) {
+          return encodeCharacter(keyId, normalizedModifiers);
+        }
+        return "";
+    }
+  }
+
+  function applyThemeDefinition(rootNode, themeDefinition) {
+    const variables = {
+      "--accent": themeDefinition.ui.accent,
+      "--app-bg": themeDefinition.ui.appBg,
+      "--button-bg": themeDefinition.ui.buttonBg,
+      "--button-border": themeDefinition.ui.buttonBorder,
+      "--button-text": themeDefinition.ui.buttonText,
+      "--danger": themeDefinition.ui.danger,
+      "--keyboard-bg": themeDefinition.ui.keyboardBg,
+      "--muted-text": themeDefinition.ui.mutedText,
+      "--panel-bg": themeDefinition.ui.panelBg,
+      "--panel-border": themeDefinition.ui.panelBorder,
+      "--shadow": themeDefinition.ui.shadow,
+      "--status-info": themeDefinition.ui.statusInfo,
+      "--status-offline": themeDefinition.ui.statusOffline,
+      "--status-online": themeDefinition.ui.statusOnline,
+      "--status-warning": themeDefinition.ui.statusWarning,
+      "--surface-bg": themeDefinition.ui.surfaceBg,
+    };
+
+    Object.keys(variables).forEach(function setVariable(name) {
+      rootNode.style.setProperty(name, variables[name]);
+    });
+    rootNode.dataset.theme = themeDefinition.id;
+    rootNode.style.colorScheme = themeDefinition.colorScheme;
+  }
+
+  function isTouchDevice(scope) {
+    if (!scope || typeof scope !== "object") {
+      return false;
+    }
+
+    if (typeof scope.matchMedia === "function" && scope.matchMedia("(pointer: coarse)").matches) {
+      return true;
+    }
+
+    const navigatorValue = scope.navigator || {};
+    return Boolean("ontouchstart" in scope || navigatorValue.maxTouchPoints > 0);
+  }
+
+  function setStatus(node, message, tone) {
+    node.textContent = message;
+    node.dataset.tone = tone;
+  }
+
+  function populateThemeSelect(selectNode, selectedTheme) {
+    Object.keys(THEME_DEFINITIONS).forEach(function addThemeOption(themeName) {
+      const theme = THEME_DEFINITIONS[themeName];
+      const option = document.createElement("option");
+      option.value = theme.id;
+      option.textContent = theme.label;
+      option.selected = theme.id === selectedTheme;
+      selectNode.appendChild(option);
     });
   }
 
-  socket.on("connect", function onConnect() {
-    statusNode.textContent = "Connected";
-    syncSize();
+  function bootstrapRemoteTerminal() {
+    if (typeof document === "undefined" || typeof window === "undefined") {
+      return null;
+    }
+
+    const terminalNode = document.getElementById("terminal");
+    const statusNode = document.getElementById("status");
+    const themeSelectNode = document.getElementById("theme-select");
+    const keyboardToggleNode = document.getElementById("keyboard-toggle");
+    const keyboardPanelNode = document.getElementById("mobile-keyboard");
+    const keyboardRowsNode = document.getElementById("keyboard-rows");
+    const keyboardHintNode = document.getElementById("keyboard-hint");
+    const search = new URLSearchParams(window.location.search);
+    const token = search.get("token");
+
+    if (!token) {
+      setStatus(statusNode, "Missing token. Re-open the QR URL from the operator terminal.", "error");
+      return null;
+    }
+
+    const savedThemeName = normalizeThemeName(readStoredValue(THEME_STORAGE_KEY));
+    populateThemeSelect(themeSelectNode, savedThemeName);
+
+    const terminal = new window.Terminal({
+      cursorBlink: true,
+      convertEol: true,
+      scrollback: 5000,
+      theme: getThemeDefinition(savedThemeName).xterm,
+    });
+    const fitAddon = new window.FitAddon.FitAddon();
+    terminal.loadAddon(fitAddon);
+    terminal.open(terminalNode);
     terminal.focus();
-  });
 
-  socket.on("disconnect", function onDisconnect(reason) {
-    statusNode.textContent = "Disconnected: " + reason;
-  });
+    applyThemeDefinition(document.documentElement, getThemeDefinition(savedThemeName));
 
-  socket.on("connect_error", function onConnectError(error) {
-    statusNode.textContent = "Connection failed: " + error.message;
-  });
+    const socket = window.io({
+      auth: { token: token },
+      transports: ["websocket"],
+    });
 
-  socket.on("output", function onOutput(data) {
-    terminal.write(data);
-  });
+    function syncSize() {
+      fitAddon.fit();
+      socket.emit("resize", {
+        cols: terminal.cols,
+        rows: terminal.rows,
+      });
+    }
 
-  socket.on("session-exit", function onSessionExit(payload) {
-    const code = payload && payload.exitCode !== null ? payload.exitCode : "null";
-    statusNode.textContent = "Shell exited (code=" + code + ")";
-  });
+    function applyTheme(themeName) {
+      const themeDefinition = getThemeDefinition(themeName);
+      applyThemeDefinition(document.documentElement, themeDefinition);
+      if (typeof terminal.setOption === "function") {
+        terminal.setOption("theme", themeDefinition.xterm);
+      } else {
+        terminal.options.theme = themeDefinition.xterm;
+      }
+      writeStoredValue(THEME_STORAGE_KEY, themeDefinition.id);
+      syncSize();
+    }
 
-  terminal.onData(function onInput(data) {
-    socket.emit("input", data);
-  });
+    themeSelectNode.addEventListener("change", function onThemeChange(event) {
+      applyTheme(event.target.value);
+    });
 
-  window.addEventListener("resize", syncSize);
-})();
+    const modifierState = {
+      alt: false,
+      ctrl: false,
+      shift: false,
+    };
+    const modifierButtons = new Map();
+
+    function syncModifierButtons() {
+      modifierButtons.forEach(function setPressedState(buttonNode, modifierName) {
+        buttonNode.setAttribute("aria-pressed", String(Boolean(modifierState[modifierName])));
+      });
+    }
+
+    function resetModifiers() {
+      modifierState.alt = false;
+      modifierState.ctrl = false;
+      modifierState.shift = false;
+      syncModifierButtons();
+      keyboardHintNode.textContent = "Touch shortcuts stay focused on the real PTY. Modifiers apply to the next tap.";
+    }
+
+    function updateKeyboardVisibility(open) {
+      document.body.classList.toggle("keyboard-open", open);
+      keyboardPanelNode.hidden = !open;
+      keyboardToggleNode.setAttribute("aria-expanded", String(open));
+      keyboardToggleNode.textContent = open ? "Hide keyboard" : "Show keyboard";
+      writeStoredValue(KEYBOARD_VISIBILITY_STORAGE_KEY, open ? "1" : "0");
+      if (open) {
+        terminal.focus();
+        syncSize();
+      }
+    }
+
+    const storedKeyboardVisibility = readStoredValue(KEYBOARD_VISIBILITY_STORAGE_KEY);
+    const keyboardOpenByDefault =
+      storedKeyboardVisibility === "1"
+        ? true
+        : storedKeyboardVisibility === "0"
+          ? false
+          : isTouchDevice(globalScope);
+    document.body.classList.toggle("touch-device", isTouchDevice(globalScope));
+
+    keyboardToggleNode.addEventListener("click", function onKeyboardToggle() {
+      updateKeyboardVisibility(keyboardPanelNode.hidden);
+    });
+
+    VIRTUAL_KEY_ROWS.forEach(function renderKeyboardRow(row) {
+      const rowNode = document.createElement("div");
+      rowNode.className = "keyboard-row";
+
+      row.forEach(function renderKeyboardKey(key) {
+        const buttonNode = document.createElement("button");
+        buttonNode.type = "button";
+        buttonNode.className = "keyboard-key";
+        buttonNode.dataset.key = key.id;
+        buttonNode.textContent = key.label;
+        buttonNode.setAttribute("aria-label", key.label);
+
+        if (key.kind === "modifier") {
+          buttonNode.classList.add("keyboard-key--modifier");
+          modifierButtons.set(key.id, buttonNode);
+        } else if (key.id === "enter" || key.id === "backspace") {
+          buttonNode.classList.add("keyboard-key--wide");
+        }
+
+        buttonNode.addEventListener("click", function onVirtualKeyPress() {
+          if (key.kind === "modifier") {
+            modifierState[key.id] = !modifierState[key.id];
+            syncModifierButtons();
+            keyboardHintNode.textContent =
+              "Armed: " +
+              Object.keys(modifierState)
+                .filter(function activeModifier(modifierName) {
+                  return modifierState[modifierName];
+                })
+                .map(function formatModifier(modifierName) {
+                  return modifierName.toUpperCase();
+                })
+                .join(" + ");
+            if (!modifierState.alt && !modifierState.ctrl && !modifierState.shift) {
+              keyboardHintNode.textContent =
+                "Touch shortcuts stay focused on the real PTY. Modifiers apply to the next tap.";
+            }
+            return;
+          }
+
+          const sequence = getVirtualKeySequence(key.id, modifierState);
+          if (sequence) {
+            socket.emit("input", sequence);
+            terminal.focus();
+          }
+          resetModifiers();
+        });
+
+        rowNode.appendChild(buttonNode);
+      });
+
+      keyboardRowsNode.appendChild(rowNode);
+    });
+
+    updateKeyboardVisibility(keyboardOpenByDefault);
+    syncModifierButtons();
+
+    socket.on("connect", function onConnect() {
+      setStatus(statusNode, "Connected", "success");
+      syncSize();
+      terminal.focus();
+    });
+
+    socket.on("disconnect", function onDisconnect(reason) {
+      setStatus(statusNode, "Disconnected: " + reason, "warning");
+    });
+
+    socket.on("connect_error", function onConnectError(error) {
+      setStatus(statusNode, "Connection failed: " + error.message, "error");
+    });
+
+    socket.on("output", function onOutput(data) {
+      terminal.write(data);
+    });
+
+    socket.on("session-exit", function onSessionExit(payload) {
+      const code = payload && payload.exitCode !== null ? payload.exitCode : "null";
+      setStatus(statusNode, "Shell exited (code=" + code + ")", "error");
+    });
+
+    terminal.onData(function onInput(data) {
+      socket.emit("input", data);
+    });
+
+    window.addEventListener("resize", syncSize);
+
+    return {
+      applyTheme: applyTheme,
+      socket: socket,
+      terminal: terminal,
+      updateKeyboardVisibility: updateKeyboardVisibility,
+    };
+  }
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+      KEYBOARD_VISIBILITY_STORAGE_KEY,
+      THEME_DEFINITIONS,
+      THEME_STORAGE_KEY,
+      VIRTUAL_KEY_ROWS,
+      bootstrapRemoteTerminal,
+      getThemeDefinition,
+      getVirtualKeySequence,
+      normalizeThemeName,
+    };
+  }
+
+  if (typeof window !== "undefined" && window.document) {
+    bootstrapRemoteTerminal();
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/remote-terminal/public/index.html
+++ b/remote-terminal/public/index.html
@@ -10,6 +10,31 @@
         color-scheme: dark;
         font-family:
           Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        --accent: #7dd3fc;
+        --app-bg: #050816;
+        --button-bg: rgba(15, 23, 42, 0.92);
+        --button-border: rgba(125, 211, 252, 0.28);
+        --button-text: #e2e8f0;
+        --danger: #f87171;
+        --keyboard-bg: rgba(15, 23, 42, 0.95);
+        --muted-text: #94a3b8;
+        --panel-bg: rgba(15, 23, 42, 0.92);
+        --panel-border: rgba(148, 163, 184, 0.18);
+        --shadow: 0 18px 40px rgba(2, 6, 23, 0.35);
+        --status-info: #7dd3fc;
+        --status-offline: #fda4af;
+        --status-online: #86efac;
+        --status-warning: #facc15;
+        --surface-bg: #020617;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        min-height: 100%;
       }
 
       body {
@@ -17,57 +42,294 @@
         min-height: 100vh;
         display: flex;
         flex-direction: column;
-        background: #050816;
-        color: #e2e8f0;
+        background:
+          radial-gradient(circle at top right, rgba(125, 211, 252, 0.12), transparent 32%),
+          var(--app-bg);
+        color: var(--button-text);
       }
 
       header {
-        padding: 1rem 1.25rem 0.75rem;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
-        background: rgba(15, 23, 42, 0.92);
+        display: grid;
+        gap: 0.9rem;
+        padding: 1rem 1.25rem;
+        border-bottom: 1px solid var(--panel-border);
+        background: var(--panel-bg);
         backdrop-filter: blur(12px);
       }
 
       h1 {
         margin: 0 0 0.35rem;
-        font-size: 1.2rem;
+        font-size: clamp(1.15rem, 2vw, 1.35rem);
       }
 
       p {
         margin: 0;
       }
 
+      .hero-copy {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .hero-copy p {
+        color: var(--muted-text);
+        line-height: 1.5;
+      }
+
+      .hero-controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: end;
+      }
+
+      .control-group {
+        display: grid;
+        gap: 0.35rem;
+        min-width: 12rem;
+      }
+
+      .control-group label {
+        font-size: 0.78rem;
+        font-weight: 600;
+        letter-spacing: 0.03em;
+        color: var(--muted-text);
+        text-transform: uppercase;
+      }
+
+      select,
+      button {
+        appearance: none;
+        border: 1px solid var(--button-border);
+        background: var(--button-bg);
+        color: var(--button-text);
+        border-radius: 0.9rem;
+        min-height: 2.75rem;
+        padding: 0.7rem 0.95rem;
+        font: inherit;
+        box-shadow: var(--shadow);
+      }
+
+      button {
+        cursor: pointer;
+        font-weight: 600;
+      }
+
+      select:focus,
+      button:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
       #status {
-        margin-top: 0.5rem;
-        color: #7dd3fc;
-        font-size: 0.92rem;
+        font-size: 0.94rem;
+        font-weight: 600;
+      }
+
+      #status[data-tone="info"] {
+        color: var(--status-info);
+      }
+
+      #status[data-tone="success"] {
+        color: var(--status-online);
+      }
+
+      #status[data-tone="warning"] {
+        color: var(--status-warning);
+      }
+
+      #status[data-tone="error"] {
+        color: var(--status-offline);
+      }
+
+      main {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        padding: 1rem 1.25rem;
+      }
+
+      .terminal-card {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        border: 1px solid var(--panel-border);
+        border-radius: 1.25rem;
+        overflow: hidden;
+        background: var(--surface-bg);
+        box-shadow: var(--shadow);
       }
 
       #terminal {
         flex: 1;
-        padding: 0.75rem;
         min-height: 0;
-      }
-
-      footer {
-        padding: 0.7rem 1.25rem 1rem;
-        font-size: 0.9rem;
-        color: #94a3b8;
+        padding: 0.8rem;
       }
 
       .xterm {
         height: 100%;
       }
+
+      .keyboard-panel {
+        position: sticky;
+        bottom: 0;
+        z-index: 2;
+        display: grid;
+        gap: 0.75rem;
+        padding: 0.9rem;
+        border: 1px solid var(--panel-border);
+        border-radius: 1.1rem;
+        background: var(--keyboard-bg);
+        box-shadow: var(--shadow);
+        backdrop-filter: blur(14px);
+      }
+
+      .keyboard-panel[hidden] {
+        display: none;
+      }
+
+      .keyboard-header {
+        display: grid;
+        gap: 0.2rem;
+      }
+
+      .keyboard-header strong {
+        font-size: 0.96rem;
+      }
+
+      #keyboard-hint {
+        color: var(--muted-text);
+        font-size: 0.9rem;
+      }
+
+      .keyboard-grid {
+        display: grid;
+        gap: 0.55rem;
+      }
+
+      .keyboard-row {
+        display: grid;
+        gap: 0.55rem;
+        grid-template-columns: repeat(auto-fit, minmax(4rem, 1fr));
+      }
+
+      .keyboard-key {
+        min-height: 3rem;
+        padding: 0.7rem 0.5rem;
+        border-radius: 0.95rem;
+        background: var(--button-bg);
+        border: 1px solid var(--button-border);
+        color: var(--button-text);
+        font-weight: 700;
+        letter-spacing: 0.01em;
+      }
+
+      .keyboard-key--wide {
+        grid-column: span 2;
+      }
+
+      .keyboard-key--modifier[aria-pressed="true"] {
+        background: var(--accent);
+        border-color: transparent;
+        color: #020617;
+      }
+
+      footer {
+        padding: 0 1.25rem 1rem;
+        color: var(--muted-text);
+        font-size: 0.92rem;
+        line-height: 1.5;
+      }
+
+      @media (min-width: 920px) {
+        header {
+          grid-template-columns: minmax(0, 1fr) auto;
+          align-items: end;
+        }
+
+        #status {
+          grid-column: 1 / -1;
+        }
+      }
+
+      @media (max-width: 720px) {
+        header,
+        main,
+        footer {
+          padding-left: 0.95rem;
+          padding-right: 0.95rem;
+        }
+
+        .control-group,
+        .hero-controls > button {
+          width: 100%;
+        }
+
+        select,
+        button {
+          width: 100%;
+        }
+
+        .keyboard-key {
+          min-height: 3.15rem;
+        }
+      }
     </style>
   </head>
   <body>
     <header>
-      <h1>Remote Terminal</h1>
-      <p>Token-authenticated terminal session powered by node-pty, Socket.IO, and xterm.js.</p>
-      <p id="status">Connecting…</p>
+      <div class="hero-copy">
+        <h1>Remote Terminal</h1>
+        <p>
+          Token-authenticated terminal access with six persistent themes, touch shortcuts,
+          and Cloudflare Quick Tunnel progress states.
+        </p>
+      </div>
+      <div class="hero-controls">
+        <div class="control-group">
+          <label for="theme-select">Terminal theme</label>
+          <select id="theme-select" aria-label="Terminal theme"></select>
+        </div>
+        <button
+          id="keyboard-toggle"
+          type="button"
+          aria-controls="mobile-keyboard"
+          aria-expanded="false"
+        >
+          Show keyboard
+        </button>
+      </div>
+      <p id="status" data-tone="info">Connecting...</p>
     </header>
-    <main id="terminal" aria-label="Terminal session"></main>
-    <footer>Use the browser like a normal terminal: resize the window, press Ctrl+C, Ctrl+D, and use tab completion.</footer>
+
+    <main>
+      <section class="terminal-card">
+        <div id="terminal" aria-label="Terminal session"></div>
+      </section>
+
+      <section
+        id="mobile-keyboard"
+        class="keyboard-panel"
+        hidden
+        aria-label="On-screen terminal keyboard"
+      >
+        <div class="keyboard-header">
+          <strong>Touch keyboard</strong>
+          <p id="keyboard-hint">
+            Touch shortcuts stay focused on the real PTY. Modifiers apply to the next tap.
+          </p>
+        </div>
+        <div id="keyboard-rows" class="keyboard-grid"></div>
+      </section>
+    </main>
+
+    <footer>
+      Use the browser like a normal terminal. The active theme is saved in this browser, and
+      the touch keyboard adds Ctrl/Alt/Shift, arrows, Tab, and F1-F12 without leaving the PTY.
+    </footer>
+
     <script src="/socket.io/socket.io.js"></script>
     <script src="/vendor/xterm.js"></script>
     <script src="/vendor/xterm-addon-fit.js"></script>

--- a/remote-terminal/server.js
+++ b/remote-terminal/server.js
@@ -1,11 +1,12 @@
 const crypto = require("node:crypto");
-const { spawn } = require("node:child_process");
+const { spawn, spawnSync } = require("node:child_process");
 const { EventEmitter } = require("node:events");
 const fs = require("node:fs");
 const http = require("node:http");
 const net = require("node:net");
 const os = require("node:os");
 const path = require("node:path");
+const zlib = require("node:zlib");
 
 const express = require("express");
 const pty = require("node-pty");
@@ -31,6 +32,7 @@ const DEFAULT_AUTH_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const DEFAULT_AUTH_RATE_LIMIT_MAX_ATTEMPTS = 5;
 const DEFAULT_DAEMON_RESTART_DELAY_MS = 1000;
 const DEFAULT_DAEMON_SESSION_ID = "default";
+const DEFAULT_TRAY_TITLE = "Remote Terminal";
 const PUBLIC_DIR = path.join(__dirname, "public");
 const PTY_DAEMON_SCRIPT = path.join(__dirname, "pty-daemon.js");
 const XTERM_DIR = path.dirname(require.resolve("@xterm/xterm/package.json"));
@@ -325,6 +327,443 @@ function formatRetryDelay(delayMs) {
   }
 
   return `${delayMs}ms`;
+}
+
+const CRC32_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < table.length; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) === 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+})();
+
+function writePixel(buffer, size, x, y, color) {
+  if (x < 0 || y < 0 || x >= size || y >= size) {
+    return;
+  }
+
+  const offset = (y * size + x) * 4;
+  buffer[offset] = color[0];
+  buffer[offset + 1] = color[1];
+  buffer[offset + 2] = color[2];
+  buffer[offset + 3] = color[3];
+}
+
+function fillRect(buffer, size, x, y, width, height, color) {
+  for (let row = y; row < y + height; row += 1) {
+    for (let column = x; column < x + width; column += 1) {
+      writePixel(buffer, size, column, row, color);
+    }
+  }
+}
+
+function createTrayPixelBuffer(template = false) {
+  const size = 16;
+  const pixels = Buffer.alloc(size * size * 4);
+  const shellFill = template ? [0, 0, 0, 255] : [5, 8, 22, 255];
+  const shellBorder = template ? [0, 0, 0, 255] : [125, 211, 252, 255];
+  const prompt = template ? [0, 0, 0, 255] : [34, 197, 94, 255];
+  const cursor = template ? [0, 0, 0, 255] : [226, 232, 240, 255];
+
+  fillRect(pixels, size, 2, 2, 12, 12, shellFill);
+  fillRect(pixels, size, 2, 2, 12, 1, shellBorder);
+  fillRect(pixels, size, 2, 13, 12, 1, shellBorder);
+  fillRect(pixels, size, 2, 2, 1, 12, shellBorder);
+  fillRect(pixels, size, 13, 2, 1, 12, shellBorder);
+  fillRect(pixels, size, 4, 4, 2, 1, shellBorder);
+  fillRect(pixels, size, 7, 4, 2, 1, shellBorder);
+  fillRect(pixels, size, 10, 4, 2, 1, shellBorder);
+
+  writePixel(pixels, size, 5, 7, prompt);
+  writePixel(pixels, size, 6, 8, prompt);
+  writePixel(pixels, size, 5, 9, prompt);
+  fillRect(pixels, size, 8, 10, 3, 1, cursor);
+
+  return {
+    pixels,
+    size,
+  };
+}
+
+function computeCrc32(buffer) {
+  let crc = 0xffffffff;
+  for (const value of buffer) {
+    crc = CRC32_TABLE[(crc ^ value) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function createPngChunk(type, data) {
+  const chunkType = Buffer.from(type, "ascii");
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(computeCrc32(Buffer.concat([chunkType, data])), 0);
+  return Buffer.concat([length, chunkType, data, crc]);
+}
+
+function createPngIconBuffer(template = false) {
+  const { pixels, size } = createTrayPixelBuffer(template);
+  const scanlines = Buffer.alloc((size * 4 + 1) * size);
+
+  for (let row = 0; row < size; row += 1) {
+    const rowOffset = row * (size * 4 + 1);
+    scanlines[rowOffset] = 0;
+    pixels.copy(scanlines, rowOffset + 1, row * size * 4, (row + 1) * size * 4);
+  }
+
+  const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(size, 0);
+  header.writeUInt32BE(size, 4);
+  header[8] = 8;
+  header[9] = 6;
+  header[10] = 0;
+  header[11] = 0;
+  header[12] = 0;
+
+  return Buffer.concat([
+    signature,
+    createPngChunk("IHDR", header),
+    createPngChunk("IDAT", zlib.deflateSync(scanlines)),
+    createPngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+function createIcoBufferFromPng(pngBuffer, size = 16) {
+  const header = Buffer.alloc(22);
+  header.writeUInt16LE(0, 0);
+  header.writeUInt16LE(1, 2);
+  header.writeUInt16LE(1, 4);
+  header[6] = size;
+  header[7] = size;
+  header[8] = 0;
+  header[9] = 0;
+  header.writeUInt16LE(1, 10);
+  header.writeUInt16LE(32, 12);
+  header.writeUInt32LE(pngBuffer.length, 14);
+  header.writeUInt32LE(22, 18);
+  return Buffer.concat([header, pngBuffer]);
+}
+
+async function createTrayIconAssets() {
+  const iconDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), "remote-terminal-tray-"));
+  const pngBuffer = createPngIconBuffer(false);
+  const templatePngBuffer = createPngIconBuffer(true);
+  const icoBuffer = createIcoBufferFromPng(pngBuffer);
+
+  const pngPath = path.join(iconDirectory, "remote-terminal-tray.png");
+  const templatePngPath = path.join(iconDirectory, "remote-terminal-tray-template.png");
+  const icoPath = path.join(iconDirectory, "remote-terminal-tray.ico");
+
+  await Promise.all([
+    fs.promises.writeFile(pngPath, pngBuffer),
+    fs.promises.writeFile(templatePngPath, templatePngBuffer),
+    fs.promises.writeFile(icoPath, icoBuffer),
+  ]);
+
+  return {
+    icoPath,
+    iconDirectory,
+    pngPath,
+    templatePngPath,
+  };
+}
+
+function getClipboardCommands(platform = process.platform, env = process.env) {
+  if (platform === "win32") {
+    return [{ command: "clip", args: [] }];
+  }
+
+  if (platform === "darwin") {
+    return [{ command: "pbcopy", args: [] }];
+  }
+
+  const candidates = [];
+  if (env.WAYLAND_DISPLAY) {
+    candidates.push({ command: "wl-copy", args: [] });
+  }
+  candidates.push(
+    { command: "xclip", args: ["-selection", "clipboard"] },
+    { command: "xsel", args: ["--clipboard", "--input"] },
+  );
+  if (!env.WAYLAND_DISPLAY) {
+    candidates.push({ command: "wl-copy", args: [] });
+  }
+  return candidates;
+}
+
+function runClipboardCommand(command, args, text, runner = spawnSync) {
+  const result = runner(command, args, {
+    encoding: "utf8",
+    input: text,
+    windowsHide: true,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    const stderr = (result.stderr || "").trim();
+    throw new Error(stderr || `${command} exited with code ${result.status}`);
+  }
+}
+
+async function copyTextToClipboard(text, options = {}) {
+  const commands = options.commands || getClipboardCommands(options.platform, options.env);
+  const runner = options.runCommand || runClipboardCommand;
+  const failures = [];
+
+  for (const { command, args } of commands) {
+    try {
+      runner(command, args, text);
+      return command;
+    } catch (error) {
+      failures.push(`${command}: ${error.message}`);
+    }
+  }
+
+  throw new Error(
+    failures.length > 0 ? failures.join("; ") : "no clipboard command available for this platform",
+  );
+}
+
+function hasDesktopSession(platform = process.platform, env = process.env) {
+  if (platform === "linux") {
+    return Boolean(env.DISPLAY || env.WAYLAND_DISPLAY);
+  }
+
+  return platform === "darwin" || platform === "win32";
+}
+
+function shouldEnableTray(options = {}, env = process.env, platform = process.platform) {
+  if (typeof options.enableTray === "boolean") {
+    return options.enableTray;
+  }
+
+  if (options.trayFactory) {
+    return true;
+  }
+
+  if (env.REMOTE_TERMINAL_ENABLE_TRAY !== undefined) {
+    return parseBoolean(env.REMOTE_TERMINAL_ENABLE_TRAY);
+  }
+
+  if (parseBoolean(env.REMOTE_TERMINAL_DISABLE_TRAY) || parseBoolean(env.CI)) {
+    return false;
+  }
+
+  return hasDesktopSession(platform, env);
+}
+
+function getPreferredAccessUrl(localUrl, publicUrl, tunnelState = TUNNEL_STATES.STOPPED) {
+  if (publicUrl && tunnelState === TUNNEL_STATES.READY) {
+    return publicUrl;
+  }
+
+  return localUrl || publicUrl || null;
+}
+
+function describeTrayConnectionState(snapshot = {}) {
+  if (!snapshot.shellRunning) {
+    return {
+      copyTitle: "Copy last URL",
+      copyTooltip: "Copy the most recent terminal URL to the clipboard",
+      title: "🔴 Disconnected",
+      tooltip: "The terminal session has stopped.",
+    };
+  }
+
+  if (!snapshot.tunnelEnabled) {
+    return {
+      copyTitle: "Copy local URL",
+      copyTooltip: "Copy the LAN access URL to the clipboard",
+      title: "🟢 Connected (LAN only)",
+      tooltip: "LAN access is ready without a Cloudflare Quick Tunnel.",
+    };
+  }
+
+  if (snapshot.publicUrl && snapshot.tunnelState === TUNNEL_STATES.READY) {
+    return {
+      copyTitle: "Copy public URL",
+      copyTooltip: "Copy the verified public tunnel URL to the clipboard",
+      title: "🟢 Connected",
+      tooltip: `Public URL ready: ${stripTokenFromUrl(snapshot.publicUrl)}`,
+    };
+  }
+
+  if (
+    [
+      TUNNEL_STATES.PREPARING,
+      TUNNEL_STATES.CONNECTING,
+      TUNNEL_STATES.TUNNELING,
+      TUNNEL_STATES.VERIFYING,
+    ].includes(snapshot.tunnelState)
+  ) {
+    return {
+      copyTitle: "Copy local URL",
+      copyTooltip: "Copy the local fallback URL while the public tunnel is starting",
+      title: "🟡 Connecting",
+      tooltip: snapshot.tunnelState === TUNNEL_STATES.VERIFYING ? "Verifying public URL…" : "Creating public tunnel…",
+    };
+  }
+
+  return {
+    copyTitle: "Copy local URL",
+    copyTooltip: "Copy the local fallback URL to the clipboard",
+    title: "🔴 Disconnected",
+    tooltip: snapshot.tunnelError
+      ? `Tunnel unavailable: ${snapshot.tunnelError}`
+      : "The public tunnel is unavailable.",
+  };
+}
+
+async function createTrayController(options = {}) {
+  const iconAssets = await createTrayIconAssets();
+  const snapshot = () => options.getSnapshot();
+  const initialState = describeTrayConnectionState(snapshot());
+  const statusItem = {
+    checked: false,
+    enabled: false,
+    title: initialState.title,
+    tooltip: initialState.tooltip,
+  };
+  const copyItem = {
+    checked: false,
+    click: async () => {
+      const current = snapshot();
+      const activeUrl = getPreferredAccessUrl(current.localUrl, current.publicUrl, current.tunnelState);
+      if (!activeUrl) {
+        throw new Error("No access URL is available yet.");
+      }
+      await (options.copyText || copyTextToClipboard)(activeUrl);
+      options.logger(
+        `Tray copied ${
+          current.publicUrl && current.tunnelState === TUNNEL_STATES.READY ? "public" : "local"
+        } access URL to the clipboard.`,
+      );
+    },
+    enabled: true,
+    title: initialState.copyTitle,
+    tooltip: initialState.copyTooltip,
+  };
+  const qrItem = {
+    checked: false,
+    click: () => {
+      const current = snapshot();
+      const activeUrl = getPreferredAccessUrl(current.localUrl, current.publicUrl, current.tunnelState);
+      if (!activeUrl) {
+        throw new Error("No access URL is available yet.");
+      }
+      const usingPublicUrl = current.publicUrl && current.tunnelState === TUNNEL_STATES.READY;
+      options.renderQr(usingPublicUrl ? "Quick tunnel QR (tray)" : "Local access QR (tray)", activeUrl);
+      options.logger(`Tray reprinted the ${usingPublicUrl ? "public" : "local"} QR code in the operator console.`);
+    },
+    enabled: true,
+    title: "Regenerate QR code",
+    tooltip: "Reprint the active QR code in the operator console",
+  };
+
+  const menu = {
+    icon:
+      process.platform === "win32"
+        ? iconAssets.icoPath
+        : process.platform === "darwin"
+          ? iconAssets.templatePngPath
+          : iconAssets.pngPath,
+    isTemplateIcon: process.platform === "darwin",
+    items: [statusItem, copyItem, qrItem],
+    title: DEFAULT_TRAY_TITLE,
+    tooltip: `${DEFAULT_TRAY_TITLE} — ${initialState.title}`,
+  };
+
+  const trayFactory =
+    options.trayFactory ||
+    (async (config) => {
+      const moduleValue = await import("systray2");
+      const SysTray = moduleValue.default || moduleValue;
+      return new SysTray(config);
+    });
+
+  let tray = null;
+
+  async function updateMenuState() {
+    if (!tray) {
+      return;
+    }
+
+    const nextState = describeTrayConnectionState(snapshot());
+    statusItem.title = nextState.title;
+    statusItem.tooltip = nextState.tooltip;
+    copyItem.title = nextState.copyTitle;
+    copyItem.tooltip = nextState.copyTooltip;
+    menu.tooltip = `${DEFAULT_TRAY_TITLE} — ${nextState.title}`;
+
+    await tray.sendAction({
+      type: "update-menu",
+      menu,
+    });
+  }
+
+  try {
+    tray = await trayFactory({
+      copyDir: false,
+      debug: false,
+      menu,
+    });
+
+    if (typeof tray.onError === "function") {
+      tray.onError((error) => {
+        options.logger(`System tray error: ${error.message}`);
+      });
+    }
+
+    if (typeof tray.onClick === "function") {
+      await tray.onClick((action) => {
+        if (!action.item || typeof action.item.click !== "function") {
+          return;
+        }
+
+        try {
+          Promise.resolve(action.item.click()).catch((error) => {
+            options.logger(`Tray action failed: ${error.message}`);
+          });
+        } catch (error) {
+          options.logger(`Tray action failed: ${error.message}`);
+        }
+      });
+    }
+
+    if (typeof tray.ready === "function") {
+      await tray.ready();
+    }
+  } catch (error) {
+    if (tray && typeof tray.kill === "function" && !tray.killed) {
+      await tray.kill(false);
+    }
+    await fs.promises.rm(iconAssets.iconDirectory, { force: true, recursive: true });
+    throw error;
+  }
+
+  return {
+    async close() {
+      try {
+        if (tray && typeof tray.kill === "function" && !tray.killed) {
+          await tray.kill(false);
+        }
+      } finally {
+        await fs.promises.rm(iconAssets.iconDirectory, { force: true, recursive: true });
+      }
+    },
+    async sync() {
+      await updateMenuState();
+    },
+  };
 }
 
 function sleep(delayMs) {
@@ -849,7 +1288,12 @@ async function startRemoteTerminal(options = {}) {
   let pendingVerification = null;
   let stopping = false;
   let activePort = null;
+  let localUrl = null;
   let ptyBackend = null;
+  let trayController = null;
+  let trayError = null;
+  let trayReady = false;
+  const trayEnabled = shouldEnableTray(options);
   const closed = new Promise((resolve) => {
     closedResolve = resolve;
   });
@@ -864,12 +1308,41 @@ async function startRemoteTerminal(options = {}) {
   });
   const spinner = tunnelEnabled ? await createSpinner(options.spinnerFactory) : createNoopSpinner();
 
+  function getTraySnapshot() {
+    return {
+      localUrl,
+      publicUrl,
+      shellRunning,
+      tunnelEnabled,
+      tunnelError,
+      tunnelState,
+    };
+  }
+
+  function syncTray() {
+    if (!trayController || !trayReady) {
+      return;
+    }
+
+    void trayController
+      .sync()
+      .then(() => {
+        trayError = null;
+      })
+      .catch((error) => {
+        trayError = error.message;
+        logger(`System tray update failed: ${error.message}`);
+      });
+  }
+
   function setPublicUrl(url) {
     publicUrl = url;
+    syncTray();
   }
 
   function setTunnelError(message) {
     tunnelError = message;
+    syncTray();
   }
 
   function updateSpinner(text, terminalAction) {
@@ -906,6 +1379,7 @@ async function startRemoteTerminal(options = {}) {
     const text = `[${nextState}] ${detail}`;
     logger(text);
     updateSpinner(text, terminalAction);
+    syncTray();
   }
 
   function clearRetryTimer() {
@@ -1118,6 +1592,17 @@ async function startRemoteTerminal(options = {}) {
         new Promise((resolve) => server.close(() => resolve())),
       ]);
 
+      if (trayController) {
+        trayReady = false;
+        try {
+          await trayController.close();
+        } catch (error) {
+          logger(`System tray shutdown failed: ${error.message}`);
+        } finally {
+          trayController = null;
+        }
+      }
+
       if (spinner && typeof spinner.stop === "function") {
         spinner.stop();
       }
@@ -1151,6 +1636,10 @@ async function startRemoteTerminal(options = {}) {
       tokenExpiresAt: accessToken.expiresAt === null ? null : new Date(accessToken.expiresAt).toISOString(),
       authRateLimitMaxAttempts,
       authRateLimitWindowMs,
+      trayEnabled,
+      trayReady,
+      trayStatus: trayEnabled ? describeTrayConnectionState(getTraySnapshot()).title : null,
+      trayError,
     });
   });
 
@@ -1292,12 +1781,13 @@ async function startRemoteTerminal(options = {}) {
       exitCode,
       signal,
     };
+    syncTray();
     io.emit("session-exit", shellExit);
     logger(`Shell exited (code=${exitCode ?? "null"}, signal=${signal ?? "none"}).`);
     void stop();
   });
 
-  const localUrl = buildAccessUrl(`http://${accessHost}:${activePort}/`, token);
+  localUrl = buildAccessUrl(`http://${accessHost}:${activePort}/`, token);
   logger(`Remote terminal listening on http://${host}:${activePort}`);
   logger(`Shell: ${shell.command}${shell.args.length ? ` ${shell.args.join(" ")}` : ""}`);
   if (accessToken.persistent) {
@@ -1310,6 +1800,28 @@ async function startRemoteTerminal(options = {}) {
     logger,
     qrWriter,
   });
+
+  if (trayEnabled) {
+    try {
+      trayController = await createTrayController({
+        copyText: options.copyText,
+        getSnapshot: getTraySnapshot,
+        logger,
+        renderQr: (label, url) => {
+          renderQrCode(url, { label, logger, qrWriter });
+        },
+        trayFactory: options.trayFactory,
+      });
+      trayReady = true;
+      trayError = null;
+      syncTray();
+      logger("System tray ready.");
+    } catch (error) {
+      trayReady = false;
+      trayError = error.message;
+      logger(`System tray unavailable: ${error.message}`);
+    }
+  }
 
   if (tunnelEnabled) {
     await connectTunnel();
@@ -1329,6 +1841,12 @@ async function startRemoteTerminal(options = {}) {
     },
     get tokenExpiresAt() {
       return accessToken.expiresAt;
+    },
+    get trayEnabled() {
+      return trayEnabled;
+    },
+    get trayReady() {
+      return trayReady;
     },
     get tunnelState() {
       return tunnelState;
@@ -1379,11 +1897,15 @@ module.exports = {
   DEFAULT_TUNNEL_VERIFY_DELAY_MS,
   TUNNEL_STATES,
   buildAccessUrl,
+  copyTextToClipboard,
   defaultVerifyTunnel,
+  describeTrayConnectionState,
   formatRetryDelay,
+  getPreferredAccessUrl,
   isValidToken,
   pickAccessHost,
   resolvePort,
+  shouldEnableTray,
   stripTokenFromUrl,
   startRemoteTerminal,
 };

--- a/remote-terminal/test/client.test.js
+++ b/remote-terminal/test/client.test.js
@@ -1,0 +1,42 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  THEME_DEFINITIONS,
+  THEME_STORAGE_KEY,
+  VIRTUAL_KEY_ROWS,
+  getThemeDefinition,
+  getVirtualKeySequence,
+  normalizeThemeName,
+} = require("../public/client.js");
+
+test("six premium terminal themes are available and normalize safely", () => {
+  assert.deepEqual(Object.keys(THEME_DEFINITIONS), [
+    "default",
+    "light",
+    "dracula",
+    "monokai",
+    "solarized-dark",
+    "solarized-light",
+  ]);
+  assert.equal(THEME_STORAGE_KEY, "remote-terminal-theme");
+  assert.equal(normalizeThemeName("monokai"), "monokai");
+  assert.equal(normalizeThemeName("missing-theme"), "default");
+  assert.equal(getThemeDefinition("missing-theme").label, "Default");
+});
+
+test("virtual keyboard layout includes modifier rows arrows and function keys", () => {
+  const ids = VIRTUAL_KEY_ROWS.flat().map((key) => key.id);
+  for (const requiredKey of ["ctrl", "alt", "shift", "esc", "tab", "left", "up", "down", "right", "f1", "f12"]) {
+    assert.equal(ids.includes(requiredKey), true, `missing virtual key: ${requiredKey}`);
+  }
+});
+
+test("virtual keyboard sequences cover control combos and navigation modifiers", () => {
+  assert.equal(getVirtualKeySequence("c", { ctrl: true }), "\u0003");
+  assert.equal(getVirtualKeySequence("d", { ctrl: true }), "\u0004");
+  assert.equal(getVirtualKeySequence("tab", { shift: true }), "\u001b[Z");
+  assert.equal(getVirtualKeySequence("up", { ctrl: true }), "\u001b[1;5A");
+  assert.equal(getVirtualKeySequence("left", { alt: true }), "\u001b[1;3D");
+  assert.equal(getVirtualKeySequence("f12", {}), "\u001b[24~");
+});

--- a/remote-terminal/test/server.test.js
+++ b/remote-terminal/test/server.test.js
@@ -82,6 +82,55 @@ function createSpinnerRecorder(events = []) {
   };
 }
 
+class FakeTray {
+  constructor(conf) {
+    this.clickHandler = null;
+    this.conf = conf;
+    this.killed = false;
+    this.readyCalled = false;
+    this.sentActions = [];
+  }
+
+  ready() {
+    this.readyCalled = true;
+    return Promise.resolve();
+  }
+
+  onClick(listener) {
+    this.clickHandler = listener;
+    return Promise.resolve(this);
+  }
+
+  onError() {}
+
+  sendAction(action) {
+    this.sentActions.push(action);
+    if (action.type === "update-menu") {
+      this.conf.menu = action.menu;
+    }
+    return Promise.resolve(this);
+  }
+
+  async clickItem(titleMatcher) {
+    const item = this.conf.menu.items.find((entry) =>
+      titleMatcher instanceof RegExp ? titleMatcher.test(entry.title) : entry.title === titleMatcher,
+    );
+    assert.ok(item, `missing tray item: ${titleMatcher}`);
+    await this.clickHandler({
+      __id: 1,
+      item,
+      seq_id: 1,
+      type: "clicked",
+    });
+  }
+
+  kill(exitNode = true) {
+    this.killed = true;
+    this.exitNode = exitNode;
+    return Promise.resolve();
+  }
+}
+
 async function connectClient(remoteTerminal, token) {
   const socket = io(`http://127.0.0.1:${remoteTerminal.port}`, {
     auth: { token },
@@ -125,7 +174,11 @@ test("health endpoint is public but the terminal page stays token gated", async 
 
   const allowed = await fetch(remoteTerminal.localUrl);
   assert.equal(allowed.status, 200);
-  assert.match(await allowed.text(), /Remote Terminal/);
+  const html = await allowed.text();
+  assert.match(html, /Remote Terminal/);
+  assert.match(html, /id="theme-select"/);
+  assert.match(html, /id="keyboard-toggle"/);
+  assert.match(html, /id="mobile-keyboard"/);
   assert.deepEqual(qrCodes, [{ label: "Local access QR", url: remoteTerminal.localUrl }]);
 });
 
@@ -314,6 +367,166 @@ test("forwarded tunnel client IPs keep auth rate limiting scoped per client", as
     headers: allowedHeaders,
   });
   assert.equal(differentForwardedClient.status, 401);
+});
+
+test("system tray exposes local URL actions and LAN-only status", async (t) => {
+  const copiedUrls = [];
+  const qrCodes = [];
+  let fakeTray = null;
+
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    copyText: async (value) => copiedUrls.push(value),
+    disableTunnel: true,
+    enableTray: true,
+    logger: () => {},
+    port: 0,
+    qrWriter: (label, url) => qrCodes.push({ label, url }),
+    token: "issue81-tray-local-token",
+    trayFactory: async (conf) => {
+      fakeTray = new FakeTray(conf);
+      return fakeTray;
+    },
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
+  const payload = await health.json();
+  assert.equal(payload.trayEnabled, true);
+  assert.equal(payload.trayReady, true);
+  assert.match(payload.trayStatus, /Connected/);
+  assert.match(fakeTray.conf.menu.items[0].title, /Connected/);
+  assert.match(fakeTray.conf.menu.items[1].title, /Copy local URL/);
+
+  await fakeTray.clickItem("Copy local URL");
+  assert.deepEqual(copiedUrls, [remoteTerminal.localUrl]);
+
+  await fakeTray.clickItem("Regenerate QR code");
+  assert.deepEqual(qrCodes.at(-1), {
+    label: "Local access QR (tray)",
+    url: remoteTerminal.localUrl,
+  });
+
+  await remoteTerminal.stop();
+  assert.equal(fakeTray.killed, true);
+  assert.equal(fakeTray.exitNode, false);
+});
+
+test("system tray switches to the public URL once the tunnel is ready", async (t) => {
+  const tunnel = new EventEmitter();
+  tunnel.stop = () => true;
+  let fakeTray = null;
+
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    enableTray: true,
+    logger: () => {},
+    port: 0,
+    spinnerFactory: () => createSpinnerRecorder(),
+    token: "issue81-tray-public-token",
+    trayFactory: async (conf) => {
+      fakeTray = new FakeTray(conf);
+      return fakeTray;
+    },
+    tunnelFactory: () => tunnel,
+    verifyTunnel: async (_url, options) => {
+      options.onProgress(1, 1);
+    },
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  tunnel.emit("connected", { location: "tray-edge" });
+  tunnel.emit("url", "https://issue81.trycloudflare.com");
+
+  await waitFor(
+    () =>
+      fakeTray.conf.menu.items.some((item) => /Copy public URL/.test(item.title)) &&
+      /Connected/.test(fakeTray.conf.menu.items[0].title),
+    "tray never updated to the public connected state",
+  );
+
+  const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
+  const payload = await health.json();
+  assert.equal(payload.trayReady, true);
+  assert.match(payload.trayStatus, /Connected/);
+  assert.equal(payload.publicOrigin, stripTokenFromUrl(remoteTerminal.publicUrl));
+  assert.match(fakeTray.conf.menu.items[1].title, /Copy public URL/);
+});
+
+test("tray startup failures clean up the spawned tray subprocess", async (t) => {
+  const logs = [];
+  const fakeTray = {
+    killed: false,
+    onClick() {
+      return Promise.resolve(this);
+    },
+    onError() {},
+    ready() {
+      return Promise.reject(new Error("tray ready failed"));
+    },
+    kill(exitNode = true) {
+      this.killed = true;
+      this.exitNode = exitNode;
+      return Promise.resolve();
+    },
+  };
+
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    disableTunnel: true,
+    enableTray: true,
+    logger: (message) => logs.push(message),
+    port: 0,
+    token: "issue81-tray-failure-token",
+    trayFactory: async () => fakeTray,
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  const health = await fetch(`http://127.0.0.1:${remoteTerminal.port}/health`);
+  const payload = await health.json();
+  assert.equal(payload.trayEnabled, true);
+  assert.equal(payload.trayReady, false);
+  assert.match(payload.trayError, /tray ready failed/);
+  assert.equal(fakeTray.killed, true);
+  assert.equal(fakeTray.exitNode, false);
+  assert.match(logs.join("\n"), /System tray unavailable: tray ready failed/);
+});
+
+test("tray action sync errors are logged instead of escaping", async (t) => {
+  let fakeTray = null;
+  let qrRenders = 0;
+  const logs = [];
+
+  const remoteTerminal = await startRemoteTerminal({
+    accessHost: "127.0.0.1",
+    disableTunnel: true,
+    enableTray: true,
+    logger: (message) => logs.push(message),
+    port: 0,
+    qrWriter: () => {
+      qrRenders += 1;
+      if (qrRenders > 1) {
+        throw new Error("tray qr failed");
+      }
+    },
+    token: "issue81-tray-sync-token",
+    trayFactory: async (conf) => {
+      fakeTray = new FakeTray(conf);
+      return fakeTray;
+    },
+  });
+  t.after(async () => {
+    await remoteTerminal.stop();
+  });
+
+  await fakeTray.clickItem("Regenerate QR code");
+  assert.match(logs.join("\n"), /Tray action failed: tray qr failed/);
 });
 
 test("server restart reattaches to the same PTY daemon session", async (t) => {


### PR DESCRIPTION
## Summary
- add a native systray2 operator tray with live status, copy URL, and regenerate QR actions
- add six persistent terminal themes plus a touch-friendly on-screen keyboard to the browser client
- cover tray lifecycle and browser keyboard/theme behavior with new remote-terminal tests

## Testing
- npm.cmd --script-shell pwsh test

Closes #81