### PR TITLE
ci(quality): add Ruff complexity advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,19 @@ jobs:
           tests/test_browse_search_v2.py
           browse/ hooks/ scripts/
 
+      - name: Complexity advisory (Ruff C90/PLR)
+        continue-on-error: true
+        run: >
+          ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statistics
+          embed.py scout-config.py scout-status.py
+          sync-config.py sync-daemon.py sync-status.py
+          migrate.py generate-summary.py
+          briefing.py learn.py query-session.py extract-knowledge.py
+          build-session-index.py tentacle.py checkpoint-diff.py
+          checkpoint-restore.py checkpoint-save.py
+          tests/test_browse_search_v2.py
+          browse/ hooks/ scripts/
+
       - name: Build browse-ui static artifact
         run: |
           cd browse-ui

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,11 @@ browse/  hooks/  scripts/
 
 If you modify any of those files and have Ruff installed locally, run `ruff format <file>` and `ruff check <file>` before committing. CI will catch scoped lint violations; the local `pre-commit` git hook enforces both `ruff format --check` and `ruff check` on the same surface when Ruff is available locally (fail-open — silently skips when Ruff is not installed). Other root scripts outside this surface are not currently linted by CI.
 
+CI also runs a non-blocking `Complexity advisory (Ruff C90/PLR)` step on the same
+surface with `ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statistics`.
+It is advisory (`continue-on-error: true`) so maintainers can track baseline counts before
+promoting complexity/refactor rules to enforcement.
+
 For `browse-ui/` changes, CI runs `pnpm format:check`. Fix formatting locally with `cd browse-ui && pnpm format` before committing.
 
 If you need a narrow syntax-only check for a modified file:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,6 +69,7 @@ This is the canonical inventory for Python Ruff coverage. Keep it in sync with
 | Package/module directories | `browse/`, `hooks/`, `scripts/` | Any staged `.py` path under `browse/`, `hooks/`, or `scripts/` | Directory coverage applies to package-like surfaces where Ruff cleanup is already baselined. |
 | Syntax gate | `python3 scripts/check_syntax.py` | All staged `.py` files via `scripts/check_syntax.py` when installed | Syntax coverage is broader than Ruff coverage. |
 | Complexity advisory | Full suite path through `run_all_tests.py`; local hook runs `scripts/check_complexity.py --json` on staged `.py` snapshots | All staged `.py` files, non-blocking and fail-open | Advisory only; it prints findings but does not deny commits. |
+| Ruff complexity/refactor advisory | `Complexity advisory (Ruff C90/PLR)` runs `ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statistics` on the same Ruff surface | Not run by local `pre-commit` | CI advisory only; `continue-on-error: true` records baseline counts before enforcement. |
 
 Root `*.py` files not listed in the exact root standalone script row are intentionally
 outside the blocking Ruff lint surface until they are baselined. They are not exempt from

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -665,6 +665,7 @@ CI_RUFF_FILES = [
 ]
 CI_RUFF_DIRS = ["browse/", "hooks/", "scripts/"]
 CI_RUFF_SURFACE = CI_RUFF_FILES + CI_RUFF_DIRS
+RUFF_COMPLEXITY_SELECT = "C90,PLR0911,PLR0912,PLR0913,PLR0915"
 
 
 def _top_level_function_body(content: str, name: str) -> str:
@@ -744,6 +745,37 @@ def test_ci_workflow_ruff_surface():
         )
 
 
+def test_ci_workflow_ruff_complexity_advisory():
+    """CI workflow must include the non-blocking Ruff complexity/refactor advisory."""
+    if not CI_WORKFLOW.exists():
+        test("ci.yml exists", False, str(CI_WORKFLOW))
+        return
+    content = CI_WORKFLOW.read_text(encoding="utf-8")
+    advisory_body = _workflow_step_body(content, "Complexity advisory (Ruff C90/PLR)")
+    normalized = " ".join(advisory_body.split())
+    test(
+        "ci.yml has Ruff complexity advisory step",
+        bool(advisory_body),
+        "ci.yml missing Complexity advisory (Ruff C90/PLR) step",
+    )
+    test(
+        "Ruff complexity advisory is non-blocking",
+        "continue-on-error: true" in advisory_body,
+        "Complexity advisory step must be continue-on-error: true",
+    )
+    test(
+        "Ruff complexity advisory uses requested rules and statistics",
+        f"ruff check --select {RUFF_COMPLEXITY_SELECT} --statistics" in normalized,
+        "Complexity advisory step must use Ruff C90/PLR select list with --statistics",
+    )
+    for surface in CI_RUFF_SURFACE:
+        test(
+            f"Ruff complexity advisory surface includes {surface}",
+            surface in advisory_body,
+            f"'{surface}' missing from Complexity advisory Ruff step",
+        )
+
+
 def test_hooks_md_documents_local_vs_ci():
     """HOOKS.md must document the local-vs-CI boundary and Ruff surface."""
     if not HOOKS_MD.exists():
@@ -791,6 +823,11 @@ def test_contributing_md_local_vs_ci():
         "CONTRIBUTING.md should require an explicit lint surface decision",
     )
     test(
+        "CONTRIBUTING.md documents Ruff complexity advisory",
+        "Complexity advisory (Ruff C90/PLR)" in content and RUFF_COMPLEXITY_SELECT in content,
+        "CONTRIBUTING.md should document the Ruff C90/PLR advisory step",
+    )
+    test(
         "CONTRIBUTING.md mentions full Ruff scope (briefing.py)",
         "briefing.py" in content,
         "CONTRIBUTING.md Ruff scope is incomplete — missing briefing.py",
@@ -828,6 +865,11 @@ def test_architecture_md_ruff_surface():
         "ARCHITECTURE.md explains uncovered root script policy",
         "outside the blocking Ruff lint surface" in content,
         "docs/ARCHITECTURE.md should explain coverage policy for unlisted root scripts",
+    )
+    test(
+        "ARCHITECTURE.md documents Ruff complexity advisory",
+        "Complexity advisory (Ruff C90/PLR)" in content and RUFF_COMPLEXITY_SELECT in content,
+        "docs/ARCHITECTURE.md should document the Ruff C90/PLR advisory step",
     )
     for fname in ("briefing.py", "tentacle.py", "tests/test_browse_search_v2.py", "browse/", "hooks/", "scripts/"):
         test(
@@ -889,6 +931,7 @@ def test_hooks_md_rules_table_complete():
 
 test_ruff_surface_in_pre_commit()
 test_ci_workflow_ruff_surface()
+test_ci_workflow_ruff_complexity_advisory()
 test_hooks_md_documents_local_vs_ci()
 test_contributing_md_local_vs_ci()
 test_architecture_md_ruff_surface()


### PR DESCRIPTION
## Summary
- add non-blocking CI step `Complexity advisory (Ruff C90/PLR)` on the documented Python lint surface
- use `ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statistics` with `continue-on-error: true`
- document the advisory in architecture/contributor docs and lock it with quality-gate tests

Closes #258

## Verification
- `python -m py_compile tests\test_quality_gates.py` → exit 0
- `ruff format --check tests\test_quality_gates.py` → exit 0
- `ruff check tests\test_quality_gates.py` → exit 0
- `python tests\test_quality_gates.py` → 206 passed, 0 failed
- `python tests\test_audit_instructions.py` → Ran 11 tests, OK
- `git diff --check` → exit 0
- local equivalent `ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statistics ...` → exit 1 with statistics: C901=151, PLR0912=117, PLR0915=76, PLR0911=48, PLR0913=38; 430 findings total
- code review agent → CLEAN
- `python run_all_tests.py` → exit 1 on existing local browse baseline failures, unrelated to this advisory CI/docs/test change