### PR TITLE
feat(hooks): add out-of-surface Ruff advisory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,9 @@ Every new Python file needs an explicit lint surface decision:
    `hooks/pre-commit`'s exact surface, update `tests/test_quality_gates.py`, and
    update the canonical table in `docs/ARCHITECTURE.md#python-lint-surface-inventory`.
 3. If it intentionally stays outside the current lint surface, state that in the PR
-   with the reason and the verification command you ran instead.
+   with the reason and the verification command you ran instead. When Ruff is
+   installed, local `pre-commit` may still print non-blocking `[advisory]` findings
+   for staged out-of-surface Python files.
 
 At minimum, run `python3 -m py_compile <new-script.py>` and the relevant tests for the
 behavior the file owns.
@@ -69,6 +71,7 @@ The local `pre-commit` git hook is **fast and scoped** — it does NOT run the f
 - `browse/routes/*.py` inline-`<style>` regression guard (always)
 - Python syntax gate on all staged `.py` files via `scripts/check_syntax.py` (fail-open when script absent)
 - Ruff format + lint on staged files in the CI surface (fail-open when Ruff absent)
+- Ruff advisory scan on staged `.py` files outside the CI surface (fail-open and non-blocking)
 - Complexity advisory on staged `.py` files via `scripts/check_complexity.py` (fail-open and non-blocking)
 - Prettier format check on staged `browse-ui/src/` files (fail-open when Prettier absent)
 - Skill/agent file lint (fail-open when lint-skills.py absent)
@@ -153,7 +156,7 @@ tests/test_browse_search_v2.py
 browse/  hooks/  scripts/
 ```
 
-If you modify any of those files and have Ruff installed locally, run `ruff format <file>` and `ruff check <file>` before committing. CI will catch scoped lint violations; the local `pre-commit` git hook enforces both `ruff format --check` and `ruff check` on the same surface when Ruff is available locally (fail-open — silently skips when Ruff is not installed). Other root scripts outside this surface are not currently linted by CI.
+If you modify any of those files and have Ruff installed locally, run `ruff format <file>` and `ruff check <file>` before committing. CI will catch scoped lint violations; the local `pre-commit` git hook enforces both `ruff format --check` and `ruff check` on the same surface when Ruff is available locally (fail-open — silently skips when Ruff is not installed). Other root scripts outside this surface are not currently linted by CI; local `pre-commit` runs `ruff check` for staged out-of-surface `.py` files only as a non-blocking `[advisory]` scan.
 
 CI also runs a non-blocking `Complexity advisory (Ruff C90/PLR)` step on the same
 surface with `ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statistics`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,12 +70,14 @@ This is the canonical inventory for Python Ruff coverage. Keep it in sync with
 | Syntax gate | `python3 scripts/check_syntax.py` | All staged `.py` files via `scripts/check_syntax.py` when installed | Syntax coverage is broader than Ruff coverage. |
 | Complexity advisory | Full suite path through `run_all_tests.py`; local hook runs `scripts/check_complexity.py --json` on staged `.py` snapshots | All staged `.py` files, non-blocking and fail-open | Advisory only; it prints findings but does not deny commits. |
 | Ruff complexity/refactor advisory | `Complexity advisory (Ruff C90/PLR)` runs `ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statistics` on the same Ruff surface | Not run by local `pre-commit` | CI advisory only; `continue-on-error: true` records baseline counts before enforcement. |
+| Out-of-surface Ruff advisory | Not run by CI | Staged `.py` files outside `in_python_cleanliness_surface()` run `ruff check` as a non-blocking `[advisory]` scan | Advisory only; it is fail-open when Ruff is absent and does not change the blocking Ruff surface. |
 
 Root `*.py` files not listed in the exact root standalone script row are intentionally
 outside the blocking Ruff lint surface until they are baselined. They are not exempt from
 the standalone-script architecture contract: keep them self-contained, run syntax/tests for
 the touched behavior, and either add them to the lint surface in the same PR or state why
-the script remains outside the current baseline.
+the script remains outside the current baseline. The local `pre-commit` hook may print
+non-blocking `[advisory]` Ruff findings for these files when Ruff is installed.
 
 ## Script Inventory
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -134,18 +134,31 @@ def in_python_cleanliness_surface(path: str) -> bool:
 def check_ruff(staged: list[str]) -> int:
     if not shutil.which("ruff"):
         return 0
-    surface_py = [f for f in staged if f.endswith(".py") and in_python_cleanliness_surface(f)]
-    if not surface_py:
-        return 0
-    print("🧹 Checking Python cleanliness (ruff)...")
-    result = run(["ruff", "format", "--check", *surface_py], timeout=60)
-    if result.returncode != 0:
-        print(f"✖ ruff format check failed. Run: ruff format {' '.join(surface_py)}")
-        return 1
-    result = run(["ruff", "check", *surface_py], timeout=60)
-    if result.returncode != 0:
-        print("✖ ruff lint check failed. Fix violations above before committing.")
-        return 1
+    staged_py = [f for f in staged if f.endswith(".py")]
+    surface_py = [f for f in staged_py if in_python_cleanliness_surface(f)]
+    outside_surface_py = [f for f in staged_py if not in_python_cleanliness_surface(f)]
+    if surface_py:
+        print("🧹 Checking Python cleanliness (ruff)...")
+        result = run(["ruff", "format", "--check", *surface_py], timeout=60)
+        if result.returncode != 0:
+            print(f"✖ ruff format check failed. Run: ruff format {' '.join(surface_py)}")
+            return 1
+        result = run(["ruff", "check", *surface_py], timeout=60)
+        if result.returncode != 0:
+            print("✖ ruff lint check failed. Fix violations above before committing.")
+            return 1
+    if outside_surface_py:
+        try:
+            result = run(["ruff", "check", *outside_surface_py], capture_output=True, timeout=60)
+        except Exception as exc:
+            print(f"[advisory] Ruff scan skipped outside the blocking lint surface: {exc}")
+            return 0
+        if result.returncode != 0:
+            print("[advisory] Ruff found issues outside the blocking lint surface:")
+            output = (result.stdout + result.stderr).strip()
+            if output:
+                print(output)
+            print("[advisory] Out-of-surface Ruff findings are non-blocking.")
     return 0
 
 

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -9,9 +9,14 @@ Run: python3 test_quality_gates.py
 """
 
 import ast
+import contextlib
+import importlib.machinery
+import importlib.util
+import io
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -491,11 +496,17 @@ def _seed_pre_commit_tools(home: Path, *, include_complexity: bool = True) -> Pa
     return tools / "hooks" / "pre-commit"
 
 
-def _run_pre_commit_hook(repo: Path, hook: Path, home: Path) -> subprocess.CompletedProcess:
+def _run_pre_commit_hook(
+    repo: Path,
+    hook: Path,
+    home: Path,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
     env = {
         **os.environ,
         "HOME": str(home),
         "USERPROFILE": str(home),
+        **(extra_env or {}),
     }
     return subprocess.run(
         [sys.executable, str(hook)],
@@ -506,6 +517,41 @@ def _run_pre_commit_hook(repo: Path, hook: Path, home: Path) -> subprocess.Compl
         errors="replace",
         env=env,
     )
+
+
+def _write_git_shim(bin_dir: Path) -> None:
+    git = shutil.which("git")
+    if not git:
+        return
+    if os.name == "nt":
+        (bin_dir / "git.cmd").write_text(f'@echo off\r\n"{git}" %*\r\n', encoding="utf-8")
+        return
+    shim = bin_dir / "git"
+    shim.write_text(f'#!/bin/sh\nexec {shlex.quote(git)} "$@"\n', encoding="utf-8")
+    shim.chmod(0o755)
+
+
+def _write_fake_ruff(bin_dir: Path, body: str) -> None:
+    script = bin_dir / "ruff.py"
+    script.write_text(body, encoding="utf-8")
+    if os.name == "nt":
+        wrapper = f'@echo off\r\n"{sys.executable}" "%~dp0ruff.py" %*\r\n'
+        (bin_dir / "ruff.cmd").write_text(wrapper, encoding="utf-8")
+        (bin_dir / "ruff.bat").write_text(wrapper, encoding="utf-8")
+        return
+    shim = bin_dir / "ruff"
+    shim.write_text(
+        f'#!/bin/sh\nexec {shlex.quote(sys.executable)} {shlex.quote(str(script))} "$@"\n', encoding="utf-8"
+    )
+    shim.chmod(0o755)
+
+
+def _isolated_path_env(bin_dir: Path) -> dict[str, str]:
+    _write_git_shim(bin_dir)
+    env = {"PATH": str(bin_dir) + os.pathsep + os.environ.get("PATH", "")}
+    if os.name == "nt":
+        env["PATHEXT"] = os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+    return env
 
 
 def test_pre_commit_complexity_advisory():
@@ -627,10 +673,145 @@ def test_pre_commit_ast_parse():
     )
 
 
+def _load_pre_commit_module():
+    loader = importlib.machinery.SourceFileLoader("pre_commit_hook_for_tests", str(PRE_COMMIT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_pre_commit_out_of_surface_ruff_advisory():
+    """Out-of-surface staged Python with Ruff findings should warn without blocking."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base = Path(tmpdir)
+        repo = base / "repo"
+        home = base / "home"
+        bin_dir = base / "bin"
+        repo.mkdir()
+        home.mkdir()
+        bin_dir.mkdir()
+        hook = _seed_pre_commit_tools(home)
+        _write_fake_ruff(
+            bin_dir,
+            "import sys\n"
+            "args = sys.argv[1:]\n"
+            "if args[:2] == ['format', '--check']:\n"
+            "    raise SystemExit(0)\n"
+            "if args and args[0] == 'check':\n"
+            "    print(f'{args[-1]}:1:1: F401 fake violation')\n"
+            "    raise SystemExit(1)\n"
+            "raise SystemExit(0)\n",
+        )
+        env = _isolated_path_env(bin_dir)
+        git_init = _git_ok(repo, "init")
+        staged = repo / "outside_surface.py"
+        staged.write_text("import os\n")
+        git_add = _git_ok(repo, "add", "outside_surface.py")
+        result = _run_pre_commit_hook(repo, hook, home, env)
+        output = result.stdout + result.stderr
+        test(
+            "pre-commit out-of-surface Ruff advisory exits 0",
+            git_init.returncode == 0 and git_add.returncode == 0 and result.returncode == 0,
+            f"returncode={result.returncode}, output={output}",
+        )
+        test(
+            "pre-commit out-of-surface Ruff advisory prints [advisory]",
+            "[advisory]" in output and "outside_surface.py" in output and "F401" in output,
+            f"output={output}",
+        )
+
+
+def test_pre_commit_in_surface_ruff_still_blocks():
+    """In-surface staged Python should keep blocking on Ruff failures."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base = Path(tmpdir)
+        repo = base / "repo"
+        home = base / "home"
+        bin_dir = base / "bin"
+        repo.mkdir()
+        home.mkdir()
+        bin_dir.mkdir()
+        hook = _seed_pre_commit_tools(home)
+        _write_fake_ruff(
+            bin_dir,
+            "import sys\n"
+            "args = sys.argv[1:]\n"
+            "if args[:2] == ['format', '--check']:\n"
+            "    raise SystemExit(0)\n"
+            "if args and args[0] == 'check':\n"
+            "    print(f'{args[-1]}:1:1: F401 fake violation')\n"
+            "    raise SystemExit(1)\n"
+            "raise SystemExit(0)\n",
+        )
+        env = _isolated_path_env(bin_dir)
+        git_init = _git_ok(repo, "init")
+        scripts_dir = repo / "scripts"
+        scripts_dir.mkdir()
+        staged = scripts_dir / "in_surface.py"
+        staged.write_text("import os\n")
+        git_add = _git_ok(repo, "add", "scripts/in_surface.py")
+        result = _run_pre_commit_hook(repo, hook, home, env)
+        output = result.stdout + result.stderr
+        test(
+            "pre-commit in-surface Ruff failure exits non-zero",
+            git_init.returncode == 0 and git_add.returncode == 0 and result.returncode != 0,
+            f"returncode={result.returncode}, output={output}",
+        )
+        test(
+            "pre-commit in-surface Ruff failure remains blocking",
+            "ruff lint check failed" in output and "[advisory]" not in output,
+            f"output={output}",
+        )
+
+
+def test_pre_commit_missing_ruff_fail_open():
+    """Missing Ruff binary should not block staged Python commits."""
+    content = PRE_COMMIT.read_text(encoding="utf-8")
+    test(
+        "pre-commit missing Ruff binary stays fail-open",
+        'if not shutil.which("ruff"):\n        return 0' in content,
+        "hooks/pre-commit should skip Ruff checks when Ruff is absent",
+    )
+
+
+def test_pre_commit_out_of_surface_ruff_exception_fail_open():
+    """Advisory Ruff subprocess errors should skip instead of blocking."""
+    try:
+        module = _load_pre_commit_module()
+    except Exception as exc:
+        test("pre-commit module loads for Ruff exception test", False, str(exc))
+        return
+
+    class FakeShutil:
+        @staticmethod
+        def which(_name: str) -> str:
+            return "ruff"
+
+    def raising_run(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="ruff check outside_surface.py", timeout=60)
+
+    module.shutil = FakeShutil
+    module.run = raising_run
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        result = module.check_ruff(["outside_surface.py"])
+    output = stdout.getvalue()
+    test(
+        "pre-commit out-of-surface Ruff exception stays fail-open",
+        result == 0 and "Ruff scan skipped outside the blocking lint surface" in output,
+        f"result={result}, output={output}",
+    )
+
+
 test_pre_commit_complexity_advisory()
 test_pre_commit_complexity_missing_checker_fail_open()
 test_pre_commit_complexity_malformed_json_fail_open()
 test_pre_commit_ast_parse()
+test_pre_commit_out_of_surface_ruff_advisory()
+test_pre_commit_in_surface_ruff_still_blocks()
+test_pre_commit_missing_ruff_fail_open()
+test_pre_commit_out_of_surface_ruff_exception_fail_open()
 
 
 # ── Test 12–20: Ruff surface consistency ────────────────────────────────────
@@ -715,6 +896,11 @@ def test_ruff_surface_in_pre_commit():
             dirname in surface_body,
             f"'{dirname}' not found in pre-commit _py_in_surface()",
         )
+    test(
+        "pre-commit has out-of-surface Ruff advisory",
+        "outside_surface_py" in content and "[advisory] Ruff" in content,
+        "hooks/pre-commit should run a non-blocking Ruff advisory for staged Python outside the blocking surface",
+    )
 
 
 def test_ci_workflow_ruff_surface():
@@ -828,6 +1014,11 @@ def test_contributing_md_local_vs_ci():
         "CONTRIBUTING.md should document the Ruff C90/PLR advisory step",
     )
     test(
+        "CONTRIBUTING.md documents out-of-surface Ruff advisory",
+        "[advisory]" in content and "out-of-surface" in content and "Ruff" in content,
+        "CONTRIBUTING.md should document the local out-of-surface Ruff advisory",
+    )
+    test(
         "CONTRIBUTING.md mentions full Ruff scope (briefing.py)",
         "briefing.py" in content,
         "CONTRIBUTING.md Ruff scope is incomplete — missing briefing.py",
@@ -870,6 +1061,11 @@ def test_architecture_md_ruff_surface():
         "ARCHITECTURE.md documents Ruff complexity advisory",
         "Complexity advisory (Ruff C90/PLR)" in content and RUFF_COMPLEXITY_SELECT in content,
         "docs/ARCHITECTURE.md should document the Ruff C90/PLR advisory step",
+    )
+    test(
+        "ARCHITECTURE.md documents out-of-surface Ruff advisory",
+        "Out-of-surface Ruff advisory" in content and "[advisory]" in content,
+        "docs/ARCHITECTURE.md should document the local out-of-surface Ruff advisory",
     )
     for fname in ("briefing.py", "tentacle.py", "tests/test_browse_search_v2.py", "browse/", "hooks/", "scripts/"):
         test(


### PR DESCRIPTION
## Summary
- add a fail-open pre-commit Ruff advisory for staged `.py` files outside `in_python_cleanliness_surface()`
- preserve existing blocking Ruff format/lint behavior for staged files inside the canonical CI surface
- document the out-of-surface advisory and lock behavior with quality-gate tests

Closes #266

## Verification
- `python -m py_compile tests\test_quality_gates.py` → exit 0
- `python -c "import ast; ast.parse(open('hooks/pre-commit', encoding='utf-8').read())"` → exit 0
- `ruff format --check tests\test_quality_gates.py` → exit 0
- `ruff check tests\test_quality_gates.py` → exit 0
- `python tests\test_quality_gates.py` → 219 passed, 0 failed
- `python test_fixes.py` → 221 passed, 0 failed
- `python test_security.py` → 12 passed, 0 failed
- `git diff --check` → exit 0
- code review agent → first pass found advisory subprocess fail-open gap; fixed with exception coverage; final pass clean
- `python run_all_tests.py` → exit 1 on existing local browse-family baseline failures; `test_quality_gates.py`, `test_fixes.py`, and `test_security.py` passed