### PR TITLE
Add Python/Rust boundary regression suite

### DIFF
--- a/.github/workflows/sk-ci.yml
+++ b/.github/workflows/sk-ci.yml
@@ -6,12 +6,16 @@ on:
     paths:
       - 'sk-rust/**'
       - 'benchmark.py'
+      - 'docs/ARCHITECTURE.md'
+      - 'tests/test_py_rust_boundary.py'
       - '.github/workflows/sk-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'sk-rust/**'
       - 'benchmark.py'
+      - 'docs/ARCHITECTURE.md'
+      - 'tests/test_py_rust_boundary.py'
       - '.github/workflows/sk-ci.yml'
 
 env:
@@ -137,3 +141,12 @@ jobs:
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('sk-rust/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-test-
       - run: cargo test
+      - name: Python/Rust boundary regression
+        working-directory: ${{ github.workspace }}
+        shell: bash
+        run: |
+          bin="sk-rust/target/debug/sk"
+          if [ "${RUNNER_OS}" = "Windows" ]; then
+            bin="sk-rust/target/debug/sk.exe"
+          fi
+          python3 tests/test_py_rust_boundary.py --rust-bin "$bin"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,15 +43,15 @@ watch-sessions.py  ──→  Incremental re-indexing (adaptive polling)
 
 `sk watch` (Rust binary) **never** spawns Python — including on error paths. The following Python surfaces are **permanent intentional architecture**, not residual code pending deletion:
 
-| Python surface | Role | Status |
-|----------------|------|--------|
-| `sk.py` shim | Thin launcher/dispatcher for non-binary installs; routes all `sk <cmd>` calls | **Intentional** — the no-binary install contract |
-| `hook_runner.py` | Python hook runner for `sk.py` shim and non-binary installs; owns all managed hook events when no Rust binary is present | **Intentional** — Python shim hook entry point |
-| `build-session-index.py` | Indexes session files → FTS5 DB; named in `sk watch` DB-failure recovery hints | **Intentional** — manual operator recovery tool |
-| `extract-knowledge.py` | Knowledge classification, relation extraction, `--semantic-only` fallback; named in `sk watch` extract-failure recovery hints | **Intentional** — manual/fallback operator tool |
-| `migrate.py` | Versioned schema migrations via `schema_version` table | **Intentional** — canonical schema upgrade owner; Rust native bootstrap does NOT replace this |
-| `sync-daemon.py` | Push/pull sync runtime for Python `sk.py` shim and non-binary installs | **Intentional** — shim sync path |
-| `briefing.py`, `learn.py`, `query-session.py`, `project-registry.py`, etc. | Admin/operator CLI scripts | **Intentional** — these are the primary Python CLI surface; the Rust binary may bypass Python for measured hot read-only subcommands such as `sk project list`, while the direct scripts and mutating fallbacks remain supported |
+| Python surface | Role | Status | Tested by |
+|----------------|------|--------|-----------|
+| `sk.py` shim | Thin launcher/dispatcher for non-binary installs; routes all `sk <cmd>` calls | **Intentional** — the no-binary install contract | `tests/test_py_rust_boundary.py::test_python_shim_dispatch_without_rust_binary`; `tests/test_py_rust_boundary.py::test_project_list_json_matches_python_shim_when_rust_available` |
+| `hook_runner.py` | Python hook runner for `sk.py` shim and non-binary installs; owns all managed hook events when no Rust binary is present | **Intentional** — Python shim hook entry point | `tests/test_py_rust_boundary.py::test_hook_runner_empty_payload_matches_native_exit_when_rust_available` |
+| `build-session-index.py` | Indexes session files → FTS5 DB; named in `sk watch` DB-failure recovery hints | **Intentional** — manual operator recovery tool | `tests/test_py_rust_boundary.py::test_watch_db_failure_recovery_hint_no_python_spawn_when_rust_available` |
+| `extract-knowledge.py` | Knowledge classification, relation extraction, `--semantic-only` fallback; named in `sk watch` extract-failure recovery hints | **Intentional** — manual/fallback operator tool | `tests/test_py_rust_boundary.py::test_watch_db_failure_recovery_hint_no_python_spawn_when_rust_available` |
+| `migrate.py` | Versioned schema migrations via `schema_version` table | **Intentional** — canonical schema upgrade owner; Rust native bootstrap does NOT replace this | `tests/test_py_rust_boundary.py::test_migrate_help_remains_manual_python_surface` |
+| `sync-daemon.py` | Push/pull sync runtime for Python `sk.py` shim and non-binary installs | **Intentional** — shim sync path | `tests/test_py_rust_boundary.py::test_python_shim_sync_run_dispatches_sync_daemon_without_rust_binary` |
+| `briefing.py`, `learn.py`, `query-session.py`, `project-registry.py`, etc. | Admin/operator CLI scripts | **Intentional** — these are the primary Python CLI surface; the Rust binary may bypass Python for measured hot read-only subcommands such as `sk project list`, while the direct scripts and mutating fallbacks remain supported | `tests/test_py_rust_boundary.py::test_python_shim_dispatch_without_rust_binary`; `tests/test_py_rust_boundary.py::test_project_list_json_matches_python_shim_when_rust_available` |
 
 **What wave20 removed:** auto-spawning Python subprocess on `sk watch` error paths. The scripts
 above remain on disk, are invoked by operators manually, and are referenced by name in `sk watch`

--- a/sk-rust/src/commands/watch.rs
+++ b/sk-rust/src/commands/watch.rs
@@ -371,7 +371,10 @@ fn check_and_index(
                     }
                     native_extract_ok = true;
                 }
-                Some(Err(e)) => eprintln!("[watch] Native extract error (continuing): {e}"),
+                Some(Err(e)) => {
+                    eprintln!("[watch] Native extract error (continuing): {e}");
+                    native_extract_needs_recovery = true;
+                }
                 None => {
                     native_extract_needs_recovery = true;
                 } // Genuine DB creation failure — recovery hint emitted below

--- a/tests/test_py_rust_boundary.py
+++ b/tests/test_py_rust_boundary.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Python/Rust boundary regression tests.
+
+The suite is intentionally stdlib-only so it can run from the regular Python
+test runner and from sk-rust CI after a Rust binary is built. Binary-dependent
+checks skip explicitly when no local Rust binary is available.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).resolve().parent.parent
+SK_PY = REPO / "sk.py"
+HOOK_RUNNER = REPO / "hooks" / "hook_runner.py"
+MIGRATE_PY = REPO / "migrate.py"
+ARCHITECTURE_MD = REPO / "docs" / "ARCHITECTURE.md"
+SK_CI = REPO / ".github" / "workflows" / "sk-ci.yml"
+
+PASS = 0
+FAIL = 0
+SKIP = 0
+
+
+def record(name: str, passed: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if passed:
+        PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        FAIL += 1
+        suffix = f" -- {detail}" if detail else ""
+        print(f"  FAIL  {name}{suffix}")
+
+
+def skip(name: str, reason: str) -> None:
+    global SKIP
+    SKIP += 1
+    print(f"  SKIP  {name} -- {reason}")
+
+
+def run_cmd(
+    cmd: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    input_text: str | None = None,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess:
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        cmd,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+        env=merged_env,
+        cwd=str(REPO),
+    )
+
+
+def isolated_env(home: Path, tools_dir: Path | None = None) -> dict[str, str]:
+    env = {
+        "HOME": str(home),
+        "USERPROFILE": str(home),
+        "COPILOT_HOME": str(home),
+        "SK_TOOLS_DIR": str(tools_dir or REPO),
+    }
+    return env
+
+
+def write_mock_script(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os\n"
+        "import sys\n"
+        "if os.name == 'nt':\n"
+        "    sys.stdout.reconfigure(encoding='utf-8', errors='replace')\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+
+
+def normalize(text: str) -> str:
+    return text.replace("\r\n", "\n").strip()
+
+
+def resolve_rust_bin(explicit: str | None) -> Path | None:
+    candidates: list[Path] = []
+    if explicit:
+        candidates.append(Path(explicit))
+    exe = "sk.exe" if os.name == "nt" else "sk"
+    candidates.extend(
+        [
+            REPO / "sk-rust" / "target" / "debug" / exe,
+            REPO / "sk-rust" / "target" / "release" / exe,
+        ]
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    return None
+
+
+def require_rust_bin(name: str, rust_bin: Path | None) -> Path | None:
+    if rust_bin is None:
+        skip(name, "Rust sk binary not found; run `cargo build --manifest-path sk-rust/Cargo.toml`")
+        return None
+    return rust_bin
+
+
+def test_python_shim_dispatch_without_rust_binary() -> None:
+    with tempfile.TemporaryDirectory(prefix="py-rust-boundary-shim-") as tmp:
+        root = Path(tmp)
+        tools = root / "tools"
+        write_mock_script(tools / "briefing.py", "print('PY_SHIM_BOUNDARY_OK')")
+        result = run_cmd(
+            [sys.executable, str(SK_PY), "briefing", "--compact"],
+            env=isolated_env(root, tools),
+        )
+        record(
+            "Python sk.py shim dispatches without Rust binary",
+            result.returncode == 0 and "PY_SHIM_BOUNDARY_OK" in result.stdout,
+            f"exit={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}",
+        )
+
+
+def test_python_shim_sync_run_dispatches_sync_daemon_without_rust_binary() -> None:
+    with tempfile.TemporaryDirectory(prefix="py-rust-boundary-sync-") as tmp:
+        root = Path(tmp)
+        tools = root / "tools"
+        write_mock_script(tools / "sync-daemon.py", "print('PY_SYNC_DAEMON_BOUNDARY_OK')")
+        result = run_cmd(
+            [sys.executable, str(SK_PY), "sync", "run", "--once"],
+            env=isolated_env(root, tools),
+        )
+        record(
+            "Python sk.py sync run dispatches sync-daemon.py",
+            result.returncode == 0 and "PY_SYNC_DAEMON_BOUNDARY_OK" in result.stdout,
+            f"exit={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}",
+        )
+
+
+def test_hooks_list_matches_python_shim_when_rust_available(rust_bin: Path | None) -> None:
+    rust = require_rust_bin("Rust/Python hooks list parity", rust_bin)
+    if rust is None:
+        return
+    with tempfile.TemporaryDirectory(prefix="py-rust-boundary-hooks-") as tmp:
+        root = Path(tmp)
+        env = isolated_env(root)
+        py_result = run_cmd([sys.executable, str(SK_PY), "hooks", "list"], env=env)
+        rust_result = run_cmd([str(rust), "hooks", "list"], env=env)
+        record(
+            "Rust hooks list exits 0 like Python shim",
+            py_result.returncode == 0 and rust_result.returncode == 0,
+            f"python={py_result.returncode} rust={rust_result.returncode}",
+        )
+        record(
+            "Rust hooks list output matches Python shim",
+            normalize(py_result.stdout) == normalize(rust_result.stdout),
+            f"python={py_result.stdout!r} rust={rust_result.stdout!r}",
+        )
+
+
+def test_hook_runner_empty_payload_matches_native_exit_when_rust_available(rust_bin: Path | None) -> None:
+    rust = require_rust_bin("Rust/Python hook runner empty payload parity", rust_bin)
+    if rust is None:
+        return
+    with tempfile.TemporaryDirectory(prefix="py-rust-boundary-hook-runner-") as tmp:
+        root = Path(tmp)
+        env = isolated_env(root)
+        py_result = run_cmd(
+            [sys.executable, str(HOOK_RUNNER), "postToolUse"],
+            env=env,
+            input_text="{}",
+        )
+        rust_result = run_cmd(
+            [str(rust), "hooks", "run", "postToolUse"],
+            env=env,
+            input_text="{}",
+        )
+        record(
+            "Python hook_runner.py accepts empty postToolUse payload",
+            py_result.returncode == 0,
+            f"exit={py_result.returncode} stderr={py_result.stderr!r}",
+        )
+        record(
+            "Rust hooks run accepts empty postToolUse payload",
+            rust_result.returncode == py_result.returncode,
+            f"python={py_result.returncode} rust={rust_result.returncode} stderr={rust_result.stderr!r}",
+        )
+
+
+def test_project_list_json_matches_python_shim_when_rust_available(rust_bin: Path | None) -> None:
+    rust = require_rust_bin("Rust/Python project list JSON parity", rust_bin)
+    if rust is None:
+        return
+    with tempfile.TemporaryDirectory(prefix="py-rust-boundary-project-") as tmp:
+        root = Path(tmp)
+        session_state = root / ".copilot" / "session-state"
+        alpha = root / "alpha"
+        beta = root / "beta"
+        session_state.mkdir(parents=True)
+        alpha.mkdir()
+        beta.mkdir()
+        registry = {
+            "projects": [
+                str(alpha),
+                {"name": "beta-custom", "path": str(beta), "created_at": "2026-05-17T00:00:00+00:00"},
+            ]
+        }
+        (session_state / "tools-managed-projects.json").write_text(
+            json.dumps(registry, indent=2),
+            encoding="utf-8",
+        )
+        env = isolated_env(root)
+        py_result = run_cmd([sys.executable, str(SK_PY), "project", "list", "--json"], env=env)
+        rust_result = run_cmd([str(rust), "project", "list", "--json"], env=env)
+        record(
+            "Python and Rust project list JSON exit 0",
+            py_result.returncode == 0 and rust_result.returncode == 0,
+            f"python={py_result.returncode} rust={rust_result.returncode}",
+        )
+        try:
+            py_json = json.loads(py_result.stdout)
+            rust_json = json.loads(rust_result.stdout)
+        except json.JSONDecodeError as exc:
+            record("project list JSON parses", False, str(exc))
+            return
+        record(
+            "Rust project list JSON matches Python shim",
+            py_json == rust_json,
+            f"python={py_json!r} rust={rust_json!r}",
+        )
+
+
+def test_watch_db_failure_recovery_hint_no_python_spawn_when_rust_available(rust_bin: Path | None) -> None:
+    rust = require_rust_bin("Rust watch DB failure recovery hint", rust_bin)
+    if rust is None:
+        return
+    with tempfile.TemporaryDirectory(prefix="py-rust-boundary-watch-") as tmp:
+        root = Path(tmp)
+        session_state = root / ".copilot" / "session-state"
+        tools = root / "tools"
+        session_dir = session_state / "11111111-2222-3333-4444-555555555555"
+        session_dir.mkdir(parents=True)
+        tools.mkdir()
+        (session_state / "knowledge.db").mkdir()
+        (session_dir / "checkpoint.md").write_text(
+            "# Boundary checkpoint\n\nNative DB failure path.\n",
+            encoding="utf-8",
+        )
+        index_flag = tools / "build-session-index-called.flag"
+        extract_flag = tools / "extract-knowledge-called.flag"
+        write_mock_script(
+            tools / "build-session-index.py",
+            f"from pathlib import Path\nPath(r'{index_flag}').write_text('called', encoding='utf-8')",
+        )
+        write_mock_script(
+            tools / "extract-knowledge.py",
+            f"from pathlib import Path\nPath(r'{extract_flag}').write_text('called', encoding='utf-8')",
+        )
+        result = run_cmd(
+            [str(rust), "watch", "--once"],
+            env=isolated_env(root, tools),
+            timeout=45,
+        )
+        combined = result.stdout + result.stderr
+        record(
+            "Rust watch DB failure exits fail-open",
+            result.returncode == 0,
+            f"exit={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}",
+        )
+        record(
+            "Rust watch DB failure emits recovery hint",
+            "Recovery hint" in combined
+            and "build-session-index.py" in combined
+            and "extract-knowledge.py" in combined,
+            combined,
+        )
+        record(
+            "Rust watch extract error branch emits extraction recovery hint",
+            "Native extract error" in combined and "extract-knowledge.py" in combined,
+            combined,
+        )
+        record(
+            "Rust watch DB failure does not panic",
+            "panicked at" not in combined and "thread 'main' panicked" not in combined,
+            combined,
+        )
+        record(
+            "Rust watch DB failure does not spawn Python helpers",
+            not index_flag.exists() and not extract_flag.exists(),
+            f"index_flag={index_flag.exists()} extract_flag={extract_flag.exists()}",
+        )
+
+
+def test_migrate_help_remains_manual_python_surface() -> None:
+    result = run_cmd([sys.executable, str(MIGRATE_PY), "--help"])
+    record(
+        "migrate.py help exits without touching DB",
+        result.returncode == 0 and "--backup-only" in result.stdout and "without touching the database" in result.stdout,
+        f"exit={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}",
+    )
+
+
+def _boundary_rows() -> list[list[str]]:
+    content = ARCHITECTURE_MD.read_text(encoding="utf-8")
+    marker = "| Python surface | Role | Status | Tested by |"
+    if marker not in content:
+        return []
+    lines = content[content.index(marker) :].splitlines()
+    rows: list[list[str]] = []
+    for line in lines[2:]:
+        if not line.startswith("|"):
+            break
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) >= 4:
+            rows.append(cells)
+    return rows
+
+
+def test_boundary_docs_rows_have_tested_by_references() -> None:
+    rows = _boundary_rows()
+    record("ARCHITECTURE boundary table has Tested by column", bool(rows), "No rows parsed")
+    for cells in rows:
+        surface = cells[0]
+        tested_by = cells[3]
+        record(
+            f"ARCHITECTURE boundary row has test reference: {surface}",
+            "tests/test_py_rust_boundary.py::" in tested_by,
+            tested_by,
+        )
+
+
+def test_sk_ci_runs_boundary_suite_after_rust_build() -> None:
+    content = SK_CI.read_text(encoding="utf-8")
+    cargo_test_idx = content.find("cargo test")
+    boundary_idx = content.find("tests/test_py_rust_boundary.py", cargo_test_idx if cargo_test_idx != -1 else 0)
+    record(
+        "sk-ci references Python/Rust boundary suite",
+        "tests/test_py_rust_boundary.py" in content,
+        "tests/test_py_rust_boundary.py missing from sk-ci.yml",
+    )
+    record(
+        "sk-ci runs boundary suite after cargo test/build",
+        cargo_test_idx != -1 and boundary_idx > cargo_test_idx,
+        "boundary test step should appear after cargo test",
+    )
+    record(
+        "sk-ci passes Rust binary path to boundary suite",
+        "--rust-bin" in content and "target/debug/sk" in content,
+        "boundary suite should receive the local Rust binary path",
+    )
+    record(
+        "sk-ci uses python3 for cross-runner boundary suite invocation",
+        "python3 tests/test_py_rust_boundary.py" in content,
+        "Linux and macOS runners do not guarantee a `python` executable",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rust-bin", default=os.environ.get("SK_RUST_BIN", ""))
+    args = parser.parse_args(argv)
+    rust_bin = resolve_rust_bin(args.rust_bin or None)
+
+    print("=== test_py_rust_boundary.py ===")
+    if rust_bin:
+        print(f"Rust binary: {rust_bin}")
+    else:
+        print("Rust binary: unavailable (binary parity tests will skip)")
+
+    test_python_shim_dispatch_without_rust_binary()
+    test_python_shim_sync_run_dispatches_sync_daemon_without_rust_binary()
+    test_hooks_list_matches_python_shim_when_rust_available(rust_bin)
+    test_hook_runner_empty_payload_matches_native_exit_when_rust_available(rust_bin)
+    test_project_list_json_matches_python_shim_when_rust_available(rust_bin)
+    test_watch_db_failure_recovery_hint_no_python_spawn_when_rust_available(rust_bin)
+    test_migrate_help_remains_manual_python_surface()
+    test_boundary_docs_rows_have_tested_by_references()
+    test_sk_ci_runs_boundary_suite_after_rust_build()
+
+    total = PASS + FAIL + SKIP
+    print("\n" + "=" * 50)
+    print(f"Results: {PASS} passed, {FAIL} failed, {SKIP} skipped out of {total}")
+    if FAIL:
+        print(f"{FAIL} boundary test(s) failed")
+        return 1
+    print("All Python/Rust boundary tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `tests/test_py_rust_boundary.py` covering Python shim fallback paths, Rust/Python parity, watch recovery/no-spawn behavior, docs references, and CI wiring
- document Python/Rust boundary rows with a `Tested by` column
- run the boundary suite in `sk-ci` after `cargo test` with the built Rust binary
- emit the extract recovery hint when native watch extract returns an error

Closes #285

## Validation
- `python -m py_compile tests\test_py_rust_boundary.py`
- `ruff check tests\test_py_rust_boundary.py`
- `python tests\test_py_rust_boundary.py --rust-bin sk-rust\target\debug\sk.exe`
- `cargo fmt --all -- --check`
- `cargo test --quiet`
- `cargo clippy -- -D warnings`
- `python tests\test_quality_gates.py`
- `python test_fixes.py`
- `python test_security.py`
- `python run_all_tests.py`