### PR TITLE
ci: expand Ruff surface to root scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,41 +42,20 @@ jobs:
       - name: Ruff lint
         run: >
           ruff check
-          embed.py scout-config.py scout-status.py
-          sync-config.py sync-daemon.py sync-status.py
-          migrate.py generate-summary.py
-          briefing.py learn.py query-session.py extract-knowledge.py
-          build-session-index.py tentacle.py _tentacle_core.py _tentacle_goal.py _tentacle_pr.py
-          _tentacle_dispatch.py _tentacle_review.py checkpoint-diff.py
-          checkpoint-restore.py checkpoint-save.py
-          tests/test_browse_search_v2.py
+          *.py
           browse/ hooks/ scripts/
 
       - name: Ruff format check
         run: >
           ruff format --check
-          embed.py scout-config.py scout-status.py
-          sync-config.py sync-daemon.py sync-status.py
-          migrate.py generate-summary.py
-          briefing.py learn.py query-session.py extract-knowledge.py
-          build-session-index.py tentacle.py _tentacle_core.py _tentacle_goal.py _tentacle_pr.py
-          _tentacle_dispatch.py _tentacle_review.py checkpoint-diff.py
-          checkpoint-restore.py checkpoint-save.py
-          tests/test_browse_search_v2.py
+          *.py
           browse/ hooks/ scripts/
 
       - name: Complexity advisory (Ruff C90/PLR)
         continue-on-error: true
         run: >
           ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statistics
-          embed.py scout-config.py scout-status.py
-          sync-config.py sync-daemon.py sync-status.py
-          migrate.py generate-summary.py
-          briefing.py learn.py query-session.py extract-knowledge.py
-          build-session-index.py tentacle.py _tentacle_core.py _tentacle_goal.py _tentacle_pr.py
-          _tentacle_dispatch.py _tentacle_review.py checkpoint-diff.py
-          checkpoint-restore.py checkpoint-save.py
-          tests/test_browse_search_v2.py
+          *.py
           browse/ hooks/ scripts/
 
       - name: Build browse-ui static artifact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,12 +47,14 @@ do not import one root script from another just to share helpers.
 
 Every new Python file needs an explicit lint surface decision:
 
-1. If it belongs to an already covered package-like area (`browse/`, `hooks/`, or
-   `scripts/`), it is already inside the CI and local pre-commit Ruff surface.
-2. If it is a new root standalone script and should be blocking-clean, add it to the
-   Ruff lint and format lists in `.github/workflows/ci.yml`, add it to
-   `hooks/pre-commit`'s exact surface, update `tests/test_quality_gates.py`, and
-   update the canonical table in `docs/ARCHITECTURE.md#python-lint-surface-inventory`.
+1. If it is a root standalone script or belongs to an already covered package-like area
+   (`browse/`, `hooks/`, or `scripts/`), it is already inside the CI and local
+   pre-commit Ruff surface.
+2. If it creates a new package-like Python directory outside that surface, either add
+   the directory to `.github/workflows/ci.yml`, `hooks/pre-commit`,
+   `tests/test_quality_gates.py`, and
+   `docs/ARCHITECTURE.md#python-lint-surface-inventory`, or document why it is
+   intentionally outside CI Ruff coverage.
 3. If it intentionally stays outside the current lint surface, state that in the PR
    with the reason and the verification command you ran instead. When Ruff is
    installed, local `pre-commit` may still print non-blocking `[advisory]` findings
@@ -146,18 +148,11 @@ CI (`quality-gates` job) runs scoped **Ruff lint** on the surface documented in
 Current coverage:
 
 ```
-embed.py  scout-config.py  scout-status.py
-sync-config.py  sync-daemon.py  sync-status.py
-migrate.py  generate-summary.py
-briefing.py  learn.py  query-session.py  extract-knowledge.py
-build-session-index.py  tentacle.py  _tentacle_core.py  _tentacle_goal.py  _tentacle_pr.py
-_tentacle_dispatch.py  _tentacle_review.py
-checkpoint-diff.py  checkpoint-restore.py  checkpoint-save.py
-tests/test_browse_search_v2.py
+*.py
 browse/  hooks/  scripts/
 ```
 
-If you modify any of those files and have Ruff installed locally, run `ruff format <file>` and `ruff check <file>` before committing. CI will catch scoped lint violations; the local `pre-commit` git hook enforces both `ruff format --check` and `ruff check` on the same surface when Ruff is available locally (fail-open — silently skips when Ruff is not installed). Other root scripts outside this surface are not currently linted by CI; local `pre-commit` runs `ruff check` for staged out-of-surface `.py` files only as a non-blocking `[advisory]` scan.
+If you modify any of those files and have Ruff installed locally, run `ruff format <file>` and `ruff check <file>` before committing. CI will catch scoped lint violations; the local `pre-commit` git hook enforces both `ruff format --check` and `ruff check` on the same surface when Ruff is available locally (fail-open — silently skips when Ruff is not installed). Python outside root scripts and the covered directories is not linted by CI; local `pre-commit` runs `ruff check` for staged out-of-surface `.py` files only as a non-blocking `[advisory]` scan.
 
 CI also runs a non-blocking `Complexity advisory (Ruff C90/PLR)` step on the same
 surface with `ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statistics`.

--- a/agent_adapters.py
+++ b/agent_adapters.py
@@ -262,9 +262,7 @@ _REGISTRY: tuple[AgentAdapter, ...] = (
 )
 
 AGENT_ADAPTERS: dict[str, AgentAdapter] = {adapter.key: adapter for adapter in _REGISTRY}
-_ALIAS_TO_KEY: dict[str, str] = {
-    alias: adapter.key for adapter in _REGISTRY for alias in adapter.aliases
-}
+_ALIAS_TO_KEY: dict[str, str] = {alias: adapter.key for adapter in _REGISTRY for alias in adapter.aliases}
 PUBLIC_AGENT_KEYS: tuple[str, ...] = tuple(adapter.key for adapter in _REGISTRY if adapter.public)
 CLI_AGENT_KEYS: tuple[str, ...] = tuple(adapter.key for adapter in _REGISTRY)
 

--- a/audit-hooks.py
+++ b/audit-hooks.py
@@ -147,13 +147,15 @@ def _classify(decision: str) -> str:
 
 def _per_hook_metrics(entries: list[dict], top_n: int = 15) -> list[dict]:
     """Compute per-rule effectiveness metrics, sorted by fire count descending."""
-    rule_stats: dict[str, dict] = defaultdict(lambda: {
-        "fire_count": 0,
-        "useful_block": 0,
-        "dry_run": 0,
-        "allow": 0,
-        "other": 0,
-    })
+    rule_stats: dict[str, dict] = defaultdict(
+        lambda: {
+            "fire_count": 0,
+            "useful_block": 0,
+            "dry_run": 0,
+            "allow": 0,
+            "other": 0,
+        }
+    )
     total = len(entries)
 
     for e in entries:
@@ -180,16 +182,18 @@ def _per_hook_metrics(entries: list[dict], top_n: int = 15) -> list[dict]:
         block_rate = round(ub / fc * 100, 1) if fc > 0 else 0.0
         ub_denom = ub + dr
         useful_block_rate: float | None = round(ub / ub_denom * 100, 1) if ub_denom > 0 else None
-        rows.append({
-            "rule": rule,
-            "fire_count": fc,
-            "fire_rate_pct": fire_rate,
-            "block_count": ub,
-            "dry_run_count": dr,
-            "allow_count": st["allow"],
-            "block_rate_pct": block_rate,
-            "useful_block_rate": useful_block_rate,
-        })
+        rows.append(
+            {
+                "rule": rule,
+                "fire_count": fc,
+                "fire_rate_pct": fire_rate,
+                "block_count": ub,
+                "dry_run_count": dr,
+                "allow_count": st["allow"],
+                "block_rate_pct": block_rate,
+                "useful_block_rate": useful_block_rate,
+            }
+        )
 
     rows.sort(key=lambda r: -r["fire_count"])
     return rows[:top_n]
@@ -219,9 +223,7 @@ def _global_summary(entries: list[dict]) -> dict:
 
 def _trend_analysis(entries: list[dict]) -> list[dict]:
     """Bucket entries by calendar day (UTC) and compute per-day metrics."""
-    day_stats: dict[str, dict] = defaultdict(lambda: {
-        "total": 0, "deny": 0, "deny_dry": 0, "allow": 0
-    })
+    day_stats: dict[str, dict] = defaultdict(lambda: {"total": 0, "deny": 0, "deny_dry": 0, "allow": 0})
 
     for e in entries:
         ts = e.get("ts", 0)
@@ -243,14 +245,16 @@ def _trend_analysis(entries: list[dict]) -> list[dict]:
     for day, st in sorted(day_stats.items()):
         total = st["total"]
         deny = st["deny"]
-        rows.append({
-            "date": day,
-            "total": total,
-            "deny": deny,
-            "deny_dry": st["deny_dry"],
-            "allow": st["allow"],
-            "deny_rate_pct": round(deny / total * 100, 1) if total > 0 else 0.0,
-        })
+        rows.append(
+            {
+                "date": day,
+                "total": total,
+                "deny": deny,
+                "deny_dry": st["deny_dry"],
+                "allow": st["allow"],
+                "deny_rate_pct": round(deny / total * 100, 1) if total > 0 else 0.0,
+            }
+        )
     return rows
 
 
@@ -319,8 +323,7 @@ def _never_fired_hooks(entries: list[dict], inventory: list[str]) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def _render_text(summary: dict, per_hook: list[dict], trend: list[dict],
-                 never_fired: list[str] | None = None) -> None:
+def _render_text(summary: dict, per_hook: list[dict], trend: list[dict], never_fired: list[str] | None = None) -> None:
     """Print a human-readable audit report to stdout."""
     print("=" * 66)
     print("  sk audit-hooks — Hook Effectiveness Audit")
@@ -377,8 +380,7 @@ def _render_text(summary: dict, per_hook: list[dict], trend: list[dict],
     print()
 
 
-def _render_json(summary: dict, per_hook: list[dict], trend: list[dict],
-                 never_fired: list[str] | None = None) -> None:
+def _render_json(summary: dict, per_hook: list[dict], trend: list[dict], never_fired: list[str] | None = None) -> None:
     """Print JSON payload to stdout.
 
     ``never_fired`` encoding:
@@ -410,23 +412,37 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Hook effectiveness audit — parses audit.jsonl and reports metrics.",
     )
     parser.add_argument(
-        "--json", action="store_true", dest="json_out",
+        "--json",
+        action="store_true",
+        dest="json_out",
         help="Emit JSON instead of text",
     )
     parser.add_argument(
-        "--days", type=int, default=None, metavar="N",
+        "--days",
+        type=int,
+        default=None,
+        metavar="N",
         help="Restrict analysis to the last N days (default: all)",
     )
     parser.add_argument(
-        "--audit-file", type=Path, default=DEFAULT_AUDIT_JSONL, metavar="PATH",
+        "--audit-file",
+        type=Path,
+        default=DEFAULT_AUDIT_JSONL,
+        metavar="PATH",
         help="Override path to audit.jsonl",
     )
     parser.add_argument(
-        "--top", type=int, default=15, metavar="N",
+        "--top",
+        type=int,
+        default=15,
+        metavar="N",
         help="Show top-N rules in per-hook table (default 15)",
     )
     parser.add_argument(
-        "--hooks-dir", type=Path, default=DEFAULT_HOOKS_DIR, metavar="DIR",
+        "--hooks-dir",
+        type=Path,
+        default=DEFAULT_HOOKS_DIR,
+        metavar="DIR",
         help="Override hooks directory for never-fired inventory scan (default: hooks/ sibling)",
     )
     return parser.parse_args(argv)

--- a/auto-update-tools.py
+++ b/auto-update-tools.py
@@ -115,41 +115,44 @@ GLOBAL_COPILOT_SKILLS_DIR = HOME / ".copilot" / "skills"
 # ---------------------------------------------------------------------------
 COVERAGE_MANIFEST: "dict[str, list[tuple[str, str]]]" = {
     "Source Scripts": [
-        ("*.py",                 "root-level Python scripts (triggers restart-services)"),
-        ("browse/",              "browse module — web session browser"),
-        ("providers/",           "provider implementations"),
-        ("tests/",               "tests/ — pytest-style subdirectory for newer test modules"),
+        ("*.py", "root-level Python scripts (triggers restart-services)"),
+        ("browse/", "browse module — web session browser"),
+        ("providers/", "provider implementations"),
+        ("tests/", "tests/ — pytest-style subdirectory for newer test modules"),
     ],
     "Skills": [
-        ("skills/",              "skill SKILL.md and assets — deployed on update"),
-        ("templates/",           "SKILL.md templates — deployed on update"),
+        ("skills/", "skill SKILL.md and assets — deployed on update"),
+        ("templates/", "SKILL.md templates — deployed on update"),
     ],
     "Hooks": [
-        ("hooks/",               "all Python hook scripts — install.py --deploy-hooks; "
-                                 "git hooks (pre-commit/pre-push): install.py --install-git-hooks per repo"),
-        (".github/hooks/",       "legacy fallback hook config source — deployed via install.py --deploy-hooks"),
-        ("hooks/rules/",         "hook rule modules (auto-discovered by install.py)"),
+        (
+            "hooks/",
+            "all Python hook scripts — install.py --deploy-hooks; "
+            "git hooks (pre-commit/pre-push): install.py --install-git-hooks per repo",
+        ),
+        (".github/hooks/", "legacy fallback hook config source — deployed via install.py --deploy-hooks"),
+        ("hooks/rules/", "hook rule modules (auto-discovered by install.py)"),
     ],
     "Workflows": [
-        ("scripts/",             "pipeline scripts (added by quality-gates tentacle)"),
-        (".github/workflows/",   "CI/CD workflow definitions (added by quality-gates tentacle)"),
+        ("scripts/", "pipeline scripts (added by quality-gates tentacle)"),
+        (".github/workflows/", "CI/CD workflow definitions (added by quality-gates tentacle)"),
     ],
     "Services": [
-        ("launchd/",             "macOS LaunchAgent templates — reinstalled on update"),
+        ("launchd/", "macOS LaunchAgent templates — reinstalled on update"),
     ],
     "Browse UI": [
-        ("browse/api/",          "browse JSON API module (Pha 5 extract — /api/* endpoints)"),
-        ("browse-ui/src/",       "browse-ui Next.js source (TS + components)"),
-        ("browse-ui/public/",    "browse-ui static assets"),
-        ("browse-ui/dist/",      "browse-ui generated local artifact (ignored; rebuild with pnpm build)"),
+        ("browse/api/", "browse JSON API module (Pha 5 extract — /api/* endpoints)"),
+        ("browse-ui/src/", "browse-ui Next.js source (TS + components)"),
+        ("browse-ui/public/", "browse-ui static assets"),
+        ("browse-ui/dist/", "browse-ui generated local artifact (ignored; rebuild with pnpm build)"),
     ],
     "Other": [
-        ("docs/",                "documentation"),
-        ("presets/",             "preset configurations"),
+        ("docs/", "documentation"),
+        ("presets/", "preset configurations"),
     ],
     "Launcher": [
-        ("~/.copilot/bin/",      "managed sk launcher directory — refreshed on sk.py / install.py changes"),
-        ("sk-rust/",             "Rust sk binary source — triggers GitHub Release asset update check"),
+        ("~/.copilot/bin/", "managed sk launcher directory — refreshed on sk.py / install.py changes"),
+        ("sk-rust/", "Rust sk binary source — triggers GitHub Release asset update check"),
     ],
 }
 
@@ -267,11 +270,14 @@ def _global_copilot_skill_dirs() -> tuple[Path, ...]:
 def log(msg: str):
     print(f"[sk-update] {msg}")
 
+
 def ok(msg: str):
     print(f"[sk-update] ✅ {msg}")
 
+
 def warn(msg: str):
     print(f"[sk-update] ⚠️  {msg}", file=sys.stderr)
+
 
 def err(msg: str):
     print(f"[sk-update] ❌ {msg}", file=sys.stderr)
@@ -337,8 +343,8 @@ def _load_project_registry() -> list[Path]:
 # ---------------------------------------------------------------------------
 # Atomic write helpers, Windows FS retry, and update lock (P0-1/2/3/4/8)
 # ---------------------------------------------------------------------------
-SELF_EXEC_GUARD = TOOLS_DIR / ".self-exec-active"   # P0-7
-_UPDATE_LOCK_FILE = TOOLS_DIR / ".update-lock"       # P0-8
+SELF_EXEC_GUARD = TOOLS_DIR / ".self-exec-active"  # P0-7
+_UPDATE_LOCK_FILE = TOOLS_DIR / ".update-lock"  # P0-8
 
 
 def _atomic_write_bytes(path: Path, data: bytes) -> None:
@@ -507,8 +513,9 @@ def pull_latest() -> tuple[bool, str, str]:
         # P0-5: check stash pop result; abort if conflicted to avoid running on broken tree
         r_pop = _git("stash", "pop", "--quiet")
         if r_pop.returncode != 0:
-            warn("Stash pop failed — local changes are in stash. "
-                 "Run 'git stash pop' manually after resolving conflicts.")
+            warn(
+                "Stash pop failed — local changes are in stash. Run 'git stash pop' manually after resolving conflicts."
+            )
             if r_pop.stderr:
                 warn(f"git stash pop stderr: {r_pop.stderr[:200]}")
             return False, old_sha, old_sha  # treat as no-update; abort pipeline
@@ -556,38 +563,40 @@ def classify_changes(old_sha: str, new_sha: str) -> dict:
     changed = diff_output.splitlines()
     return {
         "all": changed,
-        "py_scripts":   [f for f in changed if f.endswith(".py")],
-        "launchd":      [f for f in changed if f.startswith("launchd/")],
-        "templates":    [f for f in changed if f.startswith("templates/")],
-        "skills":       [f for f in changed if f.startswith("skills/")],
-        "hooks":        [f for f in changed if f.startswith("hooks/")],
+        "py_scripts": [f for f in changed if f.endswith(".py")],
+        "launchd": [f for f in changed if f.startswith("launchd/")],
+        "templates": [f for f in changed if f.startswith("templates/")],
+        "skills": [f for f in changed if f.startswith("skills/")],
+        "hooks": [f for f in changed if f.startswith("hooks/")],
         "github_hooks": [f for f in changed if f.startswith(".github/hooks/")],
-        "hooks_rules":  [f for f in changed if f.startswith("hooks/rules/")],
-        "browse":       [f for f in changed if f.startswith("browse/")],
-        "browse_ui":    [f for f in changed if f.startswith("browse-ui/") and not f.startswith("browse-ui/dist/")],
-        "providers":    [f for f in changed if f.startswith("providers/")],
-        "scripts":      [f for f in changed if f.startswith("scripts/")],
-        "workflows":    [f for f in changed if f.startswith(".github/workflows/")],
-        "embed":        [f for f in changed if "embed" in f.lower() and f.endswith(".py")],
-        "migrate":      "migrate.py" in changed,
-        "self_update":  "auto-update-tools.py" in changed,
+        "hooks_rules": [f for f in changed if f.startswith("hooks/rules/")],
+        "browse": [f for f in changed if f.startswith("browse/")],
+        "browse_ui": [f for f in changed if f.startswith("browse-ui/") and not f.startswith("browse-ui/dist/")],
+        "providers": [f for f in changed if f.startswith("providers/")],
+        "scripts": [f for f in changed if f.startswith("scripts/")],
+        "workflows": [f for f in changed if f.startswith(".github/workflows/")],
+        "embed": [f for f in changed if "embed" in f.lower() and f.endswith(".py")],
+        "migrate": "migrate.py" in changed,
+        "self_update": "auto-update-tools.py" in changed,
         "watch_sessions": "watch-sessions.py" in changed,
         "global_instructions": [
-            f for f in changed
+            f
+            for f in changed
             if f == "templates/copilot-instructions.md"
             or f == "templates/session-knowledge.instructions.md"
             or f.startswith("templates/instructions/")
         ],
         "managed_hooks": [
-            f for f in changed
+            f
+            for f in changed
             if f == "hooks/hooks.json"
             or f == ".github/hooks/hooks.json"
             or (f.startswith("hooks/") and f.endswith(".py"))
         ],
         # Refresh the managed sk launcher when sk.py or install.py changes
-        "sk_launcher":  any(f in changed for f in ("sk.py", "install.py")),
+        "sk_launcher": any(f in changed for f in ("sk.py", "install.py")),
         # Track Rust binary source changes (used for manifest; binary update is unconditional)
-        "sk_binary":    any(p.startswith("sk-rust/") for p in changed),
+        "sk_binary": any(p.startswith("sk-rust/") for p in changed),
     }
 
 
@@ -608,8 +617,13 @@ def post_pull_pipeline(old_sha: str, new_sha: str):
     if changes.get("self_update") and "--skip-pull" not in sys.argv:
         log("auto-update-tools.py changed — re-executing with new code...")
         _state_set("self_exec_from", old_sha[:8])
-        args = [sys.executable, str(TOOLS_DIR / "auto-update-tools.py"), "--skip-pull",
-                f"--old-sha={old_sha}", f"--new-sha={new_sha}"]
+        args = [
+            sys.executable,
+            str(TOOLS_DIR / "auto-update-tools.py"),
+            "--skip-pull",
+            f"--old-sha={old_sha}",
+            f"--new-sha={new_sha}",
+        ]
         # Add original flags
         for a in sys.argv[1:]:
             if a not in ("--force", "--skip-pull") and not a.startswith("--old-sha") and not a.startswith("--new-sha"):
@@ -626,11 +640,11 @@ def post_pull_pipeline(old_sha: str, new_sha: str):
             pass
         if platform.system() == "Windows":
             # os.execl behaves differently on Windows
-            SELF_EXEC_GUARD.touch()   # P0-7: block concurrent post-merge hook race
+            SELF_EXEC_GUARD.touch()  # P0-7: block concurrent post-merge hook race
             subprocess.Popen(args)
             sys.exit(0)
         else:
-            SELF_EXEC_GUARD.touch()   # P0-7
+            SELF_EXEC_GUARD.touch()  # P0-7
             os.execl(sys.executable, *args)
 
     # P0-6: wrap pipeline steps; always write manifest so --doctor reflects reality
@@ -649,8 +663,9 @@ def post_pull_pipeline(old_sha: str, new_sha: str):
         # .git/hooks/ in arbitrary repos would be unsafe.  Users must re-run install.py.
         if changes.get("managed_hooks"):
             refresh_global_hooks()
-            hook_files = [f for f in changes["managed_hooks"]
-                          if "pre-commit" in f or "pre-push" in f or "check_subagent" in f]
+            hook_files = [
+                f for f in changes["managed_hooks"] if "pre-commit" in f or "pre-push" in f or "check_subagent" in f
+            ]
             if hook_files:
                 warn("Git hook scripts updated — installed per-repo hooks are NOT automatically refreshed.")
                 warn("ACTION REQUIRED to pick up the cross-repo isolation fix (and future hook changes):")
@@ -707,11 +722,17 @@ def post_pull_pipeline(old_sha: str, new_sha: str):
         warn("Run 'sk update --force' to retry.")
         try:
             _FAILED_MARKER = TOOLS_DIR / ".update-failed.json"
-            _atomic_write_text(_FAILED_MARKER, json.dumps({
-                "failed_at": datetime.now().isoformat(),
-                "old_sha": old_sha,
-                "new_sha": new_sha,
-            }, indent=2))
+            _atomic_write_text(
+                _FAILED_MARKER,
+                json.dumps(
+                    {
+                        "failed_at": datetime.now().isoformat(),
+                        "old_sha": old_sha,
+                        "new_sha": new_sha,
+                    },
+                    indent=2,
+                ),
+            )
         except Exception:
             pass
 
@@ -733,7 +754,9 @@ def reinstall_launchagents():
         log("LaunchAgent templates changed — reinstalling...")
         r = subprocess.run(
             [sys.executable, str(installer)],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if r.returncode == 0:
             ok("LaunchAgents reinstalled")
@@ -754,10 +777,14 @@ def trigger_embedding_rebuild():
     log("Embedding logic changed — triggering rebuild...")
     subprocess.Popen(
         [sys.executable, str(embed_script), "--build"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         start_new_session=True if platform.system() != "Windows" else False,
-        **({"creationflags": subprocess.DETACHED_PROCESS | subprocess.CREATE_NO_WINDOW}
-           if platform.system() == "Windows" else {}),
+        **(
+            {"creationflags": subprocess.DETACHED_PROCESS | subprocess.CREATE_NO_WINDOW}
+            if platform.system() == "Windows"
+            else {}
+        ),
     )
     ok("Embedding rebuild triggered (background)")
 
@@ -767,6 +794,7 @@ def _pnpm_cmd() -> list[str]:
     is not directly on PATH but corepack is available.
     """
     import shutil
+
     if shutil.which("pnpm"):
         return ["pnpm"]
     if shutil.which("corepack"):
@@ -902,7 +930,9 @@ def _should_update_rust_binary(install_dir: Path, exe_name: str, remote_tag: str
     try:
         result = subprocess.run(
             [str(exe_path), "--version"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         if result.returncode != 0:
             return True
@@ -970,6 +1000,7 @@ def _refresh_rust_binary_local(local_archive: str, os_name: str, arch: str) -> b
                 zf.extractall(str(tmp_extract))
         else:
             import tarfile
+
             with tarfile.open(str(archive_path), "r:gz") as tf:
                 tf.extractall(str(tmp_extract))
 
@@ -1086,7 +1117,7 @@ def refresh_rust_binary() -> bool:
                         sha256.update(chunk)
                 actual = sha256.hexdigest()
                 if expected != actual:
-                    warn(f"[rust-binary] Checksum mismatch — aborting update")
+                    warn("[rust-binary] Checksum mismatch — aborting update")
                     return False
                 log("[rust-binary] Checksum verified")
             except Exception:
@@ -1101,6 +1132,7 @@ def refresh_rust_binary() -> bool:
                         zf.extractall(str(tmp_extract))
                 else:
                     import tarfile
+
                     with tarfile.open(str(tmp_archive), "r:gz") as tf:
                         tf.extractall(str(tmp_extract))
 
@@ -1179,7 +1211,9 @@ def _rebuild_browse_ui():
         r = subprocess.run(
             pnpm + ["install", "--frozen-lockfile"],
             cwd=str(browse_ui_dir),
-            capture_output=True, text=True, timeout=120,
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
         if r.returncode != 0:
             warn(f"pnpm install failed: {r.stderr[:300]}")
@@ -1187,7 +1221,9 @@ def _rebuild_browse_ui():
         r = subprocess.run(
             pnpm + ["build"],
             cwd=str(browse_ui_dir),
-            capture_output=True, text=True, timeout=180,
+            capture_output=True,
+            text=True,
+            timeout=180,
         )
         if r.returncode == 0:
             ok("browse-ui rebuilt successfully")
@@ -1206,7 +1242,10 @@ def ensure_post_merge_hook():
     hook_path = TOOLS_DIR / ".git" / "hooks" / "post-merge"
 
     hook_python = "python" if platform.system() == "Windows" else "python3"
-    hook_content = "#!/usr/bin/env " + hook_python + """
+    hook_content = (
+        "#!/usr/bin/env "
+        + hook_python
+        + """
 # Auto-generated by auto-update-tools.py — triggers pipeline after git pull.
 # Re-created on each update; do not edit manually.
 
@@ -1261,6 +1300,7 @@ try:
 except Exception:
     pass
 """
+    )
     try:
         hook_path.parent.mkdir(parents=True, exist_ok=True)
         desired_bytes = hook_content.encode("utf-8")
@@ -1318,7 +1358,8 @@ def write_manifest(sha: str, changes: dict):
     if system == "Darwin":
         r = subprocess.run(
             ["launchctl", "list", "com.copilot.watch-sessions"],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         # launchctl list exits 0 when the job is loaded, even when it is not
         # actively running (e.g. waiting for restart after repeated failures).
@@ -1332,7 +1373,8 @@ def write_manifest(sha: str, changes: dict):
     elif system == "Linux":
         r = subprocess.run(
             ["systemctl", "--user", "is-active", "copilot-watch-sessions.service"],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         manifest["services"]["watch-sessions"] = {
             "managed_by": "systemd",
@@ -1341,7 +1383,8 @@ def write_manifest(sha: str, changes: dict):
     elif system == "Windows":
         r = subprocess.run(
             ["schtasks", "/Query", "/TN", "CopilotSessionWatcher"],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         manifest["services"]["watch-sessions"] = {
             "managed_by": "task-scheduler",
@@ -1350,14 +1393,24 @@ def write_manifest(sha: str, changes: dict):
 
     # P0-2: atomic manifest write to prevent --doctor parse failures on crash
     # Coverage: which categories had changes this run (backwards-compat: use .get())
-    manifest["tracked_dirs"] = [
-        pat for entries in COVERAGE_MANIFEST.values() for pat, _ in entries
-    ]
+    manifest["tracked_dirs"] = [pat for entries in COVERAGE_MANIFEST.values() for pat, _ in entries]
     manifest["changed_categories"] = {
         key: bool(changes.get(key))
-        for key in ("browse", "browse_ui", "providers", "skills", "hooks", "hooks_rules",
-                    "scripts", "workflows", "launchd", "templates", "py_scripts",
-                    "sk_launcher", "sk_binary")
+        for key in (
+            "browse",
+            "browse_ui",
+            "providers",
+            "skills",
+            "hooks",
+            "hooks_rules",
+            "scripts",
+            "workflows",
+            "launchd",
+            "templates",
+            "py_scripts",
+            "sk_launcher",
+            "sk_binary",
+        )
         if key in changes
     }
     try:
@@ -1429,11 +1482,11 @@ def deploy_skills():
         # Fallback when manifest is unavailable (broken or first-run state).
         HOST_DIRS = {
             "Copilot CLI": Path.home() / ".copilot",
-            "Claude Code":  Path.home() / ".claude",
+            "Claude Code": Path.home() / ".claude",
         }
         HOST_SKILL_SUBPATHS = {
             "Copilot CLI": ".github/skills/session-knowledge/SKILL.md",
-            "Claude Code":  ".claude/skills/session-knowledge/SKILL.md",
+            "Claude Code": ".claude/skills/session-knowledge/SKILL.md",
         }
 
     # Pre-read skill sources once; skip if source doesn't exist.
@@ -1603,7 +1656,9 @@ def deploy_skills():
                         if not existed or asset_target.read_bytes() != content:
                             asset_target.parent.mkdir(parents=True, exist_ok=True)
                             asset_target.write_bytes(content)
-                            ok(f"{'Created' if not existed else 'Updated'} global Copilot CLI {skill_name}/{rel} in {global_skills_root}")
+                            ok(
+                                f"{'Created' if not existed else 'Updated'} global Copilot CLI {skill_name}/{rel} in {global_skills_root}"
+                            )
                     except Exception:
                         pass
 
@@ -1712,8 +1767,11 @@ def _restart_manual():
     if system == "Windows":
         # Find pythonw processes running watch-sessions.py
         r = subprocess.run(
-            ["powershell", "-Command",
-             "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*watch-sessions.py*' } | Select-Object ProcessId"],
+            [
+                "powershell",
+                "-Command",
+                "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*watch-sessions.py*' } | Select-Object ProcessId",
+            ],
             capture_output=True,
             text=True,
         )
@@ -1731,6 +1789,7 @@ def _restart_manual():
         # P1-2: poll for process exit on Windows before spawning replacement
         if killed_pids:
             import ctypes
+
             PROCESS_SYNCHRONIZE = 0x00100000
             for pid in killed_pids:
                 h = ctypes.windll.kernel32.OpenProcess(PROCESS_SYNCHRONIZE, False, pid)
@@ -1800,6 +1859,7 @@ def _try_healer_check():
     """Return list of healer Issues or None if healer unavailable."""
     try:
         import importlib.util as _ilu
+
         _hpath = TOOLS_DIR / "copilot-cli-healer.py"
         if not _hpath.exists():
             return None
@@ -1858,6 +1918,7 @@ def doctor():
     if DB_PATH.exists():
         try:
             import sqlite3
+
             conn = sqlite3.connect(str(DB_PATH))
             count = conn.execute("SELECT COUNT(*) FROM knowledge_entries").fetchone()[0]
             conn.close()
@@ -1914,8 +1975,10 @@ def doctor():
     if _FAILED_MARKER.exists():
         try:
             fdata = json.loads(_FAILED_MARKER.read_text(encoding="utf-8"))
-            warn(f"Previous update incomplete (failed at {fdata.get('failed_at', '?')}). "
-                 "Run 'sk update --force' to retry.")
+            warn(
+                f"Previous update incomplete (failed at {fdata.get('failed_at', '?')}). "
+                "Run 'sk update --force' to retry."
+            )
             issues += 1
         except Exception:
             pass
@@ -1944,7 +2007,8 @@ def doctor():
     elif system == "Linux":
         r = subprocess.run(
             ["systemctl", "--user", "is-active", "copilot-watch-sessions.service"],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         if r.returncode == 0:
             ok("systemd copilot-watch-sessions: active")
@@ -1953,7 +2017,8 @@ def doctor():
     elif system == "Windows":
         r = subprocess.run(
             ["schtasks", "/Query", "/TN", "CopilotSessionWatcher"],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         if r.returncode == 0:
             ok("Task Scheduler CopilotSessionWatcher: registered")
@@ -1965,7 +2030,7 @@ def doctor():
     if healer_issues is None:
         warn("Copilot CLI healer: not found (optional — run install.py --install-healer)")
     elif healer_issues:
-        warn(f"Copilot CLI pkg: stale state — run: python copilot-cli-healer.py --heal")
+        warn("Copilot CLI pkg: stale state — run: python copilot-cli-healer.py --heal")
         issues += 1
     else:
         ok("Copilot CLI pkg: healthy")
@@ -1984,7 +2049,9 @@ def doctor():
                 continue
             check_path = TOOLS_DIR / base
             if check_path.exists():
-                if pattern not in [p for p, _ in [e for ent in COVERAGE_MANIFEST.values() for e in ent] if p in present]:
+                if pattern not in [
+                    p for p, _ in [e for ent in COVERAGE_MANIFEST.values() for e in ent] if p in present
+                ]:
                     present.append(pattern)
             else:
                 absent.append(pattern)
@@ -2141,6 +2208,7 @@ def main():
                 err("copilot-cli-healer.py not found in tools dir")
                 sys.exit(1)
             import importlib.util as _ilu
+
             _hpath = TOOLS_DIR / "copilot-cli-healer.py"
             _spec = _ilu.spec_from_file_location("_healer", _hpath)
             _mod = _ilu.module_from_spec(_spec)

--- a/benchmark.py
+++ b/benchmark.py
@@ -26,8 +26,8 @@ import importlib.util
 import json
 import os
 import shlex
-import statistics
 import sqlite3
+import statistics
 import subprocess
 import sys
 import time
@@ -209,8 +209,8 @@ def cmd_record(db_path: Path, commit_sha: str, mode: str) -> int:
     retro_score = float(retro_data.get("retro_score", 0.0)) if retro_data.get("available") else 0.0
     score_confidence = retro_data.get("score_confidence", "") if retro_data.get("available") else ""
     subscores = retro_data.get("subscores", {}) if retro_data.get("available") else {}
-    health_score_val: "float | None" = None
-    health_stored: "dict | None" = None
+    health_score_val: float | None = None
+    health_stored: dict | None = None
     if health_data.get("available"):
         raw = health_data.get("score")
         if raw is not None:
@@ -352,9 +352,7 @@ def cmd_compare(db_path: Path, commits: "list[str]", limit: int) -> int:
     def _fetch_snapshot(ref: str) -> "sqlite3.Row | None":
         # Try numeric row id first
         if ref.isdigit():
-            return conn.execute(
-                "SELECT * FROM benchmark_snapshots WHERE id = ?", (int(ref),)
-            ).fetchone()
+            return conn.execute("SELECT * FROM benchmark_snapshots WHERE id = ?", (int(ref),)).fetchone()
         # Then commit sha prefix
         return conn.execute(
             "SELECT * FROM benchmark_snapshots WHERE commit_sha LIKE ? ORDER BY recorded_at DESC LIMIT 1",
@@ -371,7 +369,7 @@ def cmd_compare(db_path: Path, commits: "list[str]", limit: int) -> int:
             (limit,),
         ).fetchall()
         if len(rows) < 2:
-            print("benchmark: need at least 2 snapshots to compare (got {}).".format(len(rows)))
+            print(f"benchmark: need at least 2 snapshots to compare (got {len(rows)}).")
             conn.close()
             return 1
         snap_b, snap_a = rows[0], rows[1]  # b=newer, a=older
@@ -385,7 +383,7 @@ def cmd_compare(db_path: Path, commits: "list[str]", limit: int) -> int:
     def _row_label(r: sqlite3.Row) -> str:
         return f"#{r['id']} {(r['commit_sha'] or '?')[:12]} @ {r['recorded_at'][:19]}"
 
-    print(f"\nbenchmark compare")
+    print("\nbenchmark compare")
     print(f"  baseline : {_row_label(snap_a)}")
     print(f"  current  : {_row_label(snap_b)}")
     print()
@@ -434,7 +432,9 @@ def cmd_compare(db_path: Path, commits: "list[str]", limit: int) -> int:
 
     print()
     print("  proof summary:")
-    print(f"    retro  : {snap_a['retro_score']:.1f} → {snap_b['retro_score']:.1f}  gap {_fmt_g(gap_a_retro)} → {_fmt_g(gap_b_retro)}  {gp_retro}")
+    print(
+        f"    retro  : {snap_a['retro_score']:.1f} → {snap_b['retro_score']:.1f}  gap {_fmt_g(gap_a_retro)} → {_fmt_g(gap_b_retro)}  {gp_retro}"
+    )
     print(f"    health : {h_a} → {h_b}  gap {_fmt_g(gap_a_health)} → {_fmt_g(gap_b_health)}  {gp_health}")
     print()
     return 0
@@ -664,7 +664,7 @@ def _parse_args(argv: list) -> dict:
         if a in ("record", "compare", "list", "startup"):
             args["cmd"] = a
         elif a == "--":
-            args["startup_command"] = argv[i + 1:]
+            args["startup_command"] = argv[i + 1 :]
             break
         elif a == "--db" and i + 1 < len(argv):
             i += 1

--- a/browse.py
+++ b/browse.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """browse.py — thin shim; real implementation lives in the browse/ package."""
+
 # Re-export package symbols so existing code/tests using 'import browse' still work.
-from browse import main, _make_handler_class, _sanitize_fts_query, _esc, _SESSION_ID_RE  # noqa: F401
+from browse import _SESSION_ID_RE, _esc, _make_handler_class, _sanitize_fts_query, main  # noqa: F401
 
 if __name__ == "__main__":
     main()

--- a/buglog-export.py
+++ b/buglog-export.py
@@ -93,7 +93,8 @@ def _fetch_mistakes(
     if tags_filter:
         lower_tags = {t.lower() for t in tags_filter}
         entries = [
-            e for e in entries
+            e
+            for e in entries
             if {tok.strip().lower() for tok in (e.get("tags") or "").split(",") if tok.strip()} & lower_tags
         ]
 

--- a/claude-adapter.py
+++ b/claude-adapter.py
@@ -19,14 +19,14 @@ Claude Code session structure:
 Cross-platform: Windows, macOS, Linux (WSL). Pure Python stdlib.
 """
 
-import json
-import sqlite3
-import re
-import os
-import sys
 import hashlib
-from pathlib import Path
+import json
+import os
+import re
+import sqlite3
+import sys
 from datetime import datetime
+from pathlib import Path
 
 # Fix Windows console encoding
 if os.name == "nt":
@@ -61,12 +61,14 @@ def find_claude_sessions() -> list[dict]:
         for jsonl_file in project_dir.glob("*.jsonl"):
             if jsonl_file.stat().st_size < MIN_SESSION_BYTES:
                 continue
-            sessions.append({
-                "project_hash": project_hash,
-                "session_id": jsonl_file.stem,
-                "path": jsonl_file,
-                "size_bytes": jsonl_file.stat().st_size,
-            })
+            sessions.append(
+                {
+                    "project_hash": project_hash,
+                    "session_id": jsonl_file.stem,
+                    "path": jsonl_file,
+                    "size_bytes": jsonl_file.stat().st_size,
+                }
+            )
 
         # Also check subagents/ directories
         for subdir in project_dir.iterdir():
@@ -77,13 +79,15 @@ def find_claude_sessions() -> list[dict]:
                 for jsonl_file in subagents_dir.glob("*.jsonl"):
                     if jsonl_file.stat().st_size < MIN_SESSION_BYTES:
                         continue
-                    sessions.append({
-                        "project_hash": project_hash,
-                        "session_id": jsonl_file.stem,
-                        "path": jsonl_file,
-                        "size_bytes": jsonl_file.stat().st_size,
-                        "parent_session": subdir.name,
-                    })
+                    sessions.append(
+                        {
+                            "project_hash": project_hash,
+                            "session_id": jsonl_file.stem,
+                            "path": jsonl_file,
+                            "size_bytes": jsonl_file.stat().st_size,
+                            "parent_session": subdir.name,
+                        }
+                    )
 
     return sessions
 
@@ -91,7 +95,7 @@ def find_claude_sessions() -> list[dict]:
 def parse_jsonl(path: Path) -> list[dict]:
     """Parse JSONL file, skip malformed lines."""
     entries = []
-    with open(path, "r", encoding="utf-8", errors="replace") as f:
+    with open(path, encoding="utf-8", errors="replace") as f:
         for line_num, line in enumerate(f, 1):
             line = line.strip()
             if not line:
@@ -194,11 +198,13 @@ def parse_session(entries: list[dict]) -> dict:
             content = msg.get("content", "") if isinstance(msg, dict) else ""
             text = extract_text_from_content(content)
             if text:
-                session["conversations"].append({
-                    "role": "user",
-                    "text": text,
-                    "timestamp": timestamp,
-                })
+                session["conversations"].append(
+                    {
+                        "role": "user",
+                        "text": text,
+                        "timestamp": timestamp,
+                    }
+                )
 
         elif entry_type == "assistant":
             msg = entry.get("message", {})
@@ -220,11 +226,13 @@ def parse_session(entries: list[dict]) -> dict:
                                 session["files_touched"].add(fp)
 
             if text:
-                session["conversations"].append({
-                    "role": "assistant",
-                    "text": text,
-                    "timestamp": timestamp,
-                })
+                session["conversations"].append(
+                    {
+                        "role": "assistant",
+                        "text": text,
+                        "timestamp": timestamp,
+                    }
+                )
 
         session["timestamp_end"] = timestamp or session["timestamp_end"]
 
@@ -265,10 +273,12 @@ def session_to_sections(session: dict) -> list[dict]:
         files = session["files_touched"][:20]
         overview_parts.append(f"Files touched ({len(session['files_touched'])}): {', '.join(files)}")
     if overview_parts:
-        sections.append({
-            "section_name": "overview",
-            "content": "\n".join(overview_parts),
-        })
+        sections.append(
+            {
+                "section_name": "overview",
+                "content": "\n".join(overview_parts),
+            }
+        )
 
     # Conversation section — concatenate user+assistant messages
     conv_parts = []
@@ -285,24 +295,27 @@ def session_to_sections(session: dict) -> list[dict]:
         full_conv = "\n\n".join(conv_parts)
         if len(full_conv) > 50000:
             full_conv = full_conv[:50000] + "\n\n... (truncated)"
-        sections.append({
-            "section_name": "conversation",
-            "content": full_conv,
-        })
+        sections.append(
+            {
+                "section_name": "conversation",
+                "content": full_conv,
+            }
+        )
 
     # Technical details — files and tools
     if session["files_touched"]:
         tech = "## Files Modified/Read\n" + "\n".join(f"- {f}" for f in session["files_touched"])
-        sections.append({
-            "section_name": "technical_details",
-            "content": tech,
-        })
+        sections.append(
+            {
+                "section_name": "technical_details",
+                "content": tech,
+            }
+        )
 
     return sections
 
 
-def index_claude_session(db: sqlite3.Connection, session_info: dict,
-                         parsed: dict, incremental: bool) -> bool:
+def index_claude_session(db: sqlite3.Connection, session_info: dict, parsed: dict, incremental: bool) -> bool:
     """Index a single Claude Code session into the knowledge DB. Returns True if indexed."""
     session_id = parsed["session_id"] or session_info["session_id"]
     file_path = str(session_info["path"])
@@ -312,20 +325,21 @@ def index_claude_session(db: sqlite3.Connection, session_info: dict,
     fhash = hashlib.md5(session_info["path"].read_bytes()).hexdigest()
 
     if incremental:
-        existing = db.execute(
-            "SELECT file_hash FROM documents WHERE file_path = ?", (file_path,)
-        ).fetchone()
+        existing = db.execute("SELECT file_hash FROM documents WHERE file_path = ?", (file_path,)).fetchone()
         if existing and existing[0] == fhash:
             return False
 
     # Ensure session row exists
     summary = parsed["summary"][:500] if parsed["summary"] else ""
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO sessions (id, path, summary, total_checkpoints, source, indexed_at)
         VALUES (?, ?, ?, 0, 'claude', ?)
         ON CONFLICT(id) DO UPDATE SET
             summary=excluded.summary, source='claude', indexed_at=excluded.indexed_at
-    """, (session_id, file_path, summary, datetime.now().isoformat()))
+    """,
+        (session_id, file_path, summary, datetime.now().isoformat()),
+    )
 
     # Create document entry
     title = f"Claude session {session_id[:8]}"
@@ -334,14 +348,17 @@ def index_claude_session(db: sqlite3.Connection, session_info: dict,
 
     preview = summary[:500].replace("\n", " ") if summary else ""
 
-    db.execute("""
+    db.execute(
+        """
         INSERT INTO documents (session_id, doc_type, seq, title, file_path, file_hash,
                               size_bytes, content_preview, source, indexed_at)
         VALUES (?, 'claude-session', 0, ?, ?, ?, ?, ?, 'claude', ?)
         ON CONFLICT(file_path) DO UPDATE SET
             file_hash=excluded.file_hash, size_bytes=excluded.size_bytes,
             content_preview=excluded.content_preview, source='claude', indexed_at=excluded.indexed_at
-    """, (session_id, title, file_path, fhash, file_size, preview, datetime.now().isoformat()))
+    """,
+        (session_id, title, file_path, fhash, file_size, preview, datetime.now().isoformat()),
+    )
 
     doc_id = db.execute("SELECT id FROM documents WHERE file_path = ?", (file_path,)).fetchone()[0]
 
@@ -354,12 +371,15 @@ def index_claude_session(db: sqlite3.Connection, session_info: dict,
     for sec in sections:
         db.execute(
             "INSERT INTO sections (document_id, section_name, content) VALUES (?, ?, ?)",
-            (doc_id, sec["section_name"], sec["content"])
+            (doc_id, sec["section_name"], sec["content"]),
         )
-        db.execute("""
+        db.execute(
+            """
             INSERT INTO knowledge_fts (title, section_name, content, doc_type, session_id, document_id)
             VALUES (?, ?, ?, 'claude-session', ?, ?)
-        """, (title, sec["section_name"], sec["content"], session_id, doc_id))
+        """,
+            (title, sec["section_name"], sec["content"], session_id, doc_id),
+        )
 
     return True
 
@@ -390,9 +410,9 @@ def show_stats():
         print(f"    Sessions: {len(sess_list)}, Total: {total_kb:.1f} KB")
         for s in sorted(sess_list, key=lambda x: x["size_bytes"], reverse=True)[:5]:
             parent = f" (subagent of {s['parent_session'][:8]})" if s.get("parent_session") else ""
-            print(f"      {s['session_id'][:8]}... {s['size_bytes']/1024:.1f} KB{parent}")
+            print(f"      {s['session_id'][:8]}... {s['size_bytes'] / 1024:.1f} KB{parent}")
         if len(sess_list) > 5:
-            print(f"      ... and {len(sess_list)-5} more")
+            print(f"      ... and {len(sess_list) - 5} more")
     print()
 
 
@@ -425,12 +445,12 @@ def main():
 
     # Import create_db from build-session-index to ensure schema is ready
     sys.path.insert(0, str(Path(__file__).parent))
-    from importlib import import_module
     # Direct import approach
     import importlib.util
+    from importlib import import_module
+
     spec = importlib.util.spec_from_file_location(
-        "build_session_index",
-        Path(__file__).parent / "build-session-index.py"
+        "build_session_index", Path(__file__).parent / "build-session-index.py"
     )
     bsi = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(bsi)
@@ -469,8 +489,7 @@ def main():
                 print(f"  {short_id}... indexed {n_conv} messages, {n_sections} sections")
                 indexed += 1
             else:
-                print(f"  {short_id}... (no changes)" if incremental else
-                      f"  {short_id}... (skipped)")
+                print(f"  {short_id}... (no changes)" if incremental else f"  {short_id}... (skipped)")
                 skipped += 1
 
         except Exception as e:

--- a/codebase-map.py
+++ b/codebase-map.py
@@ -33,6 +33,7 @@ SESSION_STATE = Path.home() / ".copilot" / "session-state"
 
 # ─── Discovery helpers ────────────────────────────────────────────────────────
 
+
 def find_git_root(start: Path | None = None) -> Path | None:
     """Walk up from *start* (defaults to cwd) to locate the git repository root."""
     current = (start or Path.cwd()).resolve()
@@ -67,7 +68,10 @@ def get_git_last_commit_date(repo_root: Path) -> str:
     try:
         r = subprocess.run(
             ["git", "log", "-1", "--format=%cI"],
-            capture_output=True, text=True, timeout=5, cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(repo_root),
         )
         if r.returncode == 0:
             return r.stdout.strip()
@@ -78,6 +82,7 @@ def get_git_last_commit_date(repo_root: Path) -> str:
 
 # ─── File enumeration ─────────────────────────────────────────────────────────
 
+
 def ls_files(repo_root: Path, timeout: int = 10) -> list[str]:
     """Return all git-tracked files relative to *repo_root*.
 
@@ -87,7 +92,9 @@ def ls_files(repo_root: Path, timeout: int = 10) -> list[str]:
     try:
         result = subprocess.run(
             ["git", "ls-files"],
-            capture_output=True, text=True, timeout=timeout,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
             cwd=str(repo_root),
         )
         if result.returncode != 0:
@@ -98,6 +105,7 @@ def ls_files(repo_root: Path, timeout: int = 10) -> list[str]:
 
 
 # ─── Map generation ───────────────────────────────────────────────────────────
+
 
 def group_files(files: list[str]) -> dict[str, list[str]]:
     """Group *files* by their top-level directory (root files → key '.')."""
@@ -115,10 +123,7 @@ def ext_summary(files: list[str], cap: int = 6) -> str:
     for f in files:
         ext = Path(f).suffix or "(no ext)"
         counts[ext] += 1
-    parts = [
-        f"{ext}×{n}" if n > 1 else ext
-        for ext, n in sorted(counts.items())
-    ]
+    parts = [f"{ext}×{n}" if n > 1 else ext for ext, n in sorted(counts.items())]
     tail = f", +{len(parts) - cap} more" if len(parts) > cap else ""
     return ", ".join(parts[:cap]) + tail
 
@@ -171,6 +176,7 @@ def generate_map(repo_root: Path, files: list[str]) -> str:
 
 # ─── CLI ──────────────────────────────────────────────────────────────────────
 
+
 def resolve_output_path(args_output: str | None) -> Path | None:
     """Determine where to write the artifact.
 
@@ -187,23 +193,25 @@ def resolve_output_path(args_output: str | None) -> Path | None:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Generate codebase-map.md from git-tracked files."
-    )
+    parser = argparse.ArgumentParser(description="Generate codebase-map.md from git-tracked files.")
     parser.add_argument(
-        "--stdout", action="store_true",
+        "--stdout",
+        action="store_true",
         help="Print map to stdout instead of writing a file.",
     )
     parser.add_argument(
-        "--output", metavar="PATH",
+        "--output",
+        metavar="PATH",
         help="Write to an explicit file path.",
     )
     parser.add_argument(
-        "--repo", metavar="PATH",
+        "--repo",
+        metavar="PATH",
         help="Repository root (defaults to git root of cwd).",
     )
     parser.add_argument(
-        "--no-write", action="store_true",
+        "--no-write",
+        action="store_true",
         help="Dry-run: show the target path without writing.",
     )
     args = parser.parse_args()
@@ -222,7 +230,9 @@ def main() -> int:
         try:
             r = subprocess.run(
                 ["git", "rev-parse", "--git-dir"],
-                capture_output=True, cwd=str(repo_root), timeout=5,
+                capture_output=True,
+                cwd=str(repo_root),
+                timeout=5,
             )
             if r.returncode != 0:
                 print(
@@ -254,8 +264,7 @@ def main() -> int:
 
     if out_path is None:
         print(
-            "Error: no active Copilot session found and no --output given. "
-            "Use --output PATH or --stdout.",
+            "Error: no active Copilot session found and no --output given. Use --output PATH or --stdout.",
             file=sys.stderr,
         )
         return 1

--- a/copilot-cli-healer.py
+++ b/copilot-cli-healer.py
@@ -198,25 +198,34 @@ def check(pkg_dir: "Path | None" = None) -> list:
         for entry in entries:
             name = entry.name
             if name.startswith(".replaced-"):
-                issues.append(Issue(
-                    "replaced_dir", entry,
-                    f"Stale rename-backup dir: {name}",
-                ))
+                issues.append(
+                    Issue(
+                        "replaced_dir",
+                        entry,
+                        f"Stale rename-backup dir: {name}",
+                    )
+                )
             elif entry.is_dir() and _is_version_dir(name):
                 try:
                     contents = list(entry.iterdir())
                 except OSError:
                     contents = []
                 if not contents:
-                    issues.append(Issue(
-                        "empty_dummy", entry,
-                        f"Empty dummy version dir: {name}",
-                    ))
+                    issues.append(
+                        Issue(
+                            "empty_dummy",
+                            entry,
+                            f"Empty dummy version dir: {name}",
+                        )
+                    )
                 elif _dir_size_bytes(entry) < 1024:
-                    issues.append(Issue(
-                        "corrupt_dir", entry,
-                        f"Suspected corrupt version dir (< 1 KB): {name}",
-                    ))
+                    issues.append(
+                        Issue(
+                            "corrupt_dir",
+                            entry,
+                            f"Suspected corrupt version dir (< 1 KB): {name}",
+                        )
+                    )
 
     tmp = pkg_dir / "tmp"
     if tmp.is_dir():
@@ -225,10 +234,13 @@ def check(pkg_dir: "Path | None" = None) -> list:
         except OSError:
             tmp_entries = []
         for entry in tmp_entries:
-            issues.append(Issue(
-                "tmp_entry", entry,
-                f"Stale partial-download in tmp/: {entry.name}",
-            ))
+            issues.append(
+                Issue(
+                    "tmp_entry",
+                    entry,
+                    f"Stale partial-download in tmp/: {entry.name}",
+                )
+            )
 
     return issues
 
@@ -419,9 +431,9 @@ def _install_windows(python: str, script: Path) -> int:
         "      <Enabled>true</Enabled>\n"
         "    </CalendarTrigger>\n"
         "  </Triggers>\n"
-        "  <Actions Context=\"Author\">\n"
+        '  <Actions Context="Author">\n'
         "    <Exec>\n"
-        f'      <Command>{python}</Command>\n'
+        f"      <Command>{python}</Command>\n"
         f'      <Arguments>"{script}" --heal</Arguments>\n'
         "    </Exec>\n"
         "  </Actions>\n"
@@ -440,7 +452,9 @@ def _install_windows(python: str, script: Path) -> int:
     try:
         r = subprocess.run(
             ["schtasks", "/Create", "/F", "/TN", TASK_NAME, "/XML", str(xml_file)],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if r.returncode == 0:
             ok(f"Task Scheduler: {TASK_NAME} registered (daily 10:00)")
@@ -493,11 +507,14 @@ def _install_macos(python: str, script: Path) -> int:
     try:
         subprocess.run(
             ["launchctl", "unload", str(plist_path)],
-            capture_output=True, timeout=10,
+            capture_output=True,
+            timeout=10,
         )
         subprocess.run(
             ["launchctl", "load", str(plist_path)],
-            check=True, capture_output=True, timeout=10,
+            check=True,
+            capture_output=True,
+            timeout=10,
         )
         ok(f"launchd: {LAUNCHD_LABEL} loaded (daily 10:00)")
         return 0
@@ -537,11 +554,15 @@ def _install_linux(python: str, script: Path) -> int:
     try:
         subprocess.run(
             ["systemctl", "--user", "daemon-reload"],
-            check=True, timeout=10, capture_output=True,
+            check=True,
+            timeout=10,
+            capture_output=True,
         )
         subprocess.run(
             ["systemctl", "--user", "enable", "--now", "copilot-cli-healer.timer"],
-            check=True, timeout=10, capture_output=True,
+            check=True,
+            timeout=10,
+            capture_output=True,
         )
         ok("systemd: copilot-cli-healer.timer enabled (daily)")
         return 0
@@ -558,7 +579,9 @@ def uninstall_schedule() -> int:
         try:
             r = subprocess.run(
                 ["schtasks", "/Delete", "/F", "/TN", TASK_NAME],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             if r.returncode == 0:
                 ok(f"Task Scheduler: {TASK_NAME} removed")
@@ -575,7 +598,8 @@ def uninstall_schedule() -> int:
         if plist.exists():
             subprocess.run(
                 ["launchctl", "unload", str(plist)],
-                capture_output=True, timeout=10,
+                capture_output=True,
+                timeout=10,
             )
             plist.unlink()
             ok(f"launchd: {LAUNCHD_LABEL} removed")
@@ -587,7 +611,8 @@ def uninstall_schedule() -> int:
         try:
             subprocess.run(
                 ["systemctl", "--user", "disable", "--now", "copilot-cli-healer.timer"],
-                capture_output=True, timeout=10,
+                capture_output=True,
+                timeout=10,
             )
         except Exception:
             pass
@@ -598,7 +623,8 @@ def uninstall_schedule() -> int:
         try:
             subprocess.run(
                 ["systemctl", "--user", "daemon-reload"],
-                capture_output=True, timeout=10,
+                capture_output=True,
+                timeout=10,
             )
         except Exception:
             pass
@@ -631,31 +657,39 @@ def main() -> int:
     )
     parser.add_argument("--status", action="store_true", help="Print pkg dir summary")
     parser.add_argument(
-        "--check", action="store_true",
+        "--check",
+        action="store_true",
         help="Exit 0 if healthy, 1 if stale state detected",
     )
     parser.add_argument(
-        "--heal", action="store_true",
+        "--heal",
+        action="store_true",
         help="Remove stale .replaced-* dirs and tmp/ contents",
     )
     parser.add_argument(
-        "--update", action="store_true",
+        "--update",
+        action="store_true",
         help="Heal then invoke 'copilot update' with retry",
     )
     parser.add_argument(
-        "--install-schedule", action="store_true",
+        "--install-schedule",
+        action="store_true",
         help="Register daily healer with OS scheduler",
     )
     parser.add_argument(
-        "--uninstall-schedule", action="store_true",
+        "--uninstall-schedule",
+        action="store_true",
         help="Unregister scheduled healer",
     )
     parser.add_argument(
-        "--dry-run", action="store_true",
+        "--dry-run",
+        action="store_true",
         help="Print actions without making changes (use with --heal)",
     )
     parser.add_argument(
-        "--version", action="version", version=f"copilot-cli-healer {HEALER_VERSION}",
+        "--version",
+        action="version",
+        version=f"copilot-cli-healer {HEALER_VERSION}",
     )
 
     args = parser.parse_args()
@@ -673,10 +707,7 @@ def main() -> int:
         if not issues:
             ok("Copilot CLI pkg: healthy")
             return 0
-        warn(
-            f"Copilot CLI pkg: {len(issues)} stale item(s) — "
-            "run: python copilot-cli-healer.py --heal"
-        )
+        warn(f"Copilot CLI pkg: {len(issues)} stale item(s) — run: python copilot-cli-healer.py --heal")
         for i in issues:
             warn(f"  {i.description}")
         return 1

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,20 +64,19 @@ This is the canonical inventory for Python Ruff coverage. Keep it in sync with
 
 | Surface | CI Ruff lint/format | Local `pre-commit` Ruff | Notes |
 |---------|----------------------|--------------------------|-------|
-| Exact root standalone scripts | `embed.py`, `scout-config.py`, `scout-status.py`, `sync-config.py`, `sync-daemon.py`, `sync-status.py`, `migrate.py`, `generate-summary.py`, `briefing.py`, `learn.py`, `query-session.py`, `extract-knowledge.py`, `build-session-index.py`, `tentacle.py`, `_tentacle_core.py`, `_tentacle_goal.py`, `_tentacle_pr.py`, `_tentacle_dispatch.py`, `_tentacle_review.py`, `checkpoint-diff.py`, `checkpoint-restore.py`, `checkpoint-save.py` | Same exact set via `in_python_cleanliness_surface()` | These are the current blocking Ruff baseline for root scripts. |
-| Focused test file | `tests/test_browse_search_v2.py` | Same exact file | Included because it is already clean and protects the browse search API surface. |
+| Root standalone scripts | `*.py` | Any staged root `.py` path via `in_python_cleanliness_surface()` | Every root-level Python entry point is inside the blocking Ruff baseline. |
 | Package/module directories | `browse/`, `hooks/`, `scripts/` | Any staged `.py` path under `browse/`, `hooks/`, or `scripts/` | Directory coverage applies to package-like surfaces where Ruff cleanup is already baselined. |
 | Syntax gate | `python3 scripts/check_syntax.py` | All staged `.py` files via `scripts/check_syntax.py` when installed | Syntax coverage is broader than Ruff coverage. |
 | Complexity advisory | Full suite path through `run_all_tests.py`; local hook runs `scripts/check_complexity.py --json` on staged `.py` snapshots | All staged `.py` files, non-blocking and fail-open | Advisory only; it prints findings but does not deny commits. |
 | Ruff complexity/refactor advisory | `Complexity advisory (Ruff C90/PLR)` runs `ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statistics` on the same Ruff surface | Not run by local `pre-commit` | CI advisory only; `continue-on-error: true` records baseline counts before enforcement. |
-| Out-of-surface Ruff advisory | Not run by CI | Staged `.py` files outside `in_python_cleanliness_surface()` run `ruff check` as a non-blocking `[advisory]` scan | Advisory only; it is fail-open when Ruff is absent and does not change the blocking Ruff surface. |
+| Out-of-surface Ruff advisory | Not run by CI | Staged `.py` files outside root scripts and covered package directories run `ruff check` as a non-blocking `[advisory]` scan | Advisory only; it is fail-open when Ruff is absent and does not change the blocking Ruff surface. |
 
-Root `*.py` files not listed in the exact root standalone script row are intentionally
-outside the blocking Ruff lint surface until they are baselined. They are not exempt from
-the standalone-script architecture contract: keep them self-contained, run syntax/tests for
-the touched behavior, and either add them to the lint surface in the same PR or state why
-the script remains outside the current baseline. The local `pre-commit` hook may print
-non-blocking `[advisory]` Ruff findings for these files when Ruff is installed.
+Root `*.py` files are now inside the blocking Ruff lint surface by default. New
+root scripts still must honor the standalone-script architecture contract: keep them
+self-contained and run syntax/tests for the touched behavior. Python files outside root
+scripts, `browse/`, `hooks/`, and `scripts/` are outside CI Ruff coverage; the local
+`pre-commit` hook may print non-blocking `[advisory]` Ruff findings for those files when
+Ruff is installed.
 
 ## Script Inventory
 
@@ -394,7 +393,7 @@ Agent-authored docs and operator/research outputs (tentacle handoffs, retro summ
 ### CI Quality Gates
 
 GitHub Actions runs these jobs on every push / PR:
-- **`quality-gates`** — syntax check, scoped Ruff lint, and the Python test suites. The Ruff lint surface is: `embed.py`, `scout-config.py`, `scout-status.py`, `sync-config.py`, `sync-daemon.py`, `sync-status.py`, `migrate.py`, `generate-summary.py`, `briefing.py`, `learn.py`, `query-session.py`, `extract-knowledge.py`, `build-session-index.py`, `tentacle.py`, `_tentacle_core.py`, `_tentacle_goal.py`, `_tentacle_pr.py`, `_tentacle_dispatch.py`, `_tentacle_review.py`, `checkpoint-diff.py`, `checkpoint-restore.py`, `checkpoint-save.py`, `browse/`, `hooks/`, `scripts/`. Ruff lint is **scoped** to this surface; other root scripts outside it are not linted by CI.
+- **`quality-gates`** — syntax check, scoped Ruff lint, and the Python test suites. The Ruff lint surface is: all root `*.py` scripts plus `browse/`, `hooks/`, and `scripts/`. Ruff lint is **scoped** to this surface; Python outside root scripts and those directories is not linted by CI.
 - **`remote-terminal`** — `npm ci`, `npm test`, lint baseline, clean-zone lint gate, and blocking high-severity dependency audit for `remote-terminal/`. Legacy complexity/size warnings stay advisory in `npm run lint`; clean files (`pty-daemon.js`, `test/client.test.js`) promote the same rules to errors through `npm run lint:clean`.
 - **`browse-ui`** — `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, `pnpm build`. `browse-ui/eslint.config.mjs` keeps the repo-wide `@typescript-eslint/no-explicit-any` baseline advisory as `warn`, then promotes clean zones such as `src/lib/hosts/**/*.{ts,tsx}` to `error` so strict rules can expand without breaking legacy areas.
 - **`e2e-smoke`** — Playwright `behavioral` project (`smoke.spec.ts`, `shortcuts.spec.ts`, `chat.spec.ts`, `diagnostics.spec.ts`, and `broker-mode.spec.ts`) on Chromium.

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -69,18 +69,13 @@ hooks/
 **Ruff lint surface** (identical between local `pre-commit` and CI `quality-gates` job):
 
 ```
-embed.py  scout-config.py  scout-status.py
-sync-config.py  sync-daemon.py  sync-status.py
-migrate.py  generate-summary.py
-briefing.py  learn.py  query-session.py  extract-knowledge.py
-build-session-index.py  tentacle.py
-checkpoint-diff.py  checkpoint-restore.py  checkpoint-save.py
-browse/  hooks/
+*.py
+browse/  hooks/  scripts/
 ```
 
-Both the local hook and CI run `ruff format --check` and `ruff check` on staged/changed files in this surface. Locally, **both checks are fail-open** — they skip silently when `ruff` is not installed. CI always has Ruff and will fail hard on violations. Other root scripts (e.g., `watch-sessions.py`, `install.py`, `auto-update-tools.py`) are **not** in scope.
+Both the local hook and CI run `ruff format --check` and `ruff check` on staged/changed files in this surface. Locally, **both checks are fail-open** — they skip silently when `ruff` is not installed. CI always has Ruff and will fail hard on violations. Python outside root scripts and the covered directories is **not** in CI Ruff scope.
 
-The `browse/*` and `hooks/*` patterns in the local `_py_in_surface()` function match **all subdirectory depths** — consistent with CI's directory-level `ruff check browse/ hooks/` invocation. This ensures depth-4 files like `browse/static/vendor/_download.py` are covered locally as well as in CI.
+The `browse/*`, `hooks/*`, and `scripts/*` patterns in the local `in_python_cleanliness_surface()` function match **all subdirectory depths** — consistent with CI's directory-level `ruff check browse/ hooks/ scripts/` invocation. This ensures depth-4 files like `browse/static/vendor/_download.py` are covered locally as well as in CI.
 
 **Complexity advisory** (`scripts/check_complexity.py`): the local `pre-commit` hook runs the reporter on staged `.py` files and prints warnings for files/functions over the advisory thresholds. This is always non-blocking and fail-open: missing reporter, reporter errors, or malformed reporter output do not block the commit.
 

--- a/error-analysis.py
+++ b/error-analysis.py
@@ -203,7 +203,7 @@ def print_report(report):
     # Summary
     total_mistakes = sum(item["count"] for item in report.get("error_types", []))
     total_recurring = sum(item.get("recurrence", 0) for item in recurring)
-    print(f"\n═══ Summary ═══")
+    print("\n═══ Summary ═══")
     print(f"  Total mistakes:     {total_mistakes}")
     print(f"  Total recurrences:  {total_recurring}")
     print(f"  Unique root causes: {len(root_causes)}")

--- a/export-cerebrum.py
+++ b/export-cerebrum.py
@@ -151,7 +151,8 @@ def _fetch_entries(
     if tags_filter:
         lower_tags = {t.lower() for t in tags_filter}
         entries = [
-            e for e in entries
+            e
+            for e in entries
             if {tok.strip().lower() for tok in (e.get("tags") or "").split(",") if tok.strip()} & lower_tags
         ]
         if limit is not None:
@@ -195,8 +196,7 @@ def _render_markdown(
     lines: list[str] = []
     lines.append("# CEREBRUM — Agent Knowledge Snapshot\n")
     lines.append(
-        "> Auto-generated from the session knowledge DB.  "
-        "Read this file before starting any task — no query needed.\n"
+        "> Auto-generated from the session knowledge DB.  Read this file before starting any task — no query needed.\n"
     )
     lines.append(f"<!-- generated_at: {generated_at} -->\n")
     lines.append("---\n")
@@ -219,10 +219,7 @@ def _render_markdown(
             lines.extend(_render_entry_markdown(entry, i))
 
     lines.append("\n---\n")
-    lines.append(
-        f"*Refresh: `python export-cerebrum.py --output CEREBRUM.md`  "
-        f"— {generated_at}*\n"
-    )
+    lines.append(f"*Refresh: `python export-cerebrum.py --output CEREBRUM.md`  — {generated_at}*\n")
     return "\n".join(lines)
 
 
@@ -276,9 +273,7 @@ def export_cerebrum(
     # the largest fractional remainder, tie-broken by section key descending for
     # determinism.
     _base = total_fraction if total_fraction > 0 else 1.0
-    _exact: dict[str, float] = {
-        s: limit * (_SECTION_META[s]["limit_fraction"] / _base) for s in sections
-    }
+    _exact: dict[str, float] = {s: limit * (_SECTION_META[s]["limit_fraction"] / _base) for s in sections}
     _floor: dict[str, int] = {s: int(v) for s, v in _exact.items()}
     _remaining = limit - sum(_floor.values())
     _sorted_rem = sorted(sections, key=lambda s: (_exact[s] - _floor[s], s), reverse=True)
@@ -299,18 +294,21 @@ def export_cerebrum(
         learn_all = [e for e in pattern_pool if not _is_preference_entry(e)]
 
     if "preferences" in sections:
-        sections_data["preferences"] = pref_all[:section_limits["preferences"]]
+        sections_data["preferences"] = pref_all[: section_limits["preferences"]]
 
     for section_key in sections:
         if section_key == "preferences":
             continue  # already handled above
 
         if section_key == "learnings":
-            sections_data["learnings"] = learn_all[:section_limits["learnings"]]
+            sections_data["learnings"] = learn_all[: section_limits["learnings"]]
         else:
             sections_data[section_key] = _fetch_entries(
-                db, _SECTION_META[section_key]["category"],
-                section_limits[section_key], tags_filter, min_confidence,
+                db,
+                _SECTION_META[section_key]["category"],
+                section_limits[section_key],
+                tags_filter,
+                min_confidence,
             )
 
     if fmt == "json":
@@ -346,10 +344,7 @@ def main(argv: list[str] | None = None) -> int:
         "--sections",
         default=",".join(ALL_SECTIONS),
         metavar="SECTION[,SECTION...]",
-        help=(
-            f"Comma-separated list of sections to include "
-            f"(default: {','.join(ALL_SECTIONS)})"
-        ),
+        help=(f"Comma-separated list of sections to include (default: {','.join(ALL_SECTIONS)})"),
     )
     parser.add_argument(
         "--tags",
@@ -382,10 +377,7 @@ def main(argv: list[str] | None = None) -> int:
     raw_sections = list(dict.fromkeys(raw_sections))
     invalid = [s for s in raw_sections if s not in _SECTION_META]
     if invalid:
-        parser.error(
-            f"Unknown section(s): {', '.join(invalid)}. "
-            f"Valid: {', '.join(ALL_SECTIONS)}"
-        )
+        parser.error(f"Unknown section(s): {', '.join(invalid)}. Valid: {', '.join(ALL_SECTIONS)}")
     if not raw_sections:
         parser.error("--sections must include at least one valid section name.")
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -108,32 +108,9 @@ def check_python_syntax(staged: list[str]) -> int:
 # Canonical surface inventory: docs/ARCHITECTURE.md#python-lint-surface-inventory
 # Keep this in sync with .github/workflows/ci.yml and tests/test_quality_gates.py.
 def in_python_cleanliness_surface(path: str) -> bool:
-    exact = {
-        "embed.py",
-        "scout-config.py",
-        "scout-status.py",
-        "sync-config.py",
-        "sync-daemon.py",
-        "sync-status.py",
-        "migrate.py",
-        "generate-summary.py",
-        "briefing.py",
-        "learn.py",
-        "query-session.py",
-        "extract-knowledge.py",
-        "build-session-index.py",
-        "tentacle.py",
-        "_tentacle_core.py",
-        "_tentacle_goal.py",
-        "_tentacle_pr.py",
-        "_tentacle_dispatch.py",
-        "_tentacle_review.py",
-        "checkpoint-diff.py",
-        "checkpoint-restore.py",
-        "checkpoint-save.py",
-        "tests/test_browse_search_v2.py",
-    }
-    return path in exact or path.startswith(("browse/", "hooks/", "scripts/"))
+    return (path.endswith(".py") and "/" not in path and "\\" not in path) or path.startswith(
+        ("browse/", "hooks/", "scripts/")
+    )
 
 
 def check_ruff(staged: list[str]) -> int:

--- a/host_manifest.py
+++ b/host_manifest.py
@@ -36,11 +36,11 @@ if os.name == "nt":
 _HOME = Path(os.environ["COPILOT_HOME"]) if "COPILOT_HOME" in os.environ else Path.home()
 
 COPILOT_DIR = _HOME / ".copilot"
-CLAUDE_DIR  = _HOME / ".claude"
+CLAUDE_DIR = _HOME / ".claude"
 
 # Session data roots (each host's location for session/project files)
-SESSION_STATE   = COPILOT_DIR / "session-state"
-CLAUDE_PROJECTS = CLAUDE_DIR  / "projects"
+SESSION_STATE = COPILOT_DIR / "session-state"
+CLAUDE_PROJECTS = CLAUDE_DIR / "projects"
 
 # ---------------------------------------------------------------------------
 # Supported-host manifests
@@ -56,7 +56,7 @@ UNSUPPORTED_HOSTS: tuple[str, ...] = ("Codex", "Cursor", "Windsurf", "Cline", "C
 # Top-level host config directories — used by install.py for existence checks.
 HOST_DIRS: dict[str, Path] = {
     "Copilot CLI": COPILOT_DIR,
-    "Claude Code":  CLAUDE_DIR,
+    "Claude Code": CLAUDE_DIR,
 }
 
 # Session file roots — used by watch-sessions.py to discover session files.
@@ -73,7 +73,7 @@ HOST_SESSION_ROOTS: tuple[tuple[str, Path], ...] = (
 HOST_INSTRUCTION_FILES: dict[str, str] = {
     "Copilot CLI": ".github/copilot-instructions.md",
     "Claude Code": "CLAUDE.md",
-    "All agents":  "AGENTS.md",   # host-agnostic; read by Claude, Codex, and others
+    "All agents": "AGENTS.md",  # host-agnostic; read by Claude, Codex, and others
 }
 
 # Project-relative paths for deploying SKILL.md into a project.
@@ -81,5 +81,5 @@ HOST_INSTRUCTION_FILES: dict[str, str] = {
 # so both consumers stay in sync when host layouts change.
 HOST_SKILL_SUBPATHS: dict[str, str] = {
     "Copilot CLI": ".github/skills/session-knowledge/SKILL.md",
-    "Claude Code":  ".claude/skills/session-knowledge/SKILL.md",
+    "Claude Code": ".claude/skills/session-knowledge/SKILL.md",
 }

--- a/improvement-signals.py
+++ b/improvement-signals.py
@@ -254,10 +254,18 @@ def cmd_stats(args, db_path: Path) -> int:
 
         fmt = getattr(args, "output_format", "text")
         if fmt == "json":
-            print(json.dumps(
-                {"db_exists": True, "total": total, "unconsumed": unconsumed, "consumed": consumed, "by_type": by_type},
-                indent=2,
-            ))
+            print(
+                json.dumps(
+                    {
+                        "db_exists": True,
+                        "total": total,
+                        "unconsumed": unconsumed,
+                        "consumed": consumed,
+                        "by_type": by_type,
+                    },
+                    indent=2,
+                )
+            )
         else:
             print("\n📊 Improvement Signal Statistics\n")
             print(f"  Total:      {total}")
@@ -289,47 +297,57 @@ Examples:
   python improvement-signals.py stats --format json
         """,
     )
-    parser.add_argument("--db", type=str, default=None, metavar="PATH",
-                        help=f"Path to knowledge.db (default: {DB_PATH})")
+    parser.add_argument(
+        "--db", type=str, default=None, metavar="PATH", help=f"Path to knowledge.db (default: {DB_PATH})"
+    )
 
     subs = parser.add_subparsers(dest="subcommand")
 
     # record
     p_record = subs.add_parser("record", help="Record a new improvement signal.")
-    p_record.add_argument("--query", required=True, metavar="TEXT",
-                          help="The query or scenario that triggered the signal.")
-    p_record.add_argument("--type", required=True, dest="type",
-                          choices=VALID_SIGNAL_TYPES,
-                          help="Signal type: missed_match | wrong_skill | outdated_skill")
-    p_record.add_argument("--skill", default="", metavar="SKILL",
-                          help="Skill name involved (for wrong_skill / outdated_skill).")
-    p_record.add_argument("--session-id", default="", metavar="ID",
-                          help="Session ID to link this signal to (optional).")
+    p_record.add_argument(
+        "--query", required=True, metavar="TEXT", help="The query or scenario that triggered the signal."
+    )
+    p_record.add_argument(
+        "--type",
+        required=True,
+        dest="type",
+        choices=VALID_SIGNAL_TYPES,
+        help="Signal type: missed_match | wrong_skill | outdated_skill",
+    )
+    p_record.add_argument(
+        "--skill", default="", metavar="SKILL", help="Skill name involved (for wrong_skill / outdated_skill)."
+    )
+    p_record.add_argument(
+        "--session-id", default="", metavar="ID", help="Session ID to link this signal to (optional)."
+    )
 
     # list
     p_list = subs.add_parser("list", help="List signals.")
-    p_list.add_argument("--consumed", action="store_true",
-                        help="Show consumed signals instead of unconsumed ones.")
-    p_list.add_argument("--type", dest="type", default=None, choices=VALID_SIGNAL_TYPES,
-                        help="Filter by signal type.")
-    p_list.add_argument("--limit", type=int, default=50, metavar="N",
-                        help="Max rows to return (default: 50).")
-    p_list.add_argument("--format", dest="output_format", choices=["text", "json"], default="text",
-                        help="Output format.")
+    p_list.add_argument("--consumed", action="store_true", help="Show consumed signals instead of unconsumed ones.")
+    p_list.add_argument("--type", dest="type", default=None, choices=VALID_SIGNAL_TYPES, help="Filter by signal type.")
+    p_list.add_argument("--limit", type=int, default=50, metavar="N", help="Max rows to return (default: 50).")
+    p_list.add_argument(
+        "--format", dest="output_format", choices=["text", "json"], default="text", help="Output format."
+    )
 
     # consume
     p_consume = subs.add_parser("consume", help="Mark signal(s) as consumed.")
-    p_consume.add_argument("--id", type=int, default=None, metavar="ID",
-                           help="Signal ID to mark consumed.")
-    p_consume.add_argument("--all", action="store_true",
-                           help="Mark all unconsumed signals as consumed.")
-    p_consume.add_argument("--type", dest="type", default=None, choices=VALID_SIGNAL_TYPES,
-                           help="With --all: only consume signals of this type.")
+    p_consume.add_argument("--id", type=int, default=None, metavar="ID", help="Signal ID to mark consumed.")
+    p_consume.add_argument("--all", action="store_true", help="Mark all unconsumed signals as consumed.")
+    p_consume.add_argument(
+        "--type",
+        dest="type",
+        default=None,
+        choices=VALID_SIGNAL_TYPES,
+        help="With --all: only consume signals of this type.",
+    )
 
     # stats
     p_stats = subs.add_parser("stats", help="Print statistics.")
-    p_stats.add_argument("--format", dest="output_format", choices=["text", "json"], default="text",
-                         help="Output format.")
+    p_stats.add_argument(
+        "--format", dest="output_format", choices=["text", "json"], default="text", help="Output format."
+    )
 
     args = parser.parse_args(argv)
 

--- a/install-binary.py
+++ b/install-binary.py
@@ -99,7 +99,7 @@ def verify_checksum(file_path: Path, checksum_url: str) -> bool:
     actual = sha256.hexdigest()
 
     if expected != actual:
-        print(f"Error: Checksum mismatch!", file=sys.stderr)
+        print("Error: Checksum mismatch!", file=sys.stderr)
         print(f"  Expected: {expected}", file=sys.stderr)
         print(f"  Got:      {actual}", file=sys.stderr)
         return False
@@ -139,10 +139,10 @@ def setup_path_posix(install_dir: Path) -> None:
     print("⚠️  Add to your PATH:")
     print()
     if shell_name == "zsh":
-        print(f'  echo \'export PATH="{install_dir}:$PATH"\' >> ~/.zshrc')
+        print(f"  echo 'export PATH=\"{install_dir}:$PATH\"' >> ~/.zshrc")
         print("  source ~/.zshrc")
     elif shell_name == "bash":
-        print(f'  echo \'export PATH="{install_dir}:$PATH"\' >> ~/.bashrc')
+        print(f"  echo 'export PATH=\"{install_dir}:$PATH\"' >> ~/.bashrc")
         print("  source ~/.bashrc")
     elif shell_name == "fish":
         print(f"  fish_add_path {install_dir}")
@@ -156,9 +156,8 @@ def setup_path_windows(install_dir: Path) -> None:
     """Add to PATH on Windows via registry."""
     try:
         import winreg
-        key = winreg.OpenKey(
-            winreg.HKEY_CURRENT_USER, r"Environment", 0, winreg.KEY_ALL_ACCESS
-        )
+
+        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Environment", 0, winreg.KEY_ALL_ACCESS)
         try:
             current_path, _ = winreg.QueryValueEx(key, "Path")
         except FileNotFoundError:

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -287,7 +287,9 @@ def _handle_request(message: dict[str, Any]) -> tuple[bool, dict[str, Any] | Non
 
     if method == "initialize":
         requested_protocol = params.get("protocolVersion")
-        protocol = requested_protocol if isinstance(requested_protocol, str) and requested_protocol else PROTOCOL_VERSION
+        protocol = (
+            requested_protocol if isinstance(requested_protocol, str) and requested_protocol else PROTOCOL_VERSION
+        )
         return False, {
             "protocolVersion": protocol,
             "capabilities": {"tools": {"listChanged": False}},

--- a/profile-builder.py
+++ b/profile-builder.py
@@ -37,6 +37,7 @@ import json
 import os
 import sys
 from pathlib import Path
+
 if os.name == "nt":
     for _s in (sys.stdout, sys.stderr):
         if hasattr(_s, "reconfigure"):
@@ -44,6 +45,7 @@ if os.name == "nt":
 
 if os.name == "nt":
     import io
+
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
     sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
 
@@ -98,10 +100,7 @@ def validate_profile(data: dict, skip_hook_validation: bool = False) -> list[str
             if not isinstance(hook, str) or not hook.endswith(".py"):
                 errors.append(f"Hook '{hook}' must be a .py filename string")
             elif not skip_hook_validation and available and hook not in available:
-                errors.append(
-                    f"Hook template not found: '{hook}' "
-                    f"(use --skip-hook-validation to bypass)"
-                )
+                errors.append(f"Hook template not found: '{hook}' (use --skip-hook-validation to bypass)")
 
     phases = data.get("workflow_phases", [])
     if not isinstance(phases, list) or len(phases) == 0:
@@ -109,10 +108,7 @@ def validate_profile(data: dict, skip_hook_validation: bool = False) -> list[str
     else:
         unknown = [p for p in phases if p not in KNOWN_PHASES]
         if unknown:
-            errors.append(
-                f"Unknown phase(s): {', '.join(unknown)}. "
-                f"Known: {', '.join(KNOWN_PHASES)}"
-            )
+            errors.append(f"Unknown phase(s): {', '.join(unknown)}. Known: {', '.join(KNOWN_PHASES)}")
 
     notes = data.get("workflow_notes", "")
     if notes and len(notes) > MAX_NOTES_LEN:
@@ -156,24 +152,21 @@ Examples:
     )
     parser.add_argument("--name", help="Profile name (alphanumeric, hyphens, underscores)")
     parser.add_argument("--description", help="Short description of the profile")
-    parser.add_argument("--hooks", nargs="+", metavar="HOOK",
-                        help="Hook filenames (e.g. dangerous-blocker.py commit-gate.py)")
-    parser.add_argument("--phases", nargs="+", metavar="PHASE",
-                        help=f"Workflow phases from: {', '.join(KNOWN_PHASES)}")
-    parser.add_argument("--notes", default="",
-                        help="Optional workflow notes (shown in WORKFLOW.md)")
-    parser.add_argument("--output-dir", default=None,
-                        help="Directory to write profile JSON (default: presets/)")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Print the generated JSON without writing any files")
-    parser.add_argument("--force", action="store_true",
-                        help="Overwrite an existing profile with the same name")
-    parser.add_argument("--skip-hook-validation", action="store_true",
-                        help="Skip validation that referenced hook templates exist on disk")
-    parser.add_argument("--list-hooks", action="store_true",
-                        help="List available hook templates and exit")
-    parser.add_argument("--list-phases", action="store_true",
-                        help="List known workflow phases and exit")
+    parser.add_argument(
+        "--hooks", nargs="+", metavar="HOOK", help="Hook filenames (e.g. dangerous-blocker.py commit-gate.py)"
+    )
+    parser.add_argument("--phases", nargs="+", metavar="PHASE", help=f"Workflow phases from: {', '.join(KNOWN_PHASES)}")
+    parser.add_argument("--notes", default="", help="Optional workflow notes (shown in WORKFLOW.md)")
+    parser.add_argument("--output-dir", default=None, help="Directory to write profile JSON (default: presets/)")
+    parser.add_argument("--dry-run", action="store_true", help="Print the generated JSON without writing any files")
+    parser.add_argument("--force", action="store_true", help="Overwrite an existing profile with the same name")
+    parser.add_argument(
+        "--skip-hook-validation",
+        action="store_true",
+        help="Skip validation that referenced hook templates exist on disk",
+    )
+    parser.add_argument("--list-hooks", action="store_true", help="List available hook templates and exit")
+    parser.add_argument("--list-phases", action="store_true", help="List known workflow phases and exit")
     args = parser.parse_args()
 
     if args.list_hooks:

--- a/profile-export.py
+++ b/profile-export.py
@@ -36,6 +36,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
 if os.name == "nt":
     for _s in (sys.stdout, sys.stderr):
         if hasattr(_s, "reconfigure"):
@@ -43,6 +44,7 @@ if os.name == "nt":
 
 if os.name == "nt":
     import io
+
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
     sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
 
@@ -60,8 +62,7 @@ def load_profile(name: str, presets_dir: Path) -> dict:
     if not path.exists():
         available = sorted(p.stem for p in presets_dir.glob("*.json"))
         raise FileNotFoundError(
-            f"Profile '{name}' not found in {presets_dir}. "
-            f"Available: {', '.join(available) or '(none)'}"
+            f"Profile '{name}' not found in {presets_dir}. Available: {', '.join(available) or '(none)'}"
         )
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -137,21 +138,23 @@ Examples:
 """,
     )
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--profile", metavar="NAME",
-                       help="Export a single named profile")
-    group.add_argument("--all", action="store_true",
-                       help="Export all profiles")
+    group.add_argument("--profile", metavar="NAME", help="Export a single named profile")
+    group.add_argument("--all", action="store_true", help="Export all profiles")
 
-    parser.add_argument("--output", metavar="PATH",
-                        help="Output file path (for single profile or --all + --format bundle)")
-    parser.add_argument("--output-dir", metavar="DIR",
-                        help="Output directory for --all (one file per profile)")
-    parser.add_argument("--format", choices=["plain", "bundle"], default="plain",
-                        help="plain = raw JSON (default), bundle = metadata wrapper")
-    parser.add_argument("--presets-dir", default=None, metavar="DIR",
-                        help=f"Presets directory (default: {PRESETS_DIR})")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Show what would be written without writing")
+    parser.add_argument(
+        "--output", metavar="PATH", help="Output file path (for single profile or --all + --format bundle)"
+    )
+    parser.add_argument("--output-dir", metavar="DIR", help="Output directory for --all (one file per profile)")
+    parser.add_argument(
+        "--format",
+        choices=["plain", "bundle"],
+        default="plain",
+        help="plain = raw JSON (default), bundle = metadata wrapper",
+    )
+    parser.add_argument(
+        "--presets-dir", default=None, metavar="DIR", help=f"Presets directory (default: {PRESETS_DIR})"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be written without writing")
     args = parser.parse_args()
 
     presets_dir = Path(args.presets_dir).resolve() if args.presets_dir else PRESETS_DIR
@@ -174,7 +177,7 @@ Examples:
         print(f"📦 Exporting profile '{args.profile}' → {args.output}")
         export_single(profile, Path(args.output), args.format, args.dry_run)
         if not args.dry_run:
-            print(f"\n✅ Done. Import with:")
+            print("\n✅ Done. Import with:")
             print(f"   python3 profile-import.py --file {args.output}")
         return
 
@@ -187,13 +190,12 @@ Examples:
     if args.output:
         # All → single bundle file
         if args.format != "bundle":
-            print("✗ --output with --all requires --format bundle "
-                  "(use --output-dir for plain per-profile export)")
+            print("✗ --output with --all requires --format bundle (use --output-dir for plain per-profile export)")
             sys.exit(1)
         print(f"📦 Exporting {len(profiles)} profile(s) → {args.output}")
         export_all_to_bundle(profiles, Path(args.output), args.dry_run)
         if not args.dry_run:
-            print(f"\n✅ Done. Import with:")
+            print("\n✅ Done. Import with:")
             print(f"   python3 profile-import.py --file {args.output}")
     else:
         # All → directory
@@ -201,7 +203,7 @@ Examples:
         print(f"📦 Exporting {len(profiles)} profile(s) → {out_dir}/")
         export_all_to_dir(profiles, out_dir, args.format, args.dry_run)
         if not args.dry_run:
-            print(f"\n✅ Done.")
+            print("\n✅ Done.")
 
 
 if __name__ == "__main__":

--- a/profile-import.py
+++ b/profile-import.py
@@ -46,7 +46,7 @@ from pathlib import Path
 if os.name == "nt":
     import io
 import os
-import sys
+
 if os.name == "nt":
     for _s in (sys.stdout, sys.stderr):
         if hasattr(_s, "reconfigure"):
@@ -92,9 +92,7 @@ def validate_profile(data: dict, skip_hook_validation: bool = False) -> list[str
     elif len(name) > MAX_NAME_LEN:
         errors.append(f"'name' exceeds {MAX_NAME_LEN} characters")
     elif not all(c.isalnum() or c in "-_" for c in name):
-        errors.append(
-            "'name' may only contain alphanumeric characters, hyphens, or underscores"
-        )
+        errors.append("'name' may only contain alphanumeric characters, hyphens, or underscores")
 
     desc = data.get("description", "")
     if not isinstance(desc, str) or not desc:
@@ -111,10 +109,7 @@ def validate_profile(data: dict, skip_hook_validation: bool = False) -> list[str
             if not isinstance(hook, str) or not hook.endswith(".py"):
                 errors.append(f"Hook entry must be a .py filename string, got: {hook!r}")
             elif not skip_hook_validation and available and hook not in available:
-                errors.append(
-                    f"Hook template not found on disk: '{hook}' "
-                    f"(use --skip-hook-validation to bypass)"
-                )
+                errors.append(f"Hook template not found on disk: '{hook}' (use --skip-hook-validation to bypass)")
 
     phases = data.get("workflow_phases", [])
     if not isinstance(phases, list) or len(phases) == 0:
@@ -122,10 +117,7 @@ def validate_profile(data: dict, skip_hook_validation: bool = False) -> list[str
     else:
         unknown = [p for p in phases if p not in KNOWN_PHASES]
         if unknown:
-            errors.append(
-                f"Unknown phase(s): {', '.join(unknown)}. "
-                f"Known: {', '.join(sorted(KNOWN_PHASES))}"
-            )
+            errors.append(f"Unknown phase(s): {', '.join(unknown)}. Known: {', '.join(sorted(KNOWN_PHASES))}")
 
     notes = data.get("workflow_notes", "")
     if notes and len(notes) > MAX_NOTES_LEN:
@@ -159,10 +151,7 @@ def import_profile(
 
     if dest.exists() and not force:
         shipped_note = " (shipped profile)" if name in SHIPPED_PROFILES else ""
-        print(
-            f"  ✗ '{name}'{shipped_note} already exists at {dest} — "
-            f"use --force to overwrite"
-        )
+        print(f"  ✗ '{name}'{shipped_note} already exists at {dest} — use --force to overwrite")
         return False
 
     hooks = profile.get("hooks", [])
@@ -170,8 +159,7 @@ def import_profile(
     action = "Would overwrite" if dest.exists() else "Would import"
 
     if dry_run:
-        print(f"  [dry-run] {action}: '{name}' "
-              f"({len(hooks)} hooks, {len(phases)} phases) → {dest}")
+        print(f"  [dry-run] {action}: '{name}' ({len(hooks)} hooks, {len(phases)} phases) → {dest}")
         return True
 
     presets_dir.mkdir(parents=True, exist_ok=True)
@@ -196,18 +184,27 @@ Examples:
   python3 profile-import.py --file custom.json --skip-hook-validation
 """,
     )
-    parser.add_argument("--file", required=True, metavar="PATH",
-                        help="Path to profile JSON or bundle JSON file to import")
-    parser.add_argument("--name", default=None, metavar="NAME",
-                        help="Import only this profile name (for bundle files with multiple profiles)")
-    parser.add_argument("--force", action="store_true",
-                        help="Overwrite existing profiles (including shipped presets)")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Validate and show what would be imported without writing")
-    parser.add_argument("--skip-hook-validation", action="store_true",
-                        help="Skip validation that referenced hook templates exist on disk")
-    parser.add_argument("--presets-dir", default=None, metavar="DIR",
-                        help=f"Destination presets directory (default: {PRESETS_DIR})")
+    parser.add_argument(
+        "--file", required=True, metavar="PATH", help="Path to profile JSON or bundle JSON file to import"
+    )
+    parser.add_argument(
+        "--name",
+        default=None,
+        metavar="NAME",
+        help="Import only this profile name (for bundle files with multiple profiles)",
+    )
+    parser.add_argument("--force", action="store_true", help="Overwrite existing profiles (including shipped presets)")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Validate and show what would be imported without writing"
+    )
+    parser.add_argument(
+        "--skip-hook-validation",
+        action="store_true",
+        help="Skip validation that referenced hook templates exist on disk",
+    )
+    parser.add_argument(
+        "--presets-dir", default=None, metavar="DIR", help=f"Destination presets directory (default: {PRESETS_DIR})"
+    )
     args = parser.parse_args()
 
     src = Path(args.file)
@@ -242,8 +239,7 @@ Examples:
     else:
         all_profiles = [data]
         if args.name and data.get("name") != args.name:
-            print(f"  ✗ File contains profile '{data.get('name')}', "
-                  f"not '{args.name}'")
+            print(f"  ✗ File contains profile '{data.get('name')}', not '{args.name}'")
             sys.exit(1)
 
     success = 0

--- a/profile-import.py
+++ b/profile-import.py
@@ -45,7 +45,6 @@ from pathlib import Path
 
 if os.name == "nt":
     import io
-import os
 
 if os.name == "nt":
     for _s in (sys.stdout, sys.stderr):

--- a/retro.py
+++ b/retro.py
@@ -408,10 +408,12 @@ def collect_scout_signals(
     # Compute elapsed / remaining hours using stdlib only (no dateutil)
     try:
         import time as _time
+
         # Parse ISO-8601 with optional timezone suffix
         ts_str = last_run_str.strip().replace("Z", "+00:00")
         # Python 3.7+ fromisoformat handles "+00:00" but not "Z" directly
-        from datetime import datetime, timezone as _tz
+        from datetime import datetime
+        from datetime import timezone as _tz
 
         last_run_dt = datetime.fromisoformat(ts_str)
         if last_run_dt.tzinfo is None:
@@ -445,12 +447,7 @@ def collect_session_behavior_signals(db_path) -> "dict | None":
     try:
         with sqlite3.connect(str(db_path)) as conn:
             conn.row_factory = sqlite3.Row
-            tables = {
-                r[0]
-                for r in conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type=?"
-                , ("table",)).fetchall()
-            }
+            tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type=?", ("table",)).fetchall()}
             if "sessions" not in tables or "documents" not in tables:
                 return None
 
@@ -482,13 +479,9 @@ def collect_session_behavior_signals(db_path) -> "dict | None":
 
             completion_rate = sessions_with_checkpoints / total_sessions
             knowledge_yield = total_entries / total_sessions
-            efficiency_ratio = (
-                min(total_entries / total_events, 1.0) if total_events > 0 else 0.0
-            )
+            efficiency_ratio = min(total_entries / total_events, 1.0) if total_events > 0 else 0.0
             one_shot_rate = (
-                sessions_with_one_checkpoint / sessions_with_checkpoints
-                if sessions_with_checkpoints > 0
-                else 0.0
+                sessions_with_one_checkpoint / sessions_with_checkpoints if sessions_with_checkpoints > 0 else 0.0
             )
 
             return {
@@ -614,12 +607,14 @@ def _compute_toward_100(
     def _add(section: str, score: float, barriers: list) -> None:
         gap = round(100.0 - score, 1)
         if gap > 0 and section in subscores:
-            items.append({
-                "section": section,
-                "score": round(score, 1),
-                "gap": gap,
-                "barriers": barriers if barriers else [f"score={score:.1f}"],
-            })
+            items.append(
+                {
+                    "section": section,
+                    "score": round(score, 1),
+                    "gap": gap,
+                    "barriers": barriers if barriers else [f"score={score:.1f}"],
+                }
+            )
 
     # knowledge
     if "knowledge" in subscores:
@@ -680,7 +675,7 @@ def _compute_toward_100(
         if commits < days:
             barriers.append(f"commit_cadence={commits}/{days}d (below 1/day target)")
         if py_files > 0 and (test_files / py_files) < 0.5:
-            barriers.append(f"test_file_ratio={test_files}/{py_files} ({test_files/py_files:.0%} below 50%)")
+            barriers.append(f"test_file_ratio={test_files}/{py_files} ({test_files / py_files:.0%} below 50%)")
         if distinct < 20:
             barriers.append(f"file_breadth={distinct} distinct (below 20 target)")
         _add("git", sc, barriers)
@@ -783,17 +778,14 @@ def compute_retro(
             f"{deny_dry} deny-dry entries excluded from hook deny rate "
             "(test/dry-run noise — not real enforcement denials)"
         )
-        improvement_actions.append(
-            "Filter synthetic deny-dry entries from audit.jsonl to keep hook stats clean"
-        )
+        improvement_actions.append("Filter synthetic deny-dry entries from audit.jsonl to keep hook stats clean")
 
     # Parse errors are legitimate (informational only)
     if hooks.get("available"):
         parse_count = int(hooks.get("decisions", {}).get("parse-error", 0))
         if parse_count > 0:
             accuracy_notes.append(
-                f"{parse_count} parse-error entries remain penalising "
-                "(indicate malformed input or runtime drift)"
+                f"{parse_count} parse-error entries remain penalising (indicate malformed input or runtime drift)"
             )
 
     # Skills verification evidence gap
@@ -829,7 +821,7 @@ def compute_retro(
     else:
         score_confidence = "high"
 
-    flag_str = (f" — distortions: {', '.join(distortion_flags)}" if distortion_flags else "")
+    flag_str = f" — distortions: {', '.join(distortion_flags)}" if distortion_flags else ""
     summary = f"Retro score {composite}/100 ({grade}), mode={mode}{flag_str}"
 
     subscores_payload = {

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -140,7 +140,7 @@ def main(argv=None):
     print(f"Results: {passed}/{total} passed in {wall:.1f}s")
 
     if failures:
-        print(f"\n{'─'*72}")
+        print(f"\n{'─' * 72}")
         print("FAILURES:")
         for name, out in failures:
             print(f"\n  ▶ {name}")

--- a/setup-project.py
+++ b/setup-project.py
@@ -48,6 +48,7 @@ def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> Non
             pass
         raise
 
+
 # Host metadata is centralised in host_manifest.py — import canonical constants.
 # Do NOT add new hosts here; update host_manifest.py through the review process.
 if os.name == "nt":
@@ -220,10 +221,7 @@ sk learn --relate "#id1" "resolved_by" "#id2"
 def find_git_root() -> Path | None:
     """Find the git repository root from cwd."""
     try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5
-        )
+        result = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, timeout=5)
         if result.returncode == 0:
             return Path(result.stdout.strip())
     except Exception:
@@ -313,7 +311,9 @@ def install_skills(project_root: Path, dry_run: bool) -> int:
                         changes += 1
                     if skill_name in VENDORED_SKILLS and _claude_skills_base:
                         asset_claude_dst = project_root / _claude_skills_base / skill_name / rel
-                        if copy_if_changed(asset_file, asset_claude_dst, dry_run, f"{item['label']} (Claude Code) → {rel}"):
+                        if copy_if_changed(
+                            asset_file, asset_claude_dst, dry_run, f"{item['label']} (Claude Code) → {rel}"
+                        ):
                             changes += 1
 
     return changes
@@ -544,24 +544,21 @@ What gets installed:
 Note: If your project already has session-knowledge installed at the user/global level
 (~/.github/instructions/session-knowledge.instructions.md), you can remove the project-level
 copy to avoid duplicate always-loaded instructions and reduce context bloat.
-"""
+""",
     )
     parser.add_argument(
-        "project_root", nargs="?", default=None,
-        help="Project root directory (default: auto-detect git root)"
+        "project_root", nargs="?", default=None, help="Project root directory (default: auto-detect git root)"
     )
     parser.add_argument(
-        "--skill-only", action="store_true",
-        help="Only install skills and instructions, don't patch CLAUDE.md etc."
+        "--skill-only", action="store_true", help="Only install skills and instructions, don't patch CLAUDE.md etc."
     )
+    parser.add_argument("--no-tentacle", action="store_true", help="Skip tentacle orchestration setup")
     parser.add_argument(
-        "--no-tentacle", action="store_true",
-        help="Skip tentacle orchestration setup"
-    )
-    parser.add_argument(
-        "--profile", default=None, metavar="PROFILE",
+        "--profile",
+        default=None,
+        metavar="PROFILE",
         help="Workflow profile to install as a hook bundle + WORKFLOW.md "
-             "(default: none; choices: default, python, typescript, mobile, fullstack)"
+        "(default: none; choices: default, python, typescript, mobile, fullstack)",
     )
     parser.add_argument(
         "--agent",
@@ -572,10 +569,7 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
         help="Initialize adapter-specific context files; repeat to target multiple adapters",
     )
     parser.add_argument("--init-mode", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument(
-        "--dry-run", action="store_true",
-        help="Show what would be done without making changes"
-    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
     args = parser.parse_args()
 
     # Find project root
@@ -599,9 +593,7 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
     print()
 
     try:
-        init_adapters, requested_init = _select_init_adapters(
-            project_root, args.agents, init_mode=args.init_mode
-        )
+        init_adapters, requested_init = _select_init_adapters(project_root, args.agents, init_mode=args.init_mode)
     except ValueError as exc:
         print(f"✗ {exc}")
         sys.exit(1)
@@ -646,12 +638,18 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
     # 5. Install workflow profile hook bundle (optional, only when --profile is given)
     if args.profile:
         import re as _re
+
         print(f"\n🔩 Hook Bundle ({args.profile} profile):")
         hook_installer = SCRIPT_DIR / "install-project-hooks.py"
-        cmd = [sys.executable, str(hook_installer),
-               "--profile", args.profile,
-               "--project", str(project_root),
-               "--workflow"]
+        cmd = [
+            sys.executable,
+            str(hook_installer),
+            "--profile",
+            args.profile,
+            "--project",
+            str(project_root),
+            "--workflow",
+        ]
         if args.dry_run:
             cmd.append("--dry-run")
         result = subprocess.run(cmd, capture_output=True, text=True)
@@ -682,10 +680,14 @@ copy to avoid duplicate always-loaded instructions and reduce context bloat.
         print("Next steps:")
         print("  1. Run: sk index build --all")
         print("     Fallbacks: macOS/Linux `python3 ~/.copilot/tools/build-session-index.py --all`;")
-        print("                Windows PowerShell `python \"$env:USERPROFILE\\.copilot\\tools\\build-session-index.py\" --all`")
+        print(
+            '                Windows PowerShell `python "$env:USERPROFILE\\.copilot\\tools\\build-session-index.py" --all`'
+        )
         print("  2. (Optional) Configure sync gateway URL: sk sync config --setup <https://gateway>")
         print("     Default provider rollout recommendation: Neon (Postgres) + Railway (thin gateway host).")
-        print("  3. Trend Scout automation: keep trend-scout.py in scheduled/manual flow (trend-scout.yml), not preToolUse/postToolUse hooks.")
+        print(
+            "  3. Trend Scout automation: keep trend-scout.py in scheduled/manual flow (trend-scout.yml), not preToolUse/postToolUse hooks."
+        )
         print("  4. Customize for your project:")
         print("     /session-knowledge-creator   — Generate project-specific knowledge skill")
         if not args.no_tentacle:

--- a/skill-curator.py
+++ b/skill-curator.py
@@ -151,9 +151,7 @@ def _discover_skills(skills_dir: Path) -> list[str]:
     if not skills_dir.is_dir():
         return []
     return sorted(
-        p.name
-        for p in skills_dir.iterdir()
-        if p.is_dir() and p.name != ARCHIVE_DIR_NAME and not p.name.startswith(".")
+        p.name for p in skills_dir.iterdir() if p.is_dir() and p.name != ARCHIVE_DIR_NAME and not p.name.startswith(".")
     )
 
 
@@ -167,11 +165,7 @@ def _archived_skills(skills_dir: Path) -> list[str]:
     archive_dir = skills_dir / ARCHIVE_DIR_NAME
     if not archive_dir.is_dir():
         return []
-    return sorted(
-        p.name
-        for p in archive_dir.iterdir()
-        if p.is_dir() and not p.name.startswith(".")
-    )
+    return sorted(p.name for p in archive_dir.iterdir() if p.is_dir() and not p.name.startswith("."))
 
 
 # ---------------------------------------------------------------------------
@@ -220,9 +214,7 @@ def _archive_skill(skills_dir: Path, skill_name: str, dry_run: bool) -> tuple[Pa
     # Check for destination collision before any backup I/O so a failed archive
     # leaves no orphaned backup directory behind.
     if not dry_run and archive_path.exists():
-        raise RuntimeError(
-            f"archive destination '{archive_path}' already exists — remove it first"
-        )
+        raise RuntimeError(f"archive destination '{archive_path}' already exists — remove it first")
     backup_path = _backup_skill(skills_dir, skill_name, dry_run)
     if not dry_run:
         archive_dir = skills_dir / ARCHIVE_DIR_NAME
@@ -404,7 +396,11 @@ def cmd_pin(args, _db, _now: datetime) -> int:
         marker = _pin_skill(skills_dir, skill_name, dry_run)
         prefix = "[DRY RUN] " if dry_run else ""
         if args.json:
-            print(json.dumps({"skill": skill_name, "action": "pinned" if not dry_run else "would-pin", "marker": str(marker)}))
+            print(
+                json.dumps(
+                    {"skill": skill_name, "action": "pinned" if not dry_run else "would-pin", "marker": str(marker)}
+                )
+            )
         else:
             print(f"{prefix}Pinned '{skill_name}' ({marker})")
         return 0
@@ -425,7 +421,11 @@ def cmd_unpin(args, _db, _now: datetime) -> int:
         removed = _unpin_skill(skills_dir, skill_name, dry_run)
         prefix = "[DRY RUN] " if dry_run else ""
         if args.json:
-            print(json.dumps({"skill": skill_name, "action": "unpinned" if not dry_run else "would-unpin", "was_pinned": removed}))
+            print(
+                json.dumps(
+                    {"skill": skill_name, "action": "unpinned" if not dry_run else "would-unpin", "was_pinned": removed}
+                )
+            )
         else:
             if removed:
                 print(f"{prefix}Unpinned '{skill_name}'")
@@ -449,7 +449,11 @@ def cmd_restore(args, _db, _now: datetime) -> int:
         dest = _restore_skill(skills_dir, skill_name, dry_run)
         prefix = "[DRY RUN] " if dry_run else ""
         if args.json:
-            print(json.dumps({"skill": skill_name, "action": "restored" if not dry_run else "would-restore", "dest": str(dest)}))
+            print(
+                json.dumps(
+                    {"skill": skill_name, "action": "restored" if not dry_run else "would-restore", "dest": str(dest)}
+                )
+            )
         else:
             print(f"{prefix}Restored '{skill_name}' → {dest}")
         return 0

--- a/skill-patch.py
+++ b/skill-patch.py
@@ -71,6 +71,7 @@ CREATE TABLE IF NOT EXISTS skill_patch_history (
 # Fuzzy-whitespace matching
 # ---------------------------------------------------------------------------
 
+
 def _fuzzy_pattern(text: str) -> re.Pattern:
     """
     Build a regex that matches *text* modulo leading/trailing whitespace on
@@ -144,6 +145,7 @@ def apply_patch(
 # Skill path resolution
 # ---------------------------------------------------------------------------
 
+
 def resolve_skill_path(raw: str) -> Path:
     p = Path(raw).expanduser().resolve()
     if p.is_dir():
@@ -159,6 +161,7 @@ def resolve_skill_path(raw: str) -> Path:
 # ---------------------------------------------------------------------------
 # Atomic write
 # ---------------------------------------------------------------------------
+
 
 def atomic_write(path: Path, content: str) -> None:
     """Write *content* to *path* atomically via a sibling tempfile + os.replace."""
@@ -202,6 +205,7 @@ def _write_to_temp(target_path: Path, content: str) -> Path:
 # Post-patch validation
 # ---------------------------------------------------------------------------
 
+
 def run_validation(skill_path: Path) -> tuple[bool, int, int]:
     """
     Run validate-skill.py against *skill_path* via subprocess.
@@ -238,6 +242,7 @@ def run_validation(skill_path: Path) -> tuple[bool, int, int]:
 # ---------------------------------------------------------------------------
 # Metrics logging
 # ---------------------------------------------------------------------------
+
 
 def _ensure_patch_history_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(_SKILL_PATCH_HISTORY_DDL)
@@ -302,13 +307,16 @@ def log_patch_history(
 # Simple unified-diff helper
 # ---------------------------------------------------------------------------
 
+
 def _simple_diff(before: str, after: str, path: Path) -> str:
     lines_before = before.splitlines(keepends=True)
     lines_after = after.splitlines(keepends=True)
     import difflib
+
     return "".join(
         difflib.unified_diff(
-            lines_before, lines_after,
+            lines_before,
+            lines_after,
             fromfile=f"a/{path.name}",
             tofile=f"b/{path.name}",
         )
@@ -319,6 +327,7 @@ def _simple_diff(before: str, after: str, path: Path) -> str:
 # Main
 # ---------------------------------------------------------------------------
 
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="skill-patch",
@@ -326,20 +335,13 @@ def main(argv: list[str] | None = None) -> int:
         add_help=True,
     )
     parser.add_argument("path", help="Path to SKILL.md or skill directory")
-    parser.add_argument("--old", required=True, metavar="TEXT",
-                        help="Text to find (fuzzy whitespace matching)")
-    parser.add_argument("--new", required=True, metavar="TEXT",
-                        help="Replacement text", dest="new_text")
-    parser.add_argument("--replace-all", action="store_true",
-                        help="Replace all occurrences (default: first only)")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Show diff; do NOT write or log anything")
-    parser.add_argument("--no-validate", action="store_true",
-                        help="Skip post-patch validation via validate-skill.py")
-    parser.add_argument("--no-metrics", action="store_true",
-                        help="Skip logging patch history to skill-metrics.db")
-    parser.add_argument("--metrics-db", metavar="PATH",
-                        help="Override the skill-metrics.db path")
+    parser.add_argument("--old", required=True, metavar="TEXT", help="Text to find (fuzzy whitespace matching)")
+    parser.add_argument("--new", required=True, metavar="TEXT", help="Replacement text", dest="new_text")
+    parser.add_argument("--replace-all", action="store_true", help="Replace all occurrences (default: first only)")
+    parser.add_argument("--dry-run", action="store_true", help="Show diff; do NOT write or log anything")
+    parser.add_argument("--no-validate", action="store_true", help="Skip post-patch validation via validate-skill.py")
+    parser.add_argument("--no-metrics", action="store_true", help="Skip logging patch history to skill-metrics.db")
+    parser.add_argument("--metrics-db", metavar="PATH", help="Override the skill-metrics.db path")
 
     args = parser.parse_args(argv)
 
@@ -381,13 +383,10 @@ def main(argv: list[str] | None = None) -> int:
     count_will = count_found if args.replace_all else 1
 
     # Apply patch
-    patched, occurrences_replaced = apply_patch(
-        original, old_text, new_text, replace_all=args.replace_all
-    )
+    patched, occurrences_replaced = apply_patch(original, old_text, new_text, replace_all=args.replace_all)
 
     if occurrences_replaced == 0:
-        print("skill-patch: error: pattern matched but replacement yielded 0 substitutions",
-              file=sys.stderr)
+        print("skill-patch: error: pattern matched but replacement yielded 0 substitutions", file=sys.stderr)
         return 1
 
     # Diff display

--- a/skill-suggest.py
+++ b/skill-suggest.py
@@ -50,19 +50,120 @@ _CATEGORY_WEIGHT: dict[str, float] = {
 
 _STOPWORDS = frozenset(
     {
-        "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
-        "of", "with", "by", "from", "is", "are", "was", "were", "be", "been",
-        "have", "has", "had", "do", "does", "did", "will", "would", "could",
-        "should", "may", "might", "can", "it", "this", "that", "these",
-        "those", "i", "we", "you", "he", "she", "they", "not", "no", "so",
-        "if", "then", "when", "where", "what", "which", "who", "how", "all",
-        "any", "each", "more", "most", "also", "just", "up", "out", "as",
-        "into", "than", "their", "its", "our", "my", "your", "his", "her",
-        "them", "us", "me", "after", "before", "during", "while", "since",
-        "until", "too", "very", "about", "use", "used", "using", "run",
-        "running", "make", "new", "only", "now", "time", "way", "need",
-        "needs", "see", "get", "set", "add", "put", "let", "say", "one",
-        "two", "per", "via", "etc", "yet", "got",
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "but",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "of",
+        "with",
+        "by",
+        "from",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "have",
+        "has",
+        "had",
+        "do",
+        "does",
+        "did",
+        "will",
+        "would",
+        "could",
+        "should",
+        "may",
+        "might",
+        "can",
+        "it",
+        "this",
+        "that",
+        "these",
+        "those",
+        "i",
+        "we",
+        "you",
+        "he",
+        "she",
+        "they",
+        "not",
+        "no",
+        "so",
+        "if",
+        "then",
+        "when",
+        "where",
+        "what",
+        "which",
+        "who",
+        "how",
+        "all",
+        "any",
+        "each",
+        "more",
+        "most",
+        "also",
+        "just",
+        "up",
+        "out",
+        "as",
+        "into",
+        "than",
+        "their",
+        "its",
+        "our",
+        "my",
+        "your",
+        "his",
+        "her",
+        "them",
+        "us",
+        "me",
+        "after",
+        "before",
+        "during",
+        "while",
+        "since",
+        "until",
+        "too",
+        "very",
+        "about",
+        "use",
+        "used",
+        "using",
+        "run",
+        "running",
+        "make",
+        "new",
+        "only",
+        "now",
+        "time",
+        "way",
+        "need",
+        "needs",
+        "see",
+        "get",
+        "set",
+        "add",
+        "put",
+        "let",
+        "say",
+        "one",
+        "two",
+        "per",
+        "via",
+        "etc",
+        "yet",
+        "got",
     }
 )
 
@@ -181,11 +282,7 @@ def _make_skill_draft(
         e_content = re.sub(r"\s+", " ", (entry.get("content") or "")[:120]).strip()
         if e_title:
             content_lines.append(f"- **{e_title}**: {e_content}")
-    content_block = (
-        "\n".join(content_lines)
-        if content_lines
-        else f"- Apply proven patterns for {name_human}."
-    )
+    content_block = "\n".join(content_lines) if content_lines else f"- Apply proven patterns for {name_human}."
 
     # Example block from the first sample entry
     if sample_entries:
@@ -194,7 +291,7 @@ def _make_skill_draft(
     else:
         ex_content = f"Apply {name_human} best practices."
     if not ex_content:
-        ex_content = f"Relevant patterns and decisions surfaced from session history."
+        ex_content = "Relevant patterns and decisions surfaced from session history."
 
     lines = [
         "---",
@@ -241,7 +338,7 @@ def _open_db_readonly(db_path: Path):
     if not db_path.exists():
         return None
     try:
-        uri = "file:{}?mode=ro".format(db_path.as_posix())
+        uri = f"file:{db_path.as_posix()}?mode=ro"
         db = sqlite3.connect(uri, uri=True)
         db.row_factory = sqlite3.Row
         return db
@@ -255,16 +352,14 @@ def _open_db_readonly(db_path: Path):
 
 
 def _table_exists(db: sqlite3.Connection, name: str) -> bool:
-    row = db.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
-    ).fetchone()
+    row = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)).fetchone()
     return row is not None
 
 
 # Signal-type score weights for boosting improvement-signal-derived candidates.
 _SIGNAL_TYPE_WEIGHT: dict[str, float] = {
-    "missed_match": 2.0,    # Strong: no skill existed — high priority to create one
-    "wrong_skill": 1.5,     # Medium: wrong skill fired — patch candidate
+    "missed_match": 2.0,  # Strong: no skill existed — high priority to create one
+    "wrong_skill": 1.5,  # Medium: wrong skill fired — patch candidate
     "outdated_skill": 1.5,  # Medium: skill is stale — update candidate
 }
 
@@ -743,10 +838,7 @@ def _print_text(result: dict) -> None:
         overlaps = sug["overlap_with_existing"]
         print(f"{'=' * 60}")
         print(f"  Suggestion #{i}: {sug['candidate_name']}")
-        print(
-            f"  Score: {sug['score']} | Occurrences: {sug['total_occurrences']}"
-            f" | Entries: {sug['entry_count']}"
-        )
+        print(f"  Score: {sug['score']} | Occurrences: {sug['total_occurrences']} | Entries: {sug['entry_count']}")
         print(f"  Source: {sug['source_cluster']} ({sug['cluster_type']})")
         if sug["top_tags"]:
             print(f"  Tags: {', '.join(sug['top_tags'][:5])}")
@@ -821,9 +913,7 @@ Examples:
     args = parser.parse_args(argv)
 
     db_path = Path(args.db).expanduser() if args.db else DB_PATH
-    skills_dir = (
-        Path(args.skills_dir).expanduser() if args.skills_dir else DEFAULT_SKILLS_DIR
-    )
+    skills_dir = Path(args.skills_dir).expanduser() if args.skills_dir else DEFAULT_SKILLS_DIR
 
     result = suggest(
         db_path=db_path,

--- a/sync-gateway.py
+++ b/sync-gateway.py
@@ -78,9 +78,7 @@ class GatewayStore:
 
     def latest_txn_id(self) -> str | None:
         with self.lock:
-            row = self.conn.execute(
-                "SELECT txn_id FROM txns ORDER BY seq DESC LIMIT 1"
-            ).fetchone()
+            row = self.conn.execute("SELECT txn_id FROM txns ORDER BY seq DESC LIMIT 1").fetchone()
         return row["txn_id"] if row else None
 
     def _insert_txn_in_current_transaction(self, txn: dict) -> bool:
@@ -143,9 +141,7 @@ class GatewayStore:
         with self.lock:
             after_seq = 0
             if after_txn_id:
-                row = self.conn.execute(
-                    "SELECT seq FROM txns WHERE txn_id = ? LIMIT 1", (after_txn_id,)
-                ).fetchone()
+                row = self.conn.execute("SELECT seq FROM txns WHERE txn_id = ? LIMIT 1", (after_txn_id,)).fetchone()
                 if row is None:
                     raise ValueError("unknown_after")
                 after_seq = int(row["seq"])
@@ -328,9 +324,7 @@ def create_server(host: str, port: int, db_path: Path) -> tuple[ThreadingHTTPSer
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Reference/mock sync gateway (local integration contract surface)"
-    )
+    parser = argparse.ArgumentParser(description="Reference/mock sync gateway (local integration contract surface)")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8787)
     parser.add_argument(

--- a/sync-status.py
+++ b/sync-status.py
@@ -114,6 +114,7 @@ def _service_manager_watch_status() -> dict:
                 ["systemctl", "--user", "is-active", "copilot-watch-sessions.service"],
                 capture_output=True,
                 text=True,
+                timeout=5,
             )
             out["manager_state"] = "active" if result.returncode == 0 else "inactive"
         elif system == "Darwin":
@@ -122,6 +123,7 @@ def _service_manager_watch_status() -> dict:
                 ["launchctl", "list", "com.copilot.watch-sessions"],
                 capture_output=True,
                 text=True,
+                timeout=5,
             )
             out["manager_state"] = "loaded" if result.returncode == 0 else "inactive"
         elif system == "Windows":
@@ -130,6 +132,7 @@ def _service_manager_watch_status() -> dict:
                 ["schtasks", "/Query", "/TN", "CopilotSessionWatcher"],
                 capture_output=True,
                 text=True,
+                timeout=5,
             )
             out["manager_state"] = "registered" if result.returncode == 0 else "inactive"
     except Exception:

--- a/tag-entries.py
+++ b/tag-entries.py
@@ -35,21 +35,128 @@ DB_PATH = SESSION_STATE / "knowledge.db"
 # Concept tag extraction (pure stdlib, no ML imports)
 # ---------------------------------------------------------------------------
 
-_CONCEPT_STOPWORDS = frozenset({
-    "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
-    "of", "with", "by", "from", "is", "are", "was", "were", "be", "been",
-    "have", "has", "had", "do", "does", "did", "will", "would", "could",
-    "should", "may", "might", "can", "it", "this", "that", "these", "those",
-    "i", "we", "you", "he", "she", "they", "not", "no", "so", "if", "then",
-    "when", "where", "what", "which", "who", "how", "all", "any", "each",
-    "more", "most", "also", "just", "up", "out", "as", "into", "than",
-    "their", "its", "our", "my", "your", "his", "her", "them", "us", "me",
-    "after", "before", "during", "while", "since", "until", "too", "very",
-    "about", "above", "below", "between", "through", "use", "used", "using",
-    "run", "running", "make", "new", "only", "now", "time", "way",
-    "need", "needs", "see", "get", "set", "add", "put", "let", "say",
-    "one", "two", "per", "via", "etc", "yet", "got",
-})
+_CONCEPT_STOPWORDS = frozenset(
+    {
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "but",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "of",
+        "with",
+        "by",
+        "from",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "have",
+        "has",
+        "had",
+        "do",
+        "does",
+        "did",
+        "will",
+        "would",
+        "could",
+        "should",
+        "may",
+        "might",
+        "can",
+        "it",
+        "this",
+        "that",
+        "these",
+        "those",
+        "i",
+        "we",
+        "you",
+        "he",
+        "she",
+        "they",
+        "not",
+        "no",
+        "so",
+        "if",
+        "then",
+        "when",
+        "where",
+        "what",
+        "which",
+        "who",
+        "how",
+        "all",
+        "any",
+        "each",
+        "more",
+        "most",
+        "also",
+        "just",
+        "up",
+        "out",
+        "as",
+        "into",
+        "than",
+        "their",
+        "its",
+        "our",
+        "my",
+        "your",
+        "his",
+        "her",
+        "them",
+        "us",
+        "me",
+        "after",
+        "before",
+        "during",
+        "while",
+        "since",
+        "until",
+        "too",
+        "very",
+        "about",
+        "above",
+        "below",
+        "between",
+        "through",
+        "use",
+        "used",
+        "using",
+        "run",
+        "running",
+        "make",
+        "new",
+        "only",
+        "now",
+        "time",
+        "way",
+        "need",
+        "needs",
+        "see",
+        "get",
+        "set",
+        "add",
+        "put",
+        "let",
+        "say",
+        "one",
+        "two",
+        "per",
+        "via",
+        "etc",
+        "yet",
+        "got",
+    }
+)
 
 
 def extract_concept_tags(text: str, top_k: int = 5) -> list[str]:
@@ -67,7 +174,7 @@ def extract_concept_tags(text: str, top_k: int = 5) -> list[str]:
     """
     if not text:
         return []
-    tokens = re.findall(r'[a-zA-Z][a-zA-Z0-9_-]{2,}', text.lower())
+    tokens = re.findall(r"[a-zA-Z][a-zA-Z0-9_-]{2,}", text.lower())
     freq: dict[str, int] = {}
     for tok in tokens:
         if tok not in _CONCEPT_STOPWORDS:
@@ -79,6 +186,7 @@ def extract_concept_tags(text: str, top_k: int = 5) -> list[str]:
 # ---------------------------------------------------------------------------
 # DB helpers
 # ---------------------------------------------------------------------------
+
 
 def get_db() -> sqlite3.Connection:
     if not DB_PATH.exists():
@@ -129,6 +237,7 @@ def _seed_sync_policy(db: sqlite3.Connection):
 # ---------------------------------------------------------------------------
 # Core batch tagging logic
 # ---------------------------------------------------------------------------
+
 
 def run_batch_tag(
     retag_all: bool = False,
@@ -247,15 +356,13 @@ def run_stats() -> dict:
     db = get_db()
     try:
         total = db.execute("SELECT COUNT(*) FROM knowledge_entries").fetchone()[0]
-        has_ect = db.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='entry_concept_tags'"
-        ).fetchone()
+        has_ect = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='entry_concept_tags'").fetchone()
         if not has_ect:
             return {"total_entries": total, "tagged_entries": 0, "coverage_pct": 0.0, "available": False}
 
-        tagged = db.execute(
-            "SELECT COUNT(DISTINCT entry_id) FROM entry_concept_tags WHERE source = 'auto'"
-        ).fetchone()[0]
+        tagged = db.execute("SELECT COUNT(DISTINCT entry_id) FROM entry_concept_tags WHERE source = 'auto'").fetchone()[
+            0
+        ]
         coverage_pct = round((tagged / total) * 100, 1) if total > 0 else 0.0
         total_tags = db.execute("SELECT COUNT(*) FROM entry_concept_tags WHERE source = 'auto'").fetchone()[0]
         top_tags = db.execute("""
@@ -282,6 +389,7 @@ def run_stats() -> dict:
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def main(argv: list | None = None) -> int:
     import argparse
 
@@ -289,16 +397,13 @@ def main(argv: list | None = None) -> int:
         description="Batch concept-tag extraction for knowledge entries.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("--all", dest="retag_all", action="store_true",
-                        help="Re-tag all entries, replacing stale auto tags")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Preview without writing to DB")
-    parser.add_argument("--limit", type=int, default=0,
-                        help="Process at most N entries (0 = no limit)")
-    parser.add_argument("--stats", action="store_true",
-                        help="Show concept tag coverage statistics")
-    parser.add_argument("--quiet", action="store_true",
-                        help="Suppress per-entry output")
+    parser.add_argument(
+        "--all", dest="retag_all", action="store_true", help="Re-tag all entries, replacing stale auto tags"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview without writing to DB")
+    parser.add_argument("--limit", type=int, default=0, help="Process at most N entries (0 = no limit)")
+    parser.add_argument("--stats", action="store_true", help="Show concept tag coverage statistics")
+    parser.add_argument("--quiet", action="store_true", help="Suppress per-entry output")
 
     args = parser.parse_args(argv)
 

--- a/tentacle-setup.py
+++ b/tentacle-setup.py
@@ -66,9 +66,7 @@ def ensure_gitignore(project_dir: Path) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Copy tentacle skills and references into a project."
-    )
+    parser = argparse.ArgumentParser(description="Copy tentacle skills and references into a project.")
     parser.add_argument(
         "project_dir",
         nargs="?",

--- a/tentacle-status.py
+++ b/tentacle-status.py
@@ -55,9 +55,7 @@ def _open_metrics_db() -> sqlite3.Connection | None:
 
 
 def _table_exists(db: sqlite3.Connection, name: str) -> bool:
-    row = db.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
-    ).fetchone()
+    row = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)).fetchone()
     return row is not None
 
 
@@ -348,10 +346,7 @@ def format_status(status: dict) -> str:
             vf = t.get("verification_failed", 0)
             outcome = t.get("recorded_outcome")
             outcome_str = f"  outcome={outcome['outcome_status']}" if outcome else ""
-            lines.append(
-                f"  {t['name']:<35} status={t['status']:<8}"
-                f"  verify={vp}✓/{vf}✗{outcome_str}"
-            )
+            lines.append(f"  {t['name']:<35} status={t['status']:<8}  verify={vp}✓/{vf}✗{outcome_str}")
     lines.extend(
         [
             "",

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -3167,8 +3167,8 @@ except Exception as _e:
 # Regression for Blocker 3: a high-priority (P0) semantic hit must not be dropped behind
 # lower-priority (P2) FTS hits due to pre-rerank truncation.
 try:
-    import sys as _sys_p11
     import sqlite3 as _sqlite3_p11
+    import sys as _sys_p11
 
     # 3 P2 FTS entries saturate cat_limit=3; without rerank the P0 semantic hit is dropped.
     _p11_fts_entries = [
@@ -3261,8 +3261,8 @@ except Exception as _e:
 # into the outer priority-aware rerank.  The mock returns a P0 entry ONLY when called with
 # limit >= fetch_limit (proving the caller passes the widened pool, not the raw cat_limit).
 try:
-    import sys as _sys_p12
     import sqlite3 as _sqlite3_p12
+    import sys as _sys_p12
 
     _p12_cat_limit = 3
     _p12_fetch_limit = max(_p12_cat_limit * 2, _p12_cat_limit + 6)  # = 9 for cat_limit=3

--- a/test_security.py
+++ b/test_security.py
@@ -2,8 +2,8 @@
 
 import json
 import os
-import sys
 import sqlite3
+import sys
 import tempfile
 from pathlib import Path
 
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 # ═══════════════════════════════════════════════════════════════════
 #  Test: FTS5 query sanitization
 # ═══════════════════════════════════════════════════════════════════
+
 
 def test_fts5_sanitization():
     """Test that FTS5 special characters and operators are stripped."""
@@ -42,7 +43,8 @@ def test_fts5_sanitization():
     # Verify no unescaped quotes remain: strip wrapping "term"* patterns, check for stray quotes
     stripped = result
     import re as _re
-    stripped = _re.sub(r'"[^"]*"\*?', '', stripped)  # remove valid "term"* patterns
+
+    stripped = _re.sub(r'"[^"]*"\*?', "", stripped)  # remove valid "term"* patterns
     assert '"' not in stripped, f"Stray quotes in sanitized result: {result}"
 
     # NEAR operator removed
@@ -68,6 +70,7 @@ def test_fts5_sanitization():
 #  Test: SQL injection via parameterized queries
 # ═══════════════════════════════════════════════════════════════════
 
+
 def test_sql_parameterized_queries():
     """Test that SQL queries use parameterized placeholders."""
     # Read query-session.py source and verify no f-string IN clauses with user data
@@ -75,8 +78,9 @@ def test_sql_parameterized_queries():
     content = source.read_text(encoding="utf-8")
 
     # The old vulnerable pattern should NOT exist
-    assert 'f"SELECT COUNT(*) FROM knowledge_relations WHERE source_id IN ({ids_str})' not in content, \
+    assert 'f"SELECT COUNT(*) FROM knowledge_relations WHERE source_id IN ({ids_str})' not in content, (
         "Vulnerable f-string SQL injection pattern still exists!"
+    )
 
     # The safe parameterized pattern SHOULD exist
     assert "placeholders" in content, "Parameterized query pattern not found"
@@ -89,19 +93,18 @@ def test_sql_parameterized_queries():
 #  Test: Pickle deserialization safety
 # ═══════════════════════════════════════════════════════════════════
 
+
 def test_pickle_safety():
     """Test that embed.py no longer uses direct pickle.loads for new models."""
     source = Path(__file__).parent / "embed.py"
     content = source.read_text(encoding="utf-8")
 
     # Should use JSON serialization for new models
-    assert "json.dumps(model" in content or "json.dumps(" in content, \
-        "New JSON serialization not found in embed.py"
+    assert "json.dumps(model" in content or "json.dumps(" in content, "New JSON serialization not found in embed.py"
 
     # Backward compat pickle should have deprecation warning
     if "pickle.loads" in content:
-        assert "deprecated" in content.lower() or "⚠" in content, \
-            "Pickle fallback exists but no deprecation warning"
+        assert "deprecated" in content.lower() or "⚠" in content, "Pickle fallback exists but no deprecation warning"
 
     print("  ✓ Pickle safety tests passed")
 
@@ -110,14 +113,14 @@ def test_pickle_safety():
 #  Test: Config file permissions
 # ═══════════════════════════════════════════════════════════════════
 
+
 def test_config_permissions():
     """Test that save_config sets restrictive file permissions."""
     source = Path(__file__).parent / "embed.py"
     content = source.read_text(encoding="utf-8")
 
     assert "0o600" in content, "File permission 0o600 not found in embed.py"
-    assert "chmod" in content.lower() or "os.chmod" in content, \
-        "chmod call not found in embed.py"
+    assert "chmod" in content.lower() or "os.chmod" in content, "chmod call not found in embed.py"
 
     print("  ✓ Config permissions tests passed")
 
@@ -126,16 +129,17 @@ def test_config_permissions():
 #  Test: Path traversal protection
 # ═══════════════════════════════════════════════════════════════════
 
+
 def test_path_traversal_protection():
     """Test that WSL path validation rejects traversal attempts."""
     source = Path(__file__).parent / "sync-knowledge.py"
     content = source.read_text(encoding="utf-8")
 
     # Should validate WSL home path
-    assert '".."' in content or "'..' not in" in content or '".." not in' in content, \
+    assert '".."' in content or "'..' not in" in content or '".." not in' in content, (
         "Path traversal check (..) not found in sync-knowledge.py"
-    assert "/home/" in content, \
-        "WSL home prefix check not found"
+    )
+    assert "/home/" in content, "WSL home prefix check not found"
 
     print("  ✓ Path traversal protection tests passed")
 
@@ -144,18 +148,19 @@ def test_path_traversal_protection():
 #  Test: Lock file atomicity
 # ═══════════════════════════════════════════════════════════════════
 
+
 def test_lock_atomicity():
     """Test that watch-sessions.py uses atomic lock creation."""
     source = Path(__file__).parent / "watch-sessions.py"
     content = source.read_text(encoding="utf-8")
 
     # Should use O_CREAT | O_EXCL for atomic creation
-    assert "O_CREAT" in content and "O_EXCL" in content, \
-        "Atomic lock creation (O_CREAT | O_EXCL) not found"
+    assert "O_CREAT" in content and "O_EXCL" in content, "Atomic lock creation (O_CREAT | O_EXCL) not found"
 
     # Old TOCTOU pattern should NOT exist
-    assert "if LOCK_FILE.exists():\n        try:\n            stored_pid" not in content, \
+    assert "if LOCK_FILE.exists():\n        try:\n            stored_pid" not in content, (
         "Old TOCTOU lock pattern still exists"
+    )
 
     print("  ✓ Lock file atomicity tests passed")
 
@@ -163,6 +168,7 @@ def test_lock_atomicity():
 # ═══════════════════════════════════════════════════════════════════
 #  Test: Input validation
 # ═══════════════════════════════════════════════════════════════════
+
 
 def test_input_validation():
     """Test that user inputs have length limits."""
@@ -184,13 +190,15 @@ def test_input_validation():
 #  Test: Database integrity check
 # ═══════════════════════════════════════════════════════════════════
 
+
 def test_db_integrity_check():
     """Test that database integrity check is performed."""
     source = Path(__file__).parent / "build-session-index.py"
     content = source.read_text(encoding="utf-8")
 
-    assert "quick_check" in content or "integrity_check" in content, \
+    assert "quick_check" in content or "integrity_check" in content, (
         "No PRAGMA integrity check found in build-session-index.py"
+    )
 
     print("  ✓ Database integrity check tests passed")
 
@@ -199,13 +207,13 @@ def test_db_integrity_check():
 #  Test: SQL whitelist validation
 # ═══════════════════════════════════════════════════════════════════
 
+
 def test_sql_whitelist():
     """Test that f-string SQL uses whitelist validation."""
     for filename in ["build-session-index.py", "extract-knowledge.py", "install.py"]:
         source = Path(__file__).parent / filename
         content = source.read_text(encoding="utf-8")
-        assert "_ALLOWED_" in content, \
-            f"Whitelist validation not found in {filename}"
+        assert "_ALLOWED_" in content, f"Whitelist validation not found in {filename}"
 
     print("  ✓ SQL whitelist validation tests passed")
 
@@ -214,17 +222,20 @@ def test_sql_whitelist():
 #  Test: DB write safety (busy_timeout)
 # ═══════════════════════════════════════════════════════════════════
 
+
 def test_db_write_safety():
     """Test that DB connections use busy_timeout for concurrent write safety."""
     learn_src = Path(__file__).parent / "learn.py"
     learn_content = learn_src.read_text(encoding="utf-8")
-    assert "busy_timeout" in learn_content, \
+    assert "busy_timeout" in learn_content, (
         "busy_timeout not set in learn.py — concurrent writes may fail with SQLITE_BUSY"
+    )
 
     sync_src = Path(__file__).parent / "sync-knowledge.py"
     sync_content = sync_src.read_text(encoding="utf-8")
-    assert "busy_timeout" in sync_content, \
+    assert "busy_timeout" in sync_content, (
         "busy_timeout not set in sync-knowledge.py — concurrent writes may fail with SQLITE_BUSY"
+    )
 
     print("  ✓ DB write safety (busy_timeout) tests passed")
 
@@ -233,19 +244,18 @@ def test_db_write_safety():
 #  Test: Hybrid change detection in watch-sessions.py
 # ═══════════════════════════════════════════════════════════════════
 
+
 def test_hybrid_change_detection_source():
     """Test that watch-sessions.py has hybrid mtime+content-hash change detection."""
     source = Path(__file__).parent / "watch-sessions.py"
     content = source.read_text(encoding="utf-8")
 
-    assert "_content_hash" in content, \
-        "_content_hash function not found in watch-sessions.py"
-    assert "hashlib.sha256" in content, \
-        "SHA256 content hashing not found in watch-sessions.py"
-    assert "prev_hash" in content, \
-        "prev_hash comparison not found — content-hash dedup logic missing"
-    assert "content unchanged" in content.lower() or "content_changed" in content, \
+    assert "_content_hash" in content, "_content_hash function not found in watch-sessions.py"
+    assert "hashlib.sha256" in content, "SHA256 content hashing not found in watch-sessions.py"
+    assert "prev_hash" in content, "prev_hash comparison not found — content-hash dedup logic missing"
+    assert "content unchanged" in content.lower() or "content_changed" in content, (
         "content-change tracking variable not found in watch-sessions.py"
+    )
 
     print("  ✓ Hybrid change detection source tests passed")
 
@@ -254,31 +264,31 @@ def test_no_proxy_http_client():
     """Test that outbound HTTP helper paths bypass proxy env vars explicitly."""
     init_src = Path(__file__).parent / "browse" / "__init__.py"
     init_content = init_src.read_text(encoding="utf-8")
-    assert "ProxyHandler({})" in init_content, \
-        "browse/__init__.py is missing ProxyHandler({}) in _probe_public_url"
-    assert "no_proxy_opener.open" in init_content, \
+    assert "ProxyHandler({})" in init_content, "browse/__init__.py is missing ProxyHandler({}) in _probe_public_url"
+    assert "no_proxy_opener.open" in init_content, (
         "browse/__init__.py still uses a proxy-sensitive opener for _probe_public_url"
+    )
 
     dl_src = Path(__file__).parent / "browse" / "static" / "vendor" / "_download.py"
     dl_content = dl_src.read_text(encoding="utf-8")
-    assert "ProxyHandler({})" in dl_content, \
+    assert "ProxyHandler({})" in dl_content, (
         "browse/static/vendor/_download.py is missing ProxyHandler({}) in download_lib"
-    assert "no_proxy_opener.open" in dl_content, \
-        "browse/static/vendor/_download.py still uses a proxy-sensitive opener"
+    )
+    assert "no_proxy_opener.open" in dl_content, "browse/static/vendor/_download.py still uses a proxy-sensitive opener"
 
     print("  ✓ No-proxy HTTP client pattern tests passed")
-
-
 
 
 # Create minimal stub modules for tests that need imports
 class query_session_sanitizer:
     """Stub to extract _sanitize_fts_query from query-session.py source."""
+
     pass
 
 
 class query_session_source:
     """Stub to verify source patterns."""
+
     pass
 
 
@@ -289,10 +299,8 @@ def _extract_sanitize_function():
 
     # Find and exec the function
     import re
-    match = re.search(
-        r'(def _sanitize_fts_query\(.*?\n(?:    .*\n)*)',
-        content
-    )
+
+    match = re.search(r"(def _sanitize_fts_query\(.*?\n(?:    .*\n)*)", content)
     if not match:
         raise RuntimeError("_sanitize_fts_query not found in query-session.py")
 
@@ -304,6 +312,7 @@ def _extract_sanitize_function():
 # ═══════════════════════════════════════════════════════════════════
 #  Main runner
 # ═══════════════════════════════════════════════════════════════════
+
 
 def main():
     print("\n🔒 Running security tests...\n")
@@ -334,7 +343,7 @@ def main():
             print(f"  ✗ {test.__name__}: {e}")
             failed += 1
 
-    print(f"\n{'='*40}")
+    print(f"\n{'=' * 40}")
     print(f"Results: {passed} passed, {failed} failed")
     if failed:
         sys.exit(1)

--- a/tests/test_hook_compat.py
+++ b/tests/test_hook_compat.py
@@ -330,20 +330,25 @@ def test_pre_commit_python_entrypoint():
 
 
 def test_pre_commit_ruff_surface_covers_all_browse_depths():
-    """Verify _py_in_surface uses browse/* to cover all subdirectory depths."""
+    """Verify in_python_cleanliness_surface covers all package subdirectory depths."""
     if not PRE_COMMIT.exists():
         test("hooks/pre-commit exists for browse depth check", False, str(PRE_COMMIT))
         return
     content = PRE_COMMIT.read_text(encoding="utf-8")
     test(
-        "pre-commit _py_in_surface uses browse/* (all depths, consistent with CI)",
-        'path.startswith(("browse/", "hooks/", "scripts/"))' in content or "browse/*)" in content,
-        "pre-commit _py_in_surface should use browse/* to match all depths under browse/",
+        "pre-commit in_python_cleanliness_surface uses browse/ (all depths, consistent with CI)",
+        "path.startswith(" in content and '"browse/"' in content,
+        "pre-commit in_python_cleanliness_surface should use browse/ to match all depths under browse/",
     )
     test(
-        "pre-commit _py_in_surface uses hooks/* (all depths, consistent with CI)",
-        'path.startswith(("browse/", "hooks/", "scripts/"))' in content or "hooks/*)" in content,
-        "pre-commit _py_in_surface should use hooks/* to match all depths under hooks/",
+        "pre-commit in_python_cleanliness_surface uses hooks/ (all depths, consistent with CI)",
+        "path.startswith(" in content and '"hooks/"' in content,
+        "pre-commit in_python_cleanliness_surface should use hooks/ to match all depths under hooks/",
+    )
+    test(
+        "pre-commit in_python_cleanliness_surface uses scripts/ (all depths, consistent with CI)",
+        "path.startswith(" in content and '"scripts/"' in content,
+        "pre-commit in_python_cleanliness_surface should use scripts/ to match all depths under scripts/",
     )
     # Depth-limited patterns that would miss browse/static/vendor/ should not be present
     test(

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -705,9 +705,11 @@ def test_pre_commit_out_of_surface_ruff_advisory():
         )
         env = _isolated_path_env(bin_dir)
         git_init = _git_ok(repo, "init")
-        staged = repo / "outside_surface.py"
+        tests_dir = repo / "tests"
+        tests_dir.mkdir()
+        staged = tests_dir / "outside_surface.py"
         staged.write_text("import os\n")
-        git_add = _git_ok(repo, "add", "outside_surface.py")
+        git_add = _git_ok(repo, "add", "tests/outside_surface.py")
         result = _run_pre_commit_hook(repo, hook, home, env)
         output = result.stdout + result.stderr
         test(
@@ -789,13 +791,13 @@ def test_pre_commit_out_of_surface_ruff_exception_fail_open():
             return "ruff"
 
     def raising_run(*_args, **_kwargs):
-        raise subprocess.TimeoutExpired(cmd="ruff check outside_surface.py", timeout=60)
+        raise subprocess.TimeoutExpired(cmd="ruff check tests/outside_surface.py", timeout=60)
 
     module.shutil = FakeShutil
     module.run = raising_run
     stdout = io.StringIO()
     with contextlib.redirect_stdout(stdout):
-        result = module.check_ruff(["outside_surface.py"])
+        result = module.check_ruff(["tests/outside_surface.py"])
     output = stdout.getvalue()
     test(
         "pre-commit out-of-surface Ruff exception stays fail-open",
@@ -831,33 +833,9 @@ REMOTE_TERMINAL_ESLINT_CONFIG = REPO / "remote-terminal" / "eslint.config.mjs"
 REMOTE_TERMINAL_PACKAGE = REPO / "remote-terminal" / "package.json"
 
 # CI Ruff surface (extracted from ci.yml)
-CI_RUFF_FILES = [
-    "embed.py",
-    "scout-config.py",
-    "scout-status.py",
-    "sync-config.py",
-    "sync-daemon.py",
-    "sync-status.py",
-    "migrate.py",
-    "generate-summary.py",
-    "briefing.py",
-    "learn.py",
-    "query-session.py",
-    "extract-knowledge.py",
-    "build-session-index.py",
-    "tentacle.py",
-    "_tentacle_core.py",
-    "_tentacle_goal.py",
-    "_tentacle_pr.py",
-    "_tentacle_dispatch.py",
-    "_tentacle_review.py",
-    "checkpoint-diff.py",
-    "checkpoint-restore.py",
-    "checkpoint-save.py",
-    "tests/test_browse_search_v2.py",
-]
+CI_RUFF_ROOT_GLOB = "*.py"
 CI_RUFF_DIRS = ["browse/", "hooks/", "scripts/"]
-CI_RUFF_SURFACE = CI_RUFF_FILES + CI_RUFF_DIRS
+CI_RUFF_SURFACE = [CI_RUFF_ROOT_GLOB] + CI_RUFF_DIRS
 RUFF_COMPLEXITY_SELECT = "C90,PLR0911,PLR0912,PLR0913,PLR0915"
 
 
@@ -905,12 +883,11 @@ def test_ruff_surface_in_pre_commit():
         bool(surface_body),
         "hooks/pre-commit missing in_python_cleanliness_surface()",
     )
-    for fname in CI_RUFF_FILES:
-        test(
-            f"pre-commit covers CI file: {fname}",
-            fname in surface_body,
-            f"'{fname}' not found in pre-commit _py_in_surface()",
-        )
+    test(
+        "pre-commit covers root Python files",
+        'path.endswith(".py")' in surface_body and '"/" not in path' in surface_body,
+        "hooks/pre-commit should include staged root *.py files in the blocking Ruff surface",
+    )
     for dirname in CI_RUFF_DIRS:
         test(
             f"pre-commit covers CI directory: {dirname}",
@@ -1303,16 +1280,11 @@ def test_contributing_md_local_vs_ci():
         "CONTRIBUTING.md should document the non-blocking RustSec cargo audit advisory",
     )
     test(
-        "CONTRIBUTING.md mentions full Ruff scope (briefing.py)",
-        "briefing.py" in content,
-        "CONTRIBUTING.md Ruff scope is incomplete — missing briefing.py",
+        "CONTRIBUTING.md mentions root Ruff scope",
+        "*.py" in content and "root" in content.lower(),
+        "CONTRIBUTING.md Ruff scope is incomplete — missing root *.py coverage",
     )
-    test(
-        "CONTRIBUTING.md mentions full Ruff scope (tentacle.py)",
-        "tentacle.py" in content,
-        "CONTRIBUTING.md Ruff scope is incomplete — missing tentacle.py",
-    )
-    for fname in ("tests/test_browse_search_v2.py", "scripts/"):
+    for fname in ("browse/", "hooks/", "scripts/"):
         test(
             f"CONTRIBUTING.md mentions full Ruff scope ({fname})",
             fname in content,
@@ -1337,9 +1309,9 @@ def test_architecture_md_ruff_surface():
         "docs/ARCHITECTURE.md should define the canonical lint surface inventory",
     )
     test(
-        "ARCHITECTURE.md explains uncovered root script policy",
-        "outside the blocking Ruff lint surface" in content,
-        "docs/ARCHITECTURE.md should explain coverage policy for unlisted root scripts",
+        "ARCHITECTURE.md explains root script Ruff policy",
+        "Root `*.py` files are now inside the blocking Ruff lint surface" in content,
+        "docs/ARCHITECTURE.md should explain that root scripts are inside Ruff coverage",
     )
     test(
         "ARCHITECTURE.md documents Ruff complexity advisory",
@@ -1367,14 +1339,7 @@ def test_architecture_md_ruff_surface():
         "docs/ARCHITECTURE.md should document the non-blocking RustSec cargo audit advisory",
     )
     for fname in (
-        "briefing.py",
-        "tentacle.py",
-        "_tentacle_core.py",
-        "_tentacle_goal.py",
-        "_tentacle_pr.py",
-        "_tentacle_dispatch.py",
-        "_tentacle_review.py",
-        "tests/test_browse_search_v2.py",
+        "*.py",
         "browse/",
         "hooks/",
         "scripts/",

--- a/trend-scout.py
+++ b/trend-scout.py
@@ -2507,7 +2507,7 @@ def run(
             skip, reason = _check_grace_window(grace_hours, run_state)
             if skip:
                 print(f"⏭  Grace window active — {reason}")
-                print(f"   Use --force to override.")
+                print("   Use --force to override.")
                 if explain:
                     _write_explain_artifact([], [], config, explain_output, skip_reason=reason)
                 if research_pack:

--- a/validate-skill.py
+++ b/validate-skill.py
@@ -10,10 +10,11 @@ Usage:
 """
 
 import collections
-import sys
-import re
-from pathlib import Path
 import os
+import re
+import sys
+from pathlib import Path
+
 if os.name == "nt":
     for _s in (sys.stdout, sys.stderr):
         if hasattr(_s, "reconfigure"):
@@ -29,9 +30,9 @@ MAX_HEAVY_HANDED = 5  # MUST/ALWAYS/NEVER without reasoning
 # ---------------------------------------------------------------------------
 
 #: Severity constants (ordered from least to most severe)
-SEVERITY_LOW      = "low"
-SEVERITY_MEDIUM   = "medium"
-SEVERITY_HIGH     = "high"
+SEVERITY_LOW = "low"
+SEVERITY_MEDIUM = "medium"
+SEVERITY_HIGH = "high"
 SEVERITY_CRITICAL = "critical"
 
 #: A single security finding produced by validate_security().
@@ -40,10 +41,10 @@ Finding = collections.namedtuple("Finding", ["severity", "category", "message", 
 #: A compiled security rule used by validate_security().
 _SecurityRule = collections.namedtuple("_SecurityRule", ["category", "severity", "rx", "message"])
 
+
 def _rule(category: str, severity: str, flags: int, pattern: str, message: str) -> _SecurityRule:
     """Compile a security rule, raising ValueError on bad regex at import time."""
-    return _SecurityRule(category=category, severity=severity,
-                         rx=re.compile(pattern, flags), message=message)
+    return _SecurityRule(category=category, severity=severity, rx=re.compile(pattern, flags), message=message)
 
 
 def _mask_code_blocks(content: str) -> str:
@@ -100,11 +101,12 @@ def _mask_code_blocks(content: str) -> str:
     for i, line in enumerate(lines):
         if i in masked_indices:
             stripped = line.rstrip("\r\n")
-            eol = line[len(stripped):]
+            eol = line[len(stripped) :]
             result.append(" " * len(stripped) + eol)
         else:
             result.append(line)
     return "".join(result)
+
 
 # ---------------------------------------------------------------------------
 # Security rules — 35 patterns across four categories
@@ -116,123 +118,263 @@ def _mask_code_blocks(content: str) -> str:
 # ---------------------------------------------------------------------------
 
 SECURITY_RULES: list[_SecurityRule] = [
-
     # ── Prompt Injection ────────────────────────────────────────────────────
-    _rule("prompt-injection", SEVERITY_HIGH, re.IGNORECASE,
-          r"ignore\s+(all\s+)?previous\s+(instructions?|commands?|context|rules?|guidelines?|prompt)",
-          "Prompt injection: 'ignore previous instructions' pattern detected"),
-    _rule("prompt-injection", SEVERITY_HIGH, re.IGNORECASE,
-          r"disregard\s+(all\s+)?previous\s+(instructions?|commands?|context|rules?|guidelines?)",
-          "Prompt injection: 'disregard previous instructions' pattern detected"),
-    _rule("prompt-injection", SEVERITY_HIGH, re.IGNORECASE,
-          r"forget\s+(everything|all\s+previous|your\s+(instructions?|training|guidelines?|rules?))",
-          "Prompt injection: 'forget your instructions' pattern detected"),
-    _rule("prompt-injection", SEVERITY_HIGH, re.IGNORECASE | re.MULTILINE,
-          r"^system:\s",
-          "Prompt injection: line starts with 'system:' — may hijack system prompt"),
-    _rule("prompt-injection", SEVERITY_HIGH, re.IGNORECASE,
-          r"<system>",
-          "Prompt injection: <system> tag may inject system-level instructions"),
-    _rule("prompt-injection", SEVERITY_HIGH, re.IGNORECASE,
-          r"\bact\s+as\b.{0,40}\b(hacker|attacker|evil|malicious|unrestricted|jailbreak|no[- ]restriction)",
-          "Prompt injection: 'act as [unconstrained role]' persona injection pattern"),
-    _rule("prompt-injection", SEVERITY_HIGH, re.IGNORECASE,
-          r"you\s+are\s+now\b.{0,40}\b(hacker|unrestricted|jailbreak|DAN|evil|no[- ]restriction)",
-          "Prompt injection: 'you are now [persona]' identity injection pattern"),
-    _rule("prompt-injection", SEVERITY_HIGH, re.IGNORECASE,
-          r"\b(jailbreak|DAN)\s+mode\b",
-          "Prompt injection: jailbreak/DAN mode activation pattern detected"),
-    _rule("prompt-injection", SEVERITY_HIGH, re.IGNORECASE,
-          r"override\s+(your|all|the)\s+(instructions?|training|guidelines?|safety[\s_-]measures?|constraints?)",
-          "Prompt injection: instruction override attempt detected"),
-    _rule("prompt-injection", SEVERITY_MEDIUM, re.IGNORECASE,
-          r"\[INST\]|\[/INST\]",
-          "Prompt injection: LLaMA/instruction-tuning special tokens detected"),
-    _rule("prompt-injection", SEVERITY_MEDIUM, re.IGNORECASE,
-          r"pretend\s+(you\s+are|to\s+be).{0,60}(unrestricted|no\s+rules?|no\s+restrictions?|no\s+limits?|without\s+restriction)",
-          "Prompt injection: 'pretend to be unrestricted' pattern detected"),
-    _rule("prompt-injection", SEVERITY_MEDIUM, re.IGNORECASE,
-          r"<\|im_start\|>|<\|im_end\|>|<\|endoftext\|>|\[SYSTEM\]",
-          "Prompt injection: model special tokens detected (ChatML/GPT format)"),
-
+    _rule(
+        "prompt-injection",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"ignore\s+(all\s+)?previous\s+(instructions?|commands?|context|rules?|guidelines?|prompt)",
+        "Prompt injection: 'ignore previous instructions' pattern detected",
+    ),
+    _rule(
+        "prompt-injection",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"disregard\s+(all\s+)?previous\s+(instructions?|commands?|context|rules?|guidelines?)",
+        "Prompt injection: 'disregard previous instructions' pattern detected",
+    ),
+    _rule(
+        "prompt-injection",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"forget\s+(everything|all\s+previous|your\s+(instructions?|training|guidelines?|rules?))",
+        "Prompt injection: 'forget your instructions' pattern detected",
+    ),
+    _rule(
+        "prompt-injection",
+        SEVERITY_HIGH,
+        re.IGNORECASE | re.MULTILINE,
+        r"^system:\s",
+        "Prompt injection: line starts with 'system:' — may hijack system prompt",
+    ),
+    _rule(
+        "prompt-injection",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"<system>",
+        "Prompt injection: <system> tag may inject system-level instructions",
+    ),
+    _rule(
+        "prompt-injection",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"\bact\s+as\b.{0,40}\b(hacker|attacker|evil|malicious|unrestricted|jailbreak|no[- ]restriction)",
+        "Prompt injection: 'act as [unconstrained role]' persona injection pattern",
+    ),
+    _rule(
+        "prompt-injection",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"you\s+are\s+now\b.{0,40}\b(hacker|unrestricted|jailbreak|DAN|evil|no[- ]restriction)",
+        "Prompt injection: 'you are now [persona]' identity injection pattern",
+    ),
+    _rule(
+        "prompt-injection",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"\b(jailbreak|DAN)\s+mode\b",
+        "Prompt injection: jailbreak/DAN mode activation pattern detected",
+    ),
+    _rule(
+        "prompt-injection",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"override\s+(your|all|the)\s+(instructions?|training|guidelines?|safety[\s_-]measures?|constraints?)",
+        "Prompt injection: instruction override attempt detected",
+    ),
+    _rule(
+        "prompt-injection",
+        SEVERITY_MEDIUM,
+        re.IGNORECASE,
+        r"\[INST\]|\[/INST\]",
+        "Prompt injection: LLaMA/instruction-tuning special tokens detected",
+    ),
+    _rule(
+        "prompt-injection",
+        SEVERITY_MEDIUM,
+        re.IGNORECASE,
+        r"pretend\s+(you\s+are|to\s+be).{0,60}(unrestricted|no\s+rules?|no\s+restrictions?|no\s+limits?|without\s+restriction)",
+        "Prompt injection: 'pretend to be unrestricted' pattern detected",
+    ),
+    _rule(
+        "prompt-injection",
+        SEVERITY_MEDIUM,
+        re.IGNORECASE,
+        r"<\|im_start\|>|<\|im_end\|>|<\|endoftext\|>|\[SYSTEM\]",
+        "Prompt injection: model special tokens detected (ChatML/GPT format)",
+    ),
     # ── Destructive Commands ────────────────────────────────────────────────
-    _rule("destructive", SEVERITY_CRITICAL, re.IGNORECASE,
-          r"\brm\s+-[rRf]*[rf][rRf]*\s+[/~]",
-          "Destructive command: recursive/force rm on root or home path"),
-    _rule("destructive", SEVERITY_HIGH, re.IGNORECASE,
-          r"\brm\s+-[rRf]*[rf][rRf]*\s+(?:\*|\.\.?(?:[/\\]|(?=\s|$)))",
-          "Destructive command: recursive/force rm with glob or relative path (may wipe project directory)"),
-    _rule("destructive", SEVERITY_HIGH, re.IGNORECASE,
-          r"\bdel(?:ete)?\s+/[fsqFSQ]|\bdel\s+\*\.[*a-zA-Z]",
-          "Destructive command: Windows forced/silent delete pattern"),
-    _rule("destructive", SEVERITY_CRITICAL, re.IGNORECASE | re.MULTILINE,
-          r"\bformat\s+[a-zA-Z]:\s*(?:/[a-zA-Z0-9]|\s*$)",
-          "Destructive command: Windows disk format command detected"),
-    _rule("destructive", SEVERITY_HIGH, re.IGNORECASE,
-          r"\bDROP\s+(TABLE|DATABASE|SCHEMA|INDEX)\b",
-          "Destructive command: SQL DROP statement detected"),
-    _rule("destructive", SEVERITY_MEDIUM, re.IGNORECASE,
-          r"\bDELETE\s+FROM\s+\w",
-          "Destructive command: SQL DELETE FROM statement detected"),
-    _rule("destructive", SEVERITY_MEDIUM, re.IGNORECASE,
-          r"\bTRUNCATE\s+TABLE\b",
-          "Destructive command: SQL TRUNCATE TABLE statement detected"),
-    _rule("destructive", SEVERITY_HIGH, re.IGNORECASE,
-          r"\bkill\s+-9\s+(-1|1)\b",
-          "Destructive command: kill -9 all/init processes detected"),
-    _rule("destructive", SEVERITY_HIGH, re.IGNORECASE,
-          r"\bshutdown\s+(now|/[sS]|-[hHrRpP])\b",
-          "Destructive command: system shutdown/reboot command detected"),
-    _rule("destructive", SEVERITY_CRITICAL, re.IGNORECASE,
-          r"\bmkfs\b",
-          "Destructive command: filesystem format utility (mkfs) detected"),
-    _rule("destructive", SEVERITY_CRITICAL, re.IGNORECASE,
-          r"\bdd\b[^\n]*\bof=/dev/(?:(?:s|h|xv|v)d|nvme\d+n\d+|mmcblk\d+|dm-\d+|loop\d+|mapper/\S+)",
-          "Destructive command: dd writing to raw block device detected"),
-
+    _rule(
+        "destructive",
+        SEVERITY_CRITICAL,
+        re.IGNORECASE,
+        r"\brm\s+-[rRf]*[rf][rRf]*\s+[/~]",
+        "Destructive command: recursive/force rm on root or home path",
+    ),
+    _rule(
+        "destructive",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"\brm\s+-[rRf]*[rf][rRf]*\s+(?:\*|\.\.?(?:[/\\]|(?=\s|$)))",
+        "Destructive command: recursive/force rm with glob or relative path (may wipe project directory)",
+    ),
+    _rule(
+        "destructive",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"\bdel(?:ete)?\s+/[fsqFSQ]|\bdel\s+\*\.[*a-zA-Z]",
+        "Destructive command: Windows forced/silent delete pattern",
+    ),
+    _rule(
+        "destructive",
+        SEVERITY_CRITICAL,
+        re.IGNORECASE | re.MULTILINE,
+        r"\bformat\s+[a-zA-Z]:\s*(?:/[a-zA-Z0-9]|\s*$)",
+        "Destructive command: Windows disk format command detected",
+    ),
+    _rule(
+        "destructive",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"\bDROP\s+(TABLE|DATABASE|SCHEMA|INDEX)\b",
+        "Destructive command: SQL DROP statement detected",
+    ),
+    _rule(
+        "destructive",
+        SEVERITY_MEDIUM,
+        re.IGNORECASE,
+        r"\bDELETE\s+FROM\s+\w",
+        "Destructive command: SQL DELETE FROM statement detected",
+    ),
+    _rule(
+        "destructive",
+        SEVERITY_MEDIUM,
+        re.IGNORECASE,
+        r"\bTRUNCATE\s+TABLE\b",
+        "Destructive command: SQL TRUNCATE TABLE statement detected",
+    ),
+    _rule(
+        "destructive",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"\bkill\s+-9\s+(-1|1)\b",
+        "Destructive command: kill -9 all/init processes detected",
+    ),
+    _rule(
+        "destructive",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"\bshutdown\s+(now|/[sS]|-[hHrRpP])\b",
+        "Destructive command: system shutdown/reboot command detected",
+    ),
+    _rule(
+        "destructive",
+        SEVERITY_CRITICAL,
+        re.IGNORECASE,
+        r"\bmkfs\b",
+        "Destructive command: filesystem format utility (mkfs) detected",
+    ),
+    _rule(
+        "destructive",
+        SEVERITY_CRITICAL,
+        re.IGNORECASE,
+        r"\bdd\b[^\n]*\bof=/dev/(?:(?:s|h|xv|v)d|nvme\d+n\d+|mmcblk\d+|dm-\d+|loop\d+|mapper/\S+)",
+        "Destructive command: dd writing to raw block device detected",
+    ),
     # ── Exfiltration ────────────────────────────────────────────────────────
-    _rule("exfiltration", SEVERITY_CRITICAL, re.IGNORECASE,
-          r"\bcurl\b[^|\n`]*\|\s*(?:sh|bash|zsh|python3?|perl|ruby|exec)\b",
-          "Exfiltration: curl-pipe-to-shell pattern (remote code execution risk)"),
-    _rule("exfiltration", SEVERITY_CRITICAL, re.IGNORECASE,
-          r"\bwget\b[^|\n`]*\|\s*(?:sh|bash|zsh|python3?|perl)\b",
-          "Exfiltration: wget-pipe-to-shell pattern (remote code execution risk)"),
-    _rule("exfiltration", SEVERITY_CRITICAL, re.IGNORECASE,
-          r"\bbase64\s*(?:--decode|-d)\b[^|\n`]*\|\s*(?:sh|bash|zsh|python3?|perl)\b",
-          "Exfiltration: base64 decode pipe to shell (obfuscated RCE risk)"),
-    _rule("exfiltration", SEVERITY_HIGH, re.IGNORECASE,
-          r"\bnc\s+\d{1,3}(?:\.\d{1,3}){3}\s+\d{2,5}\b",
-          "Exfiltration: netcat to IP address/port detected"),
-    _rule("exfiltration", SEVERITY_HIGH, re.IGNORECASE,
-          r"(?:curl|wget)\b[^\n`]*\$\(",
-          "Exfiltration: command substitution in curl/wget URL (data exfiltration risk)"),
-    _rule("exfiltration", SEVERITY_HIGH, re.IGNORECASE,
-          r"(?:curl|wget)\b[^\n`]*\$\{?(?:[A-Z0-9]*_)*(?:TOKEN|SECRET|KEY|PASSWORD|PASSWD|CREDENTIALS?|PRIVATE|AUTH)(?![A-Za-z])\w*\}?",
-          "Exfiltration: secret-like environment variable in curl/wget (credential leak risk)"),
-    _rule("exfiltration", SEVERITY_HIGH, re.IGNORECASE,
-          r"/dev/tcp/[^/\s]+/\d+",
-          "Exfiltration: bash /dev/tcp network redirect detected"),
-    _rule("exfiltration", SEVERITY_HIGH, re.IGNORECASE,
-          r"\bpython3?\s+-c\s+['\"][^'\"]*(?:import\s+socket|urllib\.request|http\.client|requests\.)"
-          r"[^'\"]*(?:send|post|get|connect)\(",
-          "Exfiltration: Python one-liner with network socket/HTTP call detected"),
-
+    _rule(
+        "exfiltration",
+        SEVERITY_CRITICAL,
+        re.IGNORECASE,
+        r"\bcurl\b[^|\n`]*\|\s*(?:sh|bash|zsh|python3?|perl|ruby|exec)\b",
+        "Exfiltration: curl-pipe-to-shell pattern (remote code execution risk)",
+    ),
+    _rule(
+        "exfiltration",
+        SEVERITY_CRITICAL,
+        re.IGNORECASE,
+        r"\bwget\b[^|\n`]*\|\s*(?:sh|bash|zsh|python3?|perl)\b",
+        "Exfiltration: wget-pipe-to-shell pattern (remote code execution risk)",
+    ),
+    _rule(
+        "exfiltration",
+        SEVERITY_CRITICAL,
+        re.IGNORECASE,
+        r"\bbase64\s*(?:--decode|-d)\b[^|\n`]*\|\s*(?:sh|bash|zsh|python3?|perl)\b",
+        "Exfiltration: base64 decode pipe to shell (obfuscated RCE risk)",
+    ),
+    _rule(
+        "exfiltration",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"\bnc\s+\d{1,3}(?:\.\d{1,3}){3}\s+\d{2,5}\b",
+        "Exfiltration: netcat to IP address/port detected",
+    ),
+    _rule(
+        "exfiltration",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"(?:curl|wget)\b[^\n`]*\$\(",
+        "Exfiltration: command substitution in curl/wget URL (data exfiltration risk)",
+    ),
+    _rule(
+        "exfiltration",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"(?:curl|wget)\b[^\n`]*\$\{?(?:[A-Z0-9]*_)*(?:TOKEN|SECRET|KEY|PASSWORD|PASSWD|CREDENTIALS?|PRIVATE|AUTH)(?![A-Za-z])\w*\}?",
+        "Exfiltration: secret-like environment variable in curl/wget (credential leak risk)",
+    ),
+    _rule(
+        "exfiltration",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"/dev/tcp/[^/\s]+/\d+",
+        "Exfiltration: bash /dev/tcp network redirect detected",
+    ),
+    _rule(
+        "exfiltration",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"\bpython3?\s+-c\s+['\"][^'\"]*(?:import\s+socket|urllib\.request|http\.client|requests\.)"
+        r"[^'\"]*(?:send|post|get|connect)\(",
+        "Exfiltration: Python one-liner with network socket/HTTP call detected",
+    ),
     # ── Obfuscation ─────────────────────────────────────────────────────────
-    _rule("obfuscation", SEVERITY_MEDIUM, 0,
-          r"[A-Za-z0-9+/]{100,}={0,2}",
-          "Obfuscation: unusually long base64-like string may hide a payload"),
-    _rule("obfuscation", SEVERITY_HIGH, 0,
-          "[\u202e\u2066\u2067\u2069\u200b\u200c\u200d\ufeff]",
-          "Obfuscation: Unicode direction-override or invisible character detected"),
-    _rule("obfuscation", SEVERITY_HIGH, re.IGNORECASE,
-          r"\beval\s*\(\s*base64_decode\s*\(",
-          "Obfuscation: eval(base64_decode()) PHP-style obfuscated code execution"),
-    _rule("obfuscation", SEVERITY_MEDIUM, re.IGNORECASE,
-          r"(?:\\x[0-9a-fA-F]{2}){4,}",
-          r"Obfuscation: multiple hex escape sequences (\xNN) may hide malicious content"),
-    _rule("obfuscation", SEVERITY_LOW, re.IGNORECASE,
-          r"(?:%[0-9a-fA-F]{2}){4,}",
-          "Obfuscation: multiple URL-encoded sequences may conceal path traversal or injection"),
+    _rule(
+        "obfuscation",
+        SEVERITY_MEDIUM,
+        0,
+        r"[A-Za-z0-9+/]{100,}={0,2}",
+        "Obfuscation: unusually long base64-like string may hide a payload",
+    ),
+    _rule(
+        "obfuscation",
+        SEVERITY_HIGH,
+        0,
+        "[\u202e\u2066\u2067\u2069\u200b\u200c\u200d\ufeff]",
+        "Obfuscation: Unicode direction-override or invisible character detected",
+    ),
+    _rule(
+        "obfuscation",
+        SEVERITY_HIGH,
+        re.IGNORECASE,
+        r"\beval\s*\(\s*base64_decode\s*\(",
+        "Obfuscation: eval(base64_decode()) PHP-style obfuscated code execution",
+    ),
+    _rule(
+        "obfuscation",
+        SEVERITY_MEDIUM,
+        re.IGNORECASE,
+        r"(?:\\x[0-9a-fA-F]{2}){4,}",
+        r"Obfuscation: multiple hex escape sequences (\xNN) may hide malicious content",
+    ),
+    _rule(
+        "obfuscation",
+        SEVERITY_LOW,
+        re.IGNORECASE,
+        r"(?:%[0-9a-fA-F]{2}){4,}",
+        "Obfuscation: multiple URL-encoded sequences may conceal path traversal or injection",
+    ),
 ]
 
 
@@ -254,13 +396,16 @@ def validate_security(content: str) -> list[Finding]:
         m = rule.rx.search(scanned)
         if m:
             line_no = scanned[: m.start()].count("\n") + 1
-            findings.append(Finding(
-                severity=rule.severity,
-                category=rule.category,
-                message=f"{rule.message} (line {line_no})",
-                line=line_no,
-            ))
+            findings.append(
+                Finding(
+                    severity=rule.severity,
+                    category=rule.category,
+                    message=f"{rule.message} (line {line_no})",
+                    line=line_no,
+                )
+            )
     return findings
+
 
 def validate(path: Path) -> tuple[list[str], list[str]]:
     """Validate a SKILL.md file. Returns (errors, warnings)."""
@@ -321,8 +466,7 @@ def validate(path: Path) -> tuple[list[str], list[str]]:
                             )
                 else:
                     errors.append(
-                        "'name' field has no value — it must not be empty "
-                        "(e.g. `name: my-skill` not just `name:`)."
+                        "'name' field has no value — it must not be empty (e.g. `name: my-skill` not just `name:`)."
                     )
             if "description:" not in fm:
                 errors.append("Frontmatter missing 'description' field")
@@ -366,35 +510,28 @@ def validate(path: Path) -> tuple[list[str], list[str]]:
     # --- 2. Line count ---
     line_count = len(lines)
     if line_count > MAX_LINES:
-        errors.append(
-            f"File is {line_count} lines (max {MAX_LINES}). "
-            f"Move detail into references/ files."
-        )
+        errors.append(f"File is {line_count} lines (max {MAX_LINES}). Move detail into references/ files.")
     elif line_count > MAX_LINES * 0.8:
         warnings.append(
-            f"File is {line_count}/{MAX_LINES} lines — approaching limit. "
-            f"Consider moving detail to references/."
+            f"File is {line_count}/{MAX_LINES} lines — approaching limit. Consider moving detail to references/."
         )
 
     # --- 3. Examples ---
     example_count = content.count("<example>")
     if example_count == 0:
-        errors.append(
-            "No <example> blocks found. Include 1-3 realistic examples "
-            "wrapped in <example> tags."
-        )
+        errors.append("No <example> blocks found. Include 1-3 realistic examples wrapped in <example> tags.")
 
     # Check for matching closing tags
     close_count = content.count("</example>")
     if example_count != close_count:
-        errors.append(
-            f"Mismatched example tags: {example_count} opening, {close_count} closing"
-        )
+        errors.append(f"Mismatched example tags: {example_count} opening, {close_count} closing")
 
     # --- 4. Required sections ---
     has_title = bool(re.search(r"^# .+", content, re.MULTILINE))
     has_when = bool(re.search(r"##.*(?:when|trigger|activat)", content, re.IGNORECASE | re.MULTILINE))
-    has_workflow = bool(re.search(r"##.*(?:workflow|process|steps|how|phase|usage)", content, re.IGNORECASE | re.MULTILINE))
+    has_workflow = bool(
+        re.search(r"##.*(?:workflow|process|steps|how|phase|usage)", content, re.IGNORECASE | re.MULTILINE)
+    )
 
     if not has_title:
         errors.append("Missing title (# heading)")
@@ -489,11 +626,11 @@ def main():
     if display_path.exists():
         line_count = len(display_path.read_text(encoding="utf-8-sig", errors="replace").splitlines())
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"  Skill Validation: {display_path.name}")
     print(f"  Path: {display_path}")
     print(f"  Lines: {line_count}")
-    print(f"{'='*60}\n")
+    print(f"{'=' * 60}\n")
 
     if errors:
         print(f"❌ ERRORS ({len(errors)}):")
@@ -514,15 +651,19 @@ def main():
 
     crit = _sev(errors, SEVERITY_CRITICAL)
     high = _sev(errors, SEVERITY_HIGH)
-    med  = _sev(warnings, SEVERITY_MEDIUM)
-    low  = _sev(warnings, SEVERITY_LOW)
+    med = _sev(warnings, SEVERITY_MEDIUM)
+    low = _sev(warnings, SEVERITY_LOW)
     sec_total = crit + high + med + low
     if sec_total:
         parts = []
-        if crit: parts.append(f"critical={crit}")
-        if high: parts.append(f"high={high}")
-        if med:  parts.append(f"medium={med}")
-        if low:  parts.append(f"low={low}")
+        if crit:
+            parts.append(f"critical={crit}")
+        if high:
+            parts.append(f"high={high}")
+        if med:
+            parts.append(f"medium={med}")
+        if low:
+            parts.append(f"low={low}")
         print(f"🔒 Security findings: {' '.join(parts)}\n")
 
     # Verdict: FAIL / WARN / PASS

--- a/workflow-health.py
+++ b/workflow-health.py
@@ -35,7 +35,7 @@ DEFAULT_SCOUT_CONFIG_PATH = _SCRIPT_DIR / "trend-scout-config.json"
 DEFAULT_SKILLS_DIR = Path.home() / ".copilot" / "skills"
 
 # ── Thresholds ─────────────────────────────────────────────────────────────
-HEAVY_SESSION_SIZE_BYTES = 500 * 1024   # 500 KB
+HEAVY_SESSION_SIZE_BYTES = 500 * 1024  # 500 KB
 HEAVY_SESSION_MIN_FILES = 10
 LOW_YIELD_MIN_EVENTS = 20
 STALE_PACK_DAYS = 7
@@ -43,6 +43,7 @@ UNUSED_SKILLS_LOOKBACK_DAYS = 30
 
 
 # ── Utilities ──────────────────────────────────────────────────────────────
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -64,6 +65,7 @@ def _grade(findings: list) -> str:
 
 
 # ── Heuristic 1: Heavy sessions ────────────────────────────────────────────
+
 
 def check_heavy_sessions(db: sqlite3.Connection) -> list:
     """Flag sessions that are very large but have 0 checkpoints and many files.
@@ -111,6 +113,7 @@ def check_heavy_sessions(db: sqlite3.Connection) -> list:
 
 # ── Heuristic 2: Low-yield sessions ───────────────────────────────────────
 
+
 def check_low_yield_sessions(db: sqlite3.Connection) -> list:
     """Flag fully-indexed sessions with many events but 0 extracted knowledge entries."""
     try:
@@ -155,6 +158,7 @@ def check_low_yield_sessions(db: sqlite3.Connection) -> list:
 
 
 # ── Heuristic 3: Stale research packs ─────────────────────────────────────
+
 
 def check_stale_research_packs(
     scout_config_path: Path | None = None,
@@ -212,6 +216,7 @@ def check_stale_research_packs(
 
 
 # ── Heuristic 4: Unused skills ─────────────────────────────────────────────
+
 
 def check_unused_skills(
     skills_dir: Path | None = None,
@@ -281,6 +286,7 @@ def check_unused_skills(
 
 # ── Orchestrator ───────────────────────────────────────────────────────────
 
+
 def run_health(
     db_path: Path | None = None,
     scout_config_path: Path | None = None,
@@ -335,6 +341,7 @@ def run_health(
 
 # ── Text renderer ──────────────────────────────────────────────────────────
 
+
 def _print_text(result: dict) -> None:
     grade = result.get("health_grade", "?")
     findings = result.get("findings", [])
@@ -354,6 +361,7 @@ def _print_text(result: dict) -> None:
 
 
 # ── CLI ────────────────────────────────────────────────────────────────────
+
 
 def main() -> None:
     import argparse


### PR DESCRIPTION
## Summary
- expands the blocking Python Ruff surface to all root `*.py` scripts plus `browse/`, `hooks/`, and `scripts/`
- syncs CI, local pre-commit, docs, and quality-gate tests around the new surface contract
- baselines newly covered root scripts with Ruff-safe fixes/formatting
- adds fail-open timeouts to `sync-status.py` service-manager probes so Windows diagnostics cannot hang validation

## Verification
- `ruff check *.py browse/ hooks/ scripts/` → all checks passed
- `ruff format --check *.py browse/ hooks/ scripts/` → 197 files already formatted
- `python tests\test_quality_gates.py` → 347 passed, 0 failed
- `python run_all_tests.py` → 96/96 passed before the 5-minute budget skip
- budget-skipped tail tests run individually, including `python tests\test_sync_status.py` → 74/74 passed and `python tests\test_hook_compat.py` → 239/239 passed
- `ruff check --select C90,PLR0911,PLR0912,PLR0913,PLR0915 --statistics *.py browse/ hooks/ scripts/` → emitted baseline counts; advisory exit 1 as expected under CI `continue-on-error: true`
- independent code review agent → no significant issues found

Closes #267