### PR TITLE
Add DB migration rehearsal tests

### DIFF
--- a/docs/RESILIENCE-RUNBOOK.md
+++ b/docs/RESILIENCE-RUNBOOK.md
@@ -14,8 +14,9 @@
 2. [Compaction / State-Loss Recovery](#2-compaction--state-loss-recovery)
 3. [Session Interruption Recovery](#3-session-interruption-recovery)
 4. [Quota and Rate-Limit Recovery](#4-quota-and-rate-limit-recovery)
-5. [Goal Status Reference](#5-goal-status-reference)
-6. [Recovery Decision Tree (Quick Reference)](#6-recovery-decision-tree-quick-reference)
+5. [Database Schema Backup and Rollback](#5-database-schema-backup-and-rollback)
+6. [Goal Status Reference](#6-goal-status-reference)
+7. [Recovery Decision Tree (Quick Reference)](#7-recovery-decision-tree-quick-reference)
 
 ---
 
@@ -332,7 +333,39 @@ sk tentacle goal verify-loop --escalate
 
 ---
 
-## 5. Goal Status Reference
+## 5. Database Schema Backup and Rollback
+
+Use this before manual database repair, schema rehearsals, or risky local upgrades.
+`migrate.py --backup-only` uses SQLite's online backup API, so it captures a
+consistent copy even when the source database is in WAL mode.
+
+```bash
+# Create a rollback copy without applying migrations
+python migrate.py ~/.copilot/session-state/knowledge.db --backup-only --backup-path /tmp/knowledge.db.backup
+
+# Apply migrations after the backup exists
+python migrate.py ~/.copilot/session-state/knowledge.db
+```
+
+If migration reports a corrupt database or schema failure, do not keep retrying against
+the same file. Restore the backup, or move the bad database aside and let migration
+bootstrap a fresh schema:
+
+```bash
+# Restore known-good backup
+cp /tmp/knowledge.db.backup ~/.copilot/session-state/knowledge.db
+
+# Or preserve the bad file for investigation and bootstrap a new DB
+mv ~/.copilot/session-state/knowledge.db ~/.copilot/session-state/knowledge.db.corrupt
+python migrate.py ~/.copilot/session-state/knowledge.db
+```
+
+When validating a rollback, run migration twice: the first run should apply missing
+versions, and the second run should report `Schema up to date`.
+
+---
+
+## 6. Goal Status Reference
 
 | Status | Meaning | How to resume |
 |--------|---------|--------------|
@@ -345,7 +378,7 @@ sk tentacle goal verify-loop --escalate
 
 ---
 
-## 6. Recovery Decision Tree (Quick Reference)
+## 7. Recovery Decision Tree (Quick Reference)
 
 ```
 After compaction / new session:

--- a/docs/RESILIENCE-RUNBOOK.md
+++ b/docs/RESILIENCE-RUNBOOK.md
@@ -349,14 +349,22 @@ python migrate.py ~/.copilot/session-state/knowledge.db
 
 If migration reports a corrupt database or schema failure, do not keep retrying against
 the same file. Restore the backup, or move the bad database aside and let migration
-bootstrap a fresh schema:
+bootstrap a fresh schema. Stop all session-knowledge writers first, then remove or move
+the matching WAL sidecars so SQLite cannot replay stale `knowledge.db-wal` state after
+the main DB file is restored or replaced:
 
 ```bash
+# Stop active writers before manipulating DB files
+# Examples: stop `sk watch`, sync daemons, launchd services, or CI jobs using this DB.
+
 # Restore known-good backup
+rm -f ~/.copilot/session-state/knowledge.db-wal ~/.copilot/session-state/knowledge.db-shm
 cp /tmp/knowledge.db.backup ~/.copilot/session-state/knowledge.db
 
 # Or preserve the bad file for investigation and bootstrap a new DB
 mv ~/.copilot/session-state/knowledge.db ~/.copilot/session-state/knowledge.db.corrupt
+mv ~/.copilot/session-state/knowledge.db-wal ~/.copilot/session-state/knowledge.db-wal.corrupt 2>/dev/null || true
+mv ~/.copilot/session-state/knowledge.db-shm ~/.copilot/session-state/knowledge.db-shm.corrupt 2>/dev/null || true
 python migrate.py ~/.copilot/session-state/knowledge.db
 ```
 

--- a/migrate.py
+++ b/migrate.py
@@ -109,26 +109,32 @@ def _create_backup_copy(db_path: str, backup_path: str | None = None) -> Path:
     destination.parent.mkdir(parents=True, exist_ok=True)
     src_conn = sqlite3.connect(str(source))
     dst_conn = sqlite3.connect(str(destination))
+    backup_error = None
     try:
         src_conn.backup(dst_conn)
-    except sqlite3.Error:
-        destination.unlink(missing_ok=True)
-        raise
+    except sqlite3.Error as exc:
+        backup_error = exc
     finally:
         dst_conn.close()
         src_conn.close()
+    if backup_error is not None:
+        destination.unlink(missing_ok=True)
+        raise backup_error
 
     verify_conn = sqlite3.connect(str(destination))
+    verify_error = None
     try:
         row = verify_conn.execute("PRAGMA quick_check").fetchone()
         status = row[0] if row else "no quick_check result"
         if str(status).lower() != "ok":
             raise sqlite3.DatabaseError(f"backup quick_check returned {status!r}")
-    except sqlite3.Error:
-        destination.unlink(missing_ok=True)
-        raise
+    except sqlite3.Error as exc:
+        verify_error = exc
     finally:
         verify_conn.close()
+    if verify_error is not None:
+        destination.unlink(missing_ok=True)
+        raise verify_error
     return destination
 
 
@@ -142,9 +148,26 @@ def _print_database_recovery_hint(db_path: str, error: str) -> None:
     )
 
 
+def _print_database_retry_hint(db_path: str, error: str) -> None:
+    print(f"  [migrate] Database check failed for {db_path}: {error}", file=sys.stderr)
+    print(
+        "  [migrate] Recovery hint: database appears locked or busy; stop active session-knowledge "
+        "writers such as watch/sync processes, then retry the migration.",
+        file=sys.stderr,
+    )
+
+
 def _validate_database_or_exit(db: sqlite3.Connection, db_path: str) -> None:
     try:
         row = db.execute("PRAGMA integrity_check").fetchone()
+    except sqlite3.OperationalError as exc:
+        db.close()
+        message = str(exc).lower()
+        if "locked" in message or "busy" in message:
+            _print_database_retry_hint(db_path, str(exc))
+        else:
+            _print_database_recovery_hint(db_path, str(exc))
+        raise SystemExit(1) from None
     except sqlite3.DatabaseError as exc:
         db.close()
         _print_database_recovery_hint(db_path, str(exc))
@@ -1235,7 +1258,6 @@ if __name__ == "__main__":
         ),
     ]
     applied = 0
-    failed_migrations = []
     for ver, name, stmts in MIGRATIONS:
         if ver <= current:
             continue
@@ -1253,16 +1275,15 @@ if __name__ == "__main__":
             applied += 1
             print(f"  [migrate] v{ver}: {name}")
         except Exception as e:
-            failed_migrations.append((ver, name, str(e)))
+            db.rollback()
             print(f"  [migrate] v{ver} {name}: {e}", file=sys.stderr)
-    if failed_migrations:
-        print(
-            "  [migrate] Recovery hint: restore a backup or fix the schema error before retrying. "
-            "Run `python migrate.py DB_PATH --backup-only --backup-path BACKUP_PATH` before manual repair.",
-            file=sys.stderr,
-        )
-        db.close()
-        raise SystemExit(1)
+            print(
+                "  [migrate] Recovery hint: restore a backup or fix the schema error before retrying. "
+                "Run `python migrate.py DB_PATH --backup-only --backup-path BACKUP_PATH` before manual repair.",
+                file=sys.stderr,
+            )
+            db.close()
+            raise SystemExit(1) from None
     try:
         repaired_priority, renamed_priority = _repair_legacy_priority_collision(db)
         if repaired_priority:

--- a/migrate.py
+++ b/migrate.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """Versioned DB migration for session-knowledge tools."""
 
+import ast
+from datetime import datetime, timezone
 import hashlib
 import os
+from pathlib import Path
 import re
 import sqlite3
 import sys
@@ -11,6 +14,145 @@ if os.name == "nt":
     for _s in (sys.stdout, sys.stderr):
         if hasattr(_s, "reconfigure"):
             _s.reconfigure(encoding="utf-8", errors="replace")
+
+
+def _default_db_path() -> str:
+    return os.environ.get("SK_DB_PATH") or os.path.expanduser("~/.copilot/session-state/knowledge.db")
+
+
+def _latest_declared_migration_version() -> int | None:
+    """Read the local migration literal for help text without executing migrations."""
+    try:
+        tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(isinstance(target, ast.Name) and target.id == "MIGRATIONS" for target in node.targets):
+                continue
+            migrations = ast.literal_eval(node.value)
+            versions = [int(item[0]) for item in migrations]
+            return max(versions) if versions else None
+    except (OSError, SyntaxError, ValueError, TypeError):
+        return None
+    return None
+
+
+def _usage() -> str:
+    latest = _latest_declared_migration_version()
+    latest_line = f"Latest declared migration: v{latest}" if latest is not None else "Latest declared migration: unknown"
+    return "\n".join(
+        [
+            "Usage: python migrate.py [DB_PATH] [--backup-only] [--backup-path PATH]",
+            "",
+            "Run schema migrations for the session-knowledge SQLite database.",
+            "If DB_PATH is omitted, SK_DB_PATH or ~/.copilot/session-state/knowledge.db is used.",
+            "",
+            "Options:",
+            "  --backup-only       Copy DB_PATH to a rollback backup and exit without migrating.",
+            "  --backup-path PATH  Destination path for --backup-only; fails if PATH exists.",
+            "  -h, --help          Show this help and exit without touching the database.",
+            "",
+            latest_line,
+        ]
+    )
+
+
+def _parse_cli_args(argv: list[str]) -> tuple[str, bool, str | None]:
+    db_path = None
+    backup_only = False
+    backup_path = None
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg in {"-h", "--help"}:
+            print(_usage())
+            raise SystemExit(0)
+        if arg == "--backup-only":
+            backup_only = True
+        elif arg == "--backup-path":
+            index += 1
+            if index >= len(argv):
+                print("  [migrate] --backup-path requires a destination path", file=sys.stderr)
+                raise SystemExit(2)
+            backup_path = argv[index]
+        elif arg.startswith("-"):
+            print(f"  [migrate] Unknown option: {arg}", file=sys.stderr)
+            print(_usage(), file=sys.stderr)
+            raise SystemExit(2)
+        elif db_path is None:
+            db_path = arg
+        else:
+            print(f"  [migrate] Unexpected extra argument: {arg}", file=sys.stderr)
+            print(_usage(), file=sys.stderr)
+            raise SystemExit(2)
+        index += 1
+
+    if backup_path and not backup_only:
+        print("  [migrate] --backup-path can only be used with --backup-only", file=sys.stderr)
+        raise SystemExit(2)
+    return db_path or _default_db_path(), backup_only, backup_path
+
+
+def _create_backup_copy(db_path: str, backup_path: str | None = None) -> Path:
+    source = Path(db_path).expanduser()
+    if not source.is_file():
+        raise FileNotFoundError(f"database does not exist: {source}")
+    if backup_path:
+        destination = Path(backup_path).expanduser()
+    else:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        destination = source.with_name(f"{source.name}.backup-{stamp}")
+    if destination.exists():
+        raise FileExistsError(f"backup destination already exists: {destination}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    src_conn = sqlite3.connect(str(source))
+    dst_conn = sqlite3.connect(str(destination))
+    try:
+        src_conn.backup(dst_conn)
+    except sqlite3.Error:
+        destination.unlink(missing_ok=True)
+        raise
+    finally:
+        dst_conn.close()
+        src_conn.close()
+
+    verify_conn = sqlite3.connect(str(destination))
+    try:
+        row = verify_conn.execute("PRAGMA quick_check").fetchone()
+        status = row[0] if row else "no quick_check result"
+        if str(status).lower() != "ok":
+            raise sqlite3.DatabaseError(f"backup quick_check returned {status!r}")
+    except sqlite3.Error:
+        destination.unlink(missing_ok=True)
+        raise
+    finally:
+        verify_conn.close()
+    return destination
+
+
+def _print_database_recovery_hint(db_path: str, error: str) -> None:
+    print(f"  [migrate] Database check failed for {db_path}: {error}", file=sys.stderr)
+    print(
+        "  [migrate] Recovery hint: restore a known-good backup, or move the database aside "
+        "and rerun migration to bootstrap a fresh schema. See "
+        "docs/RESILIENCE-RUNBOOK.md#5-database-schema-backup-and-rollback.",
+        file=sys.stderr,
+    )
+
+
+def _validate_database_or_exit(db: sqlite3.Connection, db_path: str) -> None:
+    try:
+        row = db.execute("PRAGMA integrity_check").fetchone()
+    except sqlite3.DatabaseError as exc:
+        db.close()
+        _print_database_recovery_hint(db_path, str(exc))
+        raise SystemExit(1) from None
+
+    status = row[0] if row else "no integrity_check result"
+    if str(status).lower() != "ok":
+        db.close()
+        _print_database_recovery_hint(db_path, f"integrity_check returned {status!r}")
+        raise SystemExit(1)
 
 
 def _normalize_title(title: str) -> str:
@@ -587,9 +729,22 @@ def _ensure_base_schema(db: sqlite3.Connection):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        sys.argv.append(os.environ.get("SK_DB_PATH") or os.path.expanduser("~/.copilot/session-state/knowledge.db"))
-    db = sqlite3.connect(sys.argv[1])
+    db_path, backup_only, backup_path = _parse_cli_args(sys.argv[1:])
+    if backup_only:
+        try:
+            created = _create_backup_copy(db_path, backup_path)
+        except (FileNotFoundError, FileExistsError, OSError, sqlite3.Error) as exc:
+            print(f"  [migrate] Backup failed: {exc}", file=sys.stderr)
+            raise SystemExit(1) from None
+        print(f"  [migrate] Backup created: {created}")
+        raise SystemExit(0)
+
+    try:
+        db = sqlite3.connect(db_path)
+    except sqlite3.Error as exc:
+        _print_database_recovery_hint(db_path, str(exc))
+        raise SystemExit(1) from None
+    _validate_database_or_exit(db, db_path)
     _ensure_base_schema(db)
     try:
         db.execute("ALTER TABLE schema_version ADD COLUMN name TEXT DEFAULT ''")
@@ -1078,6 +1233,7 @@ if __name__ == "__main__":
         ),
     ]
     applied = 0
+    failed_migrations = []
     for ver, name, stmts in MIGRATIONS:
         if ver <= current:
             continue
@@ -1095,7 +1251,16 @@ if __name__ == "__main__":
             applied += 1
             print(f"  [migrate] v{ver}: {name}")
         except Exception as e:
+            failed_migrations.append((ver, name, str(e)))
             print(f"  [migrate] v{ver} {name}: {e}", file=sys.stderr)
+    if failed_migrations:
+        print(
+            "  [migrate] Recovery hint: restore a backup or fix the schema error before retrying. "
+            "Run `python migrate.py DB_PATH --backup-only --backup-path BACKUP_PATH` before manual repair.",
+            file=sys.stderr,
+        )
+        db.close()
+        raise SystemExit(1)
     try:
         repaired_priority, renamed_priority = _repair_legacy_priority_collision(db)
         if repaired_priority:

--- a/migrate.py
+++ b/migrate.py
@@ -1091,6 +1091,8 @@ if __name__ == "__main__":
             15,
             "confidence_backfill_wave3",
             [
+                "ALTER TABLE knowledge_entries ADD COLUMN confidence REAL DEFAULT 1.0",
+                "ALTER TABLE knowledge_entries ADD COLUMN occurrence_count INTEGER DEFAULT 1",
                 # Raise confidence floor for extracted patterns to 0.5
                 "UPDATE knowledge_entries SET confidence = MAX(confidence, 0.5) WHERE category = 'pattern' AND confidence < 0.5",
                 # Recurrence reward: bump entries seen 2+ times (capped to avoid runaway)

--- a/migrate.py
+++ b/migrate.py
@@ -2,13 +2,13 @@
 """Versioned DB migration for session-knowledge tools."""
 
 import ast
-from datetime import datetime, timezone
 import hashlib
 import os
-from pathlib import Path
 import re
 import sqlite3
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
 
 if os.name == "nt":
     for _s in (sys.stdout, sys.stderr):

--- a/migrate.py
+++ b/migrate.py
@@ -39,7 +39,9 @@ def _latest_declared_migration_version() -> int | None:
 
 def _usage() -> str:
     latest = _latest_declared_migration_version()
-    latest_line = f"Latest declared migration: v{latest}" if latest is not None else "Latest declared migration: unknown"
+    latest_line = (
+        f"Latest declared migration: v{latest}" if latest is not None else "Latest declared migration: unknown"
+    )
     return "\n".join(
         [
             "Usage: python migrate.py [DB_PATH] [--backup-only] [--backup-path PATH]",

--- a/tests/test_migration_rehearsal.py
+++ b/tests/test_migration_rehearsal.py
@@ -230,12 +230,9 @@ class MigrationRehearsalTests(unittest.TestCase):
                     migrated_at TEXT DEFAULT (datetime('now')),
                     name TEXT DEFAULT ''
                 );
-                INSERT INTO schema_version(version, name) VALUES (14, 'benchmark_snapshots');
-                CREATE TABLE knowledge_entries (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    session_id TEXT NOT NULL,
-                    category TEXT NOT NULL,
-                    title TEXT NOT NULL
+                INSERT INTO schema_version(version, name) VALUES (16, 'error_lifecycle_columns');
+                CREATE TABLE briefing_deliveries (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT
                 );
                 """
             )
@@ -249,7 +246,7 @@ class MigrationRehearsalTests(unittest.TestCase):
         self.assertNotIn("Traceback", combined)
         self.assertEqual(
             _db_scalar(db_path, "SELECT MAX(version) FROM schema_version"),
-            14,
+            16,
         )
 
 

--- a/tests/test_migration_rehearsal.py
+++ b/tests/test_migration_rehearsal.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Hermetic database migration rehearsal tests.
+
+Run: python3 tests/test_migration_rehearsal.py
+"""
+
+import ast
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).resolve().parent.parent
+MIGRATE = REPO / "migrate.py"
+
+
+def _declared_migrations() -> list[tuple[int, str, list[str]]]:
+    tree = ast.parse(MIGRATE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(target, ast.Name) and target.id == "MIGRATIONS" for target in node.targets):
+            return ast.literal_eval(node.value)
+    raise AssertionError("MIGRATIONS literal not found in migrate.py")
+
+
+def _latest_version() -> int:
+    versions = [version for version, _name, _statements in _declared_migrations()]
+    if not versions:
+        raise AssertionError("No declared migrations found")
+    return max(versions)
+
+
+def _run_migrate(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(
+        [sys.executable, str(MIGRATE), *args],
+        cwd=str(cwd or REPO),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def _db_scalar(db_path: Path, sql: str, params: tuple = ()):
+    with sqlite3.connect(db_path) as db:
+        return db.execute(sql, params).fetchone()[0]
+
+
+class MigrationRehearsalTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="migration-rehearsal-"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_help_is_side_effect_free_and_reports_latest_version(self):
+        result = _run_migrate("--help", cwd=self.tmpdir)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Usage: python migrate.py", result.stdout)
+        self.assertIn("--backup-only", result.stdout)
+        self.assertIn(f"Latest declared migration: v{_latest_version()}", result.stdout)
+        self.assertFalse((self.tmpdir / "--help").exists())
+
+    def test_v0_database_migrates_to_current_schema(self):
+        db_path = self.tmpdir / "knowledge.db"
+
+        result = _run_migrate(str(db_path))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Applied", result.stdout)
+        self.assertEqual(
+            _db_scalar(db_path, "SELECT MAX(version) FROM schema_version"),
+            _latest_version(),
+        )
+        self.assertEqual(
+            _db_scalar(db_path, "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='improvement_signals'"),
+            1,
+        )
+
+    def test_second_migration_run_is_idempotent(self):
+        db_path = self.tmpdir / "knowledge.db"
+        first = _run_migrate(str(db_path))
+        self.assertEqual(first.returncode, 0, first.stderr)
+
+        second = _run_migrate(str(db_path))
+
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertIn(f"Schema up to date (v{_latest_version()})", second.stdout)
+        self.assertEqual(
+            _db_scalar(db_path, "SELECT MAX(version) FROM schema_version"),
+            _latest_version(),
+        )
+
+    def test_n_minus_two_rehearsal_preserves_sentinel_data(self):
+        db_path = self.tmpdir / "knowledge.db"
+        initial = _run_migrate(str(db_path))
+        self.assertEqual(initial.returncode, 0, initial.stderr)
+
+        n_minus_two = _latest_version() - 2
+        with sqlite3.connect(db_path) as db:
+            db.execute(
+                """
+                INSERT INTO knowledge_entries(session_id, category, title, content, tags)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                ("n-2", "pattern", "sentinel migration row", "preserve me", "migration"),
+            )
+            db.execute("DELETE FROM schema_version WHERE version > ?", (n_minus_two,))
+            db.execute("DROP TABLE IF EXISTS file_annotations")
+            db.execute("DROP TABLE IF EXISTS improvement_signals")
+
+        result = _run_migrate(str(db_path))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            _db_scalar(db_path, "SELECT MAX(version) FROM schema_version"),
+            _latest_version(),
+        )
+        self.assertEqual(
+            _db_scalar(db_path, "SELECT content FROM knowledge_entries WHERE title = ?", ("sentinel migration row",)),
+            "preserve me",
+        )
+        self.assertEqual(
+            _db_scalar(db_path, "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='file_annotations'"),
+            1,
+        )
+        self.assertEqual(
+            _db_scalar(db_path, "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='improvement_signals'"),
+            1,
+        )
+
+    def test_backup_only_uses_online_backup_for_wal_database(self):
+        db_path = self.tmpdir / "knowledge.db"
+        backup_path = self.tmpdir / "knowledge.backup.db"
+        initial = _run_migrate(str(db_path))
+        self.assertEqual(initial.returncode, 0, initial.stderr)
+
+        live = sqlite3.connect(db_path)
+        try:
+            live.execute("PRAGMA journal_mode=WAL")
+            live.execute(
+                """
+                INSERT INTO knowledge_entries(session_id, category, title, content, tags)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                ("backup", "decision", "wal backup sentinel", "copy me from wal", "migration"),
+            )
+            live.commit()
+
+            result = _run_migrate(str(db_path), "--backup-only", "--backup-path", str(backup_path))
+        finally:
+            live.close()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Backup created", result.stdout)
+        self.assertTrue(backup_path.is_file())
+        self.assertEqual(
+            _db_scalar(backup_path, "SELECT MAX(version) FROM schema_version"),
+            _latest_version(),
+        )
+        self.assertEqual(
+            _db_scalar(backup_path, "SELECT content FROM knowledge_entries WHERE title = ?", ("wal backup sentinel",)),
+            "copy me from wal",
+        )
+        self.assertEqual(_db_scalar(backup_path, "PRAGMA quick_check"), "ok")
+
+    def test_corrupt_database_failure_has_recovery_hint_not_traceback(self):
+        db_path = self.tmpdir / "corrupt.db"
+        db_path.write_bytes(b"not a sqlite database")
+
+        result = _run_migrate(str(db_path))
+
+        self.assertNotEqual(result.returncode, 0)
+        combined = result.stdout + result.stderr
+        self.assertIn("Recovery hint", combined)
+        self.assertIn("restore", combined.lower())
+        self.assertNotIn("Traceback", combined)
+
+    def test_schema_failure_has_recovery_hint_not_success_shape(self):
+        db_path = self.tmpdir / "bad-schema.db"
+        with sqlite3.connect(db_path) as db:
+            db.executescript(
+                """
+                CREATE TABLE schema_version (
+                    version INTEGER PRIMARY KEY,
+                    migrated_at TEXT DEFAULT (datetime('now')),
+                    name TEXT DEFAULT ''
+                );
+                INSERT INTO schema_version(version, name) VALUES (14, 'benchmark_snapshots');
+                CREATE TABLE knowledge_entries (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    category TEXT NOT NULL,
+                    title TEXT NOT NULL
+                );
+                """
+            )
+
+        result = _run_migrate(str(db_path))
+
+        self.assertNotEqual(result.returncode, 0)
+        combined = result.stdout + result.stderr
+        self.assertIn("Recovery hint", combined)
+        self.assertNotIn("Schema up to date", combined)
+        self.assertNotIn("Traceback", combined)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_migration_rehearsal.py
+++ b/tests/test_migration_rehearsal.py
@@ -6,6 +6,7 @@ Run: python3 tests/test_migration_rehearsal.py
 
 import ast
 import os
+import re
 import shutil
 import sqlite3
 import subprocess
@@ -21,6 +22,10 @@ if os.name == "nt":
 
 REPO = Path(__file__).resolve().parent.parent
 MIGRATE = REPO / "migrate.py"
+CREATE_TABLE_RE = re.compile(
+    r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)",
+    re.IGNORECASE,
+)
 
 
 def _declared_migrations() -> list[tuple[int, str, list[str]]]:
@@ -38,6 +43,18 @@ def _latest_version() -> int:
     if not versions:
         raise AssertionError("No declared migrations found")
     return max(versions)
+
+
+def _tables_created_after(version: int) -> list[str]:
+    tables = []
+    for migration_version, _name, statements in _declared_migrations():
+        if migration_version <= version:
+            continue
+        for statement in statements:
+            match = CREATE_TABLE_RE.search(statement)
+            if match and match.group(1) not in tables:
+                tables.append(match.group(1))
+    return tables
 
 
 def _run_migrate(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
@@ -111,6 +128,8 @@ class MigrationRehearsalTests(unittest.TestCase):
         self.assertEqual(initial.returncode, 0, initial.stderr)
 
         n_minus_two = _latest_version() - 2
+        future_tables = _tables_created_after(n_minus_two)
+        self.assertGreater(len(future_tables), 0)
         with sqlite3.connect(db_path) as db:
             db.execute(
                 """
@@ -120,8 +139,8 @@ class MigrationRehearsalTests(unittest.TestCase):
                 ("n-2", "pattern", "sentinel migration row", "preserve me", "migration"),
             )
             db.execute("DELETE FROM schema_version WHERE version > ?", (n_minus_two,))
-            db.execute("DROP TABLE IF EXISTS file_annotations")
-            db.execute("DROP TABLE IF EXISTS improvement_signals")
+            for table in future_tables:
+                db.execute(f"DROP TABLE IF EXISTS {table}")
 
         result = _run_migrate(str(db_path))
 
@@ -134,14 +153,12 @@ class MigrationRehearsalTests(unittest.TestCase):
             _db_scalar(db_path, "SELECT content FROM knowledge_entries WHERE title = ?", ("sentinel migration row",)),
             "preserve me",
         )
-        self.assertEqual(
-            _db_scalar(db_path, "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='file_annotations'"),
-            1,
-        )
-        self.assertEqual(
-            _db_scalar(db_path, "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='improvement_signals'"),
-            1,
-        )
+        for table in future_tables:
+            self.assertEqual(
+                _db_scalar(db_path, "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?", (table,)),
+                1,
+                table,
+            )
 
     def test_backup_only_uses_online_backup_for_wal_database(self):
         db_path = self.tmpdir / "knowledge.db"
@@ -190,6 +207,19 @@ class MigrationRehearsalTests(unittest.TestCase):
         self.assertIn("restore", combined.lower())
         self.assertNotIn("Traceback", combined)
 
+    def test_backup_only_failure_removes_requested_destination(self):
+        db_path = self.tmpdir / "corrupt.db"
+        backup_path = self.tmpdir / "corrupt.backup.db"
+        db_path.write_bytes(b"not a sqlite database")
+
+        result = _run_migrate(str(db_path), "--backup-only", "--backup-path", str(backup_path))
+
+        self.assertNotEqual(result.returncode, 0)
+        combined = result.stdout + result.stderr
+        self.assertIn("Backup failed", combined)
+        self.assertFalse(backup_path.exists())
+        self.assertNotIn("Traceback", combined)
+
     def test_schema_failure_has_recovery_hint_not_success_shape(self):
         db_path = self.tmpdir / "bad-schema.db"
         with sqlite3.connect(db_path) as db:
@@ -217,6 +247,10 @@ class MigrationRehearsalTests(unittest.TestCase):
         self.assertIn("Recovery hint", combined)
         self.assertNotIn("Schema up to date", combined)
         self.assertNotIn("Traceback", combined)
+        self.assertEqual(
+            _db_scalar(db_path, "SELECT MAX(version) FROM schema_version"),
+            14,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add hermetic migration rehearsal coverage for v0 -> current, idempotent reruns, N-2 upgrades preserving sentinel data, backup-only, corrupt DB, broken schema failures, and legacy backfill inputs.
- Add `migrate.py --help`, `--backup-only`, and `--backup-path`; backup-only uses SQLite online backup and verifies the backup with `PRAGMA quick_check`.
- Surface actionable recovery hints instead of raw tracebacks for corrupt databases and migration schema failures, while locked/busy databases get a retry/stop-writers hint.
- Document database schema backup and rollback commands, including WAL sidecar handling, in the resilience runbook.

## Verification
- `ruff format migrate.py tests\test_migration_rehearsal.py`
- `ruff check migrate.py tests\test_migration_rehearsal.py`
- `python -m py_compile migrate.py tests\test_migration_rehearsal.py`
- `python tests\test_migration_rehearsal.py` — 8 tests passed
- `PYTHONIOENCODING=utf-8 python tests\test_hooks.py` — 860 tests passed
- `python test_security.py` — 12 tests passed
- `python test_fixes.py` — 221 tests passed
- `git diff --check`
- GitHub Actions: `quality-gates`, `browse-ui`, `remote-terminal`, and `e2e-smoke` succeeded; `pairing-e2e` and `e2e-visual` skipped by workflow rules.

Closes #282