### PR TITLE
feat(quality): add complexity reporter

### DIFF
--- a/.github/steps/issue-257-check-complexity.md
+++ b/.github/steps/issue-257-check-complexity.md
@@ -1,0 +1,86 @@
+# STEPS: Issue #257 check_complexity reporter
+
+**Task:** Add a stdlib-only AST complexity reporter with text and JSON output.
+**Scope:** `scripts/check_complexity.py`, `CONTRIBUTING.md`, `tests/test_quality_gates.py`, `.github/steps/issue-257-check-complexity.md`.
+
+## Step 1: CLARIFY - Confirm metrics and surfaces
+
+**Goal:** Confirm the reporter is measurement-only and dependency-free.
+
+**Actions:**
+1. Read issue #257 and confirm thresholds: function complexity warning >15, high >25; function lines warning >50, high >100; file lines warning >400, high >800.
+2. Inspect `scripts/check_syntax.py`, `tests/test_quality_gates.py`, and `CONTRIBUTING.md` for existing quality-gate patterns.
+3. Confirm default scan surfaces: root `.py`, `browse/`, `hooks/`, and `scripts/`.
+
+**Done when:** Metric thresholds, output modes, and test/doc surfaces are known.
+
+## Step 2: BUILD - Add the reporter
+
+**Goal:** Implement `scripts/check_complexity.py` as a standalone Python script.
+
+**Actions:**
+1. Add a Windows UTF-8 block and use only stdlib imports.
+2. Discover default/targeted Python files while skipping `.git`, virtualenvs, cache directories, and fixtures.
+3. Parse files with `ast`, collect file line counts, function line counts, and approximate cyclomatic complexity.
+4. Emit text by default and JSON with `--json`.
+5. Exit non-zero only for missing paths or parse/read errors.
+
+**Done when:** Targeted text and JSON reports are produced without non-stdlib dependencies.
+
+## Step 3: TEST - Cover acceptance criteria
+
+**Goal:** Prove the reporter works and stays dependency-free.
+
+**Actions:**
+1. Add tests in `tests/test_quality_gates.py` for `tentacle.py` text output, `--json browse/`, self-check, invalid path handling, stdlib import scan, and py_compile.
+2. Run `python tests/test_quality_gates.py`.
+
+**Done when:** The quality-gate test runner passes with the new complexity reporter assertions.
+
+## Step 4: DOCS - Document contributor usage
+
+**Goal:** Make the advisory reporter discoverable for contributors.
+
+**Actions:**
+1. Add `python3 scripts/check_complexity.py` to the manual pre-PR command list.
+2. Document default surfaces, targeted path usage, and `--json`.
+
+**Done when:** `CONTRIBUTING.md` explains what the reporter measures and how to run it.
+
+## Step 5: REVIEW - Verify repository gates
+
+**Goal:** Confirm no regression in existing quality gates.
+
+**Actions:**
+1. Run `python -m py_compile scripts/check_complexity.py tests/test_quality_gates.py`.
+2. Run `python scripts/check_complexity.py tentacle.py`.
+3. Run `python scripts/check_complexity.py --json browse/`.
+4. Run `python tests/test_quality_gates.py`.
+5. Run `python test_fixes.py`.
+6. Run `python run_all_tests.py`.
+7. Run `git diff --check`.
+8. Run a code-review agent on the diff.
+
+**Done when:** Local gate output is recorded and review returns CLEAN or all findings are addressed.
+
+## Step 6: COMMIT - Package and ship
+
+**Goal:** Merge #257 through the isolated lane and clean local state.
+
+**Actions:**
+1. Commit only expected files with the required co-author trailer.
+2. Open a PR with `Closes #257` and mirror labels.
+3. Wait for CI, merge, move #257 project item to Done, and delete branch/worktree/tentacle.
+
+**Done when:** PR is merged, issue #257 is closed, project item is Done, and the isolated lane is removed.
+
+## Phase Gates
+
+| Phase | Artifact | Status |
+|-------|----------|--------|
+| CLARIFY | Metrics and surfaces confirmed | [ ] |
+| BUILD | `scripts/check_complexity.py` added | [ ] |
+| TEST | `tests/test_quality_gates.py` passes | [ ] |
+| DOCS | Contributor command documented | [ ] |
+| REVIEW | Local gates and code review complete | [ ] |
+| COMMIT | PR merged and lane cleaned | [ ] |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,15 @@ The full test suite is **not** run by the hook. Run it manually before submittin
 
 ```bash
 python3 scripts/check_syntax.py
+python3 scripts/check_complexity.py
 python3 run_all_tests.py
 ```
+
+`scripts/check_complexity.py` is a stdlib-only advisory reporter for Python file
+size, function size, and approximate cyclomatic complexity. It scans root
+Python scripts plus `browse/`, `hooks/`, and `scripts/` by default, or accepts
+targeted paths such as `python3 scripts/check_complexity.py tentacle.py`. Use
+`--json` when CI or automation needs machine-readable metrics.
 
 For faster targeted loops, these focused checks are still useful:
 

--- a/scripts/check_complexity.py
+++ b/scripts/check_complexity.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""check_complexity.py - stdlib-only Python complexity reporter.
+
+Reports file line counts, function line counts, and approximate cyclomatic
+complexity for targeted Python files/directories. Warnings are advisory: valid
+Python files with high complexity still exit 0. Missing paths and parse errors
+exit non-zero because the report could not be produced.
+
+Usage:
+    python3 scripts/check_complexity.py
+    python3 scripts/check_complexity.py tentacle.py
+    python3 scripts/check_complexity.py --json browse/
+"""
+
+import argparse
+import ast
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).resolve().parent.parent
+EXCLUDE_DIRS = {".octogent", "__pycache__", ".git", ".venv", "venv", "node_modules"}
+
+FUNCTION_COMPLEXITY_WARNING = 15
+FUNCTION_COMPLEXITY_HIGH = 25
+FUNCTION_LINES_WARNING = 50
+FUNCTION_LINES_HIGH = 100
+FILE_LINES_WARNING = 400
+FILE_LINES_HIGH = 800
+
+SEVERITY_RANK = {"ok": 0, "warning": 1, "high": 2}
+
+
+@dataclass
+class FunctionMetric:
+    name: str
+    line: int
+    end_line: int
+    lines: int
+    complexity: int
+    severity: str
+
+
+@dataclass
+class FileMetric:
+    path: str
+    lines: int
+    functions: list[FunctionMetric]
+    severity: str
+
+
+class ComplexityVisitor(ast.NodeVisitor):
+    """Compute a simple cyclomatic complexity score for one function body."""
+
+    def __init__(self) -> None:
+        self.complexity = 1
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        return None
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        return None
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return None
+
+    def visit_If(self, node: ast.If) -> None:
+        self.complexity += 1
+        self.generic_visit(node)
+
+    def visit_IfExp(self, node: ast.IfExp) -> None:
+        self.complexity += 1
+        self.generic_visit(node)
+
+    def visit_For(self, node: ast.For) -> None:
+        self.complexity += 1
+        self.generic_visit(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self.complexity += 1
+        self.generic_visit(node)
+
+    def visit_While(self, node: ast.While) -> None:
+        self.complexity += 1
+        self.generic_visit(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        self.complexity += 1
+        self.generic_visit(node)
+
+    def visit_Assert(self, node: ast.Assert) -> None:
+        self.complexity += 1
+        self.generic_visit(node)
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> None:
+        self.complexity += max(0, len(node.values) - 1)
+        self.generic_visit(node)
+
+    def visit_comprehension(self, node: ast.comprehension) -> None:
+        self.complexity += 1 + len(node.ifs)
+        self.generic_visit(node)
+
+    def visit_Match(self, node: ast.Match) -> None:
+        self.complexity += len(node.cases)
+        self.generic_visit(node)
+
+
+class FunctionCollector(ast.NodeVisitor):
+    """Collect function metrics while preserving class/nested names."""
+
+    def __init__(self) -> None:
+        self.functions: list[FunctionMetric] = []
+        self._scope: list[str] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._scope.append(node.name)
+        self.generic_visit(node)
+        self._scope.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        visitor = ComplexityVisitor()
+        for child in node.body:
+            visitor.visit(child)
+
+        end_line = getattr(node, "end_lineno", node.lineno)
+        line_count = max(1, end_line - node.lineno + 1)
+        qualified_name = ".".join([*self._scope, node.name])
+        self.functions.append(
+            FunctionMetric(
+                name=qualified_name,
+                line=node.lineno,
+                end_line=end_line,
+                lines=line_count,
+                complexity=visitor.complexity,
+                severity=max_severity(
+                    severity_for(visitor.complexity, FUNCTION_COMPLEXITY_WARNING, FUNCTION_COMPLEXITY_HIGH),
+                    severity_for(line_count, FUNCTION_LINES_WARNING, FUNCTION_LINES_HIGH),
+                ),
+            )
+        )
+
+        self._scope.append(node.name)
+        self.generic_visit(node)
+        self._scope.pop()
+
+
+def severity_for(value: int, warning_threshold: int, high_threshold: int) -> str:
+    if value > high_threshold:
+        return "high"
+    if value > warning_threshold:
+        return "warning"
+    return "ok"
+
+
+def max_severity(*values: str) -> str:
+    return max(values, key=lambda item: SEVERITY_RANK[item])
+
+
+def path_label(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def iter_py_files(target: Path) -> list[Path]:
+    if target.is_file():
+        return [target] if target.suffix == ".py" else []
+
+    files: list[Path] = []
+    for entry in sorted(target.rglob("*.py")):
+        try:
+            rel_parts = entry.relative_to(target).parts
+        except ValueError:
+            rel_parts = entry.parts
+        if set(rel_parts) & EXCLUDE_DIRS:
+            continue
+        if "fixtures" in rel_parts[:-1]:
+            continue
+        if any(part.startswith(".") for part in rel_parts[:-1]):
+            continue
+        files.append(entry)
+    return files
+
+
+def default_targets() -> list[Path]:
+    targets = sorted(path for path in REPO.iterdir() if path.is_file() and path.suffix == ".py")
+    for name in ("browse", "hooks", "scripts"):
+        path = REPO / name
+        if path.exists():
+            targets.append(path)
+    return targets
+
+
+def resolve_targets(args: list[str]) -> tuple[list[Path], list[str]]:
+    raw_targets = [Path(arg) for arg in args] if args else default_targets()
+    targets: list[Path] = []
+    errors: list[str] = []
+    for target in raw_targets:
+        resolved = target if target.is_absolute() else (Path.cwd() / target)
+        if not resolved.exists():
+            errors.append(f"{target}: path does not exist")
+            continue
+        targets.append(resolved)
+    return targets, errors
+
+
+def analyze_file(path: Path) -> FileMetric:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    tree = ast.parse(text, filename=str(path))
+    collector = FunctionCollector()
+    collector.visit(tree)
+    line_count = len(text.splitlines())
+    file_severity = severity_for(line_count, FILE_LINES_WARNING, FILE_LINES_HIGH)
+    function_severity = max_severity(*(fn.severity for fn in collector.functions), "ok")
+    return FileMetric(
+        path=path_label(path),
+        lines=line_count,
+        functions=collector.functions,
+        severity=max_severity(file_severity, function_severity),
+    )
+
+
+def build_report(targets: list[Path]) -> tuple[list[FileMetric], list[str]]:
+    files: list[Path] = []
+    for target in targets:
+        files.extend(iter_py_files(target))
+    files = sorted(set(files), key=lambda item: path_label(item))
+
+    metrics: list[FileMetric] = []
+    errors: list[str] = []
+    for path in files:
+        try:
+            metrics.append(analyze_file(path))
+        except SyntaxError as exc:
+            errors.append(f"{path_label(path)}:{exc.lineno}: SyntaxError: {exc.msg}")
+        except ValueError as exc:
+            errors.append(f"{path_label(path)}: {exc}")
+        except OSError as exc:
+            errors.append(f"{path_label(path)}: {exc}")
+    return metrics, errors
+
+
+def summarize(files: list[FileMetric]) -> dict:
+    functions = [fn for file in files for fn in file.functions]
+    return {
+        "files_checked": len(files),
+        "functions_checked": len(functions),
+        "warning_files": sum(1 for file in files if file.severity == "warning"),
+        "high_files": sum(1 for file in files if file.severity == "high"),
+        "warning_functions": sum(1 for fn in functions if fn.severity == "warning"),
+        "high_functions": sum(1 for fn in functions if fn.severity == "high"),
+    }
+
+
+def thresholds() -> dict:
+    return {
+        "function_complexity": {
+            "warning": FUNCTION_COMPLEXITY_WARNING,
+            "high": FUNCTION_COMPLEXITY_HIGH,
+        },
+        "function_lines": {
+            "warning": FUNCTION_LINES_WARNING,
+            "high": FUNCTION_LINES_HIGH,
+        },
+        "file_lines": {
+            "warning": FILE_LINES_WARNING,
+            "high": FILE_LINES_HIGH,
+        },
+    }
+
+
+def report_dict(files: list[FileMetric], errors: list[str]) -> dict:
+    return {
+        "summary": summarize(files),
+        "thresholds": thresholds(),
+        "files": [
+            {
+                **asdict(file),
+                "functions": [asdict(fn) for fn in file.functions],
+            }
+            for file in files
+        ],
+        "errors": errors,
+    }
+
+
+def print_text_report(files: list[FileMetric], errors: list[str]) -> None:
+    summary = summarize(files)
+    print("Complexity report")
+    print(f"Files checked: {summary['files_checked']} | Functions checked: {summary['functions_checked']}")
+    print(
+        "Thresholds: "
+        f"function complexity >{FUNCTION_COMPLEXITY_WARNING}/>{FUNCTION_COMPLEXITY_HIGH}, "
+        f"function lines >{FUNCTION_LINES_WARNING}/>{FUNCTION_LINES_HIGH}, "
+        f"file lines >{FILE_LINES_WARNING}/>{FILE_LINES_HIGH}"
+    )
+    print()
+
+    for file in files:
+        print(f"{file.path}: lines={file.lines} functions={len(file.functions)} severity={file.severity}")
+        for fn in file.functions:
+            if fn.severity == "ok":
+                continue
+            print(f"  {fn.severity}: {fn.name} line={fn.line} complexity={fn.complexity} lines={fn.lines}")
+
+    if errors:
+        print("\nErrors:", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+    elif not files:
+        print("No Python files found.")
+    elif not any(file.severity != "ok" for file in files):
+        print("\nNo complexity advisories.")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Report Python complexity metrics.")
+    parser.add_argument("paths", nargs="*", help="Python files or directories to inspect")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    targets, target_errors = resolve_targets(args.paths)
+    files, report_errors = build_report(targets)
+    errors = [*target_errors, *report_errors]
+
+    if args.json:
+        print(json.dumps(report_dict(files, errors), indent=2, sort_keys=True))
+    else:
+        print_text_report(files, errors)
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -8,6 +8,8 @@ Verifies:
 Run: python3 test_quality_gates.py
 """
 
+import ast
+import json
 import os
 import re
 import shutil
@@ -26,6 +28,7 @@ FAIL = 0
 REPO = Path(__file__).parent.parent
 
 CHECK_SYNTAX = REPO / "scripts" / "check_syntax.py"
+CHECK_COMPLEXITY = REPO / "scripts" / "check_complexity.py"
 RUN_ALL_TESTS = REPO / "run_all_tests.py"
 FIXTURE = REPO / "tests" / "fixtures" / "broken_syntax_example.py.txt"
 
@@ -42,6 +45,7 @@ def test(name: str, condition: bool, detail: str = ""):
 
 # ── Test 1: check_syntax.py detects broken syntax ───────────────────────────
 
+
 def test_syntax_gate_detects_broken():
     """Copy the broken fixture to a scratch dir as .py, run check_syntax.py, expect exit 1."""
     scratch = Path(REPO) / "_quality_gate_scratch"
@@ -51,7 +55,8 @@ def test_syntax_gate_detects_broken():
         shutil.copy(FIXTURE, broken_py)
         result = subprocess.run(
             [sys.executable, str(CHECK_SYNTAX), str(scratch)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         test(
             "check_syntax exits non-zero for broken file",
@@ -70,6 +75,7 @@ def test_syntax_gate_detects_broken():
 
 # ── Test 2: check_syntax.py passes on valid Python ──────────────────────────
 
+
 def test_syntax_gate_passes_valid():
     """Create a valid .py file, run check_syntax.py, expect exit 0."""
     scratch = Path(REPO) / "_quality_gate_scratch2"
@@ -79,7 +85,8 @@ def test_syntax_gate_passes_valid():
         valid_py.write_text("def hello():\n    return 'world'\n")
         result = subprocess.run(
             [sys.executable, str(CHECK_SYNTAX), str(scratch)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         test(
             "check_syntax exits 0 for valid file",
@@ -92,11 +99,13 @@ def test_syntax_gate_passes_valid():
 
 # ── Test 3: run_all_tests.py --dry works ────────────────────────────────────
 
+
 def test_run_all_tests_dry():
     """run_all_tests.py --dry should list files and exit 0."""
     result = subprocess.run(
         [sys.executable, str(RUN_ALL_TESTS), "--dry"],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
         cwd=str(REPO),
     )
     test(
@@ -113,11 +122,13 @@ def test_run_all_tests_dry():
 
 # ── Test 4: run_all_tests.py --help works ───────────────────────────────────
 
+
 def test_run_all_tests_help():
     """run_all_tests.py --help should print usage and exit 0."""
     result = subprocess.run(
         [sys.executable, str(RUN_ALL_TESTS), "--help"],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
         cwd=str(REPO),
     )
     test(
@@ -129,11 +140,13 @@ def test_run_all_tests_help():
 
 # ── Test 5: scripts/check_syntax.py is self-consistent ──────────────────────
 
+
 def test_check_syntax_is_valid_python():
     """check_syntax.py itself should pass its own check."""
     result = subprocess.run(
         [sys.executable, "-m", "py_compile", str(CHECK_SYNTAX)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     test(
         "check_syntax.py compiles cleanly",
@@ -142,16 +155,18 @@ def test_check_syntax_is_valid_python():
     )
 
 
+# ── SyntaxGateRule.evaluate() unit tests ────────────────────────────────────
 
-# ── Test 6–11: SyntaxGateRule.evaluate() unit tests ─────────────────────────
 
 def _make_syntax_gate():
     """Import and return a fresh SyntaxGateRule instance."""
     import importlib
     import sys as _sys
+
     _sys.path.insert(0, str(REPO))
     # Import the package hierarchy so relative imports resolve.
     import hooks.rules  # noqa: F401
+
     mod = importlib.import_module("hooks.rules.syntax_gate")
     return mod.SyntaxGateRule()
 
@@ -170,10 +185,13 @@ def test_syntax_gate_rule():
         # (a) edit with indented snippet → final file valid → allow
         target_a = tmp / "module_a.py"
         target_a.write_text("def foo():\n    x = 1\n")
-        result_a = rule.evaluate("preToolUse", {
-            "toolName": "edit",
-            "toolArgs": {"path": str(target_a), "old_str": "    x = 1\n", "new_str": "    return 42\n"},
-        })
+        result_a = rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "edit",
+                "toolArgs": {"path": str(target_a), "old_str": "    x = 1\n", "new_str": "    return 42\n"},
+            },
+        )
         test(
             "SyntaxGateRule: edit indented snippet → valid final file → allow",
             result_a is None,
@@ -183,10 +201,13 @@ def test_syntax_gate_rule():
         # (b) edit that introduces a true syntax error → deny
         target_b = tmp / "module_b.py"
         target_b.write_text("def foo():\n    x = 1\n")
-        result_b = rule.evaluate("preToolUse", {
-            "toolName": "edit",
-            "toolArgs": {"path": str(target_b), "old_str": "    x = 1\n", "new_str": "    if x:\nreturn\n"},
-        })
+        result_b = rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "edit",
+                "toolArgs": {"path": str(target_b), "old_str": "    x = 1\n", "new_str": "    if x:\nreturn\n"},
+            },
+        )
         test(
             "SyntaxGateRule: edit introducing syntax error → deny",
             result_b is not None and result_b.get("permissionDecision") == "deny",
@@ -194,10 +215,13 @@ def test_syntax_gate_rule():
         )
 
         # (c) create with valid file_text → allow
-        result_c = rule.evaluate("preToolUse", {
-            "toolName": "create",
-            "toolArgs": {"path": str(tmp / "new_c.py"), "file_text": "print('hi')\n"},
-        })
+        result_c = rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "create",
+                "toolArgs": {"path": str(tmp / "new_c.py"), "file_text": "print('hi')\n"},
+            },
+        )
         test(
             "SyntaxGateRule: create with valid file_text → allow",
             result_c is None,
@@ -205,10 +229,13 @@ def test_syntax_gate_rule():
         )
 
         # (d) create with broken file_text → deny
-        result_d = rule.evaluate("preToolUse", {
-            "toolName": "create",
-            "toolArgs": {"path": str(tmp / "new_d.py"), "file_text": "def foo(:\n"},
-        })
+        result_d = rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "create",
+                "toolArgs": {"path": str(tmp / "new_d.py"), "file_text": "def foo(:\n"},
+            },
+        )
         test(
             "SyntaxGateRule: create with broken file_text → deny",
             result_d is not None and result_d.get("permissionDecision") == "deny",
@@ -216,10 +243,13 @@ def test_syntax_gate_rule():
         )
 
         # (e) non-python path → allow (no-op)
-        result_e = rule.evaluate("preToolUse", {
-            "toolName": "create",
-            "toolArgs": {"path": str(tmp / "README.md"), "file_text": "def foo(:\n"},
-        })
+        result_e = rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "create",
+                "toolArgs": {"path": str(tmp / "README.md"), "file_text": "def foo(:\n"},
+            },
+        )
         test(
             "SyntaxGateRule: non-.py path → allow",
             result_e is None,
@@ -227,10 +257,13 @@ def test_syntax_gate_rule():
         )
 
         # (f) edit on non-existent file → allow
-        result_f = rule.evaluate("preToolUse", {
-            "toolName": "edit",
-            "toolArgs": {"path": str(tmp / "ghost.py"), "old_str": "x", "new_str": "y"},
-        })
+        result_f = rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "edit",
+                "toolArgs": {"path": str(tmp / "ghost.py"), "old_str": "x", "new_str": "y"},
+            },
+        )
         test(
             "SyntaxGateRule: edit on non-existent file → allow",
             result_f is None,
@@ -241,12 +274,191 @@ def test_syntax_gate_rule():
 test_syntax_gate_rule()
 
 
-
 test_syntax_gate_detects_broken()
 test_syntax_gate_passes_valid()
 test_run_all_tests_dry()
 test_run_all_tests_help()
 test_check_syntax_is_valid_python()
+
+
+# ── Test 6–12: check_complexity.py reporter ─────────────────────────────────
+
+
+def test_check_complexity_text_report():
+    """check_complexity.py should report file and function metrics."""
+    result = subprocess.run(
+        [sys.executable, str(CHECK_COMPLEXITY), "tentacle.py"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    output = result.stdout + result.stderr
+    test(
+        "check_complexity text report exits 0 for tentacle.py",
+        result.returncode == 0,
+        f"returncode={result.returncode}, output={output[:300]}",
+    )
+    test(
+        "check_complexity text report includes file/function metrics",
+        "tentacle.py" in output and "functions=" in output and "Complexity report" in output,
+        f"output={output[:300]}",
+    )
+
+
+def test_check_complexity_json_report():
+    """--json output should be parseable and contain the frozen top-level shape."""
+    result = subprocess.run(
+        [sys.executable, str(CHECK_COMPLEXITY), "--json", "browse"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    test(
+        "check_complexity --json exits 0 for browse/",
+        result.returncode == 0,
+        f"returncode={result.returncode}, stderr={result.stderr[:300]}",
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        test("check_complexity --json emits parseable JSON", False, str(exc))
+        return
+    test(
+        "check_complexity JSON top-level shape",
+        sorted(payload) == ["errors", "files", "summary", "thresholds"],
+        f"keys={sorted(payload)}",
+    )
+    test(
+        "check_complexity JSON summary has file/function counts",
+        isinstance(payload["summary"].get("files_checked"), int)
+        and isinstance(payload["summary"].get("functions_checked"), int),
+        f"summary={payload.get('summary')}",
+    )
+
+
+def test_check_complexity_self_and_invalid_path():
+    """Self-check exits 0; missing paths exit non-zero with a clear error."""
+    self_result = subprocess.run(
+        [sys.executable, str(CHECK_COMPLEXITY), "scripts/check_complexity.py"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    test(
+        "check_complexity exits 0 for itself",
+        self_result.returncode == 0,
+        f"returncode={self_result.returncode}, output={self_result.stdout + self_result.stderr}",
+    )
+
+    missing_result = subprocess.run(
+        [sys.executable, str(CHECK_COMPLEXITY), "missing-nope.py"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    test(
+        "check_complexity invalid path exits non-zero",
+        missing_result.returncode != 0,
+        f"returncode={missing_result.returncode}",
+    )
+    test(
+        "check_complexity invalid path has clear error",
+        "path does not exist" in (missing_result.stdout + missing_result.stderr),
+        f"output={missing_result.stdout + missing_result.stderr}",
+    )
+
+    mixed_result = subprocess.run(
+        [sys.executable, str(CHECK_COMPLEXITY), "--json", "scripts/check_complexity.py", "missing-nope.py"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    test(
+        "check_complexity mixed valid+invalid path exits non-zero",
+        mixed_result.returncode != 0,
+        f"returncode={mixed_result.returncode}",
+    )
+    try:
+        mixed_payload = json.loads(mixed_result.stdout)
+    except json.JSONDecodeError as exc:
+        test("check_complexity mixed valid+invalid emits parseable JSON", False, str(exc))
+        mixed_payload = {"files": [], "errors": []}
+    test(
+        "check_complexity mixed valid+invalid still reports valid targets",
+        any(item.get("path") == "scripts/check_complexity.py" for item in mixed_payload.get("files", []))
+        and any("path does not exist" in error for error in mixed_payload.get("errors", [])),
+        f"payload={mixed_payload}",
+    )
+
+
+def test_check_complexity_null_byte_json_error():
+    """Null-byte files should return structured JSON errors, not tracebacks."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        bad_file = Path(tmpdir) / "bad.py"
+        bad_file.write_bytes(b"print('before')\n\x00\n")
+        result = subprocess.run(
+            [sys.executable, str(CHECK_COMPLEXITY), "--json", str(bad_file)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO),
+        )
+    test(
+        "check_complexity null-byte file exits non-zero",
+        result.returncode != 0,
+        f"returncode={result.returncode}",
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        test("check_complexity null-byte file emits parseable JSON", False, str(exc))
+        return
+    test(
+        "check_complexity null-byte file reports structured error",
+        payload.get("files") == []
+        and any(
+            "null" in error.lower() or "source code string" in error.lower() for error in payload.get("errors", [])
+        ),
+        f"payload={payload}",
+    )
+
+
+def test_check_complexity_stdlib_imports_only():
+    """The complexity reporter must stay stdlib-only."""
+    allowed = {"argparse", "ast", "dataclasses", "json", "os", "pathlib", "sys"}
+    tree = ast.parse(CHECK_COMPLEXITY.read_text(encoding="utf-8"))
+    imports = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module.split(".", 1)[0])
+    test(
+        "check_complexity uses stdlib imports only",
+        imports <= allowed,
+        f"imports={sorted(imports)}",
+    )
+
+
+def test_check_complexity_script_compiles():
+    """check_complexity.py itself should parse/compile cleanly."""
+    result = subprocess.run(
+        [sys.executable, "-m", "py_compile", str(CHECK_COMPLEXITY)],
+        capture_output=True,
+        text=True,
+    )
+    test(
+        "check_complexity.py compiles cleanly",
+        result.returncode == 0,
+        result.stderr,
+    )
+
+
+test_check_complexity_text_report()
+test_check_complexity_json_report()
+test_check_complexity_self_and_invalid_path()
+test_check_complexity_null_byte_json_error()
+test_check_complexity_stdlib_imports_only()
+test_check_complexity_script_compiles()
 
 
 # ── Test 12–20: Ruff surface consistency ────────────────────────────────────
@@ -261,12 +473,23 @@ CONTRIBUTING = REPO / "CONTRIBUTING.md"
 
 # CI Ruff surface (extracted from ci.yml)
 CI_RUFF_FILES = [
-    "embed.py", "scout-config.py", "scout-status.py",
-    "sync-config.py", "sync-daemon.py", "sync-status.py",
-    "migrate.py", "generate-summary.py",
-    "briefing.py", "learn.py", "query-session.py", "extract-knowledge.py",
-    "build-session-index.py", "tentacle.py",
-    "checkpoint-diff.py", "checkpoint-restore.py", "checkpoint-save.py",
+    "embed.py",
+    "scout-config.py",
+    "scout-status.py",
+    "sync-config.py",
+    "sync-daemon.py",
+    "sync-status.py",
+    "migrate.py",
+    "generate-summary.py",
+    "briefing.py",
+    "learn.py",
+    "query-session.py",
+    "extract-knowledge.py",
+    "build-session-index.py",
+    "tentacle.py",
+    "checkpoint-diff.py",
+    "checkpoint-restore.py",
+    "checkpoint-save.py",
 ]
 
 
@@ -285,7 +508,7 @@ def test_ruff_surface_in_pre_commit():
     test("pre-commit covers browse/*.py", "browse/" in content or "browse/*" in content)
     test(
         "pre-commit covers hooks/ Python surface",
-        "path.startswith((\"browse/\", \"hooks/\", \"scripts/\"))" in content
+        'path.startswith(("browse/", "hooks/", "scripts/"))' in content
         or "hooks/*)" in content
         or "hooks/*.py" in content
         or "hooks/*/*.py" in content,
@@ -312,17 +535,23 @@ def test_hooks_md_documents_local_vs_ci():
         test("docs/HOOKS.md exists", False)
         return
     content = HOOKS_MD.read_text(encoding="utf-8")
-    test("HOOKS.md documents local-vs-CI section",
-         "Local vs CI" in content,
-         "Add 'Local vs CI enforcement boundary' section to docs/HOOKS.md")
+    test(
+        "HOOKS.md documents local-vs-CI section",
+        "Local vs CI" in content,
+        "Add 'Local vs CI enforcement boundary' section to docs/HOOKS.md",
+    )
     # Key files from the Ruff surface should be named in HOOKS.md
     for fname in ("briefing.py", "tentacle.py", "browse/"):
-        test(f"HOOKS.md mentions Ruff surface file: {fname}",
-             fname in content,
-             f"'{fname}' not mentioned in HOOKS.md Ruff surface")
-    test("HOOKS.md notes full test suite is NOT enforced by local hook",
-         "not" in content.lower() and "run_all_tests" in content,
-         "HOOKS.md should clarify that run_all_tests is not enforced by the local pre-commit hook")
+        test(
+            f"HOOKS.md mentions Ruff surface file: {fname}",
+            fname in content,
+            f"'{fname}' not mentioned in HOOKS.md Ruff surface",
+        )
+    test(
+        "HOOKS.md notes full test suite is NOT enforced by local hook",
+        "not" in content.lower() and "run_all_tests" in content,
+        "HOOKS.md should clarify that run_all_tests is not enforced by the local pre-commit hook",
+    )
 
 
 def test_contributing_md_local_vs_ci():
@@ -331,15 +560,21 @@ def test_contributing_md_local_vs_ci():
         test("CONTRIBUTING.md exists", False)
         return
     content = CONTRIBUTING.read_text(encoding="utf-8")
-    test("CONTRIBUTING.md mentions full Ruff scope (briefing.py)",
-         "briefing.py" in content,
-         "CONTRIBUTING.md Ruff scope is incomplete — missing briefing.py")
-    test("CONTRIBUTING.md mentions full Ruff scope (tentacle.py)",
-         "tentacle.py" in content,
-         "CONTRIBUTING.md Ruff scope is incomplete — missing tentacle.py")
-    test("CONTRIBUTING.md explains pre-commit is fast/scoped",
-         "fail-open" in content or "full test suite" in content.lower(),
-         "CONTRIBUTING.md should explain that the local pre-commit hook is scoped, not a full gate")
+    test(
+        "CONTRIBUTING.md mentions full Ruff scope (briefing.py)",
+        "briefing.py" in content,
+        "CONTRIBUTING.md Ruff scope is incomplete — missing briefing.py",
+    )
+    test(
+        "CONTRIBUTING.md mentions full Ruff scope (tentacle.py)",
+        "tentacle.py" in content,
+        "CONTRIBUTING.md Ruff scope is incomplete — missing tentacle.py",
+    )
+    test(
+        "CONTRIBUTING.md explains pre-commit is fast/scoped",
+        "fail-open" in content or "full test suite" in content.lower(),
+        "CONTRIBUTING.md should explain that the local pre-commit hook is scoped, not a full gate",
+    )
 
 
 def test_architecture_md_ruff_surface():
@@ -349,9 +584,11 @@ def test_architecture_md_ruff_surface():
         return
     content = ARCH_MD.read_text(encoding="utf-8")
     for fname in ("briefing.py", "tentacle.py", "browse/", "hooks/"):
-        test(f"ARCHITECTURE.md Ruff section names {fname}",
-             fname in content,
-             f"ARCHITECTURE.md quality-gates section missing '{fname}'")
+        test(
+            f"ARCHITECTURE.md Ruff section names {fname}",
+            fname in content,
+            f"ARCHITECTURE.md quality-gates section missing '{fname}'",
+        )
 
 
 def _registered_hook_rule_names():
@@ -427,9 +664,7 @@ def test_pre_commit_syntax_gate_present():
     )
     test(
         "pre-commit syntax gate is fail-open (checks for script existence)",
-        "SYNTAX_CHECKER" in content
-        and "if not SYNTAX_CHECKER.is_file()" in content
-        and "return 0" in content,
+        "SYNTAX_CHECKER" in content and "if not SYNTAX_CHECKER.is_file()" in content and "return 0" in content,
         "hooks/pre-commit syntax gate should skip silently when check_syntax.py is absent",
     )
 
@@ -492,10 +727,13 @@ def test_file_size_advisory_rule():
         large_py = "\n".join(f"print({i})" for i in range(700))
         small_py = "\n".join(f"print({i})" for i in range(250))
 
-        create_large = rule.evaluate("preToolUse", {
-            "toolName": "create",
-            "toolArgs": {"path": str(tmp / "large.py"), "file_text": large_py},
-        })
+        create_large = rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "create",
+                "toolArgs": {"path": str(tmp / "large.py"), "file_text": large_py},
+            },
+        )
         test(
             "FileSizeAdvisoryRule: 700-line create returns advisory info",
             create_large is not None
@@ -505,10 +743,13 @@ def test_file_size_advisory_rule():
             f"got: {create_large}",
         )
 
-        create_small = rule.evaluate("preToolUse", {
-            "toolName": "create",
-            "toolArgs": {"path": str(tmp / "small.py"), "file_text": small_py},
-        })
+        create_small = rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "create",
+                "toolArgs": {"path": str(tmp / "small.py"), "file_text": small_py},
+            },
+        )
         test(
             "FileSizeAdvisoryRule: 250-line create returns no warning",
             create_small is None,
@@ -517,14 +758,17 @@ def test_file_size_advisory_rule():
 
         target = tmp / "module.py"
         target.write_text("print('start')\n", encoding="utf-8")
-        edit_large = rule.evaluate("preToolUse", {
-            "toolName": "edit",
-            "toolArgs": {
-                "path": str(target),
-                "old_str": "print('start')\n",
-                "new_str": large_py,
+        edit_large = rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "edit",
+                "toolArgs": {
+                    "path": str(target),
+                    "old_str": "print('start')\n",
+                    "new_str": large_py,
+                },
             },
-        })
+        )
         test(
             "FileSizeAdvisoryRule: 700-line edit returns advisory info",
             edit_large is not None
@@ -534,24 +778,30 @@ def test_file_size_advisory_rule():
             f"got: {edit_large}",
         )
 
-        edit_small = rule.evaluate("preToolUse", {
-            "toolName": "edit",
-            "toolArgs": {
-                "path": str(target),
-                "old_str": "print('start')\n",
-                "new_str": small_py,
+        edit_small = rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "edit",
+                "toolArgs": {
+                    "path": str(target),
+                    "old_str": "print('start')\n",
+                    "new_str": small_py,
+                },
             },
-        })
+        )
         test(
             "FileSizeAdvisoryRule: 250-line edit returns no warning",
             edit_small is None,
             f"got: {edit_small}",
         )
 
-        create_js = rule.evaluate("preToolUse", {
-            "toolName": "create",
-            "toolArgs": {"path": str(tmp / "large.js"), "file_text": large_py},
-        })
+        create_js = rule.evaluate(
+            "preToolUse",
+            {
+                "toolName": "create",
+                "toolArgs": {"path": str(tmp / "large.js"), "file_text": large_py},
+            },
+        )
         test(
             "FileSizeAdvisoryRule: non-Python file returns no warning",
             create_js is None,
@@ -613,10 +863,13 @@ def test_new_file_advisory_rule():
         test("NewFileAdvisoryRule import", False, str(exc))
         return
 
-    create_root = rule.evaluate("preToolUse", {
-        "toolName": "create",
-        "toolArgs": {"path": "new_script.py", "file_text": "print('hi')\n"},
-    })
+    create_root = rule.evaluate(
+        "preToolUse",
+        {
+            "toolName": "create",
+            "toolArgs": {"path": "new_script.py", "file_text": "print('hi')\n"},
+        },
+    )
     test(
         "NewFileAdvisoryRule: root Python create returns advisory info",
         create_root is not None
@@ -626,30 +879,39 @@ def test_new_file_advisory_rule():
         f"got: {create_root}",
     )
 
-    create_nested = rule.evaluate("preToolUse", {
-        "toolName": "create",
-        "toolArgs": {"path": "browse/core/new_module.py", "file_text": "print('hi')\n"},
-    })
+    create_nested = rule.evaluate(
+        "preToolUse",
+        {
+            "toolName": "create",
+            "toolArgs": {"path": "browse/core/new_module.py", "file_text": "print('hi')\n"},
+        },
+    )
     test(
         "NewFileAdvisoryRule: nested Python create returns no warning",
         create_nested is None,
         f"got: {create_nested}",
     )
 
-    edit_root = rule.evaluate("preToolUse", {
-        "toolName": "edit",
-        "toolArgs": {"path": "new_script.py", "old_str": "x", "new_str": "y"},
-    })
+    edit_root = rule.evaluate(
+        "preToolUse",
+        {
+            "toolName": "edit",
+            "toolArgs": {"path": "new_script.py", "old_str": "x", "new_str": "y"},
+        },
+    )
     test(
         "NewFileAdvisoryRule: edit event returns no warning",
         edit_root is None,
         f"got: {edit_root}",
     )
 
-    create_abs_root = rule.evaluate("preToolUse", {
-        "toolName": "create",
-        "toolArgs": {"path": str(REPO / "new_script.py"), "file_text": "print('hi')\n"},
-    })
+    create_abs_root = rule.evaluate(
+        "preToolUse",
+        {
+            "toolName": "create",
+            "toolArgs": {"path": str(REPO / "new_script.py"), "file_text": "print('hi')\n"},
+        },
+    )
     test(
         "NewFileAdvisoryRule: absolute root Python create returns advisory info",
         create_abs_root is not None
@@ -658,13 +920,16 @@ def test_new_file_advisory_rule():
         f"got: {create_abs_root}",
     )
 
-    create_abs_nested = rule.evaluate("preToolUse", {
-        "toolName": "create",
-        "toolArgs": {
-            "path": str(REPO / "browse" / "core" / "new_module.py"),
-            "file_text": "print('hi')\n",
+    create_abs_nested = rule.evaluate(
+        "preToolUse",
+        {
+            "toolName": "create",
+            "toolArgs": {
+                "path": str(REPO / "browse" / "core" / "new_module.py"),
+                "file_text": "print('hi')\n",
+            },
         },
-    })
+    )
     test(
         "NewFileAdvisoryRule: absolute nested Python create returns no warning",
         create_abs_nested is None,
@@ -703,7 +968,7 @@ test_new_file_advisory_rule()
 test_new_file_advisory_registered()
 test_hooks_md_new_file_advisory_documented()
 
-print(f"\n{'='*50}")
+print(f"\n{'=' * 50}")
 print(f"Results: {PASS} passed, {FAIL} failed out of {PASS + FAIL}")
 if FAIL == 0:
     print("🎉 All quality gate tests passed!")


### PR DESCRIPTION
## Summary
- adds `scripts/check_complexity.py`, a stdlib-only AST reporter with text and JSON output
- reports file lines, function lines, approximate cyclomatic complexity, and advisory severity thresholds
- documents contributor usage and adds quality-gate coverage plus the issue step scaffold

Closes #257

## Verification
- `ruff check scripts\check_complexity.py tests\test_quality_gates.py`
- `ruff format --check scripts\check_complexity.py tests\test_quality_gates.py`
- `python -m py_compile scripts\check_complexity.py tests\test_quality_gates.py`
- `python scripts\check_complexity.py tentacle.py`
- `python scripts\check_complexity.py --json browse`
- `python tests\test_quality_gates.py` (124 passed, 0 failed)
- `python test_fixes.py`
- `git diff --check`
- code review agents: CLEAN after follow-up fixes

## Note
- `python run_all_tests.py` was also attempted; it hit the existing browse-surface failures and the runner budget, unrelated to this reporter diff.