### PR TITLE
ci(sk-rust): add clippy complexity advisory

### DIFF
--- a/.github/steps/issue-259-rust-clippy-advisory.md
+++ b/.github/steps/issue-259-rust-clippy-advisory.md
@@ -1,0 +1,93 @@
+# STEPS: Issue 259 Rust Clippy advisory complexity thresholds
+
+**Task:** Add Rust Clippy complexity thresholds and warn-only advisory CI coverage for `sk-rust/`.
+**Scope:** `sk-rust/clippy.toml`, `.github/workflows/sk-ci.yml`, `docs/ARCHITECTURE.md`.
+
+## Step 1: CLARIFY — Confirm scoped surfaces
+
+**Goal:** Confirm issue #259 can be completed without touching the dirty root checkout or dependent documentation issues.
+
+**Actions:**
+1. `git status --short --branch` in the isolated worktree.
+2. Read `.github/workflows/sk-ci.yml`, `sk-rust/Cargo.toml`, and `docs/ARCHITECTURE.md`.
+3. Confirm no existing `sk-rust/clippy.toml` exists.
+
+**Done when:** The worktree is clean on `issue-259-rust-clippy-advisory`, no existing Clippy threshold file is present, and the issue scope remains limited to the three expected surfaces.
+
+## Step 2: BUILD — Add Clippy threshold config
+
+**Goal:** Add warn-only threshold values that Clippy can read without changing release/build behavior.
+
+**Actions:**
+1. Create `sk-rust/clippy.toml`.
+2. Add `cognitive-complexity-threshold`, `too-many-lines-threshold`, and `too-many-arguments-threshold`.
+
+**Done when:** `sk-rust/clippy.toml` exists and contains all three required threshold keys.
+
+## Step 3: BUILD — Add advisory CI invocation
+
+**Goal:** Measure complexity lints in CI without breaking the existing strict Clippy job.
+
+**Actions:**
+1. Add a new step to the existing `clippy` job in `.github/workflows/sk-ci.yml`.
+2. Name the step `Complexity advisory (Rust Clippy)`.
+3. Run `cargo clippy --all-targets -- -W clippy::cognitive_complexity -W clippy::too_many_lines`.
+4. Set `continue-on-error: true`.
+
+**Done when:** The workflow has the advisory step, keeps the existing `cargo clippy -- -D warnings` gate intact, and the advisory step is non-blocking.
+
+## Step 4: BUILD — Document the advisory policy
+
+**Goal:** Make the Rust complexity advisory visible in the canonical architecture docs.
+
+**Actions:**
+1. Add a short `Rust complexity advisory` note to `docs/ARCHITECTURE.md`.
+2. Mention `sk-rust/clippy.toml`, the warn-only CI step, and that warnings are measured before enforcement.
+
+**Done when:** `docs/ARCHITECTURE.md` names the Clippy threshold file and explains the advisory CI behavior.
+
+## Step 5: TEST — Run issue acceptance checks
+
+**Goal:** Prove the scoped change is syntactically valid and does not break Rust checks.
+
+**Actions:**
+1. `Test-Path sk-rust\clippy.toml`
+2. `Select-String -Path sk-rust\clippy.toml -Pattern 'cognitive-complexity-threshold|too-many-lines-threshold|too-many-arguments-threshold'`
+3. `Select-String -Path .github\workflows\sk-ci.yml -Pattern 'Complexity advisory|continue-on-error: true|clippy::cognitive_complexity|clippy::too_many_lines'`
+4. `Set-Location sk-rust; cargo clippy --all-targets`
+5. `Set-Location sk-rust; cargo test --all`
+
+**Done when:** The string checks find all required configuration and both Cargo commands exit 0.
+
+## Step 6: REVIEW — Check for scope creep and gate safety
+
+**Goal:** Confirm the advisory step cannot fail CI on existing complexity warnings and does not alter unrelated jobs.
+
+**Actions:**
+1. Review `git diff --stat`.
+2. Confirm only the scoped files changed.
+3. Confirm the new CI step has `continue-on-error: true`.
+
+**Done when:** The diff is limited to the intended surfaces and no blocking complexity gate was introduced.
+
+## Step 7: COMMIT — Package and ship
+
+**Goal:** Produce a reviewed PR that closes #259 and preserves audit evidence.
+
+**Actions:**
+1. Commit the scoped changes.
+2. Push `issue-259-rust-clippy-advisory`.
+3. Open a PR with `Closes #259`.
+4. Copy issue labels to the PR.
+
+**Done when:** The PR exists with a closing keyword and the expected labels.
+
+## Phase Gates
+
+| Phase | Artifact | Status |
+|-------|---------|--------|
+| CLARIFY | Clean isolated worktree on fresh `origin/main` | ☐ |
+| BUILD | `sk-rust/clippy.toml` and advisory CI/docs updates | ☐ |
+| TEST | Required string checks + `cargo clippy --all-targets` + `cargo test --all` | ☐ |
+| REVIEW | Diff limited to scoped files and advisory step is non-blocking | ☐ |
+| COMMIT | PR closes #259 and mirrors labels | ☐ |

--- a/.github/workflows/sk-ci.yml
+++ b/.github/workflows/sk-ci.yml
@@ -50,6 +50,9 @@ jobs:
             sk-rust/target/
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('sk-rust/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-clippy-
+      - name: Complexity advisory (Rust Clippy)
+        continue-on-error: true
+        run: cargo clippy --all-targets -- -W clippy::cognitive_complexity -W clippy::too_many_lines
       - run: cargo clippy -- -D warnings
 
   test:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -367,6 +367,8 @@ GitHub Actions runs two jobs on every push / PR:
 - **`quality-gates`** — syntax check, scoped Ruff lint, and the Python test suites. The Ruff lint surface is: `embed.py`, `scout-config.py`, `scout-status.py`, `sync-config.py`, `sync-daemon.py`, `sync-status.py`, `migrate.py`, `generate-summary.py`, `briefing.py`, `learn.py`, `query-session.py`, `extract-knowledge.py`, `build-session-index.py`, `tentacle.py`, `checkpoint-diff.py`, `checkpoint-restore.py`, `checkpoint-save.py`, `browse/`, `hooks/`. Ruff lint is **scoped** to this surface; other root scripts outside it are not linted by CI.
 - **`browse-ui`** — `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, `pnpm build`.
 
+For `sk-rust/**` changes, `sk CI` also runs Rust formatting, strict Clippy, and tests across Ubuntu, Windows, and macOS. `sk-rust/clippy.toml` defines advisory complexity thresholds (`cognitive-complexity-threshold`, `too-many-lines-threshold`, `too-many-arguments-threshold`). The `Complexity advisory (Rust Clippy)` step runs before the strict Clippy gate with `continue-on-error: true`, so complexity warnings are measured before any future enforcement change.
+
 Playwright E2E runs are manual-dispatch only. The stable `behavioral` project covers `smoke.spec.ts`, `shortcuts.spec.ts`, and `chat.spec.ts`; `visual.spec.ts` remains outside always-on CI because screenshot output differs across platforms.
 
 ### Automation Surfaces

--- a/sk-rust/clippy.toml
+++ b/sk-rust/clippy.toml
@@ -1,0 +1,5 @@
+# Advisory complexity thresholds for sk-rust. These values are measured first in
+# CI before any future enforcement change.
+cognitive-complexity-threshold = 25
+too-many-lines-threshold = 400
+too-many-arguments-threshold = 8

--- a/sk-rust/src/hooks/rules.rs
+++ b/sk-rust/src/hooks/rules.rs
@@ -8798,6 +8798,8 @@ mod tests {
     /// environment `verify_marker` requires a valid HMAC-SHA256 signature.
     #[test]
     fn git_guard_hmac_unsigned_no_secret_backward_compat() {
+        let _guard = env_lock();
+
         // Derive the real secret path the same way marker_auth does.
         let secret_exists = resolve_home_dir()
             .map(|h| {
@@ -9147,6 +9149,8 @@ mod tests {
     /// Test that read_tentacle_edits_paths handles flat legacy format correctly.
     #[test]
     fn read_tentacle_edits_paths_handles_legacy_flat_format() {
+        let _guard = env_lock();
+
         use std::collections::HashSet;
 
         let tmp = std::env::temp_dir().join("sk_tentacle_edits_test");
@@ -9179,6 +9183,8 @@ mod tests {
     /// Test that read_tentacle_edits_paths handles new JSON-dict format correctly.
     #[test]
     fn read_tentacle_edits_paths_handles_json_dict_format() {
+        let _guard = env_lock();
+
         use std::collections::HashSet;
 
         let tmp = std::env::temp_dir().join("sk_tentacle_edits_json_test");


### PR DESCRIPTION
## Summary
- add advisory Clippy complexity thresholds for sk-rust
- run complexity Clippy lints in CI as a non-blocking advisory before strict Clippy
- document the Rust complexity advisory policy and harden related Rust hook-rule tests against shared HOME races

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --all-targets`
- `cargo test --all`

Closes #259