### PR TITLE
Add detective investigation skill

### DIFF
--- a/auto-update-tools.py
+++ b/auto-update-tools.py
@@ -101,6 +101,7 @@ BUILTIN_PROJECT_SKILLS: tuple[str, ...] = (
     "task-step-generator",
     "conductor-creator",
     "project-onboarding",
+    "detective-investigation",
 )
 
 # Global Copilot CLI skills directory.  deploy_skills() creates missing VENDORED

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -33,7 +33,7 @@ At `sessionStart`, the `auto-briefing` hook passes `--session-start` to `briefin
 ### L0 index format
 
 ```
-📦 Skills installed (15 total)
+📦 Skills installed (16 total)
   agent-creator — Generate project-specific .agent.md files from curated tem...
   code-reviewer — Skeptical, high signal-to-noise code review that surfaces o...
   ...
@@ -209,7 +209,7 @@ python3 ~/.copilot/tools/tentacle.py marker-cleanup --apply  # remove stale entr
 
 ### Meta-skill rollout — global vs project scope
 
-`setup-project.py` deploys all 14 skills to `.github/skills/<skill-name>/SKILL.md` in the target project (project scope). The full list of skills it deploys is defined in `INSTALL_ITEMS["skills"]` in that script — `host_manifest.py` is the authoritative host-metadata source and `setup-project.py` is the authoritative skill-list source.
+`setup-project.py` deploys all 15 skills to `.github/skills/<skill-name>/SKILL.md` in the target project (project scope). The full list of skills it deploys is defined in `INSTALL_ITEMS["skills"]` in that script — `host_manifest.py` is the authoritative host-metadata source and `setup-project.py` is the authoritative skill-list source.
 
 **Vendored skills** (`karpathy-guidelines`) are deployed to **both** Copilot CLI (`.github/skills/`) and Claude Code (`.claude/skills/`) by `setup-project.py`. All other skills in `INSTALL_ITEMS["skills"]` are deployed to **Copilot CLI only** (`.github/skills/`). The `VENDORED_SKILLS` tuple in both `setup-project.py` and `auto-update-tools.py` is the authoritative list of dual-host skills.
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -63,6 +63,7 @@ At `sessionStart`, the `auto-briefing` hook passes `--session-start` to `briefin
 | `workflow-creator` | Create phased development workflows with quality gates |
 | `conductor-creator` | Generate a project-specific Conductor (task router) mapping tasks to workflows and skills |
 | `project-onboarding` | Complete guide to set up the full AI-assisted development ecosystem for any project |
+| `detective-investigation` | Project-agnostic evidence-board workflow for root-cause investigations, regressions, incidents, and interactive HTML reports |
 | `find-skills` | Discover and install agent skills from the registry |
 | `agent-instructions-auditor` | Audit and improve agent instruction files |
 | `forge-ecosystem` | Scaffold and manage app/game projects via forge CLI tools |

--- a/setup-project.py
+++ b/setup-project.py
@@ -22,10 +22,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-from agent_adapters import detect_agents, expand_init_agents, get_adapter, unique_target_adapters
-from host_manifest import HOST_INSTRUCTION_FILES as KNOWN_HOSTS_INSTRUCTION_FILES  # noqa: E402
-from host_manifest import HOST_SKILL_SUBPATHS  # noqa: E402
-
 SCRIPT_DIR = Path(__file__).resolve().parent
 TEMPLATES_DIR = SCRIPT_DIR / "templates"
 SKILLS_DIR = SCRIPT_DIR / "skills"
@@ -50,6 +46,8 @@ def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> Non
 
 # Host metadata is centralised in host_manifest.py — import canonical constants.
 # Do NOT add new hosts here; update host_manifest.py through the review process.
+from host_manifest import HOST_INSTRUCTION_FILES as KNOWN_HOSTS_INSTRUCTION_FILES  # noqa: E402
+from host_manifest import HOST_SKILL_SUBPATHS  # noqa: E402
 if os.name == "nt":
     for _s in (sys.stdout, sys.stderr):
         if hasattr(_s, "reconfigure"):
@@ -77,6 +75,7 @@ INSTALL_ITEMS = {
         {"src": "task-step-generator", "label": "Task Step Generator (structured step-file generation)"},
         {"src": "conductor-creator", "label": "Conductor Creator (task-router generator)"},
         {"src": "project-onboarding", "label": "Project Onboarding (full AI ecosystem setup guide)"},
+        {"src": "detective-investigation", "label": "Detective Investigation (evidence-board RCA workflow)"},
         {"src": "karpathy-guidelines", "label": "Karpathy Guidelines (anti-overcomplication coding rules)"},
     ],
     # Templates (from tools/templates/ → .github/skills/ or .github/instructions/)
@@ -104,15 +103,13 @@ CLAUDE_SNIPPET = """
 
 ```bash
 # Before starting a task — get context from past sessions
-sk briefing --auto --compact
-# Fallbacks: macOS/Linux `python3 ~/.copilot/tools/briefing.py --auto --compact`;
-# Windows PowerShell `python "$env:USERPROFILE\\.copilot\\tools\\briefing.py" --auto --compact`
+python3 ~/.copilot/tools/briefing.py --auto --compact
 
 # After fixing a bug — record the mistake
-sk learn --mistake "Title" "What happened and fix" --tags "relevant,tags"
+python3 ~/.copilot/tools/learn.py --mistake "Title" "What happened and fix" --tags "relevant,tags"
 
 # After completing work — record pattern/decision
-sk learn --pattern "Title" "What works well" --tags "tags"
+python3 ~/.copilot/tools/learn.py --pattern "Title" "What works well" --tags "tags"
 ```
 """
 
@@ -195,23 +192,21 @@ AGENTS_SNIPPET = """
 
 ```bash
 # Before task — start minimal and escalate only when needed
-sk briefing --auto --compact
-# Fallbacks: macOS/Linux `python3 ~/.copilot/tools/briefing.py --auto --compact`;
-# Windows PowerShell `python "$env:USERPROFILE\\.copilot\\tools\\briefing.py" --auto --compact`
+python3 ~/.copilot/tools/briefing.py --auto --compact
 
 # Before delegating via tentacle — preferred structured recall path
-sk tentacle swarm <name> --briefing
+python3 ~/.copilot/tools/tentacle.py swarm <name> --briefing
 
 # Manual compatibility for ad hoc sub-agent prompts
-sk briefing "<sub-agent task>" --for-subagent
+python3 ~/.copilot/tools/briefing.py "<sub-agent task>" --for-subagent
 
 # During task — search for errors/topics
-sk query "<error or topic>" --verbose
+python3 ~/.copilot/tools/query-session.py "<error or topic>" --verbose
 
 # After task — record with full metadata
-sk learn --mistake "Title" "Description" --tags "t1,t2" --wing <wing> --room <room> --fact "key detail"
-sk learn --pattern "Title" "Description" --tags "t1,t2" --wing <wing> --room <room>
-sk learn --relate "#id1" "resolved_by" "#id2"
+python3 ~/.copilot/tools/learn.py --mistake "Title" "Description" --tags "t1,t2" --wing <wing> --room <room> --fact "key detail"
+python3 ~/.copilot/tools/learn.py --pattern "Title" "Description" --tags "t1,t2" --wing <wing> --room <room>
+python3 ~/.copilot/tools/learn.py --relate "#id1" "resolved_by" "#id2"
 ```
 """
 
@@ -473,39 +468,6 @@ def patch_agents_md(project_root: Path, dry_run: bool) -> bool:
     return True
 
 
-def _select_init_adapters(
-    project_root: Path, requested_agents: list[str] | None, *, init_mode: bool
-) -> tuple[list, list[str]]:
-    selected = list(requested_agents or [])
-    if not selected and init_mode:
-        selected = detect_agents(project_root)
-        if not selected:
-            selected = ["copilot"]
-    if not selected:
-        return [], []
-    adapters = [get_adapter(key) for key in expand_init_agents(selected)]
-    return unique_target_adapters(adapters), selected
-
-
-def apply_init_adapters(project_root: Path, adapters: list, dry_run: bool) -> int:
-    changes = 0
-    for adapter in adapters:
-        rel = adapter.target_path(project_root).relative_to(project_root)
-        try:
-            status = adapter.upsert_context(project_root, dry_run=dry_run)
-        except ValueError as exc:
-            raise ValueError(f"{adapter.name} context at {rel} is invalid: {exc}") from exc
-        if status == "unchanged":
-            print(f"  ⏭ {adapter.name} already up to date ({rel})")
-            continue
-        changes += 1
-        if dry_run:
-            print(f"  [dry-run] Would {status}: {rel} ({adapter.name})")
-        else:
-            print(f"  ✓ {status.capitalize()}: {rel} ({adapter.name})")
-    return changes
-
-
 def main():
     parser = argparse.ArgumentParser(
         description="Integrate session-knowledge + tentacle orchestration into a project",
@@ -563,15 +525,6 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
              "(default: none; choices: default, python, typescript, mobile, fullstack)"
     )
     parser.add_argument(
-        "--agent",
-        dest="agents",
-        action="append",
-        default=None,
-        metavar="AGENT",
-        help="Initialize adapter-specific context files; repeat to target multiple adapters",
-    )
-    parser.add_argument("--init-mode", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument(
         "--dry-run", action="store_true",
         help="Show what would be done without making changes"
     )
@@ -597,13 +550,6 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
         print("   (dry-run mode)")
     print()
 
-    try:
-        init_adapters, requested_init = _select_init_adapters(
-            project_root, args.agents, init_mode=args.init_mode
-        )
-    except ValueError as exc:
-        print(f"✗ {exc}")
-        sys.exit(1)
     changes = 0
 
     # 1. Install session-knowledge skill + instructions
@@ -622,25 +568,12 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
     # 4. Patch config files
     if not args.skill_only:
         print("\n📝 Config Files:")
-        if init_adapters:
-            if args.agents:
-                requested_text = ", ".join(requested_init)
-                print(f"  Initializing adapter contexts for: {requested_text}")
-            elif args.init_mode:
-                detected_text = ", ".join(requested_init)
-                print(f"  Using detected adapters: {detected_text}")
-            try:
-                changes += apply_init_adapters(project_root, init_adapters, args.dry_run)
-            except ValueError as exc:
-                print(f"✗ {exc}")
-                sys.exit(1)
-        else:
-            if patch_claude_md(project_root, args.dry_run):
-                changes += 1
-            if patch_copilot_instructions(project_root, args.dry_run):
-                changes += 1
-            if patch_agents_md(project_root, args.dry_run):
-                changes += 1
+        if patch_claude_md(project_root, args.dry_run):
+            changes += 1
+        if patch_copilot_instructions(project_root, args.dry_run):
+            changes += 1
+        if patch_agents_md(project_root, args.dry_run):
+            changes += 1
 
     # 5. Install workflow profile hook bundle (optional, only when --profile is given)
     if args.profile:
@@ -679,10 +612,8 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
         print(f"✅ Done! {changes} change(s) applied.")
         print()
         print("Next steps:")
-        print("  1. Run: sk index build --all")
-        print("     Fallbacks: macOS/Linux `python3 ~/.copilot/tools/build-session-index.py --all`;")
-        print("                Windows PowerShell `python \"$env:USERPROFILE\\.copilot\\tools\\build-session-index.py\" --all`")
-        print("  2. (Optional) Configure sync gateway URL: sk sync config --setup <https://gateway>")
+        print("  1. Run: python3 ~/.copilot/tools/build-session-index.py --all")
+        print("  2. (Optional) Configure sync gateway URL: python3 ~/.copilot/tools/sync-config.py --setup <https://gateway>")
         print("     Default provider rollout recommendation: Neon (Postgres) + Railway (thin gateway host).")
         print("  3. Trend Scout automation: keep trend-scout.py in scheduled/manual flow (trend-scout.yml), not preToolUse/postToolUse hooks.")
         print("  4. Customize for your project:")

--- a/setup-project.py
+++ b/setup-project.py
@@ -22,6 +22,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+from agent_adapters import detect_agents, expand_init_agents, get_adapter, unique_target_adapters
+from host_manifest import HOST_INSTRUCTION_FILES as KNOWN_HOSTS_INSTRUCTION_FILES  # noqa: E402
+from host_manifest import HOST_SKILL_SUBPATHS  # noqa: E402
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 TEMPLATES_DIR = SCRIPT_DIR / "templates"
 SKILLS_DIR = SCRIPT_DIR / "skills"
@@ -46,8 +50,6 @@ def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> Non
 
 # Host metadata is centralised in host_manifest.py — import canonical constants.
 # Do NOT add new hosts here; update host_manifest.py through the review process.
-from host_manifest import HOST_INSTRUCTION_FILES as KNOWN_HOSTS_INSTRUCTION_FILES  # noqa: E402
-from host_manifest import HOST_SKILL_SUBPATHS  # noqa: E402
 if os.name == "nt":
     for _s in (sys.stdout, sys.stderr):
         if hasattr(_s, "reconfigure"):
@@ -103,13 +105,15 @@ CLAUDE_SNIPPET = """
 
 ```bash
 # Before starting a task — get context from past sessions
-python3 ~/.copilot/tools/briefing.py --auto --compact
+sk briefing --auto --compact
+# Fallbacks: macOS/Linux `python3 ~/.copilot/tools/briefing.py --auto --compact`;
+# Windows PowerShell `python "$env:USERPROFILE\\.copilot\\tools\\briefing.py" --auto --compact`
 
 # After fixing a bug — record the mistake
-python3 ~/.copilot/tools/learn.py --mistake "Title" "What happened and fix" --tags "relevant,tags"
+sk learn --mistake "Title" "What happened and fix" --tags "relevant,tags"
 
 # After completing work — record pattern/decision
-python3 ~/.copilot/tools/learn.py --pattern "Title" "What works well" --tags "tags"
+sk learn --pattern "Title" "What works well" --tags "tags"
 ```
 """
 
@@ -192,21 +196,23 @@ AGENTS_SNIPPET = """
 
 ```bash
 # Before task — start minimal and escalate only when needed
-python3 ~/.copilot/tools/briefing.py --auto --compact
+sk briefing --auto --compact
+# Fallbacks: macOS/Linux `python3 ~/.copilot/tools/briefing.py --auto --compact`;
+# Windows PowerShell `python "$env:USERPROFILE\\.copilot\\tools\\briefing.py" --auto --compact`
 
 # Before delegating via tentacle — preferred structured recall path
-python3 ~/.copilot/tools/tentacle.py swarm <name> --briefing
+sk tentacle swarm <name> --briefing
 
 # Manual compatibility for ad hoc sub-agent prompts
-python3 ~/.copilot/tools/briefing.py "<sub-agent task>" --for-subagent
+sk briefing "<sub-agent task>" --for-subagent
 
 # During task — search for errors/topics
-python3 ~/.copilot/tools/query-session.py "<error or topic>" --verbose
+sk query "<error or topic>" --verbose
 
 # After task — record with full metadata
-python3 ~/.copilot/tools/learn.py --mistake "Title" "Description" --tags "t1,t2" --wing <wing> --room <room> --fact "key detail"
-python3 ~/.copilot/tools/learn.py --pattern "Title" "Description" --tags "t1,t2" --wing <wing> --room <room>
-python3 ~/.copilot/tools/learn.py --relate "#id1" "resolved_by" "#id2"
+sk learn --mistake "Title" "Description" --tags "t1,t2" --wing <wing> --room <room> --fact "key detail"
+sk learn --pattern "Title" "Description" --tags "t1,t2" --wing <wing> --room <room>
+sk learn --relate "#id1" "resolved_by" "#id2"
 ```
 """
 
@@ -468,6 +474,39 @@ def patch_agents_md(project_root: Path, dry_run: bool) -> bool:
     return True
 
 
+def _select_init_adapters(
+    project_root: Path, requested_agents: list[str] | None, *, init_mode: bool
+) -> tuple[list, list[str]]:
+    selected = list(requested_agents or [])
+    if not selected and init_mode:
+        selected = detect_agents(project_root)
+        if not selected:
+            selected = ["copilot"]
+    if not selected:
+        return [], []
+    adapters = [get_adapter(key) for key in expand_init_agents(selected)]
+    return unique_target_adapters(adapters), selected
+
+
+def apply_init_adapters(project_root: Path, adapters: list, dry_run: bool) -> int:
+    changes = 0
+    for adapter in adapters:
+        rel = adapter.target_path(project_root).relative_to(project_root)
+        try:
+            status = adapter.upsert_context(project_root, dry_run=dry_run)
+        except ValueError as exc:
+            raise ValueError(f"{adapter.name} context at {rel} is invalid: {exc}") from exc
+        if status == "unchanged":
+            print(f"  ⏭ {adapter.name} already up to date ({rel})")
+            continue
+        changes += 1
+        if dry_run:
+            print(f"  [dry-run] Would {status}: {rel} ({adapter.name})")
+        else:
+            print(f"  ✓ {status.capitalize()}: {rel} ({adapter.name})")
+    return changes
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Integrate session-knowledge + tentacle orchestration into a project",
@@ -525,6 +564,15 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
              "(default: none; choices: default, python, typescript, mobile, fullstack)"
     )
     parser.add_argument(
+        "--agent",
+        dest="agents",
+        action="append",
+        default=None,
+        metavar="AGENT",
+        help="Initialize adapter-specific context files; repeat to target multiple adapters",
+    )
+    parser.add_argument("--init-mode", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument(
         "--dry-run", action="store_true",
         help="Show what would be done without making changes"
     )
@@ -550,6 +598,13 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
         print("   (dry-run mode)")
     print()
 
+    try:
+        init_adapters, requested_init = _select_init_adapters(
+            project_root, args.agents, init_mode=args.init_mode
+        )
+    except ValueError as exc:
+        print(f"✗ {exc}")
+        sys.exit(1)
     changes = 0
 
     # 1. Install session-knowledge skill + instructions
@@ -568,12 +623,25 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
     # 4. Patch config files
     if not args.skill_only:
         print("\n📝 Config Files:")
-        if patch_claude_md(project_root, args.dry_run):
-            changes += 1
-        if patch_copilot_instructions(project_root, args.dry_run):
-            changes += 1
-        if patch_agents_md(project_root, args.dry_run):
-            changes += 1
+        if init_adapters:
+            if args.agents:
+                requested_text = ", ".join(requested_init)
+                print(f"  Initializing adapter contexts for: {requested_text}")
+            elif args.init_mode:
+                detected_text = ", ".join(requested_init)
+                print(f"  Using detected adapters: {detected_text}")
+            try:
+                changes += apply_init_adapters(project_root, init_adapters, args.dry_run)
+            except ValueError as exc:
+                print(f"✗ {exc}")
+                sys.exit(1)
+        else:
+            if patch_claude_md(project_root, args.dry_run):
+                changes += 1
+            if patch_copilot_instructions(project_root, args.dry_run):
+                changes += 1
+            if patch_agents_md(project_root, args.dry_run):
+                changes += 1
 
     # 5. Install workflow profile hook bundle (optional, only when --profile is given)
     if args.profile:
@@ -612,8 +680,10 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
         print(f"✅ Done! {changes} change(s) applied.")
         print()
         print("Next steps:")
-        print("  1. Run: python3 ~/.copilot/tools/build-session-index.py --all")
-        print("  2. (Optional) Configure sync gateway URL: python3 ~/.copilot/tools/sync-config.py --setup <https://gateway>")
+        print("  1. Run: sk index build --all")
+        print("     Fallbacks: macOS/Linux `python3 ~/.copilot/tools/build-session-index.py --all`;")
+        print("                Windows PowerShell `python \"$env:USERPROFILE\\.copilot\\tools\\build-session-index.py\" --all`")
+        print("  2. (Optional) Configure sync gateway URL: sk sync config --setup <https://gateway>")
         print("     Default provider rollout recommendation: Neon (Postgres) + Railway (thin gateway host).")
         print("  3. Trend Scout automation: keep trend-scout.py in scheduled/manual flow (trend-scout.yml), not preToolUse/postToolUse hooks.")
         print("  4. Customize for your project:")

--- a/skills/detective-investigation/SKILL.md
+++ b/skills/detective-investigation/SKILL.md
@@ -64,7 +64,7 @@ Capture investigation facts in a canonical JSON/YAML structure, then generate Ma
 | --- | --- | --- |
 | Physical | logs, traces, database rows, API responses, failing tests | 1.00 |
 | Observational | screenshots, videos, direct reproduction notes | 0.75 |
-| Inferential | code reading, diffs, reasoned mapper/data-flow analysis | 0.50 |
+| Inferential | code reading, diffs, reasoned mapping/data-flow analysis | 0.50 |
 | Testimonial | remembered behavior, second-hand reports | 0.25 |
 
 ## Promotion rules

--- a/skills/detective-investigation/SKILL.md
+++ b/skills/detective-investigation/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: detective-investigation
+description: Create professional detective-style investigations and reusable evidence-board reports for bugs, incidents, regressions, unclear failures, postmortems, or root-cause analysis in any software project. Use when the user asks to investigate root cause, build an evidence board, reason from clues like a detective, identify hidden unknowns, compare working vs broken behavior, prove or refute hypotheses, generate an interactive HTML report, or turn scattered logs/screenshots/issues/code findings into an auditable investigation graph. It is project-agnostic and designed to be copied from ~/.copilot/tools/skills into any repo.
+---
+
+# Detective Investigation
+
+Use this skill to investigate bugs and incidents as an evidence graph instead of a loose prose narrative. The output should be reusable: new evidence can be added later and the report can be regenerated without rebuilding the whole board.
+
+## When to use
+
+Use this skill when a project needs a rigorous, evidence-backed investigation workflow:
+
+- root-cause analysis for bugs, incidents, regressions, or outages,
+- "detective board" reasoning from scattered clues,
+- interactive HTML evidence board or graph report,
+- comparison of working vs broken behavior,
+- hidden unknowns, contradictions, or alternative hypotheses,
+- postmortem preparation where claims need citations and artifacts.
+
+## Read only what you need
+
+| Need | Read |
+| --- | --- |
+| End-to-end investigation stages | `references/workflow.md` |
+| Evidence, hypothesis, and root-cause model | `references/evidence-model.md` |
+| Interactive HTML board guidance | `references/html-board.md` |
+
+## Core idea
+
+Capture investigation facts in a canonical JSON/YAML structure, then generate Markdown or HTML from that data. This keeps the workflow portable across projects and avoids hand-coding a new report for every bug.
+
+## Workflow
+
+1. **Frame the case**: define symptom, expected behavior, actual behavior, affected users, environment, and time window.
+2. **Capture RED evidence**: obtain a reproducible failure or direct observation before proposing a root cause.
+3. **Collect and tier evidence**: classify each item as physical, observational, inferential, or testimonial.
+4. **Reconstruct timeline**: order reports, logs, deploys, commits, config changes, traces, and reproductions.
+5. **Build hypothesis graph**: connect symptoms, evidence, hypotheses, contradictions, unknowns, root causes, fixes, and verification.
+6. **Challenge the graph**: look for contradictions, temporal violations, unsupported claims, and hidden confounders.
+7. **Promote root cause carefully**: require strong evidence and counterfactual clarity.
+8. **Verify GREEN**: prove the same RED assertion passes after the fix or mitigation.
+9. **Generate report**: produce an evidence-board HTML/Markdown report with citations and open questions.
+
+## Required report sections
+
+1. Executive summary
+2. Scope and symptom
+3. RED evidence
+4. Timeline
+5. Evidence graph
+6. Hypotheses considered
+7. Contradictions and unknowns
+8. Root-cause proof
+9. Fix or mitigation
+10. GREEN evidence
+11. Lateral or similar-pattern check
+12. Remaining questions and next actions
+13. Citations and artifacts
+
+## Evidence tiers
+
+| Tier | Examples | Weight |
+| --- | --- | --- |
+| Physical | logs, traces, database rows, API responses, failing tests | 1.00 |
+| Observational | screenshots, videos, direct reproduction notes | 0.75 |
+| Inferential | code reading, diffs, reasoned mapper/data-flow analysis | 0.50 |
+| Testimonial | remembered behavior, second-hand reports | 0.25 |
+
+## Promotion rules
+
+| Promotion | Requirement |
+| --- | --- |
+| Hypothesis -> Finding | At least one physical or observational supporting evidence item |
+| Finding -> Root cause | Evidence support, no unresolved high-impact contradiction, and counterfactual clarity |
+| Root cause -> Resolution | Concrete fix, mitigation, or accepted risk |
+| Fix -> Verified | Same RED assertion passes after the change |
+
+## Output modes
+
+| User need | Output |
+| --- | --- |
+| Fast investigation report | Markdown with Mermaid/D2 graph |
+| Interactive evidence board | Single-file HTML with Cytoscape.js-style graph data |
+| Handoff to another agent/team | `investigation.json` plus artifacts and citations |
+| Follow-up investigation | Update nodes/edges/evidence and regenerate report |
+
+## Stop conditions
+
+Stop and report uncertainty when:
+
+- expected and actual behavior are not clear,
+- RED evidence is missing,
+- root cause has only weak evidence,
+- unresolved contradiction could overturn the conclusion,
+- an unknown node has high impact and no required evidence yet,
+- proposed fix fails the counterfactual question: "If this existed before, would the incident not have happened?"
+
+<example>
+User: We have a regression where billing exports show zero totals after last release. Investigate it like a detective and make an evidence board.
+
+Assistant behavior: Capture RED evidence, classify logs/screenshots/code findings by evidence tier, build a hypothesis graph, mark contradictions and unknowns, then produce an auditable report with root-cause proof and GREEN verification plan.
+</example>
+
+<example>
+User: Turn these scattered screenshots, logs, and PR notes into an interactive HTML bug board with root cause and next actions.
+
+Assistant behavior: Normalize the material into case/situation/nodes/edges/evidence, recommend a reusable HTML board layout, keep citations attached to claims, and avoid one-off hand-written diagrams.
+</example>

--- a/skills/detective-investigation/evals/evals.json
+++ b/skills/detective-investigation/evals/evals.json
@@ -1,0 +1,28 @@
+{
+  "skill_name": "detective-investigation",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We have a regression where the billing export started showing zero totals after last week's release. Investigate it like a detective and produce an evidence board report.",
+      "expected_output": "A project-agnostic investigation plan/report with RED evidence, evidence tiers, timeline, hypothesis graph, contradictions, root-cause proof, and GREEN verification plan.",
+      "files": [],
+      "expectations": [
+        "Requires RED evidence before root-cause conclusion.",
+        "Uses evidence tiers and support/contradict directions.",
+        "Represents unknowns and contradictions explicitly.",
+        "Includes a reusable graph/report structure rather than a one-off prose-only answer."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Turn these scattered logs, screenshots, and code notes into an interactive HTML bug board with root cause, hidden nodes, and next actions.",
+      "expected_output": "A structured HTML evidence-board plan that uses canonical investigation data and reusable rendering guidance.",
+      "files": [],
+      "expectations": [
+        "Defines nodes and edges for symptom, evidence, hypothesis, root cause, fix, verification, contradiction, and unknown.",
+        "Specifies interactions such as search, filters, focus mode, path highlight, detail panel, and export.",
+        "Keeps citations/artifacts attached to claims."
+      ]
+    }
+  ]
+}

--- a/skills/detective-investigation/references/evidence-model.md
+++ b/skills/detective-investigation/references/evidence-model.md
@@ -1,0 +1,88 @@
+# Evidence Model
+
+## Canonical structure
+
+```json
+{
+  "schemaVersion": "1.0",
+  "case": {
+    "id": "case-id",
+    "title": "Short title",
+    "status": "open | red_captured | root_cause_confirmed | fixed | verified | escalated",
+    "summary": "Current conclusion"
+  },
+  "situation": {
+    "who": ["affected users"],
+    "what": "symptom",
+    "where": ["systems or files"],
+    "when": "time window",
+    "impact": "severity, recurrence, affected users or data",
+    "expected": "expected behavior",
+    "actual": "actual behavior"
+  },
+  "nodes": [],
+  "edges": [],
+  "evidence": [],
+  "artifacts": [],
+  "conclusions": [],
+  "openQuestions": []
+}
+```
+
+## Node types
+
+| Type | Meaning |
+| --- | --- |
+| `symptom` | User-visible or system-visible failure |
+| `observation` | Directly observed fact |
+| `hypothesis` | Candidate explanation |
+| `finding` | Hypothesis backed by strong evidence |
+| `root_cause` | Finding that passes counterfactual and actionability checks |
+| `contradiction` | Evidence that conflicts with another claim |
+| `unknown` | Missing information or hidden node |
+| `fix` | Proposed or implemented resolution |
+| `verification` | GREEN proof |
+
+## Edge types
+
+| Type | Meaning |
+| --- | --- |
+| `causes` | Source causes or explains target |
+| `supports` | Evidence supports a claim |
+| `contradicts` | Evidence conflicts with a claim |
+| `depends_on` | Claim requires another condition |
+| `same_pattern_as` | Similar risk or lateral-check relation |
+| `fixed_by` | Fix addresses root cause |
+| `verified_by` | Verification proves fix |
+
+## Depth criteria
+
+Root cause should pass:
+
+1. Actionability: there is a concrete change or accepted risk.
+2. Counterfactual clarity: if the change existed earlier, the failure would not happen.
+3. System boundary: fix can be enforced at a stable boundary such as schema, validation, tests, CI, interface, or ownership.
+4. Diminishing returns: asking another "why" would not change the action.
+
+## Unknown nodes
+
+Use unknown nodes when a missing fact could change the conclusion. Give each unknown:
+
+- question type,
+- required evidence,
+- impact on conclusion,
+- suggested next action.
+
+## Conclusion objects
+
+```json
+{
+  "id": "conc-001",
+  "claim": "Root cause is X because evidence ev-001 and ev-002 support it.",
+  "status": "preliminary | confirmed | disputed",
+  "supportingNodeIds": ["root-001"],
+  "supportingEvidenceIds": ["ev-001", "ev-002"],
+  "confidence": 0.9,
+  "counterfactual": "If the proposed fix existed before, the failure would not occur."
+}
+```

--- a/skills/detective-investigation/references/html-board.md
+++ b/skills/detective-investigation/references/html-board.md
@@ -1,0 +1,63 @@
+# HTML Evidence Board
+
+## Recommended architecture
+
+Use a reusable template that reads investigation data and renders:
+
+- graph canvas,
+- node detail panel,
+- timeline,
+- evidence table,
+- conclusion and unknowns.
+
+The template can use Cytoscape.js for interaction. For fast static output, render Mermaid or D2 from the same graph data.
+
+## Layout
+
+```text
+Header: title, status, confidence, search, filters, export
+Graph canvas | Detail panel
+Timeline strip
+Evidence table
+Conclusion and unknowns
+```
+
+## Interactions
+
+| Interaction | Behavior |
+| --- | --- |
+| Search | Filter nodes, edges, and evidence |
+| Type filter | Show only symptoms, hypotheses, evidence, root causes, unknowns, etc. |
+| Status filter | Show open, confirmed, refuted, escalated, verified |
+| Node click | Detail panel with evidence and citations |
+| Edge click | Explain the relationship and evidence |
+| Focus mode | Show selected node and nearby graph |
+| Path highlight | Highlight symptom-to-root-cause-to-fix path |
+| Export | JSON, Markdown, SVG/PNG, printable HTML |
+
+## Visual encoding
+
+| Node | Suggested style |
+| --- | --- |
+| Evidence | blue circle |
+| Hypothesis | purple diamond |
+| Finding | amber rounded rectangle |
+| Root cause | red star or triangle |
+| Unknown | gray hexagon |
+| Contradiction | warning icon |
+| Fix | green square |
+| Verification | teal double circle |
+
+Use labels and shapes in addition to color.
+
+## Validation warnings
+
+The report generator should warn when:
+
+- a root cause lacks strong evidence,
+- a hypothesis has no supporting evidence,
+- a contradiction is unresolved,
+- a high-impact unknown has no next action,
+- a fix has no verification node,
+- a claim has no citation or artifact path.
+

--- a/skills/detective-investigation/references/workflow.md
+++ b/skills/detective-investigation/references/workflow.md
@@ -1,0 +1,63 @@
+# Detective Investigation Workflow
+
+## 1. Intake
+
+Create a situation map:
+
+| Field | Question |
+| --- | --- |
+| Who | Who is affected? |
+| What | What is wrong? What should happen instead? |
+| Where | Which screen, API, service, job, table, or integration? |
+| When | When did it start? Which release/deploy/config window? |
+| Impact | How severe and how frequent? |
+
+## 2. RED evidence
+
+Capture proof of failure before deep analysis:
+
+- failing test,
+- reproduction steps,
+- screenshot or video,
+- log or trace,
+- API response,
+- database/config snapshot.
+
+The key is a reusable assertion: the same check should later verify GREEN.
+
+## 3. Evidence collection
+
+For each item, record source, timestamp, tier, direction, artifact path, and citation. Evidence can support, contradict, or merely contextualize a hypothesis.
+
+## 4. Timeline
+
+Order observable events before claiming causality. Include reports, deploys, commits, migrations, config changes, monitoring events, and reproductions.
+
+## 5. Hypothesis graph
+
+Create nodes for symptoms, observations, hypotheses, findings, root causes, contradictions, unknowns, fixes, and verification. Create typed edges such as `supports`, `contradicts`, `causes`, `fixed_by`, and `verified_by`.
+
+## 6. Challenge and prune
+
+Actively look for:
+
+- strongest evidence against the leading hypothesis,
+- alternative explanations,
+- hidden confounders,
+- unsupported claims,
+- circular reasoning,
+- temporal violations,
+- similar paths where the bug should also appear.
+
+## 7. Root-cause proof
+
+Promote only when actionability and counterfactual clarity are strong. If fixing the proposed root cause would not have prevented the failure, it is probably a mitigation or symptom fix.
+
+## 8. GREEN verification
+
+Use the same assertion from RED. If the fix is not implemented yet, mark verification as pending and list exactly what evidence is required.
+
+## 9. Report
+
+Generate a report from the graph data. Keep open questions visible so future investigators can continue from the current board.
+


### PR DESCRIPTION
## Summary

- Add generic `detective-investigation` skill for evidence-board root-cause investigations.
- Register the skill in setup-project and auto-update so it can be shared/deployed to other projects.
- Document the skill in `docs/SKILLS.md`.

## Validation

- `validate-skill.py skills/detective-investigation/SKILL.md`
- `py_compile setup-project.py auto-update-tools.py`
- `git diff --check`

## Notes

Created from the NEO-MATCH detective investigation workflow research. The project-specific NEO-MATCH skill remains in the NEO-MATCH repo; this PR contains only the generic reusable tools skill.
