### PR TITLE
docs(lint): document Python lint surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Syntax check
         run: python3 scripts/check_syntax.py
 
+      # Canonical surface inventory: docs/ARCHITECTURE.md#python-lint-surface-inventory
+      # Keep this list in sync with hooks/pre-commit and tests/test_quality_gates.py.
       - name: Ruff lint
         run: >
           ruff check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,26 @@ python3 test_fixes.py       # 65 tests
 - **Windows encoding fix** — every script starts with `if os.name == "nt": sys.stdout.reconfigure(encoding="utf-8")`
 - **JSON serialization only** — never use pickle
 
+## Adding New Scripts
+
+Before adding a new standalone script, first check whether an existing script, hook rule,
+or package directory can own the behavior. Root scripts are independent CLI entry points:
+do not import one root script from another just to share helpers.
+
+Every new Python file needs an explicit lint surface decision:
+
+1. If it belongs to an already covered package-like area (`browse/`, `hooks/`, or
+   `scripts/`), it is already inside the CI and local pre-commit Ruff surface.
+2. If it is a new root standalone script and should be blocking-clean, add it to the
+   Ruff lint and format lists in `.github/workflows/ci.yml`, add it to
+   `hooks/pre-commit`'s exact surface, update `tests/test_quality_gates.py`, and
+   update the canonical table in `docs/ARCHITECTURE.md#python-lint-surface-inventory`.
+3. If it intentionally stays outside the current lint surface, state that in the PR
+   with the reason and the verification command you ran instead.
+
+At minimum, run `python3 -m py_compile <new-script.py>` and the relevant tests for the
+behavior the file owns.
+
 ## Testing
 
 ### Local vs CI enforcement boundary
@@ -118,7 +138,9 @@ shutil.rmtree(_isolated_home, ignore_errors=True)
 > **Do not** rely on `HOOK_DRY_RUN=1` alone for isolation — dry-run suppresses deny output but
 > still writes `deny-dry` and `parse-error` audit entries.
 
-CI (`quality-gates` job) runs a scoped **Ruff lint** on the following files and directories:
+CI (`quality-gates` job) runs scoped **Ruff lint** on the surface documented in
+[`docs/ARCHITECTURE.md#python-lint-surface-inventory`](docs/ARCHITECTURE.md#python-lint-surface-inventory).
+Current coverage:
 
 ```
 embed.py  scout-config.py  scout-status.py
@@ -127,7 +149,8 @@ migrate.py  generate-summary.py
 briefing.py  learn.py  query-session.py  extract-knowledge.py
 build-session-index.py  tentacle.py
 checkpoint-diff.py  checkpoint-restore.py  checkpoint-save.py
-browse/  hooks/
+tests/test_browse_search_v2.py
+browse/  hooks/  scripts/
 ```
 
 If you modify any of those files and have Ruff installed locally, run `ruff format <file>` and `ruff check <file>` before committing. CI will catch scoped lint violations; the local `pre-commit` git hook enforces both `ruff format --check` and `ruff check` on the same surface when Ruff is available locally (fail-open — silently skips when Ruff is not installed). Other root scripts outside this surface are not currently linted by CI.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,6 +57,25 @@ watch-sessions.py  ──→  Incremental re-indexing (adaptive polling)
 above remain on disk, are invoked by operators manually, and are referenced by name in `sk watch`
 recovery hints. None of these scripts are candidates for deletion as a consequence of wave20.
 
+## Python Lint Surface Inventory
+
+This is the canonical inventory for Python Ruff coverage. Keep it in sync with
+`.github/workflows/ci.yml`, `hooks/pre-commit`, and `tests/test_quality_gates.py`.
+
+| Surface | CI Ruff lint/format | Local `pre-commit` Ruff | Notes |
+|---------|----------------------|--------------------------|-------|
+| Exact root standalone scripts | `embed.py`, `scout-config.py`, `scout-status.py`, `sync-config.py`, `sync-daemon.py`, `sync-status.py`, `migrate.py`, `generate-summary.py`, `briefing.py`, `learn.py`, `query-session.py`, `extract-knowledge.py`, `build-session-index.py`, `tentacle.py`, `checkpoint-diff.py`, `checkpoint-restore.py`, `checkpoint-save.py` | Same exact set via `in_python_cleanliness_surface()` | These are the current blocking Ruff baseline for root scripts. |
+| Focused test file | `tests/test_browse_search_v2.py` | Same exact file | Included because it is already clean and protects the browse search API surface. |
+| Package/module directories | `browse/`, `hooks/`, `scripts/` | Any staged `.py` path under `browse/`, `hooks/`, or `scripts/` | Directory coverage applies to package-like surfaces where Ruff cleanup is already baselined. |
+| Syntax gate | `python3 scripts/check_syntax.py` | All staged `.py` files via `scripts/check_syntax.py` when installed | Syntax coverage is broader than Ruff coverage. |
+| Complexity advisory | Full suite path through `run_all_tests.py`; local hook runs `scripts/check_complexity.py --json` on staged `.py` snapshots | All staged `.py` files, non-blocking and fail-open | Advisory only; it prints findings but does not deny commits. |
+
+Root `*.py` files not listed in the exact root standalone script row are intentionally
+outside the blocking Ruff lint surface until they are baselined. They are not exempt from
+the standalone-script architecture contract: keep them self-contained, run syntax/tests for
+the touched behavior, and either add them to the lint surface in the same PR or state why
+the script remains outside the current baseline.
+
 ## Script Inventory
 
 | Script | Role |

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -105,6 +105,8 @@ def check_python_syntax(staged: list[str]) -> int:
     return 0
 
 
+# Canonical surface inventory: docs/ARCHITECTURE.md#python-lint-surface-inventory
+# Keep this in sync with .github/workflows/ci.yml and tests/test_quality_gates.py.
 def in_python_cleanliness_surface(path: str) -> bool:
     exact = {
         "embed.py",

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -664,6 +664,25 @@ CI_RUFF_FILES = [
     "tests/test_browse_search_v2.py",
 ]
 CI_RUFF_DIRS = ["browse/", "hooks/", "scripts/"]
+CI_RUFF_SURFACE = CI_RUFF_FILES + CI_RUFF_DIRS
+
+
+def _top_level_function_body(content: str, name: str) -> str:
+    match = re.search(
+        rf"^def {re.escape(name)}\([^)]*\)(?:\s*->[^:]+)?:\n(?P<body>.*?)(?=^\S|\Z)",
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    return match.group("body") if match else ""
+
+
+def _workflow_step_body(content: str, step_name: str) -> str:
+    match = re.search(
+        rf"^      - name: {re.escape(step_name)}\n(?P<body>.*?)(?=^      - name: |\Z)",
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    return match.group("body") if match else ""
 
 
 def test_ruff_surface_in_pre_commit():
@@ -677,16 +696,22 @@ def test_ruff_surface_in_pre_commit():
         "docs/ARCHITECTURE.md#python-lint-surface-inventory" in content,
         "hooks/pre-commit should point maintainers to the canonical lint surface inventory",
     )
+    surface_body = _top_level_function_body(content, "in_python_cleanliness_surface")
+    test(
+        "pre-commit has in_python_cleanliness_surface function",
+        bool(surface_body),
+        "hooks/pre-commit missing in_python_cleanliness_surface()",
+    )
     for fname in CI_RUFF_FILES:
         test(
             f"pre-commit covers CI file: {fname}",
-            fname in content,
+            fname in surface_body,
             f"'{fname}' not found in pre-commit _py_in_surface()",
         )
     for dirname in CI_RUFF_DIRS:
         test(
             f"pre-commit covers CI directory: {dirname}",
-            dirname in content,
+            dirname in surface_body,
             f"'{dirname}' not found in pre-commit _py_in_surface()",
         )
 
@@ -702,17 +727,20 @@ def test_ci_workflow_ruff_surface():
         "docs/ARCHITECTURE.md#python-lint-surface-inventory" in content,
         ".github/workflows/ci.yml Ruff step should point to the canonical lint surface inventory",
     )
-    for fname in CI_RUFF_FILES:
+    ruff_lint_body = _workflow_step_body(content, "Ruff lint")
+    ruff_format_body = _workflow_step_body(content, "Ruff format check")
+    test("ci.yml has Ruff lint step", bool(ruff_lint_body), "ci.yml missing Ruff lint step")
+    test("ci.yml has Ruff format step", bool(ruff_format_body), "ci.yml missing Ruff format check step")
+    for surface in CI_RUFF_SURFACE:
         test(
-            f"ci.yml Ruff surface includes {fname}",
-            fname in content,
-            f"'{fname}' missing from ci.yml Ruff step",
+            f"ci.yml Ruff lint surface includes {surface}",
+            surface in ruff_lint_body,
+            f"'{surface}' missing from ci.yml Ruff lint step",
         )
-    for dirname in CI_RUFF_DIRS:
         test(
-            f"ci.yml Ruff surface includes {dirname}",
-            dirname in content,
-            f"'{dirname}' missing from ci.yml Ruff step",
+            f"ci.yml Ruff format surface includes {surface}",
+            surface in ruff_format_body,
+            f"'{surface}' missing from ci.yml Ruff format check step",
         )
 
 

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -634,8 +634,8 @@ test_pre_commit_ast_parse()
 
 
 # ── Test 12–20: Ruff surface consistency ────────────────────────────────────
-# Verify that the pre-commit hook's _py_in_surface() covers the same files
-# as CI ci.yml, and that HOOKS.md documents the correct local-vs-CI boundary.
+# Verify that the pre-commit hook covers the same Ruff files as CI and that
+# docs name the canonical lint surface / standalone-script boundary.
 
 CI_WORKFLOW = REPO / ".github" / "workflows" / "ci.yml"
 HOOKS_MD = REPO / "docs" / "HOOKS.md"
@@ -661,7 +661,9 @@ CI_RUFF_FILES = [
     "checkpoint-diff.py",
     "checkpoint-restore.py",
     "checkpoint-save.py",
+    "tests/test_browse_search_v2.py",
 ]
+CI_RUFF_DIRS = ["browse/", "hooks/", "scripts/"]
 
 
 def test_ruff_surface_in_pre_commit():
@@ -670,20 +672,23 @@ def test_ruff_surface_in_pre_commit():
         test("pre-commit hook exists", False, str(PRE_COMMIT))
         return
     content = PRE_COMMIT.read_text(encoding="utf-8")
+    test(
+        "pre-commit points to canonical lint surface inventory",
+        "docs/ARCHITECTURE.md#python-lint-surface-inventory" in content,
+        "hooks/pre-commit should point maintainers to the canonical lint surface inventory",
+    )
     for fname in CI_RUFF_FILES:
         test(
             f"pre-commit covers CI file: {fname}",
             fname in content,
             f"'{fname}' not found in pre-commit _py_in_surface()",
         )
-    test("pre-commit covers browse/*.py", "browse/" in content or "browse/*" in content)
-    test(
-        "pre-commit covers hooks/ Python surface",
-        'path.startswith(("browse/", "hooks/", "scripts/"))' in content
-        or "hooks/*)" in content
-        or "hooks/*.py" in content
-        or "hooks/*/*.py" in content,
-    )
+    for dirname in CI_RUFF_DIRS:
+        test(
+            f"pre-commit covers CI directory: {dirname}",
+            dirname in content,
+            f"'{dirname}' not found in pre-commit _py_in_surface()",
+        )
 
 
 def test_ci_workflow_ruff_surface():
@@ -692,11 +697,22 @@ def test_ci_workflow_ruff_surface():
         test("ci.yml exists", False, str(CI_WORKFLOW))
         return
     content = CI_WORKFLOW.read_text(encoding="utf-8")
+    test(
+        "ci.yml points to canonical lint surface inventory",
+        "docs/ARCHITECTURE.md#python-lint-surface-inventory" in content,
+        ".github/workflows/ci.yml Ruff step should point to the canonical lint surface inventory",
+    )
     for fname in CI_RUFF_FILES:
         test(
             f"ci.yml Ruff surface includes {fname}",
             fname in content,
             f"'{fname}' missing from ci.yml Ruff step",
+        )
+    for dirname in CI_RUFF_DIRS:
+        test(
+            f"ci.yml Ruff surface includes {dirname}",
+            dirname in content,
+            f"'{dirname}' missing from ci.yml Ruff step",
         )
 
 
@@ -732,6 +748,21 @@ def test_contributing_md_local_vs_ci():
         return
     content = CONTRIBUTING.read_text(encoding="utf-8")
     test(
+        "CONTRIBUTING.md has Adding New Scripts guidance",
+        "Adding New Scripts" in content,
+        "CONTRIBUTING.md should include an 'Adding New Scripts' section",
+    )
+    test(
+        "CONTRIBUTING.md mentions standalone script",
+        "standalone script" in content.lower(),
+        "CONTRIBUTING.md should explain the standalone script boundary",
+    )
+    test(
+        "CONTRIBUTING.md mentions lint surface",
+        "lint surface" in content.lower(),
+        "CONTRIBUTING.md should require an explicit lint surface decision",
+    )
+    test(
         "CONTRIBUTING.md mentions full Ruff scope (briefing.py)",
         "briefing.py" in content,
         "CONTRIBUTING.md Ruff scope is incomplete — missing briefing.py",
@@ -741,6 +772,12 @@ def test_contributing_md_local_vs_ci():
         "tentacle.py" in content,
         "CONTRIBUTING.md Ruff scope is incomplete — missing tentacle.py",
     )
+    for fname in ("tests/test_browse_search_v2.py", "scripts/"):
+        test(
+            f"CONTRIBUTING.md mentions full Ruff scope ({fname})",
+            fname in content,
+            f"CONTRIBUTING.md Ruff scope is incomplete — missing {fname}",
+        )
     test(
         "CONTRIBUTING.md explains pre-commit is fast/scoped",
         "fail-open" in content or "full test suite" in content.lower(),
@@ -754,7 +791,17 @@ def test_architecture_md_ruff_surface():
         test("docs/ARCHITECTURE.md exists", False)
         return
     content = ARCH_MD.read_text(encoding="utf-8")
-    for fname in ("briefing.py", "tentacle.py", "browse/", "hooks/"):
+    test(
+        "ARCHITECTURE.md has Python lint surface inventory",
+        "Python Lint Surface Inventory" in content,
+        "docs/ARCHITECTURE.md should define the canonical lint surface inventory",
+    )
+    test(
+        "ARCHITECTURE.md explains uncovered root script policy",
+        "outside the blocking Ruff lint surface" in content,
+        "docs/ARCHITECTURE.md should explain coverage policy for unlisted root scripts",
+    )
+    for fname in ("briefing.py", "tentacle.py", "tests/test_browse_search_v2.py", "browse/", "hooks/", "scripts/"):
         test(
             f"ARCHITECTURE.md Ruff section names {fname}",
             fname in content,


### PR DESCRIPTION
## Summary
- add a canonical Python lint surface inventory to `docs/ARCHITECTURE.md`
- add `CONTRIBUTING.md` guidance for new standalone scripts and explicit lint-surface decisions
- point CI and pre-commit Ruff surfaces back to the canonical inventory
- strengthen `tests/test_quality_gates.py` so CI, pre-commit, and docs stay aligned, including scoped assertions for the actual Ruff step/function bodies

Closes #255

## Verification
- `python -m py_compile tests\test_quality_gates.py hooks\pre-commit` → exit 0
- `ruff format --check hooks\pre-commit tests\test_quality_gates.py` → exit 0
- `ruff check hooks\pre-commit tests\test_quality_gates.py` → exit 0
- `python tests\test_quality_gates.py` → 180 passed, 0 failed
- `python tests\test_audit_instructions.py` → Ran 11 tests, OK
- `python test_fixes.py` → 221 passed, 0 failed
- `git diff --check` → exit 0
- code review agent → CLEAN after review-comment fixes
- `python run_all_tests.py` → exit 1 on existing local browse baseline failures (`test_browse_palette.py`, `test_browse_search_v2.py`, `test_browse_timeline.py`), unrelated to the lint-surface docs/tests change