### PR TITLE
ci(remote-terminal): promote quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,11 @@ jobs:
       - name: Run lint baseline
         run: npm run lint
 
-      - name: Dependency audit advisory
-        continue-on-error: true
-        run: npm run audit:advisory
+      - name: Run clean-zone lint gate
+        run: npm run lint:clean
+
+      - name: Dependency audit
+        run: npm run audit:high
 
   browse-ui:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,13 @@ The browse-ui ESLint baseline promotes strictness by clean zone: repo-wide
 low-churn directories such as `src/lib/hosts/**/*.{ts,tsx}` set the same rule to
 `error`. Expand this pattern only after a directory has a clean lint baseline.
 
+For `remote-terminal/`, `npm run lint` still reports legacy complexity, size,
+parameter, and unused-variable warnings without blocking the whole package. Clean
+files (`pty-daemon.js` and `test/client.test.js`) promote those same rules to
+errors and are enforced by `npm run lint:clean` with `--max-warnings=0`. The
+remote-terminal high-severity dependency audit is blocking via `npm run
+audit:high` because the current audit baseline is clean.
+
 If you need a narrow syntax-only check for a modified file:
 
 ```bash

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -387,7 +387,7 @@ Agent-authored docs and operator/research outputs (tentacle handoffs, retro summ
 
 GitHub Actions runs these jobs on every push / PR:
 - **`quality-gates`** — syntax check, scoped Ruff lint, and the Python test suites. The Ruff lint surface is: `embed.py`, `scout-config.py`, `scout-status.py`, `sync-config.py`, `sync-daemon.py`, `sync-status.py`, `migrate.py`, `generate-summary.py`, `briefing.py`, `learn.py`, `query-session.py`, `extract-knowledge.py`, `build-session-index.py`, `tentacle.py`, `checkpoint-diff.py`, `checkpoint-restore.py`, `checkpoint-save.py`, `browse/`, `hooks/`. Ruff lint is **scoped** to this surface; other root scripts outside it are not linted by CI.
-- **`remote-terminal`** — `npm ci`, `npm test`, lint baseline, and dependency audit advisory for `remote-terminal/`.
+- **`remote-terminal`** — `npm ci`, `npm test`, lint baseline, clean-zone lint gate, and blocking high-severity dependency audit for `remote-terminal/`. Legacy complexity/size warnings stay advisory in `npm run lint`; clean files (`pty-daemon.js`, `test/client.test.js`) promote the same rules to errors through `npm run lint:clean`.
 - **`browse-ui`** — `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, `pnpm build`. `browse-ui/eslint.config.mjs` keeps the repo-wide `@typescript-eslint/no-explicit-any` baseline advisory as `warn`, then promotes clean zones such as `src/lib/hosts/**/*.{ts,tsx}` to `error` so strict rules can expand without breaking legacy areas.
 - **`e2e-smoke`** — Playwright `behavioral` project (`smoke.spec.ts`, `shortcuts.spec.ts`, `chat.spec.ts`, `diagnostics.spec.ts`, and `broker-mode.spec.ts`) on Chromium.
 

--- a/remote-terminal/README.md
+++ b/remote-terminal/README.md
@@ -25,10 +25,11 @@ cd remote-terminal
 npm ci
 npm test
 npm run lint
-npm run audit:advisory
+npm run lint:clean
+npm run audit:high
 ```
 
-`npm run lint` uses ESLint flat config with warning-only complexity, size, parameter, and unused-variable rules so the current large-file baseline is visible without blocking normal development. The CI job runs lint after tests and then runs `npm run audit:advisory` as a non-blocking high-severity dependency audit.
+`npm run lint` uses ESLint flat config with warning-only complexity, size, parameter, and unused-variable rules so the current large-file baseline is visible without blocking normal development. Clean files (`pty-daemon.js` and `test/client.test.js`) promote the same rules to errors and are checked by `npm run lint:clean` with `--max-warnings=0`. The CI job runs lint after tests, blocks on the clean-zone lint gate, and runs `npm run audit:high` as a blocking high-severity dependency audit because the current dependency baseline is clean.
 
 By default the server:
 

--- a/remote-terminal/eslint.config.mjs
+++ b/remote-terminal/eslint.config.mjs
@@ -36,6 +36,19 @@ const advisoryRules = {
   ],
 };
 
+function promoteRulesToError(rules) {
+  return Object.fromEntries(
+    Object.entries(rules).map(([name, config]) => {
+      if (Array.isArray(config)) {
+        return [name, ["error", ...config.slice(1)]];
+      }
+      return [name, "error"];
+    }),
+  );
+}
+
+const cleanZoneRules = promoteRulesToError(advisoryRules);
+
 export default [
   {
     ignores: ["coverage/**", "node_modules/**"],
@@ -51,6 +64,10 @@ export default [
       reportUnusedDisableDirectives: "warn",
     },
     rules: advisoryRules,
+  },
+  {
+    files: ["pty-daemon.js", "test/client.test.js"],
+    rules: cleanZoneRules,
   },
   {
     files: ["public/**/*.js"],

--- a/remote-terminal/package.json
+++ b/remote-terminal/package.json
@@ -10,6 +10,8 @@
     "start": "node server.js",
     "test": "node --test",
     "lint": "eslint .",
+    "lint:clean": "eslint pty-daemon.js test/client.test.js --max-warnings=0",
+    "audit:high": "npm audit --audit-level=high",
     "audit:advisory": "npm audit --audit-level=high"
   },
   "dependencies": {

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -825,6 +825,8 @@ ARCH_MD = REPO / "docs" / "ARCHITECTURE.md"
 CONTRIBUTING = REPO / "CONTRIBUTING.md"
 PLAYWRIGHT_CONFIG = REPO / "browse-ui" / "playwright.config.ts"
 ESLINT_CONFIG = REPO / "browse-ui" / "eslint.config.mjs"
+REMOTE_TERMINAL_ESLINT_CONFIG = REPO / "remote-terminal" / "eslint.config.mjs"
+REMOTE_TERMINAL_PACKAGE = REPO / "remote-terminal" / "package.json"
 
 # CI Ruff surface (extracted from ci.yml)
 CI_RUFF_FILES = [
@@ -1089,6 +1091,61 @@ def test_browse_ui_eslint_clean_zone_strategy():
     )
 
 
+def test_remote_terminal_quality_gate_promotion():
+    """remote-terminal must promote clean lint zones and keep clean audits blocking."""
+    if not REMOTE_TERMINAL_ESLINT_CONFIG.exists():
+        test("remote-terminal eslint config exists", False, str(REMOTE_TERMINAL_ESLINT_CONFIG))
+        return
+    if not REMOTE_TERMINAL_PACKAGE.exists():
+        test("remote-terminal package.json exists", False, str(REMOTE_TERMINAL_PACKAGE))
+        return
+    if not CI_WORKFLOW.exists():
+        test("ci.yml exists", False, str(CI_WORKFLOW))
+        return
+
+    eslint_content = REMOTE_TERMINAL_ESLINT_CONFIG.read_text(encoding="utf-8")
+    package_content = REMOTE_TERMINAL_PACKAGE.read_text(encoding="utf-8")
+    ci_content = CI_WORKFLOW.read_text(encoding="utf-8")
+    lint_gate_body = _workflow_step_body(ci_content, "Run clean-zone lint gate")
+    audit_body = _workflow_step_body(ci_content, "Dependency audit")
+
+    test(
+        "remote-terminal legacy lint baseline remains advisory",
+        'complexity: ["warn", { max: 24 }]' in eslint_content,
+        "remote-terminal should keep legacy complexity/size rules as warnings outside clean files",
+    )
+    test(
+        "remote-terminal clean-zone files are declared",
+        '"pty-daemon.js", "test/client.test.js"' in eslint_content,
+        "remote-terminal eslint config should declare the clean files promoted to errors",
+    )
+    test(
+        "remote-terminal clean-zone rules promote advisory rules to errors",
+        "promoteRulesToError(advisoryRules)" in eslint_content,
+        "remote-terminal clean zones should derive error-level rules from the advisory baseline",
+    )
+    test(
+        "remote-terminal package exposes clean-zone lint command",
+        '"lint:clean": "eslint pty-daemon.js test/client.test.js --max-warnings=0"' in package_content,
+        "remote-terminal package.json should expose the blocking clean-zone lint command",
+    )
+    test(
+        "remote-terminal package exposes blocking high audit command",
+        '"audit:high": "npm audit --audit-level=high"' in package_content,
+        "remote-terminal package.json should expose the blocking high-severity audit command",
+    )
+    test(
+        "ci.yml runs remote-terminal clean-zone lint gate",
+        "npm run lint:clean" in lint_gate_body,
+        "remote-terminal CI job should run the clean-zone lint gate",
+    )
+    test(
+        "remote-terminal dependency audit is blocking",
+        "npm run audit:high" in audit_body and "continue-on-error" not in audit_body,
+        "remote-terminal audit baseline is clean, so CI should not mark the audit step advisory",
+    )
+
+
 def test_sk_ci_cargo_audit_advisory():
     """sk CI must run RustSec cargo audit as a non-blocking advisory with a blocking TODO."""
     if not SK_CI_WORKFLOW.exists():
@@ -1335,6 +1392,7 @@ test_ci_workflow_ruff_complexity_advisory()
 test_ci_workflow_e2e_smoke_visual_split()
 test_playwright_behavioral_project_contract()
 test_browse_ui_eslint_clean_zone_strategy()
+test_remote_terminal_quality_gate_promotion()
 test_sk_ci_cargo_audit_advisory()
 test_hooks_md_documents_local_vs_ci()
 test_contributing_md_local_vs_ci()


### PR DESCRIPTION
## Summary
- promote `remote-terminal/pty-daemon.js` and `remote-terminal/test/client.test.js` into a blocking ESLint clean zone
- add `npm run lint:clean` and make the clean high-severity dependency audit blocking via `npm run audit:high`
- document the remote-terminal clean-zone/audit workflow and add drift tests

Closes #271

## Evidence
- `npm --script-shell "C:\Program Files\PowerShell\7\pwsh.exe" run lint:clean`
- `npm --script-shell "C:\Program Files\PowerShell\7\pwsh.exe" run lint`
- `npm --script-shell "C:\Program Files\PowerShell\7\pwsh.exe" test` — 25 passed, 3 skipped
- `npm --script-shell "C:\Program Files\PowerShell\7\pwsh.exe" run audit:high` — 0 vulnerabilities
- temporary clean-zone probe in `pty-daemon.js` failed `npm run lint:clean` with 1 ESLint error
- `python tests\test_quality_gates.py` — 258 passed, 0 failed
- `python test_security.py` — 12 passed, 0 failed
- `python test_fixes.py` — 221 passed, 0 failed
- `git diff --check`
- code-review agent verdict: CLEAN