### PR TITLE
docs(agents): add minimum footprint rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -126,6 +126,29 @@ Any claim about test status, lint, format, CI, or runtime correctness must be ba
 
 If you did not run a verification command, say so: "not proven yet — run `<command>`." A `DONE` handoff with no evidence for its claims is treated as `AMBIGUOUS` by the orchestrator. Issue closeouts must include verification evidence per acceptance criterion or explicitly list unproven items.
 
+### 10. Minimum Footprint
+
+Make the smallest complete change that satisfies the task. Every changed line should trace to the request or to verification needed for the request.
+
+**Rules:**
+
+1. Do not create a new file without a clear justification that an existing file is not the right home.
+2. Do not add speculative abstractions, configuration, extension points, or general-purpose helpers for a single current use case.
+3. Reuse existing patterns, helpers, commands, and test harnesses before introducing new ones.
+4. If a changed or newly added function grows beyond 50 lines, decompose it or explain why keeping it together is safer.
+5. If a changed file grows beyond 400 lines, flag it in the PR/issue with the reason it remains acceptable or the follow-up needed to split it.
+6. Avoid formatting churn, opportunistic cleanup, or adjacent refactors that are not required by the task.
+
+### 11. New File Justification
+
+New files are durable maintenance surface. Before adding one:
+
+1. Search for an existing home first (`glob`, `rg`, LSP, or the relevant project registry) and reuse it when it can own the behavior cleanly.
+2. State the new file's responsibility in the issue, PR, step file, or handoff.
+3. Wire the file into the relevant lint, test, hook, docs, packaging, or CI surface, or explicitly justify why no surface applies.
+4. Add or update tests for the behavior the new file owns, or document the exact verification command when tests are not applicable.
+5. Avoid duplicate entry points; consolidate with existing scripts, hooks, routes, skills, or modules unless separation is justified.
+
 > **Drift-lock:** `docs/AGENT-RULES.md` is the canonical source for all agent rules. This file (`copilot-instructions.md`) is the Copilot CLI runtime enforcement surface — keep it in sync with `docs/AGENT-RULES.md`. Changes to agent rules should be reflected in both places.
 
 ## Hook Enforcement (Summary)
@@ -140,6 +163,8 @@ Hooks **fail-open**: if a hook crashes or is unavailable, the guarded operation 
 | No git ops in sub-agents | `subagent-git-guard` | Blocks `git commit`/`git push` while dispatched-subagent marker is active |
 | Syntax errors | `syntax-gate` | Blocks `.py` edit/create payloads that fail `py_compile` |
 | Evidence for closeout claims (Rule 9) | `verification-gate` | Tracks dirty Python / browse-ui surfaces, records fresh test / format / lint / typecheck / build evidence, and blocks `task_complete`, `gh issue close/comment`, and tentacle `DONE` / `complete` actions when that evidence is missing. CI/runtime proof beyond those gates remains policy-level. |
+| Minimum footprint (Rule 10) | `file-size-advisory` | Warns on large Python create/edit payloads so agents can decompose or justify oversized changes before they land. |
+| New file justification (Rule 11) | `new-file-advisory` | Warns on new root-level Python files and points agents back to the search/reuse/test-surface checklist. |
 
 > Full hook inventory: **[docs/AGENT-RULES.md](../docs/AGENT-RULES.md)** · **[docs/HOOKS.md](../docs/HOOKS.md)**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@
 7. **Docs output quality** — distinguish Facts / Interpretation / Actions / Verification evidence; never present inference as fact; every action must include the executable command.
 8. **Tentacle execution obligations** — when dispatched inside a tentacle: (a) read bundle files first, (b) stay in declared scope, (c) mark todos done with `sk tentacle todo <name> done <index>`, (d) do NOT run `git commit`/`git push`, (e) write a structured handoff with explicit `--status` (`DONE`, `BLOCKED`, `TOO_BIG`, `AMBIGUOUS`, or `REGRESSED`) via `sk tentacle handoff <name> "<summary>" --status <STATUS> [--changed-file <path>] --learn` before stopping, (f) do NOT use the platform `create` file-creation tool to save research output — the `create` tool is not available in all agent runtimes (cloud agents, background tasks); write all persistent output via `sk tentacle handoff` to `handoff.md`, or print to chat as a fallback.
 9. **Claims require evidence** — any claim about test status, lint, format, CI, or runtime correctness must be backed by concrete output. If you did not run a verification command, say "not proven yet — run `<command>`." A `DONE` handoff with no evidence is treated as `AMBIGUOUS`. Issue closeouts must include verification evidence per acceptance criterion.
+10. **Minimum Footprint** — make the smallest complete change: no unjustified new files, no speculative abstractions, reuse existing patterns first, decompose functions over 50 lines or explain why not, flag files over 400 lines, and keep every changed line traceable to the task.
+11. **New File Justification** — before adding a file, search for an existing home, state the new file's responsibility, wire it into the relevant lint/test/docs/CI surface, and add or update tests for its behavior.
 
 **Goal-loop (orchestrators only)** — after all tentacle handoffs pass verification gates, evaluate whether the overarching goal is met. If unmet, loop back to Phase 1 (new tentacles for remaining gaps). Only commit and close when success criteria are verifiably satisfied. Sub-agents report via handoff and stop; orchestrators own continuation. Use `sk tentacle goal criteria check` to verify success criteria and `sk tentacle goal eval --decision continue|complete` to advance the loop. For automated retries with stall detection, use `sk tentacle goal verify-loop [--escalate]`; on `needs-human` escalation, fix the issues and run `sk tentacle goal resume` to continue. Record gate evidence with `sk tentacle goal gate pass <id> --reason "..."` and iteration verification with `sk tentacle verify <name> "<check-command>" --label "goal-eval"`.
 
@@ -78,6 +80,7 @@ For `browse-ui/` changes: `cd browse-ui && pnpm typecheck && pnpm lint && pnpm f
 - NEVER use pickle for serialization
 - NEVER run `git commit` or `git push` as a dispatched sub-agent
 - NEVER modify files outside your declared tentacle scope without a scope escalation note in the handoff
+- NEVER add a new file without a documented responsibility, existing-home search, and lint/test/docs/CI surface decision
 - ALWAYS use `O_CREAT | O_EXCL` for process locks (no TOCTOU races)
 - ALWAYS run `sk briefing` before starting work on unfamiliar code (fallback: `python3 ~/.copilot/tools/briefing.py`)
 

--- a/docs/AGENT-RULES.md
+++ b/docs/AGENT-RULES.md
@@ -153,6 +153,60 @@ When running inside a tentacle (dispatched by the orchestrator via `tentacle.py`
 
 ---
 
+## Rule 10 — Minimum Footprint
+
+Prefer the smallest change that fully satisfies the task. Every changed line should
+trace directly to the requested outcome or to verification needed for that outcome.
+In short: no unjustified new file, no speculative abstraction, reuse existing pattern, and changed-line traceability.
+
+**Rules:**
+
+1. Do not create a new file without a clear justification that an existing file is
+   not the right home.
+2. Do not add speculative abstractions, configuration, extension points, or
+   general-purpose helpers for a single current use case.
+3. Reuse an existing pattern, helper, command, or test harness before introducing
+   a new one.
+4. If a changed or newly added function grows beyond 50 lines, decompose it or
+   explain in the PR/issue why keeping it together is safer.
+5. If a changed file grows beyond 400 lines, flag it in the PR/issue with the
+   reason it remains acceptable or the follow-up needed to split it.
+6. Keep diffs surgical: avoid formatting churn, opportunistic cleanup, or
+   adjacent refactors that are not required by the task.
+
+```
+❌ BAD:  Add a new "utils" module because it might be useful later.
+✅ GOOD: Reuse the nearby helper; if a new file is unavoidable, document its single responsibility and tests.
+```
+
+---
+
+## Rule 11 — New File Justification
+
+New files are durable maintenance surface. Before adding one, prove that it has a
+clear home, responsibility, and verification path.
+
+**Rules:**
+
+1. Search for an existing home first (`glob`, `rg`, LSP, or the relevant project
+   registry) and reuse it when it can own the behavior cleanly.
+2. State the new file's responsibility in the issue, PR, step file, or handoff.
+   The responsibility must be narrow enough that future contributors know what
+   belongs there and what does not.
+3. Wire the file into the relevant lint, test, hook, docs, packaging, or CI
+   surface. A file that is invisible to quality gates needs explicit justification.
+4. Add or update tests for the behavior the new file owns, or document the exact
+   verification command when tests are not applicable.
+5. Avoid duplicate entry points. If the new file overlaps with an existing script,
+   hook, route, skill, or module, consolidate or explain why separation is required.
+
+```
+❌ BAD:  Create scripts/new_checker.py without checking scripts/check_*.py or adding tests.
+✅ GOOD: Confirm no existing checker fits, define the checker's responsibility, add tests, and document its command.
+```
+
+---
+
 ## Orchestrator Goal-Loop
 
 When acting as an orchestrator with an active goal, the lifecycle is iterative, not linear. After all tentacle handoffs are collected and verification gates pass, the orchestrator evaluates the goal before closing:
@@ -235,6 +289,8 @@ These rules are partially enforced at the tool level. All hooks **fail-open**: i
 | Tentacle todo progress | runtime injection | Orchestrator expects `tentacle.py todo done` calls as tasks complete |
 | Tentacle handoff | runtime injection | Orchestrator expects `tentacle.py handoff` before agent stops |
 | Evidence for closeout claims (Rule 9) | `verification-gate` (preToolUse + postToolUse) | Tracks dirty Python / browse-ui surfaces, records fresh test / format / lint / typecheck / build evidence, and blocks `task_complete`, `gh issue close/comment`, and tentacle `DONE` / `complete` actions when that evidence is missing. CI/runtime proof beyond those gates remains policy-level. |
+| Minimum footprint (Rule 10) | `file-size-advisory` (preToolUse) | Warns on large Python create/edit payloads so agents can decompose or justify oversized changes before they land. |
+| New file justification (Rule 11) | `new-file-advisory` (preToolUse) | Warns on new root-level Python files and points agents back to the search/reuse/test-surface checklist. |
 
 > Full hook rule inventory: **[docs/HOOKS.md](HOOKS.md)**
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -47,7 +47,7 @@ hooks/
 | `pnpm-lockfile-guard` | preToolUse | Blocks staging `browse-ui/package.json` changes without a matching `pnpm-lock.yaml` update. Prevents lockfile drift. |
 | `block-unsafe-html` | preToolUse | Blocks `dangerouslySetInnerHTML` usage in `.ts`/`.tsx` files without `DOMPurify.sanitize()` or the `<Highlight>` component. |
 | `verification-gate` | preToolUse + postToolUse | Tracks dirty Python / `browse-ui` TS/JS surfaces, records successful verification commands, and blocks closeout-style actions (`task_complete`, `gh issue close/comment`, tentacle `handoff --status DONE`, tentacle `complete`) until the required fresh evidence exists. |
-| `file-size-advisory` | preToolUse | Warns when an `edit`/`create` payload would leave a Python file over 600 lines. Advisory-only and fail-open: emits information but never denies the tool call. |
+| `file-size-advisory` | preToolUse | Warns when an `edit`/`create` payload would leave a Python file over 400 lines. Advisory-only and fail-open: emits information but never denies the tool call. |
 | `new-file-advisory` | preToolUse | Warns when a `create` payload targets a new root Python script. Advisory-only and fail-open: cites Rule 11 and asks agents to justify the new file, reuse an existing home when possible, and update tests/lint coverage. |
 | `track-edits` | postToolUse | Detects file changes via `git status` (language-agnostic) |
 | `learn-reminder` | postToolUse | Reminds to record learnings after task_complete; also surfaces [docs/SYNC-MATRIX.md](SYNC-MATRIX.md) for docs/memory follow-ups |

--- a/hooks/rules/file_size_advisory.py
+++ b/hooks/rules/file_size_advisory.py
@@ -23,7 +23,7 @@ class FileSizeAdvisoryRule(Rule):
     events = ["preToolUse"]
     tools = ["edit", "create"]
 
-    MAX_PYTHON_LINES = 600
+    MAX_PYTHON_LINES = 400
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -45,6 +45,7 @@ Before implementing:
 - No "flexibility" or "configurability" that wasn't requested.
 - No error handling for impossible scenarios.
 - If you write 200 lines and it could be 50, rewrite it.
+- Project Rule 10, **Minimum Footprint**: no unjustified new files, no speculative abstractions, reuse existing patterns first, decompose functions over 50 lines or explain why not, flag files over 400 lines, and keep every changed line traceable to the task.
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
@@ -63,6 +64,10 @@ When your changes create orphans:
 - Don't remove pre-existing dead code unless asked.
 
 The test: Every changed line should trace directly to the user's request.
+
+Project Rule 11, **New File Justification**: before adding a file, search for an
+existing home, state the new file's responsibility, wire it into the relevant
+lint/test/docs/CI surface, and add or update tests for the behavior it owns.
 
 ### 4. Goal-Driven Execution
 

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -895,8 +895,8 @@ def test_file_size_advisory_rule():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
-        large_py = "\n".join(f"print({i})" for i in range(700))
-        small_py = "\n".join(f"print({i})" for i in range(250))
+        large_py = "\n".join(f"print({i})" for i in range(401))
+        small_py = "\n".join(f"print({i})" for i in range(400))
 
         create_large = rule.evaluate(
             "preToolUse",
@@ -906,11 +906,11 @@ def test_file_size_advisory_rule():
             },
         )
         test(
-            "FileSizeAdvisoryRule: 700-line create returns advisory info",
+            "FileSizeAdvisoryRule: 401-line create returns advisory info",
             create_large is not None
             and create_large.get("permissionDecision") != "deny"
             and "File-size advisory" in create_large.get("message", "")
-            and "700 lines" in create_large.get("message", ""),
+            and "401 lines" in create_large.get("message", ""),
             f"got: {create_large}",
         )
 
@@ -922,7 +922,7 @@ def test_file_size_advisory_rule():
             },
         )
         test(
-            "FileSizeAdvisoryRule: 250-line create returns no warning",
+            "FileSizeAdvisoryRule: 400-line create returns no warning",
             create_small is None,
             f"got: {create_small}",
         )
@@ -941,11 +941,11 @@ def test_file_size_advisory_rule():
             },
         )
         test(
-            "FileSizeAdvisoryRule: 700-line edit returns advisory info",
+            "FileSizeAdvisoryRule: 401-line edit returns advisory info",
             edit_large is not None
             and edit_large.get("permissionDecision") != "deny"
             and "File-size advisory" in edit_large.get("message", "")
-            and "700 lines" in edit_large.get("message", ""),
+            and "401 lines" in edit_large.get("message", ""),
             f"got: {edit_large}",
         )
 
@@ -961,7 +961,7 @@ def test_file_size_advisory_rule():
             },
         )
         test(
-            "FileSizeAdvisoryRule: 250-line edit returns no warning",
+            "FileSizeAdvisoryRule: 400-line edit returns no warning",
             edit_small is None,
             f"got: {edit_small}",
         )


### PR DESCRIPTION
## Summary
- add Rule 10 (Minimum Footprint) and Rule 11 (New File Justification) to the canonical and runtime agent instruction surfaces
- mirror the new rules in the Karpathy guidelines skill
- align `file-size-advisory` enforcement, docs, and tests with the Rule 10 400-line threshold

Closes #254

## Verification
- Rule acceptance text checks passed for Rule 10, Rule 11, Minimum Footprint, New File Justification, and required phrases
- `python -m py_compile hooks\rules\file_size_advisory.py tests\test_quality_gates.py` → exit 0
- `python tests\test_quality_gates.py` → 139 passed, 0 failed
- `python tests\test_audit_instructions.py` → Ran 11 tests, OK
- `python test_fixes.py` → 221 passed, 0 failed
- `git diff --check` → exit 0
- `python run_all_tests.py` → exit 1 on existing local browse baseline failures (`test_browse_palette.py`, `test_browse_search_v2.py`, `test_browse_timeline.py`), unrelated to these rule/hook docs changes