### PR TITLE
test(hooks): add hook security regressions

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -547,6 +547,22 @@ redirected audit writes away from operator state.
 Do **not** rely on `HOOK_DRY_RUN=1` alone for isolation: dry-run suppresses `deny` output but
 still writes `deny-dry` and `parse-error` entries to the audit log.
 
+## Fail-open Regression Evidence
+
+The hook runner is intentionally fail-open: malformed input, optional helper absence, telemetry
+contention, or individual rule crashes must not break the agent loop. The dedicated regression
+suite below keeps those guarantees executable.
+
+| Risk | Expected behavior | Evidence test |
+|------|-------------------|---------------|
+| Malformed JSON hook payload | `hook_runner.py` exits 0 and records a `parse-error` audit entry under isolated `HOME` | `tests/test_hook_security.py::test_malformed_json_logs_parse_error` |
+| Oversized hook payload | Payload parsing completes within the subprocess timeout and exits 0 | `tests/test_hook_security.py::test_oversized_payload_completes_within_timeout` |
+| Missing optional hook script | `sessionStart` skips absent `briefing.py` without traceback or denial | `tests/test_hook_security.py::test_missing_optional_briefing_script_fail_open` |
+| Hook crash isolation | A rule exception is caught, audited as `error`, and does not propagate out of the runner | `tests/test_hook_security.py::test_rule_crash_isolation_records_error` |
+| Concurrent hook invocations | Concurrent telemetry writes do not surface `SQLITE_LOCKED`, `database is locked`, or tracebacks | `tests/test_hook_security.py::test_concurrent_skill_usage_hooks_do_not_surface_sqlite_locked` |
+| Path traversal-like payload | Session-derived marker names are sanitized and stay under `~/.copilot/markers` | `tests/test_hook_security.py::test_path_traversal_session_id_stays_inside_markers_dir` |
+| FTS operator input | FTS operators are stripped before `MATCH ?` use in `query-session.py` | `tests/test_hook_security.py::test_fts_operator_input_is_sanitized_before_match_use` |
+
 ## `hooks.json` Schema Notes
 
 ### `comment` field

--- a/tests/test_hook_security.py
+++ b/tests/test_hook_security.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Security and edge-case regression tests for Copilot hook execution.
+
+Run:
+    python tests/test_hook_security.py
+"""
+
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+import types
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+PASS = 0
+FAIL = 0
+REPO = Path(__file__).parent.parent
+RUNNER = REPO / "hooks" / "hook_runner.py"
+QUERY_SESSION = REPO / "query-session.py"
+
+
+def test(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        FAIL += 1
+        print(f"  FAIL  {name}" + (f" - {detail}" if detail else ""))
+
+
+def _isolated_home(prefix: str) -> Path:
+    home = Path(tempfile.mkdtemp(prefix=prefix))
+    (home / ".copilot" / "markers").mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def _env_for_home(home: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "USERPROFILE": str(home),
+        "PYTHONIOENCODING": "utf-8",
+    }
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _run_hook(
+    event: str,
+    payload,
+    *,
+    home: Path,
+    extra_env: dict[str, str] | None = None,
+    timeout: int = 10,
+) -> subprocess.CompletedProcess:
+    input_text = payload if isinstance(payload, str) else json.dumps(payload)
+    return subprocess.run(
+        [sys.executable, str(RUNNER), event],
+        input=input_text,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=str(REPO),
+        env=_env_for_home(home, extra_env),
+        timeout=timeout,
+    )
+
+
+def _read_audit(home: Path) -> list[dict]:
+    audit = home / ".copilot" / "markers" / "audit.jsonl"
+    entries = []
+    if not audit.is_file():
+        return entries
+    for line in audit.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            pass
+    return entries
+
+
+print("\n-- Hook payload fail-open behavior -----------------------------------")
+
+
+def test_malformed_json_logs_parse_error() -> None:
+    home = _isolated_home("hook-security-malformed-")
+    try:
+        result = _run_hook("preToolUse", "{not valid json", home=home)
+        decisions = [entry.get("decision") for entry in _read_audit(home)]
+        test(
+            "malformed JSON exits 0",
+            result.returncode == 0,
+            f"returncode={result.returncode}, stderr={result.stderr[:200]}",
+        )
+        test(
+            "malformed JSON records parse-error audit entry",
+            "parse-error" in decisions,
+            f"decisions={decisions}",
+        )
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+def test_oversized_payload_completes_within_timeout() -> None:
+    home = _isolated_home("hook-security-oversized-")
+    try:
+        payload = {
+            "toolName": "view",
+            "toolArgs": {"path": str(REPO / "README.md"), "blob": "A" * 1_000_000},
+            "sessionId": "oversized-payload",
+        }
+        start = time.monotonic()
+        try:
+            result = _run_hook("preToolUse", payload, home=home, timeout=8)
+        except subprocess.TimeoutExpired as exc:
+            test("oversized hook payload exits 0", False, f"timed out after {exc.timeout}s")
+            test("oversized hook payload stays within bounded timeout", False, f"timed out after {exc.timeout}s")
+            return
+        elapsed = time.monotonic() - start
+        test(
+            "oversized hook payload exits 0",
+            result.returncode == 0,
+            f"returncode={result.returncode}, stderr={result.stderr[:200]}",
+        )
+        test(
+            "oversized hook payload stays within bounded timeout",
+            elapsed < 8,
+            f"elapsed={elapsed:.2f}s",
+        )
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+def test_missing_optional_briefing_script_fail_open() -> None:
+    home = _isolated_home("hook-security-missing-script-")
+    tools_dir = home / "empty-tools"
+    tools_dir.mkdir()
+    try:
+        result = _run_hook(
+            "sessionStart",
+            {},
+            home=home,
+            extra_env={"SK_TOOLS_DIR": str(tools_dir)},
+        )
+        combined = result.stdout + result.stderr
+        test(
+            "missing optional briefing.py does not break sessionStart",
+            result.returncode == 0 and "Traceback" not in combined,
+            f"returncode={result.returncode}, output={combined[:300]}",
+        )
+        test(
+            "missing optional briefing.py does not emit briefing output",
+            "Session briefing" not in combined,
+            f"output={combined[:300]}",
+        )
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+def test_rule_crash_isolation_records_error() -> None:
+    loader = importlib.machinery.SourceFileLoader("hook_runner_for_security", str(RUNNER))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    hook_runner = importlib.util.module_from_spec(spec)
+    loader.exec_module(hook_runner)
+
+    class ExplodingRule:
+        name = "exploding-rule"
+        tools = []
+
+        def evaluate(self, event, data):
+            raise RuntimeError("intentional regression-test crash")
+
+    fake_rules = types.ModuleType("rules")
+    fake_rules.get_rules_for_event = lambda event: [ExplodingRule()]
+
+    home = _isolated_home("hook-security-crash-")
+    markers = home / ".copilot" / "markers"
+    old_rules = sys.modules.get("rules")
+    old_argv = sys.argv
+    old_stdin = sys.stdin
+    old_stdout = sys.stdout
+    old_markers = hook_runner.MARKERS_DIR
+    condition = False
+    detail = ""
+    try:
+        sys.modules["rules"] = fake_rules
+        sys.argv = ["hook_runner.py", "preToolUse"]
+        sys.stdin = io.StringIO(json.dumps({"toolName": "view"}))
+        captured = io.StringIO()
+        sys.stdout = captured
+        hook_runner.MARKERS_DIR = markers
+        hook_runner.main()
+        decisions = [entry.get("decision") for entry in _read_audit(home)]
+        condition = "error" in decisions
+        detail = f"decisions={decisions}, stdout={captured.getvalue()[:200]}"
+    except Exception as exc:
+        detail = repr(exc)
+    finally:
+        if old_rules is None:
+            sys.modules.pop("rules", None)
+        else:
+            sys.modules["rules"] = old_rules
+        sys.argv = old_argv
+        sys.stdin = old_stdin
+        sys.stdout = old_stdout
+        hook_runner.MARKERS_DIR = old_markers
+        shutil.rmtree(home, ignore_errors=True)
+    test("rule exception is isolated by hook_runner", condition, detail)
+
+
+test_malformed_json_logs_parse_error()
+test_oversized_payload_completes_within_timeout()
+test_missing_optional_briefing_script_fail_open()
+test_rule_crash_isolation_records_error()
+
+
+print("\n-- Hook state isolation and injection resistance ----------------------")
+
+
+def test_concurrent_skill_usage_hooks_do_not_surface_sqlite_locked() -> None:
+    home = _isolated_home("hook-security-concurrent-")
+    try:
+        payload = {
+            "toolName": "skill",
+            "toolArgs": {"skill": "hook-security-regression"},
+            "toolResult": {"exitCode": 0, "output": "loaded"},
+            "sessionId": "concurrent-skill-usage",
+        }
+
+        def run_once(index: int) -> subprocess.CompletedProcess:
+            return _run_hook(
+                "postToolUse",
+                {**payload, "nonce": index},
+                home=home,
+                timeout=15,
+            )
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(run_once, range(8)))
+
+        combined = "\n".join(result.stdout + result.stderr for result in results)
+        all_zero = all(result.returncode == 0 for result in results)
+        locked_surface = "SQLITE_LOCKED" in combined or "database is locked" in combined or "Traceback" in combined
+        metrics_db = home / ".copilot" / "session-state" / "skill-metrics.db"
+        row_count = 0
+        if metrics_db.is_file():
+            db = sqlite3.connect(str(metrics_db))
+            try:
+                row_count = db.execute("SELECT COUNT(*) FROM skill_usage_events").fetchone()[0]
+            finally:
+                db.close()
+        test(
+            "concurrent hook invocations exit 0",
+            all_zero,
+            f"returncodes={[r.returncode for r in results]}",
+        )
+        test(
+            "concurrent hook invocations do not surface SQLITE_LOCKED",
+            not locked_surface,
+            combined[:500],
+        )
+        test(
+            "concurrent skill usage writes at least one telemetry row",
+            row_count > 0,
+            f"row_count={row_count}",
+        )
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+def test_path_traversal_session_id_stays_inside_markers_dir() -> None:
+    base = Path(tempfile.mkdtemp(prefix="hook-security-path-base-"))
+    home = base / "home"
+    (home / ".copilot" / "markers").mkdir(parents=True, exist_ok=True)
+    sample = home / "sample.txt"
+    sample.write_text("sample", encoding="utf-8")
+    try:
+        payload = {
+            "toolName": "view",
+            "toolArgs": {"path": str(sample)},
+            "sessionId": "..\\..//escape/../../owned",
+        }
+        result = _run_hook("postToolUse", payload, home=home, timeout=10)
+        markers = (home / ".copilot" / "markers").resolve()
+        marker_paths = list(markers.rglob("*"))
+        unsafe_names = [p.name for p in marker_paths if ".." in p.name or "/" in p.name or "\\" in p.name]
+        unexpected_siblings = [p for p in base.iterdir() if p != home]
+        expected_dirs = {(home / ".copilot").resolve(), markers}
+        expected_files = {sample.resolve()}
+        unexpected_home_paths = [
+            p
+            for p in home.rglob("*")
+            if p.resolve() not in expected_dirs
+            and p.resolve() not in expected_files
+            and not p.resolve().is_relative_to(markers)
+        ]
+        test(
+            "path traversal-like sessionId hook exits 0",
+            result.returncode == 0,
+            f"returncode={result.returncode}, stderr={result.stderr[:200]}",
+        )
+        test(
+            "sessionId-derived marker names are sanitized",
+            not unsafe_names,
+            f"unsafe_names={unsafe_names}",
+        )
+        test(
+            "sessionId payload does not create files outside markers dir",
+            not unexpected_siblings and not unexpected_home_paths,
+            f"unexpected_siblings={unexpected_siblings}, unexpected_home_paths={unexpected_home_paths}",
+        )
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+def test_fts_operator_input_is_sanitized_before_match_use() -> None:
+    loader = importlib.machinery.SourceFileLoader("query_session_for_hook_security", str(QUERY_SESSION))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+
+    sanitized = module._sanitize_fts_query('alpha OR beta AND gamma NOT delta NEAR "quoted"*')
+    stripped_terms = sanitized.replace('"alpha"*', "").replace('"beta"*', "").replace('"gamma"*', "")
+    stripped_terms = stripped_terms.replace('"delta"*', "").replace('"quoted"*', "")
+    source = QUERY_SESSION.read_text(encoding="utf-8")
+    test(
+        "FTS operators are stripped from sanitized query",
+        all(op not in stripped_terms for op in ("OR", "AND", "NOT", "NEAR", "*")),
+        f"sanitized={sanitized}",
+    )
+    test(
+        "FTS MATCH clauses use parameterized query values",
+        "MATCH ?" in source and "WHERE knowledge_fts MATCH ?" in source,
+        "query-session.py should keep sanitized FTS input bound through MATCH ? placeholders",
+    )
+
+
+test_concurrent_skill_usage_hooks_do_not_surface_sqlite_locked()
+test_path_traversal_session_id_stays_inside_markers_dir()
+test_fts_operator_input_is_sanitized_before_match_use()
+
+print(f"\n{'=' * 50}")
+print(f"Results: {PASS} passed, {FAIL} failed out of {PASS + FAIL}")
+if FAIL:
+    print(f"{FAIL} hook security regression test(s) need attention")
+    sys.exit(1)
+print("All hook security regression tests passed!")

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -823,6 +823,8 @@ SK_CI_WORKFLOW = REPO / ".github" / "workflows" / "sk-ci.yml"
 HOOKS_MD = REPO / "docs" / "HOOKS.md"
 ARCH_MD = REPO / "docs" / "ARCHITECTURE.md"
 CONTRIBUTING = REPO / "CONTRIBUTING.md"
+HOOKS_JSON = REPO / "hooks" / "hooks.json"
+GITHUB_HOOKS_JSON = REPO / ".github" / "hooks" / "hooks.json"
 PLAYWRIGHT_CONFIG = REPO / "browse-ui" / "playwright.config.ts"
 ESLINT_CONFIG = REPO / "browse-ui" / "eslint.config.mjs"
 REMOTE_TERMINAL_ESLINT_CONFIG = REPO / "remote-terminal" / "eslint.config.mjs"
@@ -1417,6 +1419,135 @@ def test_hooks_md_rules_table_complete():
         )
 
 
+_ALLOWED_HOOK_EVENTS = {
+    "sessionStart",
+    "sessionEnd",
+    "preToolUse",
+    "postToolUse",
+    "agentStop",
+    "subagentStop",
+    "errorOccurred",
+}
+_ALLOWED_HOOK_ENTRY_KEYS = {"type", "bash", "powershell", "cwd", "env", "timeoutSec", "comment"}
+
+
+def _validate_hooks_json_schema(label: str, path: Path):
+    """Validate the repo's managed hooks.json shape without external schema deps."""
+    if not path.exists():
+        test(f"{label} exists", False, str(path))
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        test(f"{label} parses as JSON", False, str(exc))
+        return None
+
+    test(f"{label} root object is a dict", isinstance(payload, dict), f"type={type(payload).__name__}")
+    hooks = payload.get("hooks")
+    test(f"{label} hooks object is a dict", isinstance(hooks, dict), f"type={type(hooks).__name__}")
+    if not isinstance(hooks, dict):
+        return payload
+
+    events = set(hooks)
+    test(
+        f"{label} declares exactly managed hook events",
+        events == _ALLOWED_HOOK_EVENTS,
+        f"events={sorted(events)}",
+    )
+    for event, entries in hooks.items():
+        test(
+            f"{label} event '{event}' is supported",
+            event in _ALLOWED_HOOK_EVENTS,
+            f"unsupported event={event}",
+        )
+        test(
+            f"{label} event '{event}' has non-empty command list",
+            isinstance(entries, list) and bool(entries),
+            f"entries={entries!r}",
+        )
+        if not isinstance(entries, list):
+            continue
+        for index, entry in enumerate(entries):
+            prefix = f"{label} {event}[{index}]"
+            test(f"{prefix} is an object", isinstance(entry, dict), f"type={type(entry).__name__}")
+            if not isinstance(entry, dict):
+                continue
+            unexpected = set(entry) - _ALLOWED_HOOK_ENTRY_KEYS
+            test(f"{prefix} has only allowed keys", not unexpected, f"unexpected={sorted(unexpected)}")
+            test(f"{prefix} type is command", entry.get("type") == "command", f"type={entry.get('type')!r}")
+            bash = entry.get("bash", "")
+            powershell = entry.get("powershell", "")
+            timeout_sec = entry.get("timeoutSec")
+            test(
+                f"{prefix} bash command prefers sk hooks run",
+                isinstance(bash, str) and f"sk hooks run {event}" in bash,
+                f"bash={bash!r}",
+            )
+            test(
+                f"{prefix} powershell command prefers sk hooks run",
+                isinstance(powershell, str) and f"sk hooks run {event}" in powershell,
+                f"powershell={powershell!r}",
+            )
+            test(
+                f"{prefix} bash fallback invokes hook_runner.py",
+                isinstance(bash, str) and "hook_runner.py" in bash and event in bash,
+                f"bash={bash!r}",
+            )
+            test(
+                f"{prefix} powershell fallback invokes hook_runner.py",
+                isinstance(powershell, str) and "hook_runner.py" in powershell and event in powershell,
+                f"powershell={powershell!r}",
+            )
+            test(
+                f"{prefix} timeoutSec is bounded",
+                isinstance(timeout_sec, int) and 1 <= timeout_sec <= 30,
+                f"timeoutSec={timeout_sec!r}",
+            )
+    return payload
+
+
+def test_hooks_json_schema_validation():
+    """hooks.json source copies must keep the managed hook schema in sync."""
+    payloads = []
+    for label, path in [("hooks/hooks.json", HOOKS_JSON), (".github/hooks/hooks.json", GITHUB_HOOKS_JSON)]:
+        payload = _validate_hooks_json_schema(label, path)
+        if payload is not None:
+            payloads.append((label, payload))
+    if len(payloads) == 2:
+        test(
+            "hooks.json source copies are structurally identical",
+            payloads[0][1] == payloads[1][1],
+            f"{payloads[0][0]} and {payloads[1][0]} differ",
+        )
+
+
+def test_hooks_md_fail_open_regression_evidence_table():
+    """HOOKS.md must list the hook-security fail-open regression evidence."""
+    if not HOOKS_MD.exists():
+        test("docs/HOOKS.md exists", False)
+        return
+    content = HOOKS_MD.read_text(encoding="utf-8")
+    test(
+        "HOOKS.md documents fail-open regression evidence table",
+        "Fail-open Regression Evidence" in content and "tests/test_hook_security.py" in content,
+        "docs/HOOKS.md should include a fail-open/security evidence table for issue 283",
+    )
+    for phrase in (
+        "Malformed JSON hook payload",
+        "Oversized hook payload",
+        "Missing optional hook script",
+        "Hook crash isolation",
+        "Concurrent hook invocations",
+        "Path traversal-like payload",
+        "FTS operator input",
+    ):
+        test(
+            f"HOOKS.md evidence table covers {phrase}",
+            phrase in content,
+            f"Missing evidence row for {phrase}",
+        )
+
+
 test_ruff_surface_in_pre_commit()
 test_ci_workflow_ruff_surface()
 test_ci_workflow_ruff_complexity_advisory()
@@ -1430,6 +1561,8 @@ test_hooks_md_documents_local_vs_ci()
 test_contributing_md_local_vs_ci()
 test_architecture_md_ruff_surface()
 test_hooks_md_rules_table_complete()
+test_hooks_json_schema_validation()
+test_hooks_md_fail_open_regression_evidence_table()
 
 # ── Test 21–24: Syntax gate in pre-commit ───────────────────────────────────
 


### PR DESCRIPTION
Closes #283

## Summary
- Added `tests/test_hook_security.py` covering malformed JSON fail-open audit logging, oversized payload bounds, missing optional briefing script behavior, rule crash isolation, concurrent hook telemetry, path traversal-like session IDs, and FTS operator sanitization.
- Added `hooks/hooks.json` and `.github/hooks/hooks.json` schema validation to `tests/test_quality_gates.py`.
- Documented hook fail-open/security evidence in `docs/HOOKS.md`.

## Verification
- `python tests\test_hook_security.py` — 15 passed, 0 failed
- `python tests\test_hook_compat.py` — 238 passed, 0 failed
- `python tests\test_quality_gates.py` — 417 passed, 0 failed
- `python test_security.py` — 12 passed, 0 failed
- `python test_fixes.py` — 221 passed, 0 failed
- `python tests\test_hooks.py` — 860 passed, 0 failed
- `ruff format --check tests\test_hook_security.py tests\test_quality_gates.py` — 2 files already formatted
- `ruff check tests\test_hook_security.py tests\test_quality_gates.py` — All checks passed
- AST parse for modified Python files — passed