### PR TITLE
fix(hooks): address complexity review comments

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -11,6 +11,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 if os.name == "nt":
@@ -146,6 +147,62 @@ def check_ruff(staged: list[str]) -> int:
     return 0
 
 
+def write_staged_python_snapshot(staged_py: list[str], temp_root: Path) -> tuple[list[str], dict[str, str]]:
+    report_paths: list[str] = []
+    path_map: dict[str, str] = {}
+    for staged_path in staged_py:
+        temp_path = temp_root / staged_path
+        temp_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path.write_text(staged_content(staged_path), encoding="utf-8", errors="replace")
+        report_paths.append(str(temp_path))
+        path_map[str(temp_path)] = staged_path
+        path_map[temp_path.as_posix()] = staged_path
+    return report_paths, path_map
+
+
+def restore_report_path(value: object, path_map: dict[str, str]) -> str:
+    label = str(value or "")
+    return path_map.get(label, label)
+
+
+def restore_error_paths(error: object, path_map: dict[str, str]) -> str:
+    message = str(error)
+    for temp_path, staged_path in path_map.items():
+        message = message.replace(temp_path, staged_path)
+    return message
+
+
+def complexity_advisory_lines(payload: object, path_map: dict[str, str]) -> tuple[list[str], list[str]] | None:
+    if not isinstance(payload, dict):
+        return None
+    files = payload.get("files", [])
+    errors = payload.get("errors", [])
+    if not isinstance(files, list) or not isinstance(errors, list):
+        return None
+    advisory_lines: list[str] = []
+    for file_info in files:
+        if not isinstance(file_info, dict):
+            return None
+        functions = file_info.get("functions", [])
+        if not isinstance(functions, list):
+            return None
+        path = restore_report_path(file_info.get("path"), path_map)
+        if file_info.get("severity") in {"warning", "high"}:
+            advisory_lines.append(
+                f"  {file_info.get('severity')}: {path} lines={file_info.get('lines')} functions={len(functions)}"
+            )
+        for fn in functions:
+            if not isinstance(fn, dict):
+                return None
+            if fn.get("severity") not in {"warning", "high"}:
+                continue
+            advisory_lines.append(
+                f"  {fn.get('severity')}: {path}:{fn.get('line')} {fn.get('name')} "
+                f"complexity={fn.get('complexity')} lines={fn.get('lines')}"
+            )
+    return advisory_lines, [restore_error_paths(error, path_map) for error in errors]
+
+
 def check_complexity(staged: list[str]) -> int:
     if not COMPLEXITY_CHECKER.is_file():
         return 0
@@ -153,15 +210,16 @@ def check_complexity(staged: list[str]) -> int:
     if not staged_py:
         return 0
     try:
-        result = run(
-            [sys.executable, str(COMPLEXITY_CHECKER), "--json", *staged_py],
-            capture_output=True,
-            timeout=60,
-        )
+        with tempfile.TemporaryDirectory(prefix="pre-commit-complexity-") as temp_dir:
+            report_paths, path_map = write_staged_python_snapshot(staged_py, Path(temp_dir))
+            result = run(
+                [sys.executable, str(COMPLEXITY_CHECKER), "--json", *report_paths],
+                capture_output=True,
+                timeout=60,
+            )
     except Exception as exc:
         print(f"⚠️ Complexity advisory skipped: {exc}")
         return 0
-
     try:
         payload = json.loads(result.stdout)
     except json.JSONDecodeError:
@@ -171,23 +229,11 @@ def check_complexity(staged: list[str]) -> int:
             print(output)
         return 0
 
-    advisory_lines: list[str] = []
-    for file_info in payload.get("files", []):
-        path = file_info.get("path", "")
-        if file_info.get("severity") in {"warning", "high"}:
-            advisory_lines.append(
-                f"  {file_info.get('severity')}: {path} "
-                f"lines={file_info.get('lines')} functions={len(file_info.get('functions', []))}"
-            )
-        for fn in file_info.get("functions", []):
-            if fn.get("severity") not in {"warning", "high"}:
-                continue
-            advisory_lines.append(
-                f"  {fn.get('severity')}: {path}:{fn.get('line')} {fn.get('name')} "
-                f"complexity={fn.get('complexity')} lines={fn.get('lines')}"
-            )
-
-    errors = payload.get("errors", [])
+    parsed = complexity_advisory_lines(payload, path_map)
+    if parsed is None:
+        print("⚠️ Complexity advisory skipped: reporter JSON shape was unexpected")
+        return 0
+    advisory_lines, errors = parsed
     if advisory_lines or errors:
         print("⚠️ Complexity advisory (non-blocking):")
         for line in advisory_lines:

--- a/scripts/check_complexity.py
+++ b/scripts/check_complexity.py
@@ -287,13 +287,7 @@ def report_dict(files: list[FileMetric], errors: list[str]) -> dict:
     return {
         "summary": summarize(files),
         "thresholds": thresholds(),
-        "files": [
-            {
-                **asdict(file),
-                "functions": [asdict(fn) for fn in file.functions],
-            }
-            for file in files
-        ],
+        "files": [asdict(file) for file in files],
         "errors": errors,
     }
 

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -425,7 +425,9 @@ def test_check_complexity_null_byte_json_error():
 
 def test_check_complexity_stdlib_imports_only():
     """The complexity reporter must stay stdlib-only."""
-    allowed = {"argparse", "ast", "dataclasses", "json", "os", "pathlib", "sys"}
+    allowed = set(getattr(sys, "stdlib_module_names", ()))
+    if not allowed:
+        allowed = {"argparse", "ast", "dataclasses", "json", "os", "pathlib", "sys"}
     tree = ast.parse(CHECK_COMPLEXITY.read_text(encoding="utf-8"))
     imports = set()
     for node in ast.walk(tree):
@@ -469,6 +471,16 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(["git", *args], cwd=str(repo), capture_output=True, text=True)
 
 
+def _git_ok(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    result = _git(repo, *args)
+    test(
+        f"git {' '.join(args)} succeeds",
+        result.returncode == 0,
+        f"returncode={result.returncode}, output={result.stdout + result.stderr}",
+    )
+    return result
+
+
 def _seed_pre_commit_tools(home: Path, *, include_complexity: bool = True) -> Path:
     tools = home / ".copilot" / "tools"
     (tools / "hooks").mkdir(parents=True, exist_ok=True)
@@ -505,41 +517,45 @@ def test_pre_commit_complexity_advisory():
         repo.mkdir()
         home.mkdir()
         hook = _seed_pre_commit_tools(home)
-        _git(repo, "init")
+        git_init = _git_ok(repo, "init")
 
         complex_file = repo / "complex_module.py"
         branches = "\n".join(f"    if value == {i}:\n        total += {i}" for i in range(20))
         complex_file.write_text(f"def complex_func(value):\n    total = 0\n{branches}\n    return total\n")
-        _git(repo, "add", "complex_module.py")
+        git_add_complex = _git_ok(repo, "add", "complex_module.py")
+        complex_file.write_text("def complex_func(value):\n    return value\n")
         complex_result = _run_pre_commit_hook(repo, hook, home)
         complex_output = complex_result.stdout + complex_result.stderr
         test(
             "pre-commit complexity advisory exits 0 for complex staged file",
-            complex_result.returncode == 0,
+            git_init.returncode == 0 and git_add_complex.returncode == 0 and complex_result.returncode == 0,
             f"returncode={complex_result.returncode}, output={complex_output}",
         )
         test(
             "pre-commit complexity advisory prints warning for complex staged file",
-            "Complexity advisory" in complex_output
+            git_init.returncode == 0
+            and git_add_complex.returncode == 0
+            and "Complexity advisory" in complex_output
             and "complex_module.py" in complex_output
             and "complex_func" in complex_output,
             f"output={complex_output}",
         )
 
-        _git(repo, "reset")
+        git_reset = _git_ok(repo, "reset")
         small_file = repo / "small_module.py"
         small_file.write_text("def small_func():\n    return 1\n")
-        _git(repo, "add", "small_module.py")
+        git_add_small = _git_ok(repo, "add", "small_module.py")
+        small_file.write_text(f"def small_func(value):\n    total = 0\n{branches}\n    return total\n")
         small_result = _run_pre_commit_hook(repo, hook, home)
         small_output = small_result.stdout + small_result.stderr
         test(
             "pre-commit complexity advisory exits 0 for small staged file",
-            small_result.returncode == 0,
+            git_reset.returncode == 0 and git_add_small.returncode == 0 and small_result.returncode == 0,
             f"returncode={small_result.returncode}, output={small_output}",
         )
         test(
             "pre-commit complexity advisory prints no warning for small staged file",
-            "Complexity advisory" not in small_output,
+            git_reset.returncode == 0 and git_add_small.returncode == 0 and "Complexity advisory" not in small_output,
             f"output={small_output}",
         )
 
@@ -553,15 +569,45 @@ def test_pre_commit_complexity_missing_checker_fail_open():
         repo.mkdir()
         home.mkdir()
         hook = _seed_pre_commit_tools(home, include_complexity=False)
-        _git(repo, "init")
+        git_init = _git_ok(repo, "init")
         staged = repo / "module.py"
         staged.write_text("def small_func():\n    return 1\n")
-        _git(repo, "add", "module.py")
+        git_add = _git_ok(repo, "add", "module.py")
         result = _run_pre_commit_hook(repo, hook, home)
         output = result.stdout + result.stderr
         test(
             "pre-commit complexity advisory fail-open when checker missing",
-            result.returncode == 0 and "Complexity advisory" not in output,
+            git_init.returncode == 0
+            and git_add.returncode == 0
+            and result.returncode == 0
+            and "Complexity advisory" not in output,
+            f"returncode={result.returncode}, output={output}",
+        )
+
+
+def test_pre_commit_complexity_malformed_json_fail_open():
+    """Malformed-but-valid reporter JSON should not make pre-commit fail closed."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base = Path(tmpdir)
+        repo = base / "repo"
+        home = base / "home"
+        repo.mkdir()
+        home.mkdir()
+        hook = _seed_pre_commit_tools(home)
+        checker = home / ".copilot" / "tools" / "scripts" / "check_complexity.py"
+        checker.write_text("print('[]')\n", encoding="utf-8")
+        git_init = _git_ok(repo, "init")
+        staged = repo / "module.py"
+        staged.write_text("def small_func():\n    return 1\n")
+        git_add = _git_ok(repo, "add", "module.py")
+        result = _run_pre_commit_hook(repo, hook, home)
+        output = result.stdout + result.stderr
+        test(
+            "pre-commit complexity advisory fail-open on malformed JSON shape",
+            git_init.returncode == 0
+            and git_add.returncode == 0
+            and result.returncode == 0
+            and "reporter JSON shape was unexpected" in output,
             f"returncode={result.returncode}, output={output}",
         )
 
@@ -583,6 +629,7 @@ def test_pre_commit_ast_parse():
 
 test_pre_commit_complexity_advisory()
 test_pre_commit_complexity_missing_checker_fail_open()
+test_pre_commit_complexity_malformed_json_fail_open()
 test_pre_commit_ast_parse()
 
 


### PR DESCRIPTION
## Summary
- address unresolved Copilot review comments from PR #293 and PR #294
- run the pre-commit complexity advisory against staged index snapshots instead of working-tree paths
- fail open for malformed-but-valid reporter JSON shapes and harden hook tests against failed git setup
- simplify `report_dict()` and loosen stdlib-only import validation to real stdlib modules

## Review comment links
- #293: https://github.com/magicpro97/copilot-session-knowledge/pull/293#discussion_r3254062032
- #293: https://github.com/magicpro97/copilot-session-knowledge/pull/293#discussion_r3254062042
- #294: https://github.com/magicpro97/copilot-session-knowledge/pull/294#discussion_r3254094958
- #294: https://github.com/magicpro97/copilot-session-knowledge/pull/294#discussion_r3254094977
- #294: https://github.com/magicpro97/copilot-session-knowledge/pull/294#discussion_r3254094987

## Verification
- `python -m py_compile hooks\pre-commit scripts\check_complexity.py tests\test_quality_gates.py`
- `python tests\test_quality_gates.py` → 139 passed, 0 failed
- `python test_fixes.py` → 221 passed, 0 failed
- `ruff check hooks\pre-commit scripts\check_complexity.py tests\test_quality_gates.py`
- `ruff format --check hooks\pre-commit scripts\check_complexity.py tests\test_quality_gates.py`
- `git diff --check`
- `python run_all_tests.py` → exit 1 with existing local browse baseline failures; log saved in session artifacts