### PR TITLE
ci(browse-ui): split E2E smoke and visual jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,17 +157,63 @@ jobs:
       - name: Build
         run: pnpm build
 
-  # E2E tests are gated to manual dispatch only.
+  # E2E smoke runs on every push / PR. Visual snapshots remain manual-only.
   #
   # Reason: visual.spec.ts contains screenshot-comparison tests whose pixel
   # output differs between macOS (local) and Linux (CI runners), so they would
-  # produce false negatives on every push. The smoke, shortcuts, and chat specs
-  # are behaviorally stable, but bundling them with visual tests makes the
-  # whole suite unreliable for always-on use.
+  # produce false negatives on every push. The smoke, shortcuts, chat,
+  # diagnostics, and broker-mode specs run under the Playwright behavioral
+  # project and are stable enough for always-on use.
+  e2e-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: browse-ui
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: browse-ui/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E smoke tests
+        run: pnpm exec playwright test --project=behavioral --reporter=html
+
+      - name: Upload Playwright smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-smoke-report
+          path: browse-ui/playwright-report/
+          retention-days: 30
+
+  # Visual E2E remains gated to manual dispatch only.
   #
-  # To run E2E: trigger this workflow manually via the GitHub Actions UI or
+  # To run visual E2E: trigger this workflow manually via the GitHub Actions UI or
   #   gh workflow run ci.yml
-  e2e:
+  e2e-visual:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: github.event_name == 'workflow_dispatch'
@@ -202,8 +248,19 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
 
-      - name: Run E2E tests
-        run: pnpm test:e2e
+      - name: Run visual E2E snapshots
+        run: >
+          pnpm exec playwright test e2e/visual.spec.ts
+          --project=visual
+          --reporter=html
+
+      - name: Upload Playwright visual report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-visual-report
+          path: browse-ui/playwright-report/
+          retention-days: 30
 
   # Pairing E2E — Edge desktop + mobile Chrome (#58 acceptance proof).
   #
@@ -270,7 +327,7 @@ jobs:
 
   agents-release-hook:
     runs-on: ubuntu-latest
-    needs: [quality-gates, browse-ui]
+    needs: [quality-gates, browse-ui, e2e-smoke]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ surface with `ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statisti
 It is advisory (`continue-on-error: true`) so maintainers can track baseline counts before
 promoting complexity/refactor rules to enforcement.
 
-For `browse-ui/` changes, CI runs `pnpm format:check`. Fix formatting locally with `cd browse-ui && pnpm format` before committing.
+For `browse-ui/` changes, CI runs `pnpm format:check`. Fix formatting locally with `cd browse-ui && pnpm format` before committing. The always-on `e2e-smoke` job runs the Playwright `behavioral` project on push/PR; visual snapshots stay in the manual-only `e2e-visual` job gated by `workflow_dispatch`.
 
 If you need a narrow syntax-only check for a modified file:
 

--- a/browse-ui/e2e/shortcuts.spec.ts
+++ b/browse-ui/e2e/shortcuts.spec.ts
@@ -2,6 +2,34 @@ import { expect, test } from "./fixtures";
 import { aliasPlaceholderSession } from "./session-detail-alias";
 
 const modKey = process.platform === "darwin" ? "Meta" : "Control";
+const KNOWLEDGE_INSIGHTS_FIXTURE = {
+  generated_at: "2026-05-01T00:00:00Z",
+  summary: "Knowledge coverage is healthy enough to render diagnostics.",
+  overview: {
+    health_score: 82,
+    total_entries: 120,
+    sessions: 18,
+    high_confidence_pct: 70,
+    low_confidence_pct: 8,
+    stale_pct: 6,
+    relation_density: 2.4,
+    embedding_pct: 78,
+  },
+  quality_alerts: [],
+  recommended_actions: [],
+  recurring_noise_titles: [],
+  hot_files: [],
+  entries: { mistakes: [], patterns: [], decisions: [], tools: [] },
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/api/knowledge/insights*", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(KNOWLEDGE_INSIGHTS_FIXTURE),
+    });
+  });
+});
 
 test("command palette opens and navigates", async ({ page }) => {
   await page.goto("/sessions/");

--- a/browse-ui/e2e/smoke.spec.ts
+++ b/browse-ui/e2e/smoke.spec.ts
@@ -68,6 +68,15 @@ const KNOWLEDGE_INSIGHTS_FIXTURE = {
   entries: { mistakes: [], patterns: [], decisions: [], tools: [] },
 };
 
+test.beforeEach(async ({ page }) => {
+  await page.route("**/api/knowledge/insights*", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(KNOWLEDGE_INSIGHTS_FIXTURE),
+    });
+  });
+});
+
 test("root routes render expected headings", async ({ page }) => {
   const headingByRoute = [
     ["/sessions/", "Sessions"],
@@ -451,13 +460,6 @@ test("insights search quality tab renders Wave 2 diagnostics", async ({ page }) 
       }),
     });
   });
-  await page.route("**/api/knowledge/insights*", async (route) => {
-    await route.fulfill({
-      contentType: "application/json",
-      body: JSON.stringify(KNOWLEDGE_INSIGHTS_FIXTURE),
-    });
-  });
-
   await page.goto("/insights/#search-quality");
   await expect(page.getByRole("tab", { name: "Search Quality" })).toHaveAttribute(
     "aria-selected",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -385,13 +385,15 @@ Agent-authored docs and operator/research outputs (tentacle handoffs, retro summ
 
 ### CI Quality Gates
 
-GitHub Actions runs two jobs on every push / PR:
+GitHub Actions runs these jobs on every push / PR:
 - **`quality-gates`** — syntax check, scoped Ruff lint, and the Python test suites. The Ruff lint surface is: `embed.py`, `scout-config.py`, `scout-status.py`, `sync-config.py`, `sync-daemon.py`, `sync-status.py`, `migrate.py`, `generate-summary.py`, `briefing.py`, `learn.py`, `query-session.py`, `extract-knowledge.py`, `build-session-index.py`, `tentacle.py`, `checkpoint-diff.py`, `checkpoint-restore.py`, `checkpoint-save.py`, `browse/`, `hooks/`. Ruff lint is **scoped** to this surface; other root scripts outside it are not linted by CI.
+- **`remote-terminal`** — `npm ci`, `npm test`, lint baseline, and dependency audit advisory for `remote-terminal/`.
 - **`browse-ui`** — `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, `pnpm build`.
+- **`e2e-smoke`** — Playwright `behavioral` project (`smoke.spec.ts`, `shortcuts.spec.ts`, `chat.spec.ts`, `diagnostics.spec.ts`, and `broker-mode.spec.ts`) on Chromium.
 
 For `sk-rust/**` changes, `sk CI` also runs Rust formatting, strict Clippy, and tests across Ubuntu, Windows, and macOS. `sk-rust/clippy.toml` defines advisory complexity thresholds (`cognitive-complexity-threshold`, `too-many-lines-threshold`, `too-many-arguments-threshold`). The `Complexity advisory (Rust Clippy)` step runs before the strict Clippy gate with `continue-on-error: true`, so complexity warnings are measured before any future enforcement change.
 
-Playwright E2E runs are manual-dispatch only. The stable `behavioral` project covers `smoke.spec.ts`, `shortcuts.spec.ts`, and `chat.spec.ts`; `visual.spec.ts` remains outside always-on CI because screenshot output differs across platforms.
+Playwright visual snapshot E2E is manual-dispatch only in **`e2e-visual`** because screenshot output differs across platforms. The always-on **`e2e-smoke`** job runs only the stable `behavioral` project and excludes `visual.spec.ts`.
 
 ### Automation Surfaces
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -92,7 +92,7 @@ The `/chat` operator console does **not** introduce a new hook class. Existing g
 
 - Python-side operator files (`browse/core/operator_console.py`, `browse/api/operator.py`) stay inside the normal `browse/` syntax + Ruff surface.
 - Frontend operator files under `browse-ui/src/app/chat/` and `browse-ui/src/components/chat/` stay under `block-edit-dist`, `block-unsafe-html`, `nextjs-typecheck-reminder`, and the staged Prettier check in `pre-commit`.
-- `browse-ui/e2e/chat.spec.ts` is not hook-enforced directly; quality for that surface comes from `pnpm test:e2e` locally and the manual-dispatch CI `e2e` job.
+- `browse-ui/e2e/chat.spec.ts` is not hook-enforced directly; quality for that surface comes from `pnpm test:e2e` locally and the always-on CI `e2e-smoke` job. Screenshot-based visual snapshots stay in the manual-only `e2e-visual` job gated by `workflow_dispatch`.
 
 ### Browse host management surfaces
 

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -1039,7 +1039,13 @@ def test_playwright_behavioral_project_contract():
         bool(behavioral_body),
         "playwright.config.ts missing behavioral project",
     )
-    for spec in ("smoke.spec.ts", "shortcuts.spec.ts", "chat.spec.ts"):
+    for spec in (
+        "smoke.spec.ts",
+        "shortcuts.spec.ts",
+        "chat.spec.ts",
+        "diagnostics.spec.ts",
+        "broker-mode.spec.ts",
+    ):
         test(
             f"playwright behavioral project includes {spec}",
             spec in behavioral_body,
@@ -1074,6 +1080,11 @@ def test_hooks_md_documents_local_vs_ci():
         "HOOKS.md notes full test suite is NOT enforced by local hook",
         "not" in content.lower() and "run_all_tests" in content,
         "HOOKS.md should clarify that run_all_tests is not enforced by the local pre-commit hook",
+    )
+    test(
+        "HOOKS.md documents E2E smoke/visual split",
+        "e2e-smoke" in content and "e2e-visual" in content and "workflow_dispatch" in content,
+        "docs/HOOKS.md should document e2e-smoke and manual-only e2e-visual",
     )
 
 

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -822,6 +822,7 @@ CI_WORKFLOW = REPO / ".github" / "workflows" / "ci.yml"
 HOOKS_MD = REPO / "docs" / "HOOKS.md"
 ARCH_MD = REPO / "docs" / "ARCHITECTURE.md"
 CONTRIBUTING = REPO / "CONTRIBUTING.md"
+PLAYWRIGHT_CONFIG = REPO / "browse-ui" / "playwright.config.ts"
 
 # CI Ruff surface (extracted from ci.yml)
 CI_RUFF_FILES = [
@@ -861,6 +862,15 @@ def _top_level_function_body(content: str, name: str) -> str:
 def _workflow_step_body(content: str, step_name: str) -> str:
     match = re.search(
         rf"^      - name: {re.escape(step_name)}\n(?P<body>.*?)(?=^      - name: |\Z)",
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    return match.group("body") if match else ""
+
+
+def _workflow_job_body(content: str, job_name: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
         content,
         re.MULTILINE | re.DOTALL,
     )
@@ -962,6 +972,86 @@ def test_ci_workflow_ruff_complexity_advisory():
         )
 
 
+def test_ci_workflow_e2e_smoke_visual_split():
+    """CI must run behavioral E2E smoke on push/PR while keeping visual snapshots manual-only."""
+    if not CI_WORKFLOW.exists():
+        test("ci.yml exists", False, str(CI_WORKFLOW))
+        return
+    content = CI_WORKFLOW.read_text(encoding="utf-8")
+    smoke_body = _workflow_job_body(content, "e2e-smoke")
+    visual_body = _workflow_job_body(content, "e2e-visual")
+    release_body = _workflow_job_body(content, "agents-release-hook")
+    test("ci.yml has e2e-smoke job", bool(smoke_body), "ci.yml missing e2e-smoke job")
+    test("ci.yml has e2e-visual job", bool(visual_body), "ci.yml missing e2e-visual job")
+    test(
+        "e2e-smoke is push/PR enabled",
+        "github.event_name == 'workflow_dispatch'" not in smoke_body,
+        "e2e-smoke should not be gated to workflow_dispatch",
+    )
+    smoke_normalized = " ".join(smoke_body.split())
+    test(
+        "e2e-smoke runs behavioral Playwright project",
+        "pnpm exec playwright test --project=behavioral" in smoke_normalized,
+        "e2e-smoke should run the behavioral Playwright project",
+    )
+    test(
+        "e2e-smoke excludes visual snapshots",
+        "visual.spec.ts" not in smoke_body and "--project=visual" not in smoke_body,
+        "e2e-smoke must not run visual snapshots",
+    )
+    test(
+        "e2e-visual remains manual-only",
+        "if: github.event_name == 'workflow_dispatch'" in visual_body,
+        "e2e-visual should stay gated to workflow_dispatch",
+    )
+    visual_normalized = " ".join(visual_body.split())
+    test(
+        "e2e-visual runs visual snapshot spec",
+        "pnpm exec playwright test e2e/visual.spec.ts --project=visual" in visual_normalized,
+        "e2e-visual should run only visual snapshots",
+    )
+    test(
+        "old combined e2e job removed",
+        re.search(r"^  e2e:\n", content, re.MULTILINE) is None,
+        "combined manual-only e2e job should be split into e2e-smoke and e2e-visual",
+    )
+    test(
+        "agents release waits for e2e-smoke",
+        "needs: [quality-gates, browse-ui, e2e-smoke]" in release_body,
+        "agents-release-hook should not dispatch before e2e-smoke passes on main",
+    )
+
+
+def test_playwright_behavioral_project_contract():
+    """Playwright behavioral project must include stable smoke specs and exclude visual snapshots."""
+    if not PLAYWRIGHT_CONFIG.exists():
+        test("playwright.config.ts exists", False, str(PLAYWRIGHT_CONFIG))
+        return
+    content = PLAYWRIGHT_CONFIG.read_text(encoding="utf-8")
+    behavioral_match = re.search(
+        r'name: "behavioral",(?P<body>.*?)(?=^\s+\{|\n\s+\],)',
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    behavioral_body = behavioral_match.group("body") if behavioral_match else ""
+    test(
+        "playwright behavioral project exists",
+        bool(behavioral_body),
+        "playwright.config.ts missing behavioral project",
+    )
+    for spec in ("smoke.spec.ts", "shortcuts.spec.ts", "chat.spec.ts"):
+        test(
+            f"playwright behavioral project includes {spec}",
+            spec in behavioral_body,
+            f"behavioral project missing {spec}",
+        )
+    test(
+        "playwright behavioral project excludes visual.spec.ts",
+        "visual.spec.ts" not in behavioral_body,
+        "behavioral project should not include visual snapshots",
+    )
+
+
 def test_hooks_md_documents_local_vs_ci():
     """HOOKS.md must document the local-vs-CI boundary and Ruff surface."""
     if not HOOKS_MD.exists():
@@ -1019,6 +1109,11 @@ def test_contributing_md_local_vs_ci():
         "CONTRIBUTING.md should document the local out-of-surface Ruff advisory",
     )
     test(
+        "CONTRIBUTING.md documents E2E smoke/visual split",
+        "e2e-smoke" in content and "e2e-visual" in content and "workflow_dispatch" in content,
+        "CONTRIBUTING.md should document the E2E smoke/visual split",
+    )
+    test(
         "CONTRIBUTING.md mentions full Ruff scope (briefing.py)",
         "briefing.py" in content,
         "CONTRIBUTING.md Ruff scope is incomplete — missing briefing.py",
@@ -1066,6 +1161,11 @@ def test_architecture_md_ruff_surface():
         "ARCHITECTURE.md documents out-of-surface Ruff advisory",
         "Out-of-surface Ruff advisory" in content and "[advisory]" in content,
         "docs/ARCHITECTURE.md should document the local out-of-surface Ruff advisory",
+    )
+    test(
+        "ARCHITECTURE.md documents E2E smoke/visual split",
+        "e2e-smoke" in content and "e2e-visual" in content,
+        "docs/ARCHITECTURE.md should document the E2E smoke/visual split",
     )
     for fname in ("briefing.py", "tentacle.py", "tests/test_browse_search_v2.py", "browse/", "hooks/", "scripts/"):
         test(
@@ -1128,6 +1228,8 @@ def test_hooks_md_rules_table_complete():
 test_ruff_surface_in_pre_commit()
 test_ci_workflow_ruff_surface()
 test_ci_workflow_ruff_complexity_advisory()
+test_ci_workflow_e2e_smoke_visual_split()
+test_playwright_behavioral_project_contract()
 test_hooks_md_documents_local_vs_ci()
 test_contributing_md_local_vs_ci()
 test_architecture_md_ruff_surface()


### PR DESCRIPTION
## Summary
- split the prior manual-only combined E2E job into always-on `e2e-smoke` and manual-only `e2e-visual`
- run Playwright's `behavioral` project on push/PR while excluding `visual.spec.ts`
- keep visual snapshots behind `workflow_dispatch` and make the agents release hook wait for smoke E2E on main
- document and test the smoke/visual split contract

Closes #268

## Verification
- `python -m py_compile tests\test_quality_gates.py` → exit 0
- `ruff format --check tests\test_quality_gates.py` → exit 0
- `ruff check tests\test_quality_gates.py` → exit 0
- `python tests\test_quality_gates.py` → 235 passed, 0 failed
- `python test_security.py` → 12 passed, 0 failed
- `python test_fixes.py` → 221 passed, 0 failed
- `git diff --check` → exit 0
- code review agent → clean
- local `cd browse-ui; pnpm exec playwright test --list --project=behavioral` → blocked because this Windows environment has pnpm but no `node` on PATH; CI uses `actions/setup-node@v4` before running `e2e-smoke`