### PR TITLE
docs(skills): fix detective skill count

### DIFF
--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -209,7 +209,7 @@ python3 ~/.copilot/tools/tentacle.py marker-cleanup --apply  # remove stale entr
 
 ### Meta-skill rollout — global vs project scope
 
-`setup-project.py` deploys all 15 skills to `.github/skills/<skill-name>/SKILL.md` in the target project (project scope). The full list of skills it deploys is defined in `INSTALL_ITEMS["skills"]` in that script — `host_manifest.py` is the authoritative host-metadata source and `setup-project.py` is the authoritative skill-list source.
+`setup-project.py` deploys all 16 skills to `.github/skills/<skill-name>/SKILL.md` in the target project (project scope). The full list of skills it deploys is defined in `INSTALL_ITEMS["skills"]` in that script — `host_manifest.py` is the authoritative host-metadata source and `setup-project.py` is the authoritative skill-list source.
 
 **Vendored skills** (`karpathy-guidelines`) are deployed to **both** Copilot CLI (`.github/skills/`) and Claude Code (`.claude/skills/`) by `setup-project.py`. All other skills in `INSTALL_ITEMS["skills"]` are deployed to **Copilot CLI only** (`.github/skills/`). The `VENDORED_SKILLS` tuple in both `setup-project.py` and `auto-update-tools.py` is the authoritative list of dual-host skills.
 


### PR DESCRIPTION
## Summary
- address unresolved review comment from PR #295
- update `docs/SKILLS.md` deployment count from all 15 skills to all 16 skills after `detective-investigation` was added

## Review comment links
- #295: https://github.com/magicpro97/copilot-session-knowledge/pull/295#discussion_r3254111884
- #295 typo thread was already outdated/fixed in the merged code: https://github.com/magicpro97/copilot-session-knowledge/pull/295#discussion_r3254111893

## Verification
- `Select-String -Path docs\SKILLS.md -Pattern '16 total'`
- `Select-String -Path docs\SKILLS.md -Pattern 'all 16 skills'`
- `Select-String -Path skills\detective-investigation\SKILL.md -Pattern 'reasoned mapping/data-flow analysis'`
- `git diff --check`
- `git diff --stat origin/main...HEAD` → docs/SKILLS.md only