### PR TITLE
feat(hooks): add new-file advisory rule

### DIFF
--- a/.github/steps/issue-264-new-file-advisory.md
+++ b/.github/steps/issue-264-new-file-advisory.md
@@ -1,0 +1,82 @@
+# STEPS: Issue #264 new-file advisory hook rule
+
+**Task:** Add a fail-open advisory hook rule that warns when an agent creates a new root Python script.
+**Scope:** `hooks/rules/new_file_advisory.py`, `hooks/rules/__init__.py`, `docs/HOOKS.md`, `tests/test_quality_gates.py`, `.github/steps/issue-264-new-file-advisory.md`.
+
+## Step 1: CLARIFY - Confirm advisory behavior
+
+**Goal:** Confirm the rule stays narrow and advisory-only.
+
+**Actions:**
+1. Read issue #264 and confirm the required outputs: new rule module, registry entry, docs row, and unit tests.
+2. Inspect the #263 `file-size-advisory` pattern and shared hook helpers.
+3. Confirm Rule 11 text is not yet present on `main`; keep this lane scoped to the runtime nudge and do not implement #254 here.
+
+**Done when:** The event/tool scope, path scope, and fail-open result shape are known.
+
+## Step 2: BUILD - Add the advisory rule
+
+**Goal:** Implement a hook rule that detects root-level Python `create` payloads.
+
+**Actions:**
+1. Add `hooks/rules/new_file_advisory.py`.
+2. Return `info(...)` only for `toolName=create` targeting `*.py` directly under the repository root.
+3. Return `None` for nested files such as `browse/core/new_module.py`, edit events, non-Python paths, and malformed payloads.
+
+**Done when:** Root Python creates emit advisory info and the rule never returns `permissionDecision: deny`.
+
+## Step 3: BUILD - Register and document
+
+**Goal:** Make the rule active in the unified runner and visible in hook docs.
+
+**Actions:**
+1. Register `NewFileAdvisoryRule()` in `hooks/rules/__init__.py`.
+2. Add a `new-file-advisory` row to the `docs/HOOKS.md` rules table.
+
+**Done when:** `_registered_hook_rule_names()` includes `new-file-advisory`, and docs contain the matching table row.
+
+## Step 4: TEST - Cover acceptance criteria
+
+**Goal:** Prove the advisory rule behaves correctly and remains fail-open.
+
+**Actions:**
+1. Add tests in `tests/test_quality_gates.py` for import, registry, root create advisory, nested create no-op, edit no-op, Rule 11 message citation, and docs coverage.
+2. Run `python tests/test_quality_gates.py`.
+
+**Done when:** The quality-gate test runner passes with the new new-file advisory assertions.
+
+## Step 5: REVIEW - Verify repository gates
+
+**Goal:** Confirm the change does not regress existing Python hook behavior.
+
+**Actions:**
+1. Run `python -m py_compile hooks/rules/new_file_advisory.py hooks/rules/__init__.py tests/test_quality_gates.py`.
+2. Run `python tests/test_quality_gates.py`.
+3. Run `python test_fixes.py`.
+4. Run `python run_all_tests.py`.
+5. Run `git diff --check`.
+6. Run a code-review agent on the diff.
+
+**Done when:** Local gate output is recorded and review returns CLEAN or all findings are addressed.
+
+## Step 6: COMMIT - Package and ship
+
+**Goal:** Merge #264 through the isolated lane and clean local state.
+
+**Actions:**
+1. Commit only expected files with the required co-author trailer.
+2. Open a PR with `Closes #264` and mirror labels.
+3. Wait for CI, merge, move #264 project item to Done, and delete branch/worktree/tentacle.
+
+**Done when:** PR is merged, issue #264 is closed, project item is Done, and the isolated lane is removed.
+
+## Phase Gates
+
+| Phase | Artifact | Status |
+|-------|----------|--------|
+| CLARIFY | Advisory-only behavior confirmed | [ ] |
+| BUILD | `NewFileAdvisoryRule` added | [ ] |
+| BUILD | Rule registered and documented | [ ] |
+| TEST | `tests/test_quality_gates.py` passes | [ ] |
+| REVIEW | Local gates and code review complete | [ ] |
+| COMMIT | PR merged and lane cleaned | [ ] |

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -48,6 +48,7 @@ hooks/
 | `block-unsafe-html` | preToolUse | Blocks `dangerouslySetInnerHTML` usage in `.ts`/`.tsx` files without `DOMPurify.sanitize()` or the `<Highlight>` component. |
 | `verification-gate` | preToolUse + postToolUse | Tracks dirty Python / `browse-ui` TS/JS surfaces, records successful verification commands, and blocks closeout-style actions (`task_complete`, `gh issue close/comment`, tentacle `handoff --status DONE`, tentacle `complete`) until the required fresh evidence exists. |
 | `file-size-advisory` | preToolUse | Warns when an `edit`/`create` payload would leave a Python file over 600 lines. Advisory-only and fail-open: emits information but never denies the tool call. |
+| `new-file-advisory` | preToolUse | Warns when a `create` payload targets a new root Python script. Advisory-only and fail-open: cites Rule 11 and asks agents to justify the new file, reuse an existing home when possible, and update tests/lint coverage. |
 | `track-edits` | postToolUse | Detects file changes via `git status` (language-agnostic) |
 | `learn-reminder` | postToolUse | Reminds to record learnings after task_complete; also surfaces [docs/SYNC-MATRIX.md](SYNC-MATRIX.md) for docs/memory follow-ups |
 | `test-reminder` | postToolUse | Reminds to run tests after 3+ Python file edits |

--- a/hooks/rules/__init__.py
+++ b/hooks/rules/__init__.py
@@ -30,6 +30,7 @@ def get_rules_for_event(event):
     from .integrity import IntegrityRule
     from .learn_gate import EnforceLearnRule
     from .learn_reminder import LearnReminderRule
+    from .new_file_advisory import NewFileAdvisoryRule
     from .nextjs_typecheck import NextjsTypecheckRule
     from .pnpm_lockfile_guard import PnpmLockfileGuardRule
     from .read_before_edit import ReadBeforeEditRule
@@ -60,6 +61,7 @@ def get_rules_for_event(event):
         BlockUnsafeHtmlRule(),
         VerificationGateRule(),
         FileSizeAdvisoryRule(),
+        NewFileAdvisoryRule(),
         ReadBeforeEditRule(),
         ReadTrackerRule(),  # Issue #85: warn on repeat reads (preToolUse)
         # postToolUse (all run, output is informational)

--- a/hooks/rules/new_file_advisory.py
+++ b/hooks/rules/new_file_advisory.py
@@ -1,0 +1,58 @@
+"""new_file_advisory.py - warn when creating new root Python scripts.
+
+Advisory only: returns informational messages and never denies tool use.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+from . import Rule
+from .common import info
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+
+class NewFileAdvisoryRule(Rule):
+    """Warn when a create payload targets a new root-level Python script."""
+
+    name = "new-file-advisory"
+    events = ["preToolUse"]
+    tools = ["create"]
+
+    def evaluate(self, event, data):
+        tool_name = data.get("toolName", "")
+        if tool_name != "create":
+            return None
+
+        tool_args = data.get("toolArgs", {})
+        if not isinstance(tool_args, dict):
+            return None
+
+        file_path = tool_args.get("path", "")
+        if not isinstance(file_path, str) or not file_path:
+            return None
+
+        path = Path(file_path)
+        if path.suffix.lower() != ".py" or not self._is_repo_root_file(path):
+            return None
+
+        return info(
+            f"New-file advisory: Rule 11 applies to new root Python script `{path.name}`. "
+            "Before creating it, search for an existing home, state the file's "
+            "responsibility, add it to the lint/test surface if needed, and add or "
+            "update tests."
+        )
+
+    @staticmethod
+    def _is_repo_root_file(path: Path) -> bool:
+        if not path.is_absolute():
+            return path.parent == Path(".")
+
+        try:
+            return path.parent.resolve(strict=False) == Path.cwd().resolve(strict=False)
+        except OSError:
+            return False

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -590,6 +590,119 @@ test_file_size_advisory_rule()
 test_file_size_advisory_registered()
 test_hooks_md_file_size_advisory_documented()
 
+
+# ── Test 31–36: New-file advisory hook rule ─────────────────────────────────
+
+
+def _make_new_file_advisory():
+    """Import and return a fresh NewFileAdvisoryRule instance."""
+    import importlib
+    import sys as _sys
+
+    if str(REPO) not in _sys.path:
+        _sys.path.insert(0, str(REPO))
+    mod = importlib.import_module("hooks.rules.new_file_advisory")
+    return mod.NewFileAdvisoryRule()
+
+
+def test_new_file_advisory_rule():
+    """Unit tests for advisory new root Python script warnings."""
+    try:
+        rule = _make_new_file_advisory()
+    except Exception as exc:
+        test("NewFileAdvisoryRule import", False, str(exc))
+        return
+
+    create_root = rule.evaluate("preToolUse", {
+        "toolName": "create",
+        "toolArgs": {"path": "new_script.py", "file_text": "print('hi')\n"},
+    })
+    test(
+        "NewFileAdvisoryRule: root Python create returns advisory info",
+        create_root is not None
+        and create_root.get("permissionDecision") != "deny"
+        and "New-file advisory" in create_root.get("message", "")
+        and "Rule 11" in create_root.get("message", ""),
+        f"got: {create_root}",
+    )
+
+    create_nested = rule.evaluate("preToolUse", {
+        "toolName": "create",
+        "toolArgs": {"path": "browse/core/new_module.py", "file_text": "print('hi')\n"},
+    })
+    test(
+        "NewFileAdvisoryRule: nested Python create returns no warning",
+        create_nested is None,
+        f"got: {create_nested}",
+    )
+
+    edit_root = rule.evaluate("preToolUse", {
+        "toolName": "edit",
+        "toolArgs": {"path": "new_script.py", "old_str": "x", "new_str": "y"},
+    })
+    test(
+        "NewFileAdvisoryRule: edit event returns no warning",
+        edit_root is None,
+        f"got: {edit_root}",
+    )
+
+    create_abs_root = rule.evaluate("preToolUse", {
+        "toolName": "create",
+        "toolArgs": {"path": str(REPO / "new_script.py"), "file_text": "print('hi')\n"},
+    })
+    test(
+        "NewFileAdvisoryRule: absolute root Python create returns advisory info",
+        create_abs_root is not None
+        and create_abs_root.get("permissionDecision") != "deny"
+        and "Rule 11" in create_abs_root.get("message", ""),
+        f"got: {create_abs_root}",
+    )
+
+    create_abs_nested = rule.evaluate("preToolUse", {
+        "toolName": "create",
+        "toolArgs": {
+            "path": str(REPO / "browse" / "core" / "new_module.py"),
+            "file_text": "print('hi')\n",
+        },
+    })
+    test(
+        "NewFileAdvisoryRule: absolute nested Python create returns no warning",
+        create_abs_nested is None,
+        f"got: {create_abs_nested}",
+    )
+
+
+def test_new_file_advisory_registered():
+    """The runtime hook registry must include the advisory rule."""
+    try:
+        rules = _registered_hook_rule_names()
+    except Exception as exc:
+        test("NewFileAdvisoryRule registry import", False, str(exc))
+        return
+    test(
+        "ALL_RULES contains new-file-advisory",
+        "new-file-advisory" in rules,
+        f"registered={rules}",
+    )
+
+
+def test_hooks_md_new_file_advisory_documented():
+    """HOOKS.md must document the advisory rule."""
+    if not HOOKS_MD.exists():
+        test("docs/HOOKS.md exists", False)
+        return
+    content = HOOKS_MD.read_text(encoding="utf-8")
+    test(
+        "HOOKS.md documents new-file-advisory",
+        re.search(r"^\|\s*`new-file-advisory`\s*\|", content, re.MULTILINE) is not None,
+        "docs/HOOKS.md rules table missing new-file-advisory row",
+    )
+
+
+test_new_file_advisory_rule()
+test_new_file_advisory_registered()
+test_hooks_md_new_file_advisory_documented()
+
 print(f"\n{'='*50}")
 print(f"Results: {PASS} passed, {FAIL} failed out of {PASS + FAIL}")
 if FAIL == 0:


### PR DESCRIPTION
## Summary
- adds a fail-open `new-file-advisory` preToolUse rule for root-level Python create payloads
- registers the rule, documents it in `docs/HOOKS.md`, and adds quality-gate coverage
- adds the issue step scaffold for #264

Closes #264

## Verification
- `python -m py_compile hooks\rules\new_file_advisory.py hooks\rules\__init__.py tests\test_quality_gates.py`
- `python tests\test_quality_gates.py` (110 passed, 0 failed)
- `python test_fixes.py`
- `git diff --check`
- code review agent: CLEAN

## Note
- `python run_all_tests.py` was also attempted; it hit the existing browse-surface failures and the runner budget, unrelated to this hook-only diff.