### PR TITLE
chore(sk): add startup benchmark advisory

### DIFF
--- a/.github/steps/issue-261-sk-startup-benchmark.md
+++ b/.github/steps/issue-261-sk-startup-benchmark.md
@@ -1,0 +1,83 @@
+# STEPS: Issue #261 sk startup benchmark advisory
+
+**Task:** Add a non-blocking startup benchmark advisory for `sk --help`.
+**Scope:** `benchmark.py`, `.github/workflows/sk-ci.yml`, `tests/test_benchmark.py`, `.github/steps/issue-261-sk-startup-benchmark.md`.
+
+## Step 1: CLARIFY — Confirm benchmark target
+
+**Goal:** Use a stable command that exercises `sk` startup without mutating repo or user state.
+
+**Actions:**
+1. Read issue #261 and confirm the accepted command is `sk --help` or an equivalent stable no-op.
+2. Inspect `benchmark.py`, `.github/workflows/sk-ci.yml`, and `sk-rust/src/main.rs`.
+
+**Done when:** The benchmark target is confirmed as the compiled `sk` binary invoked with `--help`.
+
+## Step 2: BUILD — Add startup timing command
+
+**Goal:** Extend `benchmark.py` with a local command that measures startup latency.
+
+**Actions:**
+1. Add `benchmark.py startup` with `--runs`, `--warmups`, `--timeout`, and `-- COMMAND...`.
+2. Print `median_ms`, `min_ms`, and `max_ms` in text output, and expose the same fields in JSON output.
+3. Return non-zero if the measured command fails, times out, or is missing.
+
+**Done when:** `python3 benchmark.py startup --runs 3 --warmups 1 -- python -c "pass"` exits 0 and prints median/min/max milliseconds.
+
+## Step 3: TEST — Cover parser and output contract
+
+**Goal:** Prove the startup benchmark command is parseable and emits the required fields.
+
+**Actions:**
+1. Add `tests/test_benchmark.py` coverage for startup argument parsing.
+2. Add `tests/test_benchmark.py` coverage for text and JSON startup output.
+3. Run `python3 tests/test_benchmark.py`.
+
+**Done when:** The benchmark tests pass with the new startup assertions.
+
+## Step 4: BUILD — Add CI advisory step
+
+**Goal:** Add a CI log baseline without making startup benchmark failures block merges.
+
+**Actions:**
+1. Add a `sk-ci.yml` advisory job that builds the release binary.
+2. Run `python3 benchmark.py startup --runs 7 --warmups 2 --timeout 10 -- sk-rust/target/release/sk --help`.
+3. Set `continue-on-error: true` on the benchmark step.
+
+**Done when:** The workflow contains an advisory startup step that prints `median_ms`, `min_ms`, and `max_ms`.
+
+## Step 5: REVIEW — Verify acceptance evidence
+
+**Goal:** Confirm the issue acceptance criteria are independently evidenced.
+
+**Actions:**
+1. Run `python3 -m py_compile benchmark.py tests/test_benchmark.py`.
+2. Run `python3 tests/test_benchmark.py`.
+3. Run `python3 test_fixes.py`.
+4. Run `cargo build --release --manifest-path sk-rust/Cargo.toml`.
+5. Run `python3 benchmark.py startup --runs 3 --warmups 1 --timeout 10 -- ./sk-rust/target/release/sk --help`.
+
+**Done when:** All commands exit 0 and the local startup command prints median/min/max milliseconds.
+
+## Step 6: COMMIT — Package and ship
+
+**Goal:** Ship the issue in an isolated lane with traceable evidence.
+
+**Actions:**
+1. Run `git diff --stat` and confirm only expected files changed.
+2. Commit with the required co-author trailer.
+3. Open a PR with `Closes #261` and mirror issue labels.
+4. Merge after CI passes, move the project item to Done, then delete the branch/worktree/tentacle.
+
+**Done when:** PR is merged, issue #261 is closed, project status is Done, and the local lane is cleaned.
+
+## Phase Gates
+
+| Phase | Artifact | Status |
+|-------|----------|--------|
+| CLARIFY | `sk --help` target confirmed | Done |
+| BUILD | `benchmark.py startup` implemented | Done |
+| TEST | Startup parser/output tests pass | Pending |
+| BUILD | `sk-ci.yml` advisory step added | Done |
+| REVIEW | Local startup benchmark and regression gates pass | Pending |
+| COMMIT | PR merged and lane cleaned | Pending |

--- a/.github/workflows/sk-ci.yml
+++ b/.github/workflows/sk-ci.yml
@@ -5,10 +5,14 @@ on:
     branches: [main]
     paths:
       - 'sk-rust/**'
+      - 'benchmark.py'
+      - '.github/workflows/sk-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'sk-rust/**'
+      - 'benchmark.py'
+      - '.github/workflows/sk-ci.yml'
 
 env:
   CARGO_TERM_COLOR: always
@@ -54,6 +58,26 @@ jobs:
         continue-on-error: true
         run: cargo clippy --all-targets -- -W clippy::cognitive_complexity -W clippy::too_many_lines
       - run: cargo clippy -- -D warnings
+
+  startup-benchmark:
+    name: Startup benchmark advisory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            sk-rust/target/
+          key: ubuntu-latest-cargo-startup-${{ hashFiles('sk-rust/Cargo.lock') }}
+          restore-keys: ubuntu-latest-cargo-startup-
+      - name: Benchmark sk startup (advisory)
+        continue-on-error: true
+        run: |
+          cargo build --release --manifest-path sk-rust/Cargo.toml
+          python3 benchmark.py startup --runs 7 --warmups 2 --timeout 10 -- sk-rust/target/release/sk --help
 
   test:
     name: Test (${{ matrix.os }})

--- a/benchmark.py
+++ b/benchmark.py
@@ -9,11 +9,13 @@ Usage:
     python3 benchmark.py record [--db PATH] [--commit SHA] [--mode local|repo]
     python3 benchmark.py compare [--db PATH] [--commits SHA SHA] [--limit N]
     python3 benchmark.py list [--db PATH] [--limit N] [--json]
+    python3 benchmark.py startup [--runs N] [--warmups N] [--timeout SEC] [-- COMMAND...]
 
 Signals captured (all read-only):
     - retro.py  → retro_score, subscores, score_confidence
     - knowledge-health.py → health.score (when available)
     - git HEAD  → commit_sha, commit_msg
+    - startup command wall-clock timing → median/min/max milliseconds
 
 Standalone script: no imports from other tools at module level.
 Stdlib-only; optional dynamic loading of retro.py / knowledge-health.py.
@@ -22,9 +24,12 @@ Stdlib-only; optional dynamic loading of retro.py / knowledge-health.py.
 import importlib.util
 import json
 import os
+import shlex
+import statistics
 import sqlite3
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 if os.name == "nt":
@@ -434,6 +439,100 @@ def cmd_compare(db_path: Path, commits: "list[str]", limit: int) -> int:
     return 0
 
 
+# ── Startup timing ────────────────────────────────────────────────────────────
+
+
+def _measure_startup_once(command: "list[str]", timeout: float) -> "tuple[int, float, str]":
+    """Run one startup measurement and return (exit code, elapsed ms, error)."""
+    start = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=str(SCRIPT_DIR),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        return 127, elapsed_ms, f"command not found: {command[0]}"
+    except subprocess.TimeoutExpired:
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        return 124, elapsed_ms, f"timed out after {timeout:g}s"
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    return completed.returncode, elapsed_ms, ""
+
+
+def _print_startup_failure(phase: str, index: int, rc: int, elapsed_ms: float, error: str) -> None:
+    detail = error or f"exit code {rc}"
+    print(
+        f"benchmark startup: {phase} #{index} failed after {elapsed_ms:.2f} ms ({detail})",
+        file=sys.stderr,
+    )
+
+
+def cmd_startup(
+    command: "list[str]",
+    runs: int,
+    warmups: int,
+    timeout: float,
+    as_json: bool,
+) -> int:
+    """Measure startup latency for a stable no-op command."""
+    if not command:
+        print("benchmark startup: command is required", file=sys.stderr)
+        return 2
+    if runs <= 0:
+        print("benchmark startup: --runs must be greater than 0", file=sys.stderr)
+        return 2
+    if warmups < 0:
+        print("benchmark startup: --warmups must be 0 or greater", file=sys.stderr)
+        return 2
+    if timeout <= 0:
+        print("benchmark startup: --timeout must be greater than 0", file=sys.stderr)
+        return 2
+
+    for i in range(1, warmups + 1):
+        rc, elapsed_ms, error = _measure_startup_once(command, timeout)
+        if rc != 0:
+            _print_startup_failure("warmup", i, rc, elapsed_ms, error)
+            return rc if rc > 0 else 1
+
+    timings = []
+    for i in range(1, runs + 1):
+        rc, elapsed_ms, error = _measure_startup_once(command, timeout)
+        if rc != 0:
+            _print_startup_failure("run", i, rc, elapsed_ms, error)
+            return rc if rc > 0 else 1
+        timings.append(elapsed_ms)
+
+    median_ms = statistics.median(timings)
+    min_ms = min(timings)
+    max_ms = max(timings)
+    payload = {
+        "command": command,
+        "runs": runs,
+        "warmups": warmups,
+        "median_ms": round(median_ms, 2),
+        "min_ms": round(min_ms, 2),
+        "max_ms": round(max_ms, 2),
+    }
+
+    if as_json:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    print("benchmark startup")
+    print(f"  command:   {shlex.join(command)}")
+    print(f"  warmups:   {warmups}")
+    print(f"  runs:      {runs}")
+    print(f"  median_ms: {median_ms:.2f}")
+    print(f"  min_ms:    {min_ms:.2f}")
+    print(f"  max_ms:    {max_ms:.2f}")
+    return 0
+
+
 # ── CLI ──────────────────────────────────────────────────────────────────────
 
 
@@ -446,12 +545,19 @@ def _parse_args(argv: list) -> dict:
         "commits": [],
         "limit": 10,
         "json": False,
+        "runs": 10,
+        "warmups": 1,
+        "timeout": 10.0,
+        "startup_command": ["sk", "--help"],
     }
     i = 1
     while i < len(argv):
         a = argv[i]
-        if a in ("record", "compare", "list"):
+        if a in ("record", "compare", "list", "startup"):
             args["cmd"] = a
+        elif a == "--":
+            args["startup_command"] = argv[i + 1:]
+            break
         elif a == "--db" and i + 1 < len(argv):
             i += 1
             args["db"] = Path(argv[i])
@@ -464,6 +570,15 @@ def _parse_args(argv: list) -> dict:
         elif a == "--limit" and i + 1 < len(argv):
             i += 1
             args["limit"] = int(argv[i])
+        elif a == "--runs" and i + 1 < len(argv):
+            i += 1
+            args["runs"] = int(argv[i])
+        elif a == "--warmups" and i + 1 < len(argv):
+            i += 1
+            args["warmups"] = int(argv[i])
+        elif a == "--timeout" and i + 1 < len(argv):
+            i += 1
+            args["timeout"] = float(argv[i])
         elif a == "--commits" and i + 2 < len(argv):
             args["commits"] = [argv[i + 1], argv[i + 2]]
             i += 2
@@ -481,7 +596,8 @@ def main(argv: "list | None" = None) -> int:
     if args["cmd"] is None:
         print(
             "Usage: benchmark.py <record|compare|list> [--db PATH] [--commit SHA] "
-            "[--mode local|repo] [--limit N] [--json] [--commits SHA SHA]"
+            "[--mode local|repo] [--limit N] [--json] [--commits SHA SHA]\n"
+            "       benchmark.py startup [--runs N] [--warmups N] [--timeout SEC] [-- COMMAND...]"
         )
         return 1
 
@@ -497,6 +613,14 @@ def main(argv: "list | None" = None) -> int:
         return cmd_list(db_path, args["limit"], args["json"])
     elif args["cmd"] == "compare":
         return cmd_compare(db_path, args["commits"], args["limit"])
+    elif args["cmd"] == "startup":
+        return cmd_startup(
+            args["startup_command"],
+            args["runs"],
+            args["warmups"],
+            args["timeout"],
+            args["json"],
+        )
     else:
         print(f"benchmark: unknown command '{args['cmd']}'", file=sys.stderr)
         return 1

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -14,6 +14,7 @@ Covers:
 9. Migration round-trip: migrate.py v14 creates benchmark_snapshots
 10. No writes outside benchmark_snapshots (read-only contract)
 11. _collect_health uses the requested DB path and fails closed on SystemExit
+12. cmd_startup: prints median/min/max milliseconds for a no-op command
 
 Run:
     python3 test_benchmark.py
@@ -557,6 +558,58 @@ def test_parse_args_list_json():
     test("_parse_args: limit=5", args["limit"] == 5)
 
 
+def test_parse_args_startup_command():
+    b = _load_bench()
+    args = b._parse_args(
+        [
+            "benchmark.py",
+            "startup",
+            "--runs",
+            "3",
+            "--warmups",
+            "0",
+            "--timeout",
+            "2.5",
+            "--",
+            sys.executable,
+            "-c",
+            "pass",
+        ]
+    )
+    test("_parse_args: cmd=startup", args["cmd"] == "startup")
+    test("_parse_args: startup runs=3", args["runs"] == 3)
+    test("_parse_args: startup warmups=0", args["warmups"] == 0)
+    test("_parse_args: startup timeout=2.5", args["timeout"] == 2.5)
+    test("_parse_args: startup command captured", args["startup_command"] == [sys.executable, "-c", "pass"])
+
+
+# ── 6b. cmd_startup ──────────────────────────────────────────────────────────
+
+
+def test_cmd_startup_outputs_ms():
+    b = _load_bench()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = b.cmd_startup([sys.executable, "-c", "pass"], runs=3, warmups=1, timeout=10.0, as_json=False)
+    out = buf.getvalue()
+    test("cmd_startup: returns 0", rc == 0, f"rc={rc}")
+    test("cmd_startup: prints median_ms", "median_ms:" in out, f"out={out}")
+    test("cmd_startup: prints min_ms", "min_ms:" in out, f"out={out}")
+    test("cmd_startup: prints max_ms", "max_ms:" in out, f"out={out}")
+
+
+def test_cmd_startup_json_output():
+    b = _load_bench()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = b.cmd_startup([sys.executable, "-c", "pass"], runs=2, warmups=0, timeout=10.0, as_json=True)
+    payload = json.loads(buf.getvalue())
+    test("cmd_startup JSON: returns 0", rc == 0, f"rc={rc}")
+    test("cmd_startup JSON: median_ms present", isinstance(payload.get("median_ms"), float))
+    test("cmd_startup JSON: min_ms present", isinstance(payload.get("min_ms"), float))
+    test("cmd_startup JSON: max_ms present", isinstance(payload.get("max_ms"), float))
+
+
 # ── 7. _delta_str ────────────────────────────────────────────────────────────
 
 
@@ -774,6 +827,11 @@ def run_all():
     test_parse_args_record()
     test_parse_args_compare_commits()
     test_parse_args_list_json()
+    test_parse_args_startup_command()
+
+    print("\n── 6b. cmd_startup ───────────────────────────────────────────────────────")
+    test_cmd_startup_outputs_ms()
+    test_cmd_startup_json_output()
 
     print("\n── 7. _delta_str ─────────────────────────────────────────────────────────")
     test_delta_str_positive()


### PR DESCRIPTION
Closes #261

## Summary
- add `benchmark.py startup` for repeated no-op command timing with median/min/max milliseconds
- add a non-blocking `sk-ci` startup benchmark advisory against the release `sk --help` path
- cover startup parser, text output, and JSON output in `tests/test_benchmark.py`

## Evidence
- `python -m py_compile benchmark.py tests\test_benchmark.py`
- `python tests\test_benchmark.py` - 89 passed
- `python test_fixes.py` - 221 passed, 0 failed
- `cargo build --release --manifest-path sk-rust\Cargo.toml`
- `python benchmark.py startup --runs 3 --warmups 1 --timeout 10 -- sk-rust\target\release\sk.exe --help` - printed `median_ms`, `min_ms`, `max_ms`
- `cargo test --manifest-path sk-rust\Cargo.toml --quiet` - 670 unit + 78 integration passed
- `git diff --check`