### PR TITLE
Add rollback runbook and evidence checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What changed and why? Link the tracked issue with Closes/Fixes when applicable. -->
+
+## Evidence Checklist
+
+Mark each item with command output or `N/A - <reason>`.
+
+- [ ] Security tests: `python test_security.py`
+- [ ] Fix/regression tests: `python test_fixes.py`
+- [ ] Full Python suite: `python run_all_tests.py`
+- [ ] Rollback runbook tests: `python tests/test_rollback_runbook.py`
+- [ ] Migration rehearsal: `python tests/test_migration_rehearsal.py`
+- [ ] Install sandbox: `python tests/test_install_sandbox.py`
+- [ ] Hook compatibility/security: `python tests/test_hook_compat.py` and `python tests/test_quality_gates.py`
+- [ ] Cross-platform CI: Linux, macOS, and Windows checks are passing or explicitly not applicable
+- [ ] Migration/DB evidence: required for `migrate.py` or schema changes, otherwise `N/A`
+- [ ] Installer/update evidence: required for installer, updater, or release-install changes, otherwise `N/A`
+- [ ] Hook evidence: required for hook provisioning or hook-rule changes, otherwise `N/A`
+

--- a/docs/RESILIENCE-RUNBOOK.md
+++ b/docs/RESILIENCE-RUNBOOK.md
@@ -5,6 +5,8 @@
 >
 > **Prerequisites:** familiarity with `sk tentacle goal` commands — see [docs/USAGE.md](USAGE.md#goal-orchestration).
 > **Playbook home:** [docs/OPERATOR-PLAYBOOK.md](OPERATOR-PLAYBOOK.md)
+> **Rollback and fallback:** see [Rollback and Fallback Runbook](ROLLBACK-RUNBOOK.md) for installer,
+> database, Rust binary, hook provisioning, and PR evidence rollback checklists.
 
 ---
 

--- a/docs/ROLLBACK-RUNBOOK.md
+++ b/docs/ROLLBACK-RUNBOOK.md
@@ -1,0 +1,213 @@
+# Rollback and Fallback Runbook
+
+Operator guide for reverting failed installer, database, Rust binary, and hook
+changes. Run commands from the repository root unless a section says otherwise.
+
+## 1. Installer rollback
+
+Use this when `install.py`, `auto-update-tools.py`, or a local tool refresh leaves
+the launcher or copied tools in a bad state.
+
+### 1.1 Snapshot before risky installer work
+
+```bash
+python install.py --doctor --manifest > /tmp/sk-install-before.txt
+python install.py --install-sk --quiet
+```
+
+### 1.2 Remove only the managed `sk` launcher
+
+```bash
+python install.py --uninstall-launcher
+python install.py --doctor --manifest
+```
+
+### 1.3 Remove managed copied tools while preserving session data
+
+```bash
+python install.py --uninstall
+```
+
+`--uninstall` preserves `~/.copilot/session-state/` and the knowledge database.
+If the checkout was installed with editable pip, remove that wrapper first:
+
+```bash
+python -m pip uninstall copilot-session-knowledge
+python install.py --uninstall
+```
+
+### 1.4 Reinstall from a known-good checkout
+
+```bash
+git fetch origin main
+git switch main
+git pull --ff-only
+python install.py --install-sk --quiet
+python install.py --doctor --manifest
+```
+
+## 2. Database schema rollback
+
+Use this before migrations, manual repair, or any change that writes
+`~/.copilot/session-state/knowledge.db`.
+
+### 2.1 Create a verified rollback backup
+
+POSIX:
+
+```bash
+python migrate.py ~/.copilot/session-state/knowledge.db --backup-only --backup-path /tmp/knowledge.db.backup
+python migrate.py ~/.copilot/session-state/knowledge.db
+```
+
+Windows PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force -Path "C:\Temp" | Out-Null
+python migrate.py "$env:USERPROFILE\.copilot\session-state\knowledge.db" --backup-only --backup-path "C:\Temp\knowledge.db.backup"
+python migrate.py "$env:USERPROFILE\.copilot\session-state\knowledge.db"
+```
+
+### 2.2 Restore a known-good backup on POSIX
+
+Stop active writers first (`sk watch`, sync daemons, launchd services, CI jobs),
+then replace the database and remove WAL sidecars:
+
+```bash
+rm -f ~/.copilot/session-state/knowledge.db-wal ~/.copilot/session-state/knowledge.db-shm
+cp /tmp/knowledge.db.backup ~/.copilot/session-state/knowledge.db
+python migrate.py ~/.copilot/session-state/knowledge.db
+python migrate.py ~/.copilot/session-state/knowledge.db
+```
+
+The second migration run should report `Schema up to date`.
+
+### 2.3 Restore a known-good backup on Windows PowerShell
+
+```powershell
+Remove-Item "$env:USERPROFILE\.copilot\session-state\knowledge.db-wal" -ErrorAction SilentlyContinue
+Remove-Item "$env:USERPROFILE\.copilot\session-state\knowledge.db-shm" -ErrorAction SilentlyContinue
+Copy-Item "C:\Temp\knowledge.db.backup" "$env:USERPROFILE\.copilot\session-state\knowledge.db" -Force
+python migrate.py "$env:USERPROFILE\.copilot\session-state\knowledge.db"
+python migrate.py "$env:USERPROFILE\.copilot\session-state\knowledge.db"
+```
+
+### 2.4 Preserve a bad database for investigation
+
+```bash
+mv ~/.copilot/session-state/knowledge.db ~/.copilot/session-state/knowledge.db.corrupt
+mv ~/.copilot/session-state/knowledge.db-wal ~/.copilot/session-state/knowledge.db-wal.corrupt 2>/dev/null || true
+mv ~/.copilot/session-state/knowledge.db-shm ~/.copilot/session-state/knowledge.db-shm.corrupt 2>/dev/null || true
+python migrate.py ~/.copilot/session-state/knowledge.db
+```
+
+## 3. Rust binary rollback
+
+Use this when a released `sk` binary fails at startup, routes commands
+incorrectly, or regresses native hooks/watch behavior.
+
+### 3.1 Replace the binary with the latest release
+
+POSIX:
+
+```bash
+bash sk-rust/install.sh
+sk --help
+```
+
+Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File sk-rust\install.ps1
+sk --help
+```
+
+### 3.2 Roll back to the Python shim temporarily
+
+If the Rust binary is broken but Python tools are intact, move the binary aside
+and call the shim directly:
+
+```bash
+mv ~/.copilot/bin/sk ~/.copilot/bin/sk.broken
+python ~/.copilot/tools/sk.py --help
+python ~/.copilot/tools/sk.py hooks run sessionStart
+```
+
+Windows PowerShell:
+
+```powershell
+Rename-Item "$env:USERPROFILE\.copilot\bin\sk.exe" "sk.exe.broken"
+python "$env:USERPROFILE\.copilot\tools\sk.py" --help
+python "$env:USERPROFILE\.copilot\tools\sk.py" hooks run sessionStart
+```
+
+### 3.3 Validate before re-enabling the binary
+
+```bash
+cd sk-rust
+cargo test --quiet
+cargo clippy -- -D warnings
+cd ..
+python tests/test_py_rust_boundary.py --rust-bin sk-rust/target/debug/sk
+```
+
+Use `sk-rust\target\debug\sk.exe` for `--rust-bin` on Windows.
+
+## 4. Hook provisioning rollback
+
+Use this when hook installation, tamper protection, or generated hook config
+blocks legitimate work.
+
+### 4.1 Unlock hooks before repair
+
+```bash
+python install.py --unlock-hooks
+```
+
+### 4.2 Restore a backed-up hook
+
+```bash
+cp .git/hooks/pre-commit.backup .git/hooks/pre-commit
+cp .git/hooks/pre-push.backup .git/hooks/pre-push
+chmod +x .git/hooks/pre-commit .git/hooks/pre-push
+```
+
+Windows PowerShell:
+
+```powershell
+Copy-Item .git\hooks\pre-commit.backup .git\hooks\pre-commit -Force
+Copy-Item .git\hooks\pre-push.backup .git\hooks\pre-push -Force
+```
+
+### 4.3 Re-provision known-good hooks
+
+```bash
+python install.py --deploy-hooks
+python install.py --install-git-hooks
+python install.py --lock-hooks
+python tests/test_hook_compat.py
+python tests/test_quality_gates.py
+```
+
+### 4.4 Emergency bypass policy
+
+Prefer restoring hooks over bypassing them. If a human authorizes a one-off
+bypass, document the reason in the PR and run the same tests the hook would have
+enforced before merge.
+
+## 5. Evidence checklist for PR closeout
+
+Every PR that changes installer, migration, hook, Rust binary, or rollback
+surfaces must include either command output or an explicit `N/A` reason for:
+
+- `python test_security.py`
+- `python test_fixes.py`
+- `python run_all_tests.py`
+- `python tests/test_rollback_runbook.py`
+- `python tests/test_migration_rehearsal.py`
+- `python tests/test_install_sandbox.py`
+- `python tests/test_hook_compat.py`
+- Cross-platform CI status: Linux, macOS, and Windows
+- Migration rehearsal evidence when `migrate.py` or DB schema changes
+- Install sandbox evidence when installer/update scripts change
+- Hook security/compat evidence when hook provisioning or hook rules change

--- a/docs/ROLLBACK-RUNBOOK.md
+++ b/docs/ROLLBACK-RUNBOOK.md
@@ -77,10 +77,9 @@ then replace the database and remove WAL sidecars:
 rm -f ~/.copilot/session-state/knowledge.db-wal ~/.copilot/session-state/knowledge.db-shm
 cp /tmp/knowledge.db.backup ~/.copilot/session-state/knowledge.db
 python migrate.py ~/.copilot/session-state/knowledge.db
-python migrate.py ~/.copilot/session-state/knowledge.db
 ```
 
-The second migration run should report `Schema up to date`.
+The migration run should report `Schema up to date`.
 
 ### 2.3 Restore a known-good backup on Windows PowerShell
 
@@ -88,7 +87,6 @@ The second migration run should report `Schema up to date`.
 Remove-Item "$env:USERPROFILE\.copilot\session-state\knowledge.db-wal" -ErrorAction SilentlyContinue
 Remove-Item "$env:USERPROFILE\.copilot\session-state\knowledge.db-shm" -ErrorAction SilentlyContinue
 Copy-Item "C:\Temp\knowledge.db.backup" "$env:USERPROFILE\.copilot\session-state\knowledge.db" -Force
-python migrate.py "$env:USERPROFILE\.copilot\session-state\knowledge.db"
 python migrate.py "$env:USERPROFILE\.copilot\session-state\knowledge.db"
 ```
 

--- a/install.py
+++ b/install.py
@@ -816,6 +816,15 @@ def _inject_launcher_path(quiet: bool = False) -> None:
             print(f"  {OK} Added sk launcher PATH to {_tilde(profile)}")
 
 
+def _remove_launcher_path_block_from_text(text: str) -> tuple[str, int]:
+    """Remove the managed sk launcher PATH block without leaving an injected blank line."""
+    block_re = re.escape(_SK_PATH_MARKER_START) + r".*?" + re.escape(_SK_PATH_MARKER_END) + r"\n?"
+    updated, removed = re.subn(r"\n" + block_re, "", text, flags=re.DOTALL)
+    if removed:
+        return updated, removed
+    return re.subn(block_re, "", text, flags=re.DOTALL)
+
+
 def _inject_launcher_path_windows(quiet: bool = False) -> bool:
     """Try adding ~/.copilot/bin to user PATH in Windows Registry."""
     bin_str = str(SK_LAUNCHER_DIR)
@@ -1050,8 +1059,6 @@ def uninstall_sk_launcher(quiet: bool = False) -> int:
 
     Returns the number of items removed.
     """
-    import re
-
     removed = 0
     launcher_paths = _sk_launcher_managed_paths()
     safe_scripts, modified_scripts, untracked_scripts = _partition_manifest_removals(launcher_paths)
@@ -1098,11 +1105,10 @@ def uninstall_sk_launcher(quiet: bool = False) -> int:
                 content = profile.read_text(encoding="utf-8")
                 if _SK_PATH_MARKER_START not in content:
                     continue
-                pattern = re.escape(_SK_PATH_MARKER_START) + r".*?" + re.escape(_SK_PATH_MARKER_END) + r"\n?"
-                new_content = re.sub(pattern, "", content, flags=re.DOTALL)
+                new_content, removed_blocks = _remove_launcher_path_block_from_text(content)
                 if new_content != content:
                     _atomic_write_text(profile, new_content)
-                    removed += 1
+                    removed += removed_blocks
                     if not quiet:
                         print(f"  {OK} Removed sk PATH injection from {_tilde(profile)}")
         elif _remove_launcher_path_windows(quiet=quiet):

--- a/tests/test_rollback_runbook.py
+++ b/tests/test_rollback_runbook.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Rollback runbook and evidence checklist regression tests.
+
+Run: python tests/test_rollback_runbook.py
+"""
+
+import ast
+import hashlib
+import importlib.util
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+if os.name == "nt":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).resolve().parent.parent
+RUNBOOK = REPO / "docs" / "ROLLBACK-RUNBOOK.md"
+RESILIENCE_RUNBOOK = REPO / "docs" / "RESILIENCE-RUNBOOK.md"
+PR_TEMPLATE = REPO / ".github" / "PULL_REQUEST_TEMPLATE.md"
+INSTALL_PY = REPO / "install.py"
+MIGRATE = REPO / "migrate.py"
+
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _file_snapshot(root: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    if not root.exists():
+        return snapshot
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        snapshot[str(path.relative_to(root))] = _sha256(path)
+    return snapshot
+
+
+def _declared_migrations() -> list[tuple[int, str, list[str]]]:
+    tree = ast.parse(MIGRATE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "MIGRATIONS" for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise AssertionError("MIGRATIONS literal not found")
+
+
+def _latest_version() -> int:
+    return max(version for version, _name, _statements in _declared_migrations())
+
+
+def _run_migrate(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(
+        [sys.executable, str(MIGRATE), *args],
+        cwd=str(REPO),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def _db_scalar(db_path: Path, sql: str, params: tuple = ()):
+    with sqlite3.connect(db_path) as db:
+        return db.execute(sql, params).fetchone()[0]
+
+
+@contextmanager
+def _sandbox_env(fake_home: Path):
+    old_env = os.environ.copy()
+    fake_appdata = fake_home / "AppData" / "Roaming"
+    fake_localappdata = fake_home / "AppData" / "Local"
+    os.environ.update(
+        {
+            "HOME": str(fake_home),
+            "USERPROFILE": str(fake_home),
+            "APPDATA": str(fake_appdata),
+            "LOCALAPPDATA": str(fake_localappdata),
+            "COPILOT_HOME": str(fake_home),
+            "SHELL": "/bin/zsh",
+        }
+    )
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_env)
+
+
+@contextmanager
+def _load_install(fake_home: Path):
+    saved_host_manifest = sys.modules.pop("host_manifest", None)
+    module_name = f"_install_rollback_{abs(hash(fake_home))}"
+    saved_argv = sys.argv[:]
+    with _sandbox_env(fake_home):
+        try:
+            spec = importlib.util.spec_from_file_location(module_name, INSTALL_PY)
+            if spec is None or spec.loader is None:
+                raise RuntimeError("could not load install.py")
+            module = importlib.util.module_from_spec(spec)
+            sys.argv = [str(INSTALL_PY)]
+            spec.loader.exec_module(module)
+            yield module
+        finally:
+            sys.argv = saved_argv
+            sys.modules.pop(module_name, None)
+            sys.modules.pop("host_manifest", None)
+            if saved_host_manifest is not None:
+                sys.modules["host_manifest"] = saved_host_manifest
+
+
+class RollbackRunbookTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="rollback-runbook-"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_runbook_has_required_sections_and_commands(self):
+        text = RUNBOOK.read_text(encoding="utf-8")
+        required = [
+            "## 1. Installer rollback",
+            "## 2. Database schema rollback",
+            "## 3. Rust binary rollback",
+            "## 4. Hook provisioning rollback",
+            "## 5. Evidence checklist for PR closeout",
+            "python install.py --uninstall-launcher",
+            "python install.py --uninstall",
+            "python migrate.py ~/.copilot/session-state/knowledge.db --backup-only",
+            'python migrate.py "$env:USERPROFILE\\.copilot\\session-state\\knowledge.db" --backup-only --backup-path "C:\\Temp\\knowledge.db.backup"',
+            "cp /tmp/knowledge.db.backup ~/.copilot/session-state/knowledge.db",
+            "Copy-Item \"C:\\Temp\\knowledge.db.backup\"",
+            "bash sk-rust/install.sh",
+            "powershell -ExecutionPolicy Bypass -File sk-rust\\install.ps1",
+            "python ~/.copilot/tools/sk.py --help",
+            "python install.py --unlock-hooks",
+            "python install.py --deploy-hooks",
+            "python tests/test_rollback_runbook.py",
+        ]
+        for needle in required:
+            with self.subTest(needle=needle):
+                self.assertIn(needle, text)
+
+    def test_resilience_runbook_links_to_rollback_runbook(self):
+        text = RESILIENCE_RUNBOOK.read_text(encoding="utf-8")
+        self.assertIn("ROLLBACK-RUNBOOK.md", text)
+        self.assertIn("Rollback and Fallback Runbook", text)
+
+    def test_pr_template_has_evidence_checklist(self):
+        text = PR_TEMPLATE.read_text(encoding="utf-8")
+        required = [
+            "## Evidence Checklist",
+            "python test_security.py",
+            "python test_fixes.py",
+            "python run_all_tests.py",
+            "python tests/test_rollback_runbook.py",
+            "python tests/test_migration_rehearsal.py",
+            "python tests/test_install_sandbox.py",
+            "python tests/test_hook_compat.py",
+            "Cross-platform CI",
+            "Migration/DB evidence",
+            "Installer/update evidence",
+            "Hook evidence",
+        ]
+        for needle in required:
+            with self.subTest(needle=needle):
+                self.assertIn(needle, text)
+
+    def test_installer_launcher_rollback_restores_fake_home_file_checksums(self):
+        fake_home = self.tmpdir / "home"
+        fake_home.mkdir()
+        (fake_home / "preexisting.txt").write_text("keep me\n", encoding="utf-8")
+        if os.name != "nt":
+            (fake_home / ".zshrc").write_text("# existing profile\n", encoding="utf-8")
+        before = _file_snapshot(fake_home)
+
+        with _load_install(fake_home) as install:
+            install._inject_launcher_path_windows = lambda quiet=False: False
+            install._emit_windows_current_path_hint = lambda quiet=False: None
+
+            self.assertTrue(install.install_sk_launcher(quiet=True))
+            self.assertNotEqual(before, _file_snapshot(fake_home))
+            self.assertTrue(any(path.is_file() for path in install._sk_launcher_script_paths()))
+
+            removed = install.uninstall_sk_launcher(quiet=True)
+
+        self.assertGreater(removed, 0)
+        self.assertEqual(before, _file_snapshot(fake_home))
+
+    def test_db_backup_restore_rollback_preserves_schema_version(self):
+        db_path = self.tmpdir / "knowledge.db"
+        backup_path = self.tmpdir / "knowledge.db.backup"
+        latest = _latest_version()
+
+        first = _run_migrate(str(db_path))
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(_db_scalar(db_path, "SELECT MAX(version) FROM schema_version"), latest)
+
+        backup = _run_migrate(str(db_path), "--backup-only", "--backup-path", str(backup_path))
+        self.assertEqual(backup.returncode, 0, backup.stderr)
+        self.assertTrue(backup_path.is_file())
+
+        with sqlite3.connect(db_path) as db:
+            db.execute("DELETE FROM schema_version WHERE version = ?", (latest,))
+            db.commit()
+        self.assertLess(_db_scalar(db_path, "SELECT MAX(version) FROM schema_version"), latest)
+
+        for suffix in ("-wal", "-shm"):
+            (db_path.with_name(db_path.name + suffix)).unlink(missing_ok=True)
+        shutil.copy2(backup_path, db_path)
+
+        self.assertEqual(_db_scalar(db_path, "PRAGMA quick_check"), "ok")
+        self.assertEqual(_db_scalar(db_path, "SELECT MAX(version) FROM schema_version"), latest)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_rollback_runbook.py
+++ b/tests/test_rollback_runbook.py
@@ -202,6 +202,25 @@ class RollbackRunbookTests(unittest.TestCase):
         self.assertGreater(removed, 0)
         self.assertEqual(before, _file_snapshot(fake_home))
 
+    def test_launcher_path_block_cleanup_preserves_existing_profile_bytes(self):
+        fake_home = self.tmpdir / "home"
+        fake_home.mkdir()
+        profile_before = "# existing profile\n"
+
+        with _load_install(fake_home) as install:
+            managed_block = (
+                "\n"
+                f"{install._SK_PATH_MARKER_START}\n"
+                f'export PATH="{install.SK_LAUNCHER_DIR}:$PATH"\n'
+                f"{install._SK_PATH_MARKER_END}\n"
+            )
+            profile_after_install = profile_before.rstrip("\n") + "\n" + managed_block
+
+            cleaned, removed = install._remove_launcher_path_block_from_text(profile_after_install)
+
+        self.assertEqual(removed, 1)
+        self.assertEqual(cleaned, profile_before)
+
     def test_db_backup_restore_rollback_preserves_schema_version(self):
         db_path = self.tmpdir / "knowledge.db"
         backup_path = self.tmpdir / "knowledge.db.backup"


### PR DESCRIPTION
## Summary
- add `docs/ROLLBACK-RUNBOOK.md` with installer, DB schema, Rust binary, and hook provisioning rollback commands
- add a PR Evidence Checklist template for required closeout proof
- add `tests/test_rollback_runbook.py` covering runbook content, PR checklist, installer launcher rollback, and DB backup restore
- link the rollback runbook from `docs/RESILIENCE-RUNBOOK.md`

Closes #286

## Validation
- `python -m py_compile tests\test_rollback_runbook.py`
- `ruff check tests\test_rollback_runbook.py`
- `python tests\test_rollback_runbook.py`
- `python tests\test_install_sandbox.py`
- `python tests\test_migration_rehearsal.py`
- `python tests\test_quality_gates.py`
- `python test_security.py`
- `python test_fixes.py`
- `python tests\test_hook_compat.py`
- `python run_all_tests.py`