### PR TITLE
feat(sk): port project list to native Rust

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@ watch-sessions.py  ──→  Incremental re-indexing (adaptive polling)
 | `extract-knowledge.py` | Knowledge classification, relation extraction, `--semantic-only` fallback; named in `sk watch` extract-failure recovery hints | **Intentional** — manual/fallback operator tool |
 | `migrate.py` | Versioned schema migrations via `schema_version` table | **Intentional** — canonical schema upgrade owner; Rust native bootstrap does NOT replace this |
 | `sync-daemon.py` | Push/pull sync runtime for Python `sk.py` shim and non-binary installs | **Intentional** — shim sync path |
-| `briefing.py`, `learn.py`, `query-session.py`, etc. | Admin/operator CLI scripts | **Intentional** — these are the primary Python CLI surface |
+| `briefing.py`, `learn.py`, `query-session.py`, `project-registry.py`, etc. | Admin/operator CLI scripts | **Intentional** — these are the primary Python CLI surface; the Rust binary may bypass Python for measured hot read-only subcommands such as `sk project list`, while the direct scripts and mutating fallbacks remain supported |
 
 **What wave20 removed:** auto-spawning Python subprocess on `sk watch` error paths. The scripts
 above remain on disk, are invoked by operators manually, and are referenced by name in `sk watch`
@@ -101,7 +101,7 @@ non-blocking `[advisory]` Ruff findings for these files when Ruff is installed.
 | `migrate.py` | Versioned schema migrations via `schema_version` table |
 | `install.py` | Deploy skills/hooks; inject global AI instructions |
 | `setup-project.py` | Full project onboarding: skills + hooks + WORKFLOW.md |
-| `project-registry.py` | `sk project add/remove/list` — manage the persistent project registry (`tools-managed-projects.json`) |
+| `project-registry.py` | `sk project add/remove/list` — manage the persistent project registry (`tools-managed-projects.json`); Rust `sk project list` is a measured native read-only hot path, while `add`/`remove` and direct-script use stay on this Python owner |
 | `host_manifest.py` | Single source of truth for supported hosts + their filesystem paths |
 | `index-status.py` | Row counts, FTS integrity, event-offset coverage |
 | `knowledge-health.py` | Knowledge base health + recall telemetry |
@@ -369,6 +369,9 @@ All readers (`_load_project_registry()` in `install.py`, `setup-project.py`, and
 `auto-update-tools.py`) extract the path string from either format.
 
 `project-registry.py` is the CLI owner of this file: `sk project add|remove|list`.
+The Rust binary handles `sk project list` natively as a measured read-only hot path and
+preserves Python fallback/direct-script behavior for `add`, `remove`, help, and non-native
+forms.
 
 ### DB Migrations
 

--- a/sk-rust/src/commands/mod.rs
+++ b/sk-rust/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod embed;
 pub mod fallback;
 pub mod hooks;
 pub mod learn;
+pub mod project;
 pub mod query;
 pub mod sync_run;
 pub mod watch;

--- a/sk-rust/src/commands/project.rs
+++ b/sk-rust/src/commands/project.rs
@@ -1,0 +1,215 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::config::resolve_home_dir;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ProjectEntry {
+    name: String,
+    path: String,
+    created_at: Option<String>,
+    session_state: String,
+    db_path: String,
+}
+
+#[derive(Debug, Clone)]
+enum RawProjectEntry {
+    Path(String),
+    Object(serde_json::Map<String, Value>),
+}
+
+pub fn run_project_command(args: &[String]) -> Option<ExitCode> {
+    let subcommand = args.first().map(|s| s.as_str());
+    if subcommand != Some("list") {
+        return None;
+    }
+
+    let rest = args.get(1..).unwrap_or(&[]);
+    if rest.iter().any(|arg| arg == "-h" || arg == "--help") {
+        return None;
+    }
+    if rest.iter().any(|arg| arg != "--json") {
+        return None;
+    }
+
+    let json_output = rest.iter().any(|arg| arg == "--json");
+    Some(cmd_list(json_output))
+}
+
+fn cmd_list(json_output: bool) -> ExitCode {
+    let deduped = load_deduped_registry();
+
+    if deduped.is_empty() {
+        if json_output {
+            println!("[]");
+        } else {
+            println!("no projects registered");
+        }
+        return ExitCode::SUCCESS;
+    }
+
+    if json_output {
+        let normalized: Vec<ProjectEntry> = deduped.iter().map(normalize_entry).collect();
+        match serde_json::to_string_pretty(&normalized) {
+            Ok(payload) => {
+                println!("{payload}");
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                eprintln!("sk project list: failed to serialize registry: {e}");
+                ExitCode::from(1)
+            }
+        }
+    } else {
+        for entry in &deduped {
+            let normalized = normalize_entry(entry);
+            let mut details = Vec::new();
+            if !normalized.name.is_empty() {
+                details.push(normalized.name);
+            }
+            if let Some(added) = normalized.created_at {
+                if !added.is_empty() {
+                    details.push(format!("added {added}"));
+                }
+            }
+            if !normalized.db_path.is_empty() {
+                details.push(format!("db {}", normalized.db_path));
+            }
+
+            if details.is_empty() {
+                println!("{}", normalized.path);
+            } else {
+                println!("{}  ({})", normalized.path, details.join(", "));
+            }
+        }
+        ExitCode::SUCCESS
+    }
+}
+
+fn registry_path() -> Option<PathBuf> {
+    resolve_home_dir().map(|home| {
+        home.join(".copilot")
+            .join("session-state")
+            .join("tools-managed-projects.json")
+    })
+}
+
+fn load_raw_registry() -> Vec<RawProjectEntry> {
+    let Some(path) = registry_path() else {
+        return Vec::new();
+    };
+    let Ok(content) = fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let Ok(Value::Object(root)) = serde_json::from_str::<Value>(&content) else {
+        return Vec::new();
+    };
+    let Some(Value::Array(projects)) = root.get("projects") else {
+        return Vec::new();
+    };
+
+    projects
+        .iter()
+        .filter_map(|entry| match entry {
+            Value::String(path) => Some(RawProjectEntry::Path(path.clone())),
+            Value::Object(obj) => Some(RawProjectEntry::Object(obj.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+fn load_deduped_registry() -> Vec<RawProjectEntry> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for entry in load_raw_registry() {
+        let path = entry_path(&entry);
+        if path.is_empty() || !seen.insert(path) {
+            continue;
+        }
+        result.push(entry);
+    }
+    result
+}
+
+fn entry_path(entry: &RawProjectEntry) -> String {
+    match entry {
+        RawProjectEntry::Path(path) => path.clone(),
+        RawProjectEntry::Object(obj) => obj
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+    }
+}
+
+fn normalize_entry(entry: &RawProjectEntry) -> ProjectEntry {
+    let path = entry_path(entry);
+    let (mut name, created_at, mut session_state, mut db_path) = match entry {
+        RawProjectEntry::Path(_) => (String::new(), None, String::new(), String::new()),
+        RawProjectEntry::Object(obj) => (
+            string_field(obj, "name"),
+            optional_string_field(obj, "created_at"),
+            string_field(obj, "session_state"),
+            string_field(obj, "db_path"),
+        ),
+    };
+
+    if !path.is_empty() {
+        let root = Path::new(&path);
+        if name.is_empty() {
+            name = root
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default();
+        }
+        if session_state.is_empty() {
+            session_state = project_session_state(root);
+        }
+        if db_path.is_empty() {
+            db_path = project_db_path(root);
+        }
+    }
+
+    ProjectEntry {
+        name,
+        path,
+        created_at,
+        session_state,
+        db_path,
+    }
+}
+
+fn string_field(obj: &serde_json::Map<String, Value>, key: &str) -> String {
+    obj.get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn optional_string_field(obj: &serde_json::Map<String, Value>, key: &str) -> Option<String> {
+    obj.get(key)
+        .and_then(Value::as_str)
+        .map(std::string::ToString::to_string)
+}
+
+fn project_session_state(project_root: &Path) -> String {
+    project_root
+        .join(".copilot")
+        .join("session-state")
+        .to_string_lossy()
+        .to_string()
+}
+
+fn project_db_path(project_root: &Path) -> String {
+    project_root
+        .join(".copilot")
+        .join("session-state")
+        .join("knowledge.db")
+        .to_string_lossy()
+        .to_string()
+}

--- a/sk-rust/src/commands/project.rs
+++ b/sk-rust/src/commands/project.rs
@@ -29,21 +29,24 @@ pub fn run_project_command(args: &[String]) -> Option<ExitCode> {
         return None;
     }
 
-    let rest = args.get(1..).unwrap_or(&[]);
-    if rest.iter().any(|arg| arg == "-h" || arg == "--help") {
-        return None;
+    let mut json_output = false;
+    for arg in args.get(1..).unwrap_or(&[]) {
+        match arg.as_str() {
+            "--json" => json_output = true,
+            "-h" | "--help" => return None,
+            _ => return None,
+        }
     }
-    if rest.iter().any(|arg| arg != "--json") {
+
+    let raw = load_raw_registry();
+    if !uses_string_schema(&raw) {
         return None;
     }
 
-    let json_output = rest.iter().any(|arg| arg == "--json");
-    Some(cmd_list(json_output))
+    Some(cmd_list(json_output, load_deduped_registry(raw)))
 }
 
-fn cmd_list(json_output: bool) -> ExitCode {
-    let deduped = load_deduped_registry();
-
+fn cmd_list(json_output: bool, deduped: Vec<RawProjectEntry>) -> ExitCode {
     if deduped.is_empty() {
         if json_output {
             println!("[]");
@@ -123,10 +126,22 @@ fn load_raw_registry() -> Vec<RawProjectEntry> {
         .collect()
 }
 
-fn load_deduped_registry() -> Vec<RawProjectEntry> {
+fn uses_string_schema(entries: &[RawProjectEntry]) -> bool {
+    entries.iter().all(|entry| match entry {
+        RawProjectEntry::Path(_) => true,
+        RawProjectEntry::Object(obj) => ["path", "name", "created_at", "session_state", "db_path"]
+            .iter()
+            .all(|key| {
+                obj.get(*key)
+                    .map_or(true, |value| value.is_null() || value.is_string())
+            }),
+    })
+}
+
+fn load_deduped_registry(raw: Vec<RawProjectEntry>) -> Vec<RawProjectEntry> {
     let mut seen = HashSet::new();
     let mut result = Vec::new();
-    for entry in load_raw_registry() {
+    for entry in raw {
         let path = entry_path(&entry);
         if path.is_empty() || !seen.insert(path) {
             continue;

--- a/sk-rust/src/main.rs
+++ b/sk-rust/src/main.rs
@@ -265,21 +265,27 @@ fn main() -> ExitCode {
             // that bad subcommands fail fast with a consistent message even if
             // the Python script is missing or not invocable — matching the
             // behaviour of the Python sk.py _run_project() dispatcher.
-            const VALID_SUBS: &[&str] = &["add", "remove", "list"];
-            let sub = args.first().map(|s| s.as_str());
-            match sub {
-                // No subcommand or explicit help flag → show help
-                None | Some("-h") | Some("--help") => {
-                    run_fallback("project-registry.py", &["--help".to_string()])
-                }
-                Some(s) if VALID_SUBS.contains(&s) => run_fallback("project-registry.py", &args),
-                Some(bad) => {
-                    eprintln!(
-                        "sk project: unknown subcommand '{}'. Choose from: {}",
-                        bad,
-                        VALID_SUBS.join(", ")
-                    );
-                    ExitCode::from(2)
+            if let Some(exit_code) = commands::project::run_project_command(&args) {
+                exit_code
+            } else {
+                const VALID_SUBS: &[&str] = &["add", "remove", "list"];
+                let sub = args.first().map(|s| s.as_str());
+                match sub {
+                    // No subcommand or explicit help flag → show help
+                    None | Some("-h") | Some("--help") => {
+                        run_fallback("project-registry.py", &["--help".to_string()])
+                    }
+                    Some(s) if VALID_SUBS.contains(&s) => {
+                        run_fallback("project-registry.py", &args)
+                    }
+                    Some(bad) => {
+                        eprintln!(
+                            "sk project: unknown subcommand '{}'. Choose from: {}",
+                            bad,
+                            VALID_SUBS.join(", ")
+                        );
+                        ExitCode::from(2)
+                    }
                 }
             }
         }

--- a/sk-rust/tests/integration_test.rs
+++ b/sk-rust/tests/integration_test.rs
@@ -63,6 +63,7 @@ fn project_list_json_is_native_and_matches_python() {
         .unwrap()
         .as_nanos();
     let test_root = std::env::temp_dir().join(format!("sk_project_list_native_{unique}"));
+    let _guard = TempTree(test_root.clone());
     let session_state = test_root.join(".copilot").join("session-state");
     let mock_tools = test_root.join("mock-tools");
     let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -96,19 +97,10 @@ fn project_list_json_is_native_and_matches_python() {
     )
     .unwrap();
 
-    let mock_py = format!(
-        "from pathlib import Path\nPath(r'{}').write_text('called', encoding='utf-8')\nraise SystemExit(97)\n",
-        fallback_flag.display()
-    );
+    let mock_py = "import os\nfrom pathlib import Path\nPath(os.environ['SK_PROJECT_TEST_FLAG']).write_text('called', encoding='utf-8')\nraise SystemExit(97)\n";
     fs::write(mock_tools.join("project-registry.py"), mock_py).unwrap();
 
-    let python = if cfg!(target_os = "windows") {
-        "python"
-    } else {
-        "python3"
-    };
-
-    let expected_json = StdCommand::new(python)
+    let expected_json = StdCommand::new(python_exe())
         .arg(repo_root.join("project-registry.py"))
         .args(["list", "--json"])
         .env("HOME", &test_root)
@@ -122,7 +114,7 @@ fn project_list_json_is_native_and_matches_python() {
         String::from_utf8_lossy(&expected_json.stderr)
     );
 
-    let expected_text = StdCommand::new(python)
+    let expected_text = StdCommand::new(python_exe())
         .arg(repo_root.join("project-registry.py"))
         .arg("list")
         .env("HOME", &test_root)
@@ -141,6 +133,7 @@ fn project_list_json_is_native_and_matches_python() {
         .env("HOME", &test_root)
         .env("USERPROFILE", &test_root)
         .env("SK_TOOLS_DIR", &mock_tools)
+        .env("SK_PROJECT_TEST_FLAG", &fallback_flag)
         .assert()
         .success();
 
@@ -158,6 +151,7 @@ fn project_list_json_is_native_and_matches_python() {
         .env("HOME", &test_root)
         .env("USERPROFILE", &test_root)
         .env("SK_TOOLS_DIR", &mock_tools)
+        .env("SK_PROJECT_TEST_FLAG", &fallback_flag)
         .assert()
         .success();
     assert_eq!(
@@ -170,12 +164,78 @@ fn project_list_json_is_native_and_matches_python() {
         !fallback_flag.exists(),
         "sk project list --json must not spawn project-registry.py"
     );
+}
 
+#[test]
+fn project_list_unsupported_registry_fields_use_python_fallback() {
+    use serde_json::json;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let test_root = std::env::temp_dir().join(format!("sk_project_list_fallback_{unique}"));
+    let _guard = TempTree(test_root.clone());
+    let session_state = test_root.join(".copilot").join("session-state");
+    let mock_tools = test_root.join("mock-tools");
+    let registry_path = session_state.join("tools-managed-projects.json");
+    let fallback_flag = mock_tools.join("project-registry-called.flag");
     let _ = fs::remove_dir_all(&test_root);
+    fs::create_dir_all(&session_state).unwrap();
+    fs::create_dir_all(&mock_tools).unwrap();
+
+    fs::write(
+        &registry_path,
+        serde_json::to_string_pretty(&json!({
+            "projects": [
+                {
+                    "name": 123,
+                    "path": test_root.join("alpha").to_string_lossy()
+                }
+            ]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let mock_py = "import os\nfrom pathlib import Path\nPath(os.environ['SK_PROJECT_TEST_FLAG']).write_text('called', encoding='utf-8')\nprint('PY_FALLBACK')\n";
+    fs::write(mock_tools.join("project-registry.py"), mock_py).unwrap();
+
+    sk().args(["project", "list", "--json"])
+        .env("HOME", &test_root)
+        .env("USERPROFILE", &test_root)
+        .env("SK_TOOLS_DIR", &mock_tools)
+        .env("SK_PROJECT_TEST_FLAG", &fallback_flag)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PY_FALLBACK"));
+
+    assert!(
+        fallback_flag.exists(),
+        "unsupported registry field types must use project-registry.py fallback"
+    );
 }
 
 fn normalize_newlines(text: &str) -> String {
     text.replace("\r\n", "\n")
+}
+
+fn python_exe() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "python"
+    } else {
+        "python3"
+    }
+}
+
+struct TempTree(std::path::PathBuf);
+
+impl Drop for TempTree {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
 }
 
 #[test]

--- a/sk-rust/tests/integration_test.rs
+++ b/sk-rust/tests/integration_test.rs
@@ -52,6 +52,133 @@ fn unknown_command_returns_error() {
 }
 
 #[test]
+fn project_list_json_is_native_and_matches_python() {
+    use serde_json::json;
+    use std::fs;
+    use std::process::Command as StdCommand;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let test_root = std::env::temp_dir().join(format!("sk_project_list_native_{unique}"));
+    let session_state = test_root.join(".copilot").join("session-state");
+    let mock_tools = test_root.join("mock-tools");
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let registry_path = session_state.join("tools-managed-projects.json");
+    let fallback_flag = mock_tools.join("project-registry-called.flag");
+    let _ = fs::remove_dir_all(&test_root);
+    fs::create_dir_all(&session_state).unwrap();
+    fs::create_dir_all(&mock_tools).unwrap();
+
+    let alpha = test_root.join("alpha");
+    let beta = test_root.join("beta");
+    fs::create_dir_all(&alpha).unwrap();
+    fs::create_dir_all(&beta).unwrap();
+    let registry = json!({
+        "projects": [
+            alpha.to_string_lossy(),
+            {
+                "name": "beta-custom",
+                "path": beta.to_string_lossy(),
+                "created_at": "2026-05-17T00:00:00+00:00"
+            },
+            alpha.to_string_lossy()
+        ]
+    });
+    fs::write(
+        &registry_path,
+        serde_json::to_string_pretty(&registry).unwrap(),
+    )
+    .unwrap();
+
+    let mock_py = format!(
+        "from pathlib import Path\nPath(r'{}').write_text('called', encoding='utf-8')\nraise SystemExit(97)\n",
+        fallback_flag.display()
+    );
+    fs::write(mock_tools.join("project-registry.py"), mock_py).unwrap();
+
+    let python = if cfg!(target_os = "windows") {
+        "python"
+    } else {
+        "python3"
+    };
+
+    let expected_json = StdCommand::new(python)
+        .arg(repo_root.join("project-registry.py"))
+        .args(["list", "--json"])
+        .env("HOME", &test_root)
+        .env("USERPROFILE", &test_root)
+        .output()
+        .expect("python project-registry.py should run");
+    assert!(
+        expected_json.status.success(),
+        "python project-registry.py list --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&expected_json.stdout),
+        String::from_utf8_lossy(&expected_json.stderr)
+    );
+
+    let expected_text = StdCommand::new(python)
+        .arg(repo_root.join("project-registry.py"))
+        .arg("list")
+        .env("HOME", &test_root)
+        .env("USERPROFILE", &test_root)
+        .output()
+        .expect("python project-registry.py should run");
+    assert!(
+        expected_text.status.success(),
+        "python project-registry.py list failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&expected_text.stdout),
+        String::from_utf8_lossy(&expected_text.stderr)
+    );
+
+    let actual_json = sk()
+        .args(["project", "list", "--json"])
+        .env("HOME", &test_root)
+        .env("USERPROFILE", &test_root)
+        .env("SK_TOOLS_DIR", &mock_tools)
+        .assert()
+        .success();
+
+    let actual_json_value: serde_json::Value =
+        serde_json::from_slice(&actual_json.get_output().stdout).unwrap();
+    let expected_json_value: serde_json::Value =
+        serde_json::from_slice(&expected_json.stdout).unwrap();
+    assert_eq!(
+        actual_json_value, expected_json_value,
+        "native project list JSON must match Python project-registry.py semantically"
+    );
+
+    let actual_text = sk()
+        .args(["project", "list"])
+        .env("HOME", &test_root)
+        .env("USERPROFILE", &test_root)
+        .env("SK_TOOLS_DIR", &mock_tools)
+        .assert()
+        .success();
+    assert_eq!(
+        normalize_newlines(&String::from_utf8(actual_text.get_output().stdout.clone()).unwrap()),
+        normalize_newlines(&String::from_utf8(expected_text.stdout).unwrap()),
+        "native project list text output must match Python project-registry.py"
+    );
+
+    assert!(
+        !fallback_flag.exists(),
+        "sk project list --json must not spawn project-registry.py"
+    );
+
+    let _ = fs::remove_dir_all(&test_root);
+}
+
+fn normalize_newlines(text: &str) -> String {
+    text.replace("\r\n", "\n")
+}
+
+#[test]
 fn version_completes_under_10ms() {
     let start = Instant::now();
     sk().arg("--version").assert().success();
@@ -2809,11 +2936,9 @@ fn wave15_native_extract_sync_enqueue_fail_open() {
 /// installs and ensures SkillUsageRule is wired into the native runner.
 #[test]
 fn hooks_posttooluse_skill_usage_exits_zero() {
-    use std::io::Write;
-
     let payload = r#"{"toolName":"skill","toolInput":{"skill":"karpathy-guidelines"},"toolResult":"x","sessionId":"integration-test-sess"}"#;
-    let mut child = sk()
-        .args(&["hooks", "run", "postToolUse"])
+    let child = sk()
+        .args(["hooks", "run", "postToolUse"])
         .write_stdin(payload)
         .assert()
         .success()
@@ -2847,7 +2972,7 @@ fn hooks_posttooluse_skill_usage_writes_db() {
     let mut cmd = Command::cargo_bin("sk").unwrap();
     cmd.env("HOME", &tmp)
         .env("USERPROFILE", &tmp) // Windows
-        .args(&["hooks", "run", "postToolUse"])
+        .args(["hooks", "run", "postToolUse"])
         .write_stdin(payload)
         .assert()
         .success();


### PR DESCRIPTION
## Summary
- Ports `sk project list` / `sk project list --json` to a native Rust read-only path.
- Keeps Python fallback/direct-script behavior for `project add`, `project remove`, help, unknown flags, and non-native forms.
- Adds integration coverage proving native JSON/text output matches `project-registry.py` and does not spawn the fallback script.

## Benchmark evidence
Measured with `python benchmark.py startup --runs 15 --warmups 3 --json -- ...` against `sk-rust\target\release\sk.exe` on Windows in this worktree.

| Command | Median | Min | Max |
| --- | ---: | ---: | ---: |
| Pre-port `sk.exe project list --json` via Python fallback | 167.01 ms | 156.34 ms | 189.53 ms |
| Direct `python project-registry.py list --json` | 112.19 ms | 106.16 ms | 133.23 ms |
| Post-port native `sk.exe project list --json` | 52.48 ms | 46.15 ms | 79.72 ms |
| Post-port `sk.exe --version` process baseline | 51.90 ms | 47.33 ms | 62.08 ms |

Improvement vs pre-port Rust-wrapper fallback: 68.58%. Improvement vs direct Python script: 53.22%.

## Verification
- `cargo fmt --check`
- `cargo clippy --quiet --all-targets --all-features -- -D warnings`
- `cargo test --quiet --all -- --nocapture` (670 unit tests + 80 integration tests passed)
- `python tests\test_project_registry.py` (47 tests passed)
- `python test_security.py` (12 tests passed)
- `python test_fixes.py` (221 tests passed)
- Code review agent: clean after review-fix pass

Closes #279