### PR TITLE
test: inventory oversized test shards

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -64,6 +64,61 @@ Supporting directories:
 | `fixtures/` | Static input fixtures shared across tests |
 | `snapshots/` | Auto-generated SHA-256 baseline files; re-generate with `UPDATE_SNAPSHOTS=1 python3 tests/test_visual_snapshot.py` |
 
+## Test shard inventory
+
+Use `python3 tests/test_inventory.py --report` to regenerate the full inventory of every `test_*.py` file, including subsystem, line count, runtime class, and protected surface. The default `python3 tests/test_inventory.py` mode verifies that the inventory covers all discovered tests and that this section stays present.
+
+Current top 30 by line count:
+
+| File | Subsystem | Lines | Runtime class | Protected surface |
+| --- | --- | ---: | --- | --- |
+| `tests/test_tentacle_runtime.py` | tentacle | 9854 | oversized | tentacle orchestration |
+| `tests/test_tentacle_goal.py` | tentacle | 7509 | oversized | tentacle orchestration |
+| `tests/test_hooks.py` | hooks | 5667 | oversized | Copilot hook rules |
+| `tests/test_memory_contract.py` | memory | 3704 | oversized | memory |
+| `tests/test_trend_scout.py` | trend-scout | 3554 | oversized | trend scout |
+| `test_fixes.py` | root-runtime | 3410 | root-canary | runtime regression gate |
+| `tests/test_sync_runtime.py` | sync | 3037 | oversized | sync runtime |
+| `tests/test_retro.py` | retro | 2582 | large | retro |
+| `tests/test_hook_compat.py` | hooks | 2544 | large | Copilot hook rules |
+| `tests/test_browse_operator_api.py` | browse | 2443 | large | browse backend/UI |
+| `tests/test_hook_rules_more.py` | hooks | 2183 | large | Copilot hook rules |
+| `tests/test_quality_gates.py` | quality | 1760 | large | quality |
+| `tests/test_dream_score.py` | dream | 1741 | large | dream |
+| `tests/test_token_read_tracker.py` | token | 1739 | large | token |
+| `tests/test_indexing.py` | indexing | 1687 | large | indexing |
+| `tests/test_session_surface.py` | session | 1661 | large | session |
+| `tests/test_browse_api.py` | browse | 1522 | large | browse backend/UI |
+| `tests/test_sk_cli.py` | sk | 1499 | large | sk |
+| `tests/test_briefing.py` | briefing | 1318 | large | briefing |
+| `tests/test_hook_rules_full.py` | hooks | 1283 | large | Copilot hook rules |
+| `tests/test_validate_skill.py` | validate | 1182 | large | validate |
+| `tests/test_retrieval_evals.py` | retrieval | 1150 | large | knowledge retrieval |
+| `tests/test_install_helpers.py` | install | 1116 | large | install |
+| `tests/test_karpathy_skill_rollout.py` | karpathy | 1099 | large | karpathy |
+| `tests/test_knowledge_health.py` | knowledge | 1065 | large | knowledge |
+| `tests/test_binary_install.py` | binary | 990 | standard | binary |
+| `tests/test_benchmark.py` | benchmark | 965 | standard | benchmark |
+| `tests/test_hook_runner_entrypoints.py` | hooks | 957 | standard | Copilot hook rules |
+| `tests/test_skill_curator.py` | skills | 920 | standard | skills ecosystem |
+| `tests/test_browse_pairing.py` | browse | 855 | standard | browse backend/UI |
+
+### Size policy for new tests
+
+- Root canary files (`test_security.py`, `test_fixes.py`) stay thin entrypoints for high-signal security and runtime regressions. Add focused helpers under `tests/` when a root canary starts accumulating subsystem-specific setup.
+- New subsystem tests should prefer shards below 1,000 lines. Files over 1,000 lines need a short reason in this README or a nearby module comment explaining why the density is intentional.
+- Files over 3,000 lines are oversized. Do not add unrelated cases to them unless the change is a narrow regression for behavior already owned by that file.
+- A new shard must be directly runnable from the repo root with `python3 tests/test_<name>.py` and must also be discovered by `python3 run_all_tests.py --dry`.
+- Dense tests are allowed when the setup fixture is expensive or tightly coupled, but the exception should name the protected surface and the future extraction seam.
+
+### First safe shard extraction proposal
+
+The first no-behavior-change extraction should target `tests/test_tentacle_runtime.py`, the largest file. Proposed seam:
+
+1. Move pure bundle/manifest/context rendering assertions that do not mutate goal state into `tests/test_tentacle_runtime_bundle.py`.
+2. Keep shared subprocess helpers and scratch-directory setup byte-for-byte equivalent while both files run independently from the repo root.
+3. Prove the split with `python3 tests/test_tentacle_runtime.py`, `python3 tests/test_tentacle_runtime_bundle.py`, and `python3 run_all_tests.py`.
+
 ## Adding new tests
 
 1. Place the new file as `tests/test_<name>.py`.

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Test shard inventory and policy checks.
+
+Run:
+    python3 tests/test_inventory.py
+    python3 tests/test_inventory.py --report
+    python3 tests/test_inventory.py --json
+"""
+
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).resolve().parent.parent
+README = REPO / "tests" / "README.md"
+EXCLUDE_DIRS = {".git", ".octogent", ".venv", "__pycache__", "venv"}
+EXCLUDE_PATH_PARTS = {"fixtures"}
+TOP_LIMIT = 30
+
+PASS = 0
+FAIL = 0
+
+
+@dataclass(frozen=True)
+class InventoryRow:
+    file: str
+    subsystem: str
+    line_count: int
+    runtime_class: str
+    protected_surface: str
+
+
+def discover_test_files(root: Path = REPO) -> list[Path]:
+    found: list[Path] = []
+    for path in sorted(root.rglob("test_*.py")):
+        try:
+            rel_parts = path.relative_to(root).parts
+        except ValueError:
+            rel_parts = path.parts
+        if set(rel_parts) & EXCLUDE_DIRS:
+            continue
+        if EXCLUDE_PATH_PARTS & set(rel_parts):
+            continue
+        if any(part.startswith(".") for part in rel_parts[:-1]):
+            continue
+        found.append(path)
+    return found
+
+
+def line_count(path: Path) -> int:
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        return sum(1 for _ in handle)
+
+
+def build_inventory(root: Path = REPO) -> list[InventoryRow]:
+    rows = []
+    for path in discover_test_files(root):
+        rel = path.relative_to(root).as_posix()
+        lines = line_count(path)
+        subsystem = classify_subsystem(rel)
+        rows.append(
+            InventoryRow(
+                file=rel,
+                subsystem=subsystem,
+                line_count=lines,
+                runtime_class=classify_runtime(rel, lines),
+                protected_surface=classify_surface(rel, subsystem),
+            )
+        )
+    return sorted(rows, key=lambda row: row.file)
+
+
+def classify_subsystem(rel: str) -> str:
+    name = Path(rel).name
+    if rel == "test_security.py":
+        return "root-security"
+    if rel == "test_fixes.py":
+        return "root-runtime"
+    prefix_map = [
+        ("test_tentacle_", "tentacle"),
+        ("test_hook", "hooks"),
+        ("test_browse_", "browse"),
+        ("test_sync_", "sync"),
+        ("test_profile_", "profile"),
+        ("test_skill_", "skills"),
+        ("test_trend_scout", "trend-scout"),
+        ("test_workflow_", "workflow"),
+        ("test_checkpoint_", "checkpoint"),
+        ("test_constitution", "constitution"),
+        ("test_retrieval", "retrieval"),
+        ("test_project_", "project"),
+    ]
+    for prefix, subsystem in prefix_map:
+        if name.startswith(prefix):
+            return subsystem
+    stem = name.removeprefix("test_").removesuffix(".py")
+    return stem.split("_", 1)[0] if stem else "misc"
+
+
+def classify_runtime(rel: str, lines: int) -> str:
+    if rel in {"test_security.py", "test_fixes.py"}:
+        return "root-canary"
+    if lines >= 3_000:
+        return "oversized"
+    if lines >= 1_000:
+        return "large"
+    if lines >= 300:
+        return "standard"
+    return "small"
+
+
+def classify_surface(rel: str, subsystem: str) -> str:
+    if rel == "test_security.py":
+        return "security gate"
+    if rel == "test_fixes.py":
+        return "runtime regression gate"
+    surfaces = {
+        "browse": "browse backend/UI",
+        "checkpoint": "checkpoint tooling",
+        "constitution": "spec governance",
+        "hooks": "Copilot hook rules",
+        "profile": "agent profiles",
+        "project": "project setup/context",
+        "retrieval": "knowledge retrieval",
+        "skills": "skills ecosystem",
+        "sync": "sync runtime",
+        "tentacle": "tentacle orchestration",
+        "trend-scout": "trend scout",
+        "workflow": "workflow health",
+    }
+    return surfaces.get(subsystem, subsystem)
+
+
+def top_by_line_count(rows: list[InventoryRow], limit: int = TOP_LIMIT) -> list[InventoryRow]:
+    return sorted(rows, key=lambda row: (-row.line_count, row.file))[:limit]
+
+
+def markdown_table(rows: list[InventoryRow]) -> str:
+    lines = [
+        "| File | Subsystem | Lines | Runtime class | Protected surface |",
+        "| --- | --- | ---: | --- | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            f"| `{row.file}` | {row.subsystem} | {row.line_count} | "
+            f"{row.runtime_class} | {row.protected_surface} |"
+        )
+    return "\n".join(lines)
+
+
+def format_report(rows: list[InventoryRow]) -> str:
+    top_rows = top_by_line_count(rows)
+    return "\n\n".join(
+        [
+            f"# Test shard inventory\n\nTotal test files: {len(rows)}",
+            f"## Top {TOP_LIMIT} by line count\n\n{markdown_table(top_rows)}",
+            f"## Full inventory\n\n{markdown_table(rows)}",
+        ]
+    )
+
+
+def record(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        FAIL += 1
+        print(f"  FAIL  {name}" + (f" -- {detail}" if detail else ""))
+
+
+def run_checks() -> int:
+    rows = build_inventory()
+    files = [row.file for row in rows]
+    top_rows = top_by_line_count(rows)
+    report = format_report(rows)
+    readme = README.read_text(encoding="utf-8")
+
+    record("inventory discovers test files", len(rows) > TOP_LIMIT, str(len(rows)))
+    record("inventory includes root security canary", "test_security.py" in files)
+    record("inventory includes root fixes canary", "test_fixes.py" in files)
+    record("inventory includes this test", "tests/test_inventory.py" in files)
+    record("top 30 has expected size", len(top_rows) == min(TOP_LIMIT, len(rows)))
+    record(
+        "top 30 sorted by descending line count",
+        all(
+            top_rows[i].line_count >= top_rows[i + 1].line_count
+            for i in range(len(top_rows) - 1)
+        ),
+    )
+    record(
+        "inventory rows have required columns",
+        all(
+            row.file
+            and row.subsystem
+            and row.line_count > 0
+            and row.runtime_class
+            and row.protected_surface
+            for row in rows
+        ),
+    )
+    record(
+        "report lists every discovered test file",
+        all(f"`{row.file}`" in report for row in rows),
+    )
+    record("report includes top 30 section", f"Top {TOP_LIMIT} by line count" in report)
+    record("README has test shard inventory section", "## Test shard inventory" in readme)
+
+    print(f"\nResults: {PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    rows = build_inventory()
+
+    if "--help" in args or "-h" in args:
+        print(__doc__)
+        return 0
+    if "--json" in args:
+        print(json.dumps([asdict(row) for row in rows], indent=2))
+        return 0
+    if "--report" in args:
+        print(format_report(rows))
+        return 0
+    return run_checks()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #280

## Summary
- Added `tests/test_inventory.py` as a directly runnable inventory/report script for every `test_*.py` file.
- Documented the current top 30 largest tests, size policy, and first safe shard extraction proposal in `tests/README.md`.

## Evidence
- `python -m py_compile tests\test_inventory.py`
- `python tests\test_inventory.py` -> 10 passed, 0 failed
- `python tests\test_inventory.py --report` -> 122 discovered test files and top 30 line-count table
- `python run_all_tests.py --dry` -> 122 discovered test files, including `tests/test_inventory.py`
- `python test_security.py` -> 12 passed, 0 failed
- `python test_fixes.py` -> 221 passed, 0 failed out of 221

## Local full-run note
- `python run_all_tests.py` was attempted locally on Windows; it still hits the existing browse-test baseline failures and the 300s runner budget. The new inventory test is discovered and passes before those unrelated browse failures.