### PR TITLE
feat(hooks): add file-size advisory rule

### DIFF
--- a/.github/steps/issue-263-file-size-advisory.md
+++ b/.github/steps/issue-263-file-size-advisory.md
@@ -1,0 +1,83 @@
+# STEPS: Issue #263 file-size advisory hook rule
+
+**Task:** Add a fail-open advisory hook rule that warns when Python edits create oversized files.
+**Scope:** `hooks/rules/file_size_advisory.py`, `hooks/rules/__init__.py`, `docs/HOOKS.md`, `tests/test_quality_gates.py`, `.github/steps/issue-263-file-size-advisory.md`.
+
+## Step 1: CLARIFY - Confirm hook behavior
+
+**Goal:** Confirm the rule is advisory-only and does not block tool execution.
+
+**Actions:**
+1. Read issue #263 and confirm the required outputs: new rule module, registry entry, docs row, and unit tests.
+2. Inspect `hooks/rules/__init__.py`, `hooks/rules/common.py`, `tests/test_quality_gates.py`, and `docs/HOOKS.md`.
+3. Confirm dependency #283 is not needed for this narrow rule because the registry, docs contract, and quality-gate test file already exist on main.
+
+**Done when:** The rule threshold, event/tool scope, and fail-open result shape are known.
+
+## Step 2: BUILD - Add the advisory rule
+
+**Goal:** Implement a hook rule that computes the proposed Python file line count for create/edit payloads.
+
+**Actions:**
+1. Add `hooks/rules/file_size_advisory.py`.
+2. For `create`, read `toolArgs.file_text`.
+3. For `edit`, read the current file and apply the single `old_str` -> `new_str` replacement in memory.
+4. Return `info(...)` when the resulting `.py` file exceeds 600 lines; return `None` otherwise.
+
+**Done when:** The rule returns advisory info for oversized `.py` create/edit payloads and never returns `permissionDecision: deny`.
+
+## Step 3: BUILD - Register and document
+
+**Goal:** Make the rule active in the unified runner and visible in hook docs.
+
+**Actions:**
+1. Register `FileSizeAdvisoryRule()` in `hooks/rules/__init__.py`.
+2. Add a `file-size-advisory` row to the `docs/HOOKS.md` rules table.
+
+**Done when:** `_registered_hook_rule_names()` includes `file-size-advisory`, and docs contain the matching table row.
+
+## Step 4: TEST - Cover acceptance criteria
+
+**Goal:** Prove the advisory rule behaves correctly and remains fail-open.
+
+**Actions:**
+1. Add tests in `tests/test_quality_gates.py` for import, registry, 700-line create/edit advisory, 250-line no-op, non-Python no-op, and docs coverage.
+2. Run `python tests/test_quality_gates.py`.
+
+**Done when:** The quality-gate test runner passes with the new file-size advisory assertions.
+
+## Step 5: REVIEW - Verify repository gates
+
+**Goal:** Confirm the change does not regress existing Python hook behavior.
+
+**Actions:**
+1. Run `python -m py_compile hooks/rules/file_size_advisory.py hooks/rules/__init__.py tests/test_quality_gates.py`.
+2. Run `python tests/test_quality_gates.py`.
+3. Run `python test_fixes.py`.
+4. Run `python run_all_tests.py`.
+5. Run `git diff --check`.
+6. Run a code-review agent on the diff.
+
+**Done when:** All commands exit 0 and review returns CLEAN.
+
+## Step 6: COMMIT - Package and ship
+
+**Goal:** Merge #263 through the isolated lane and clean local state.
+
+**Actions:**
+1. Commit only expected files with the required co-author trailer.
+2. Open a PR with `Closes #263` and mirror labels.
+3. Wait for CI, merge, move #263 project item to Done, and delete branch/worktree/tentacle.
+
+**Done when:** PR is merged, issue #263 is closed, project item is Done, and the isolated lane is removed.
+
+## Phase Gates
+
+| Phase | Artifact | Status |
+|-------|----------|--------|
+| CLARIFY | Advisory-only behavior confirmed | [ ] |
+| BUILD | `FileSizeAdvisoryRule` added | [ ] |
+| BUILD | Rule registered and documented | [ ] |
+| TEST | `tests/test_quality_gates.py` passes | [ ] |
+| REVIEW | Local gates and code review complete | [ ] |
+| COMMIT | PR merged and lane cleaned | [ ] |

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -47,6 +47,7 @@ hooks/
 | `pnpm-lockfile-guard` | preToolUse | Blocks staging `browse-ui/package.json` changes without a matching `pnpm-lock.yaml` update. Prevents lockfile drift. |
 | `block-unsafe-html` | preToolUse | Blocks `dangerouslySetInnerHTML` usage in `.ts`/`.tsx` files without `DOMPurify.sanitize()` or the `<Highlight>` component. |
 | `verification-gate` | preToolUse + postToolUse | Tracks dirty Python / `browse-ui` TS/JS surfaces, records successful verification commands, and blocks closeout-style actions (`task_complete`, `gh issue close/comment`, tentacle `handoff --status DONE`, tentacle `complete`) until the required fresh evidence exists. |
+| `file-size-advisory` | preToolUse | Warns when an `edit`/`create` payload would leave a Python file over 600 lines. Advisory-only and fail-open: emits information but never denies the tool call. |
 | `track-edits` | postToolUse | Detects file changes via `git status` (language-agnostic) |
 | `learn-reminder` | postToolUse | Reminds to record learnings after task_complete; also surfaces [docs/SYNC-MATRIX.md](SYNC-MATRIX.md) for docs/memory follow-ups |
 | `test-reminder` | postToolUse | Reminds to run tests after 3+ Python file edits |

--- a/hooks/rules/__init__.py
+++ b/hooks/rules/__init__.py
@@ -26,6 +26,7 @@ def get_rules_for_event(event):
     from .constitution_gate import ConstitutionGateRule
     from .edit_tracker import TestReminderRule, TrackEditsRule
     from .error_kb import ErrorKBRule
+    from .file_size_advisory import FileSizeAdvisoryRule
     from .integrity import IntegrityRule
     from .learn_gate import EnforceLearnRule
     from .learn_reminder import LearnReminderRule
@@ -58,6 +59,7 @@ def get_rules_for_event(event):
         PnpmLockfileGuardRule(),
         BlockUnsafeHtmlRule(),
         VerificationGateRule(),
+        FileSizeAdvisoryRule(),
         ReadBeforeEditRule(),
         ReadTrackerRule(),  # Issue #85: warn on repeat reads (preToolUse)
         # postToolUse (all run, output is informational)

--- a/hooks/rules/file_size_advisory.py
+++ b/hooks/rules/file_size_advisory.py
@@ -1,0 +1,76 @@
+"""file_size_advisory.py — warn when Python edits exceed a line-count threshold.
+
+Advisory only: returns informational messages and never denies tool use.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+from . import Rule
+from .common import info
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+
+class FileSizeAdvisoryRule(Rule):
+    """Warn when a Python create/edit payload would leave a large file."""
+
+    name = "file-size-advisory"
+    events = ["preToolUse"]
+    tools = ["edit", "create"]
+
+    MAX_PYTHON_LINES = 600
+
+    def evaluate(self, event, data):
+        tool_name = data.get("toolName", "")
+        tool_args = data.get("toolArgs", {})
+        if not isinstance(tool_args, dict):
+            return None
+
+        file_path = tool_args.get("path", "")
+        if not file_path or Path(file_path).suffix.lower() != ".py":
+            return None
+
+        content = self._proposed_content(tool_name, file_path, tool_args)
+        if content is None:
+            return None
+
+        line_count = len(content.splitlines())
+        if line_count <= self.MAX_PYTHON_LINES:
+            return None
+
+        return info(
+            f"⚠️ File-size advisory: {Path(file_path).name} would be {line_count} lines "
+            f"(threshold: {self.MAX_PYTHON_LINES}). Consider splitting focused helpers or "
+            "documenting why this file should remain large."
+        )
+
+    @staticmethod
+    def _proposed_content(tool_name: str, file_path: str, tool_args: dict) -> str | None:
+        if tool_name == "create":
+            content = tool_args.get("file_text")
+            return content if isinstance(content, str) else None
+
+        if tool_name != "edit":
+            return None
+
+        disk_path = Path(file_path)
+        if not disk_path.exists():
+            return None
+        try:
+            original = disk_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+
+        old_str = tool_args.get("old_str", "")
+        new_str = tool_args.get("new_str", "")
+        if not isinstance(old_str, str) or not isinstance(new_str, str):
+            return None
+        if original.count(old_str) != 1:
+            return None
+
+        return original.replace(old_str, new_str, 1)

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -464,6 +464,132 @@ test_pre_commit_syntax_gate_present()
 test_hooks_md_syntax_gate_documented()
 test_contributing_md_syntax_gate()
 
+
+# ── Test 25–30: File-size advisory hook rule ────────────────────────────────
+
+
+def _make_file_size_advisory():
+    """Import and return a fresh FileSizeAdvisoryRule instance."""
+    import importlib
+    import sys as _sys
+
+    if str(REPO) not in _sys.path:
+        _sys.path.insert(0, str(REPO))
+    mod = importlib.import_module("hooks.rules.file_size_advisory")
+    return mod.FileSizeAdvisoryRule()
+
+
+def test_file_size_advisory_rule():
+    """Unit tests for advisory Python file size warnings."""
+    try:
+        rule = _make_file_size_advisory()
+    except Exception as exc:
+        test("FileSizeAdvisoryRule import", False, str(exc))
+        return
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        large_py = "\n".join(f"print({i})" for i in range(700))
+        small_py = "\n".join(f"print({i})" for i in range(250))
+
+        create_large = rule.evaluate("preToolUse", {
+            "toolName": "create",
+            "toolArgs": {"path": str(tmp / "large.py"), "file_text": large_py},
+        })
+        test(
+            "FileSizeAdvisoryRule: 700-line create returns advisory info",
+            create_large is not None
+            and create_large.get("permissionDecision") != "deny"
+            and "File-size advisory" in create_large.get("message", "")
+            and "700 lines" in create_large.get("message", ""),
+            f"got: {create_large}",
+        )
+
+        create_small = rule.evaluate("preToolUse", {
+            "toolName": "create",
+            "toolArgs": {"path": str(tmp / "small.py"), "file_text": small_py},
+        })
+        test(
+            "FileSizeAdvisoryRule: 250-line create returns no warning",
+            create_small is None,
+            f"got: {create_small}",
+        )
+
+        target = tmp / "module.py"
+        target.write_text("print('start')\n", encoding="utf-8")
+        edit_large = rule.evaluate("preToolUse", {
+            "toolName": "edit",
+            "toolArgs": {
+                "path": str(target),
+                "old_str": "print('start')\n",
+                "new_str": large_py,
+            },
+        })
+        test(
+            "FileSizeAdvisoryRule: 700-line edit returns advisory info",
+            edit_large is not None
+            and edit_large.get("permissionDecision") != "deny"
+            and "File-size advisory" in edit_large.get("message", "")
+            and "700 lines" in edit_large.get("message", ""),
+            f"got: {edit_large}",
+        )
+
+        edit_small = rule.evaluate("preToolUse", {
+            "toolName": "edit",
+            "toolArgs": {
+                "path": str(target),
+                "old_str": "print('start')\n",
+                "new_str": small_py,
+            },
+        })
+        test(
+            "FileSizeAdvisoryRule: 250-line edit returns no warning",
+            edit_small is None,
+            f"got: {edit_small}",
+        )
+
+        create_js = rule.evaluate("preToolUse", {
+            "toolName": "create",
+            "toolArgs": {"path": str(tmp / "large.js"), "file_text": large_py},
+        })
+        test(
+            "FileSizeAdvisoryRule: non-Python file returns no warning",
+            create_js is None,
+            f"got: {create_js}",
+        )
+
+
+def test_file_size_advisory_registered():
+    """The runtime hook registry must include the advisory rule."""
+    try:
+        rules = _registered_hook_rule_names()
+    except Exception as exc:
+        test("FileSizeAdvisoryRule registry import", False, str(exc))
+        return
+    test(
+        "ALL_RULES contains file-size-advisory",
+        "file-size-advisory" in rules,
+        f"registered={rules}",
+    )
+
+
+def test_hooks_md_file_size_advisory_documented():
+    """HOOKS.md must document the advisory rule."""
+    if not HOOKS_MD.exists():
+        test("docs/HOOKS.md exists", False)
+        return
+    content = HOOKS_MD.read_text(encoding="utf-8")
+    test(
+        "HOOKS.md documents file-size-advisory",
+        re.search(r"^\|\s*`file-size-advisory`\s*\|", content, re.MULTILINE) is not None,
+        "docs/HOOKS.md rules table missing file-size-advisory row",
+    )
+
+
+test_file_size_advisory_rule()
+test_file_size_advisory_registered()
+test_hooks_md_file_size_advisory_documented()
+
 print(f"\n{'='*50}")
 print(f"Results: {PASS} passed, {FAIL} failed out of {PASS + FAIL}")
 if FAIL == 0:


### PR DESCRIPTION
## Summary
- adds a fail-open `file-size-advisory` preToolUse rule for Python create/edit payloads over 600 lines
- registers the rule, documents it in `docs/HOOKS.md`, and adds quality-gate coverage
- adds the issue step scaffold for #263

Closes #263

## Verification
- `python -m py_compile hooks\rules\file_size_advisory.py hooks\rules\__init__.py tests\test_quality_gates.py`
- `python tests\test_quality_gates.py` (102 passed, 0 failed)
- `python test_fixes.py`
- `git diff --check`
- code review agent: CLEAN

## Note
- `python run_all_tests.py` was also attempted; it hit the existing browse-surface failures and the runner budget, unrelated to this hook-only diff.