### PR TITLE
feat: add browse debug log redaction helper

### DIFF
--- a/browse/core/redaction.py
+++ b/browse/core/redaction.py
@@ -1,0 +1,338 @@
+"""browse/core/redaction.py — Allowlist-first BrowseDebugEntry redaction helper.
+
+Write-time policy: only fields in the top-level allowlist are passed through;
+every unknown key is dropped and the ``redacted`` flag is set.  The ``attrs``
+field is further constrained to a flat scalar allowlist (no nested dicts/lists).
+
+Free-text fields (``message``) and allowlisted string attrs are additionally
+scrubbed for bearer tokens, URL query-string tokens, and path-embedded
+usernames; ``browse.core.operator_console.redact_secrets`` is applied as a
+final defence-in-depth pass on every string that leaves this module.
+
+All exceptions inside ``redact_entry`` fail closed: a minimal sentinel dict
+is returned and the error is logged (without exposing the original values).
+
+No third-party dependencies.  Python 3.10+ stdlib only.
+"""
+
+import logging
+import os
+import re
+import sys
+from typing import Any
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+_log = logging.getLogger("browse.redaction")
+
+# ── Limits ────────────────────────────────────────────────────────────────────
+
+_MESSAGE_MAX: int = 2048
+
+# ── Enum allowlists ───────────────────────────────────────────────────────────
+
+_KIND_ENUM = frozenset(
+    {
+        "session_start",
+        "turn_start",
+        "llm_request",
+        "tool_call",
+        "hook",
+        "subagent",
+        "agent_response",
+        "error",
+        "generic",
+    }
+)
+_LEVEL_ENUM = frozenset({"debug", "info", "warn", "error"})
+_SOURCE_ENUM = frozenset({"cli", "hook", "browse", "vscode", "unknown"})
+_STATUS_ENUM = frozenset({"ok", "error", "cancelled", "timeout", "pending"})
+
+# ── Top-level field allowlist ─────────────────────────────────────────────────
+
+_TOP_LEVEL_KEYS = frozenset(
+    {
+        "idx",
+        "timestamp",
+        "kind",
+        "level",
+        "source",
+        "message",
+        "tool_name",
+        "duration_ms",
+        "span_id",
+        "parent_span_id",
+        "status",
+        "attrs",
+        "redacted",
+    }
+)
+
+# ── Attrs allowlist ───────────────────────────────────────────────────────────
+
+_ATTRS_ALLOWLIST = frozenset(
+    {
+        "schema_version",
+        "session_uuid",
+        "model",
+        "route",
+        "status_code",
+        "exit_code",
+        "event_count",
+        "bytes_in",
+        "bytes_out",
+        "tokens_in",
+        "tokens_out",
+        "attempt",
+        "cache_hit",
+        "truncated",
+        "error_category",
+        "latency_ms",
+        "queue_depth",
+    }
+)
+
+# ── Compiled patterns ─────────────────────────────────────────────────────────
+
+_TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_.-]{1,64}$")
+_SPAN_ID_RE = re.compile(r"^[0-9a-f]{8,32}$")
+_ISO_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$")
+_SESSION_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+# Route must not carry a query string
+_ROUTE_QUERY_RE = re.compile(r"\?")
+
+# Text-redaction patterns applied inside _redact_text
+_BEARER_RE = re.compile(r"(?i)\bbearer\s+\S+")
+_WIN_PATH_RE = re.compile(r"(?i)([A-Za-z]:[/\\]Users[/\\])[^/\\\s]+")
+_UNIX_PATH_RE = re.compile(r"(/home/)[^/\s]+")
+_MACOS_PATH_RE = re.compile(r"(/Users/)[^/\s]+")
+_URL_QUERY_TOKEN_RE = re.compile(
+    r"([?&]\w*(?:token|key|secret|auth)\w*=)[^\s&]+",
+    re.IGNORECASE,
+)
+
+
+# ── Text redaction ────────────────────────────────────────────────────────────
+
+
+def _redact_text(text: str) -> str:
+    """Scrub bearer tokens, URL query tokens, and path usernames from *text*.
+
+    Applies ``browse.core.operator_console.redact_secrets`` as a final
+    defence-in-depth pass (pattern-matched; graceful fallback if unavailable).
+    """
+    text = _BEARER_RE.sub("[REDACTED]", text)
+    text = _URL_QUERY_TOKEN_RE.sub(r"\1[REDACTED]", text)
+    text = _WIN_PATH_RE.sub(r"\1[REDACTED]", text)
+    text = _UNIX_PATH_RE.sub(r"\1[REDACTED]", text)
+    text = _MACOS_PATH_RE.sub(r"\1[REDACTED]", text)
+    try:
+        from browse.core.operator_console import redact_secrets  # noqa: PLC0415
+
+        text = redact_secrets(text)
+    except Exception:
+        _log.debug("redact_secrets unavailable; text-pattern redaction only applied")
+    return text
+
+
+# ── Attrs validation ──────────────────────────────────────────────────────────
+
+
+def _redact_attrs(raw_attrs: Any) -> tuple[dict, bool]:
+    """Validate and scrub the ``attrs`` field.
+
+    Returns ``(cleaned_attrs, was_redacted)``; fails closed to ``{}`` if
+    *raw_attrs* is not a dict.
+    """
+    if not isinstance(raw_attrs, dict):
+        # None is not a drop (field absent); any other non-dict type is.
+        return {}, (raw_attrs is not None)
+
+    out: dict = {}
+    redacted = False
+
+    for k, v in raw_attrs.items():
+        if k not in _ATTRS_ALLOWLIST:
+            redacted = True
+            continue
+        if isinstance(v, (dict, list)):
+            redacted = True
+            continue
+        if not isinstance(v, (str, int, float, bool, type(None))):
+            redacted = True
+            continue
+        # Special validators
+        if k == "route":
+            if not isinstance(v, str) or _ROUTE_QUERY_RE.search(v):
+                redacted = True
+                continue
+        if k == "session_uuid":
+            if not isinstance(v, str) or not _SESSION_UUID_RE.match(v):
+                redacted = True
+                continue
+        # Scrub string values
+        if isinstance(v, str):
+            clean = _redact_text(v)
+            if clean != v:
+                redacted = True
+            out[k] = clean
+        else:
+            out[k] = v
+
+    return out, redacted
+
+
+# ── Core field validators ─────────────────────────────────────────────────────
+
+
+def _validate_core_fields(entry: dict, out: dict) -> bool:
+    """Populate idx/timestamp/kind/level/source into *out*.  Returns redacted flag."""
+    redacted = False
+
+    raw_idx = entry.get("idx")
+    if isinstance(raw_idx, int) and raw_idx >= 0:
+        out["idx"] = raw_idx
+    else:
+        out["idx"] = 0
+        redacted = True
+
+    raw_ts = entry.get("timestamp")
+    if raw_ts is None or (isinstance(raw_ts, str) and _ISO_UTC_RE.match(raw_ts)):
+        out["timestamp"] = raw_ts
+    else:
+        out["timestamp"] = None
+        redacted = True
+
+    raw_kind = entry.get("kind", "generic")
+    if raw_kind in _KIND_ENUM:
+        out["kind"] = raw_kind
+    else:
+        out["kind"] = "generic"
+        redacted = True
+
+    raw_level = entry.get("level")
+    out["level"] = raw_level if raw_level in _LEVEL_ENUM else "info"
+
+    raw_source = entry.get("source")
+    out["source"] = raw_source if raw_source in _SOURCE_ENUM else "unknown"
+
+    return redacted
+
+
+def _validate_payload_fields(entry: dict, out: dict) -> bool:
+    """Populate message/tool_name/duration_ms/span_id/status into *out*.  Returns redacted flag."""
+    redacted = False
+
+    raw_msg = entry.get("message")
+    if raw_msg is not None:
+        original = str(raw_msg)[:_MESSAGE_MAX]
+        clean = _redact_text(original)
+        if clean != original:
+            redacted = True
+        out["message"] = clean
+
+    raw_tn = entry.get("tool_name")
+    if raw_tn is not None:
+        if isinstance(raw_tn, str) and _TOOL_NAME_RE.match(raw_tn):
+            out["tool_name"] = raw_tn
+        else:
+            redacted = True
+
+    raw_dur = entry.get("duration_ms")
+    if raw_dur is not None:
+        if isinstance(raw_dur, int) and raw_dur >= 0:
+            out["duration_ms"] = raw_dur
+        else:
+            redacted = True
+
+    for span_key in ("span_id", "parent_span_id"):
+        raw_span = entry.get(span_key)
+        if raw_span is not None:
+            if isinstance(raw_span, str) and _SPAN_ID_RE.match(raw_span):
+                out[span_key] = raw_span
+            else:
+                redacted = True
+
+    raw_status = entry.get("status")
+    if raw_status is not None:
+        if raw_status in _STATUS_ENUM:
+            out["status"] = raw_status
+        else:
+            out["status"] = "error"
+            redacted = True
+
+    return redacted
+
+
+# ── Main redaction logic ──────────────────────────────────────────────────────
+
+
+def _redact_entry_impl(entry: Any) -> dict:
+    """Allowlist-first redaction.  Called by ``redact_entry`` with fail-closed wrapper."""
+    if not isinstance(entry, dict):
+        entry = {}
+    out: dict = {}
+    redacted = _validate_core_fields(entry, out)
+    redacted = _validate_payload_fields(entry, out) or redacted
+    attrs_out, attrs_redacted = _redact_attrs(entry.get("attrs"))
+    out["attrs"] = attrs_out
+    if attrs_redacted or any(k not in _TOP_LEVEL_KEYS for k in entry):
+        redacted = True
+    out["redacted"] = redacted
+    return out
+
+
+def _sentinel(entry: Any) -> dict:
+    """Return a minimal fail-closed sentinel for an entry that could not be processed."""
+    idx = 0
+    if isinstance(entry, dict):
+        try:
+            raw_idx = entry.get("idx")
+            if isinstance(raw_idx, int) and raw_idx >= 0:
+                idx = raw_idx
+        except Exception:
+            pass
+    return {
+        "idx": idx,
+        "kind": "generic",
+        "level": "error",
+        "source": "unknown",
+        "attrs": {},
+        "redacted": True,
+    }
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def redact_entry(entry: Any) -> dict:
+    """Redact a ``BrowseDebugEntry`` dict and return a safe copy.
+
+    Always returns a dict.  On any unexpected exception the function fails
+    closed: a minimal sentinel entry is returned and the error is logged via
+    ``logging.getLogger("browse.redaction")`` without including original field
+    values in the log message.
+
+    Args:
+        entry: A raw ``BrowseDebugEntry`` dict (or any value; non-dicts are
+               treated as empty).
+
+    Returns:
+        A new dict containing only allowlisted fields with scrubbed values and
+        a ``redacted`` boolean flag set to ``True`` whenever any field was
+        dropped or transformed.
+    """
+    try:
+        return _redact_entry_impl(entry)
+    except Exception:
+        _log.exception(
+            "redact_entry: unexpected error processing entry (type=%s); returning fail-closed sentinel",
+            type(entry).__name__,
+        )
+        return _sentinel(entry)

--- a/browse/core/redaction.py
+++ b/browse/core/redaction.py
@@ -16,6 +16,7 @@ No third-party dependencies.  Python 3.10+ stdlib only.
 """
 
 import logging
+import math
 import os
 import re
 import sys
@@ -45,11 +46,23 @@ _KIND_ENUM = frozenset(
         "agent_response",
         "error",
         "generic",
+        "raw",
     }
 )
 _LEVEL_ENUM = frozenset({"debug", "info", "warn", "error"})
-_SOURCE_ENUM = frozenset({"cli", "hook", "browse", "vscode", "unknown"})
-_STATUS_ENUM = frozenset({"ok", "error", "cancelled", "timeout", "pending"})
+_SOURCE_ENUM = frozenset(
+    {
+        "cli",
+        "hook",
+        "browse",
+        "vscode",
+        "operator_console",
+        "hook_runner",
+        "sk_watch",
+        "unknown",
+    }
+)
+_STATUS_ENUM = frozenset({"ok", "error", "cancelled"})
 
 # ── Top-level field allowlist ─────────────────────────────────────────────────
 
@@ -98,7 +111,7 @@ _ATTRS_ALLOWLIST = frozenset(
 # ── Compiled patterns ─────────────────────────────────────────────────────────
 
 _TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_.-]{1,64}$")
-_SPAN_ID_RE = re.compile(r"^[0-9a-f]{8,32}$")
+_SPAN_ID_RE = re.compile(r"^[0-9a-f]{16}$")
 _ISO_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$")
 _SESSION_UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
@@ -116,13 +129,20 @@ _URL_QUERY_TOKEN_RE = re.compile(
     r"([?&]\w*(?:token|key|secret|auth)\w*=)[^\s&]+",
     re.IGNORECASE,
 )
+# JWT fallback pattern: matches compact JWTs (header.payload.signature) even
+# when browse.core.operator_console.redact_secrets is unavailable.
+_JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
 
 
 # ── Text redaction ────────────────────────────────────────────────────────────
 
 
 def _redact_text(text: str) -> str:
-    """Scrub bearer tokens, URL query tokens, and path usernames from *text*.
+    """Scrub bearer tokens, URL query tokens, JWTs, and path usernames from *text*.
+
+    ``_JWT_RE`` runs unconditionally as a local fallback before the optional
+    ``browse.core.operator_console.redact_secrets`` pass, so JWTs are caught
+    even when that import is unavailable.
 
     Applies ``browse.core.operator_console.redact_secrets`` as a final
     defence-in-depth pass (pattern-matched; graceful fallback if unavailable).
@@ -132,12 +152,39 @@ def _redact_text(text: str) -> str:
     text = _WIN_PATH_RE.sub(r"\1[REDACTED]", text)
     text = _UNIX_PATH_RE.sub(r"\1[REDACTED]", text)
     text = _MACOS_PATH_RE.sub(r"\1[REDACTED]", text)
+    # JWT fallback: applied before redact_secrets so JWTs are caught locally.
+    text = _JWT_RE.sub("[REDACTED]", text)
     try:
         from browse.core.operator_console import redact_secrets  # noqa: PLC0415
 
         text = redact_secrets(text)
     except Exception:
         _log.debug("redact_secrets unavailable; text-pattern redaction only applied")
+    return text
+
+
+def _redact_route_text(text: str) -> str:
+    """Scrub route-safe secret patterns from an HTTP route string.
+
+    Applies ``_BEARER_RE``, ``_JWT_RE``, and ``_URL_QUERY_TOKEN_RE`` (the last
+    is defence-in-depth; query strings are already rejected before this is
+    called).  Does **not** apply the filesystem path username patterns
+    (``_WIN_PATH_RE``, ``_UNIX_PATH_RE``, ``_MACOS_PATH_RE``) so that valid
+    HTTP routes such as ``/Users/alice/settings`` are preserved unchanged.
+
+    Applies ``browse.core.operator_console.redact_secrets`` as a final
+    defence-in-depth pass (graceful fallback if unavailable).
+    """
+    text = _BEARER_RE.sub("[REDACTED]", text)
+    text = _URL_QUERY_TOKEN_RE.sub(r"\1[REDACTED]", text)
+    # JWT fallback: applied before redact_secrets so JWTs are caught locally.
+    text = _JWT_RE.sub("[REDACTED]", text)
+    try:
+        from browse.core.operator_console import redact_secrets  # noqa: PLC0415
+
+        text = redact_secrets(text)
+    except Exception:
+        _log.debug("redact_secrets unavailable; route-pattern redaction only applied")
     return text
 
 
@@ -176,12 +223,22 @@ def _redact_attrs(raw_attrs: Any) -> tuple[dict, bool]:
             if not isinstance(v, str) or not _SESSION_UUID_RE.match(v):
                 redacted = True
                 continue
-        # Scrub string values
+        # Scrub string values.
+        # `route` is an HTTP path validated above (no query string); applying
+        # generic text-redaction patterns like _MACOS_PATH_RE would corrupt
+        # valid routes such as /Users/alice/settings.  Use _redact_route_text
+        # instead of _redact_text so JWT/Bearer tokens are still scrubbed.
         if isinstance(v, str):
-            clean = _redact_text(v)
-            if clean != v:
-                redacted = True
-            out[k] = clean
+            if k == "route":
+                clean = _redact_route_text(v)
+                if clean != v:
+                    redacted = True
+                out[k] = clean
+            else:
+                clean = _redact_text(v)
+                if clean != v:
+                    redacted = True
+                out[k] = clean
         else:
             out[k] = v
 
@@ -196,7 +253,7 @@ def _validate_core_fields(entry: dict, out: dict) -> bool:
     redacted = False
 
     raw_idx = entry.get("idx")
-    if isinstance(raw_idx, int) and raw_idx >= 0:
+    if isinstance(raw_idx, int) and not isinstance(raw_idx, bool) and raw_idx >= 0:
         out["idx"] = raw_idx
     else:
         out["idx"] = 0
@@ -217,10 +274,20 @@ def _validate_core_fields(entry: dict, out: dict) -> bool:
         redacted = True
 
     raw_level = entry.get("level")
-    out["level"] = raw_level if raw_level in _LEVEL_ENUM else "info"
+    if raw_level is None:
+        out["level"] = None
+    elif raw_level in _LEVEL_ENUM:
+        out["level"] = raw_level
+    else:
+        out["level"] = None
+        redacted = True
 
     raw_source = entry.get("source")
-    out["source"] = raw_source if raw_source in _SOURCE_ENUM else "unknown"
+    if raw_source in _SOURCE_ENUM:
+        out["source"] = raw_source
+    else:
+        out["source"] = "unknown"
+        redacted = True
 
     return redacted
 
@@ -231,6 +298,10 @@ def _validate_payload_fields(entry: dict, out: dict) -> bool:
 
     raw_msg = entry.get("message")
     if raw_msg is not None:
+        if not isinstance(raw_msg, str):
+            # Type coercion: contract says message must be str; stringify for
+            # safe output but mark redacted regardless of content changes.
+            redacted = True
         original = str(raw_msg)[:_MESSAGE_MAX]
         clean = _redact_text(original)
         if clean != original:
@@ -246,7 +317,12 @@ def _validate_payload_fields(entry: dict, out: dict) -> bool:
 
     raw_dur = entry.get("duration_ms")
     if raw_dur is not None:
-        if isinstance(raw_dur, int) and raw_dur >= 0:
+        if (
+            not isinstance(raw_dur, bool)
+            and isinstance(raw_dur, (int, float))
+            and math.isfinite(raw_dur)
+            and raw_dur >= 0
+        ):
             out["duration_ms"] = raw_dur
         else:
             redacted = True
@@ -264,8 +340,7 @@ def _validate_payload_fields(entry: dict, out: dict) -> bool:
         if raw_status in _STATUS_ENUM:
             out["status"] = raw_status
         else:
-            out["status"] = "error"
-            redacted = True
+            redacted = True  # unknown status omitted, not coerced
 
     return redacted
 
@@ -294,7 +369,7 @@ def _sentinel(entry: Any) -> dict:
     if isinstance(entry, dict):
         try:
             raw_idx = entry.get("idx")
-            if isinstance(raw_idx, int) and raw_idx >= 0:
+            if isinstance(raw_idx, int) and not isinstance(raw_idx, bool) and raw_idx >= 0:
                 idx = raw_idx
         except Exception:
             pass

--- a/docs/DEBUG-LOG-REDACTION.md
+++ b/docs/DEBUG-LOG-REDACTION.md
@@ -1,7 +1,7 @@
 # DEBUG-LOG-REDACTION.md
 
-> **Status:** Implemented — `browse/core/redaction.py` (WBS-102 / Issue #427).
-> Merge is blocked on WBS-101 final field allowlist reconciliation (#426 merge-gate).
+> **Status:** Implemented and reconciled — `browse/core/redaction.py` (WBS-102 / Issue #427).
+> Reconciled against WBS-101 `docs/DEBUG-LOG-CONTRACT.md` (PR #438).
 
 ---
 
@@ -30,24 +30,24 @@ allow-listed and reviewed before they can carry data through the pipeline.
 
 | Field | Type | Rule |
 |---|---|---|
-| `idx` | `int` | Required; must be `>= 0`; coerced to `0` if invalid. |
-| `timestamp` | `str \| None` | ISO-8601 UTC string or `None`; invalid → `None`. |
+| `idx` | `int` | Required; must be `>= 0`; bool rejected; coerced to `0` if invalid. |
+| `timestamp` | `str \| None` | ISO-8601 with explicit TZ (`Z` or `±HH:MM`) or `None`; naive ISO (no TZ) → `None` + `redacted=True`. |
 | `kind` | `str` | Enum — see below; unknown → `"generic"`. |
-| `level` | `str` | Enum `debug\|info\|warn\|error`; unknown → `"info"`. |
-| `source` | `str` | Enum `cli\|hook\|browse\|vscode\|unknown`; unknown → `"unknown"`. |
-| `message` | `str` | Capped at 2048 chars; bearer/URL-token/path-username redacted. |
+| `level` | `str \| None` | Nullable enum `debug\|info\|warn\|error`; missing/`None` → `None` (no redaction); unknown → `None` + `redacted=True`. |
+| `source` | `str` | Enum `cli\|hook\|browse\|vscode\|operator_console\|hook_runner\|sk_watch\|unknown`; unknown/missing → `"unknown"` + `redacted=True`. |
+| `message` | `str` | Producer cap is upstream; redact_entry caps at **2048 chars** and scrubs bearer/URL-token/path-username; route handlers may apply a further 200-char preview cap. |
 | `tool_name` | `str` | Pattern `^[a-zA-Z0-9_.-]{1,64}$`; invalid → dropped. |
-| `duration_ms` | `int` | Must be `>= 0`; invalid → dropped. |
-| `span_id` | `str` | Lowercase hex `^[0-9a-f]{8,32}$`; invalid → dropped. |
+| `duration_ms` | `int \| float` | Must be finite `>= 0`; `bool` rejected; `NaN`/`Inf` rejected; keeps `int` as `int` and `float` as `float`; invalid → dropped + `redacted=True`. |
+| `span_id` | `str` | Exactly 16 lowercase hex chars `^[0-9a-f]{16}$`; invalid → dropped. |
 | `parent_span_id` | `str` | Same pattern as `span_id`. |
-| `status` | `str` | Enum `ok\|error\|cancelled\|timeout\|pending`; unknown → `"error"`. |
+| `status` | `str \| omitted` | Enum `ok\|error\|cancelled`; missing/`None` → omitted (no flag); unknown → omitted + `redacted=True` (not coerced to `"error"`). |
 | `attrs` | `dict` | Strict flat scalar allowlist (see below). |
 | `redacted` | `bool` | Set by the sanitizer; any input value is overwritten. |
 
 ### `kind` Enum
 
 `session_start` · `turn_start` · `llm_request` · `tool_call` · `hook` ·
-`subagent` · `agent_response` · `error` · `generic`
+`subagent` · `agent_response` · `error` · `generic` · `raw`
 
 ---
 
@@ -114,7 +114,21 @@ string value:
    JWTs, and generic `key=value` assignments.  Import failures are logged at
    DEBUG and the module-level patterns above still apply.
 
-`message` is capped at **2048 characters** before any redaction pass.
+`message` is capped at **2048 characters** before any redaction pass.  Route
+handlers may apply a further **200-character preview cap** for display surfaces;
+producers are responsible for keeping messages reasonably sized upstream.
+
+---
+
+## Timestamp Strictness
+
+`redact_entry` requires an **explicit timezone** in every ISO-8601 timestamp.
+Accepted forms: trailing `Z` (UTC) or a signed offset `±HH:MM` (e.g.,
+`+05:30`, `-07:00`).
+
+Naive timestamps (e.g., `2024-01-15T10:30:00` with no timezone indicator) are
+**rejected**: `timestamp` is set to `None` and `redacted=True` is set.  This
+prevents ambiguous local-time values from silently persisting in the log.
 
 ---
 
@@ -192,26 +206,25 @@ merge this module's allowlist logic back into `operator_console.py`.
 
 ---
 
-## #426 Merge-Gate Reconciliation
+## Reconciliation — WBS-101 × WBS-102 (Complete)
 
-This module was implemented in parallel with **WBS-101** (which produces
-`docs/DEBUG-LOG-CONTRACT.md`).  The provisional field allowlists above are
-based on the Opus security decision recorded in the WBS-102 context packet.
+This module was reconciled against **WBS-101** (`docs/DEBUG-LOG-CONTRACT.md`,
+PR #438) before merging.  The following changes were made during the
+reconciliation pass (WBS-102 / PR #439):
 
-**Before merging this PR:**
+| Item | Resolution |
+|---|---|
+| `kind="raw"` | Added to `_KIND_ENUM` and docs. |
+| `status` tightened | Removed `timeout` and `pending`; unknown status omitted + `redacted=True` (not coerced to `"error"`). |
+| `source` superset | Added `operator_console`, `hook_runner`, `sk_watch` to `_SOURCE_ENUM`; missing/unknown source → `"unknown"` + `redacted=True`. |
+| `span_id` exact 16 hex | Tightened from `{8,32}` to exactly `{16}` lowercase hex chars. |
+| `level` nullability | Missing/`None` level → `None` (no redaction trigger); unknown level → `None` + `redacted=True`; removes the prior silent coercion to `"info"`. |
+| `duration_ms` numeric alignment | Accepts finite `int` or `float` ≥ 0; `bool`, `NaN`, `Inf` rejected. |
+| `message` 200/2048 layering | Clarified: `redact_entry` enforces 2048-char cap; route handlers apply separate 200-char preview cap. |
+| Timestamp strictness | Naive ISO strings (no explicit TZ) → `None` + `redacted=True`. |
 
-1. Compare `_TOP_LEVEL_KEYS` and `_ATTRS_ALLOWLIST` in `browse/core/redaction.py`
-   against the final field table in `docs/DEBUG-LOG-CONTRACT.md` (WBS-101).
-2. For any field in the contract that is absent from the allowlists here, add
-   it with an explicit validator and a corresponding test case.
-3. For any field in the allowlists here that is absent from the contract,
-   either add it to the contract or remove it from the allowlist.
-4. Update this doc to reference the contract version after reconciliation.
-5. Re-run `python tests/test_browse_redaction.py` and `python test_security.py`
-   to confirm no regressions.
-
-See also: issue [#427](https://github.com/magicpro97/copilot-session-knowledge/issues/427)
-and the blocking issue [#426](https://github.com/magicpro97/copilot-session-knowledge/issues/426).
+See [issue #427](https://github.com/magicpro97/copilot-session-knowledge/issues/427)
+and [PR #439](https://github.com/magicpro97/copilot-session-knowledge/pull/439).
 
 ---
 

--- a/docs/DEBUG-LOG-REDACTION.md
+++ b/docs/DEBUG-LOG-REDACTION.md
@@ -1,0 +1,238 @@
+# DEBUG-LOG-REDACTION.md
+
+> **Status:** Implemented — `browse/core/redaction.py` (WBS-102 / Issue #427).
+> Merge is blocked on WBS-101 final field allowlist reconciliation (#426 merge-gate).
+
+---
+
+## Overview
+
+The `browse.core.redaction` module provides an **allowlist-first** sanitizer
+for structured `BrowseDebugEntry` dicts before they are written to any
+debug-log sink.  Every field not in the top-level allowlist is silently
+dropped; the `redacted` boolean flag is set to `True` whenever any drop or
+transformation occurs.
+
+The module is pure Python 3.10+ stdlib (no third-party dependencies) and
+follows the `browse/core/csp.py` pattern of a small, focused helper.
+
+---
+
+## Write-Time Allowlist Policy
+
+Only fields explicitly listed below may appear in a `BrowseDebugEntry` that
+leaves the sanitizer.  **Unknown keys are dropped, not passed through.**
+
+This is the opposite of a denylist approach: new fields must be explicitly
+allow-listed and reviewed before they can carry data through the pipeline.
+
+### Top-Level Allowlist
+
+| Field | Type | Rule |
+|---|---|---|
+| `idx` | `int` | Required; must be `>= 0`; coerced to `0` if invalid. |
+| `timestamp` | `str \| None` | ISO-8601 UTC string or `None`; invalid → `None`. |
+| `kind` | `str` | Enum — see below; unknown → `"generic"`. |
+| `level` | `str` | Enum `debug\|info\|warn\|error`; unknown → `"info"`. |
+| `source` | `str` | Enum `cli\|hook\|browse\|vscode\|unknown`; unknown → `"unknown"`. |
+| `message` | `str` | Capped at 2048 chars; bearer/URL-token/path-username redacted. |
+| `tool_name` | `str` | Pattern `^[a-zA-Z0-9_.-]{1,64}$`; invalid → dropped. |
+| `duration_ms` | `int` | Must be `>= 0`; invalid → dropped. |
+| `span_id` | `str` | Lowercase hex `^[0-9a-f]{8,32}$`; invalid → dropped. |
+| `parent_span_id` | `str` | Same pattern as `span_id`. |
+| `status` | `str` | Enum `ok\|error\|cancelled\|timeout\|pending`; unknown → `"error"`. |
+| `attrs` | `dict` | Strict flat scalar allowlist (see below). |
+| `redacted` | `bool` | Set by the sanitizer; any input value is overwritten. |
+
+### `kind` Enum
+
+`session_start` · `turn_start` · `llm_request` · `tool_call` · `hook` ·
+`subagent` · `agent_response` · `error` · `generic`
+
+---
+
+## `attrs` Allowlist
+
+The `attrs` dict is constrained to **flat scalar values only** (`str`, `int`,
+`float`, `bool`, `None`).  Nested dicts or lists are dropped regardless of
+the key name.
+
+### Allowed Keys
+
+| Key | Notes |
+|---|---|
+| `schema_version` | Integer schema version tag. |
+| `session_uuid` | Must match RFC 4122 UUID format; malformed → dropped. |
+| `model` | Free string; run through text-redaction pass. |
+| `route` | Path only — **query string forbidden**; `?` present → dropped. |
+| `status_code` | HTTP status integer. |
+| `exit_code` | Process exit code. |
+| `event_count` | Non-negative integer. |
+| `bytes_in` | Ingress byte count. |
+| `bytes_out` | Egress byte count. |
+| `tokens_in` | LLM input token count. |
+| `tokens_out` | LLM output token count. |
+| `attempt` | Retry attempt number. |
+| `cache_hit` | Boolean cache indicator. |
+| `truncated` | Boolean truncation indicator. |
+| `error_category` | Short error classifier string. |
+| `latency_ms` | Latency in milliseconds. |
+| `queue_depth` | Queue depth integer. |
+
+### Explicitly Forbidden Keys (representative list)
+
+The following are dropped even if they appear in `attrs`.  Any key **not**
+in the allowed list above is also dropped.
+
+`args` · `input` · `output` · `result` · `payload` · `body` · `request` ·
+`response` · `messages` · `prompt` · `completion` · `headers` · `cookies` ·
+`authorization` · `env` · `environment` · `cwd` · `path` · `file` ·
+`filename` · `url` · `referer` · `origin` · `host` · `dom` · `html` ·
+`network` · `localStorage` · `sessionStorage` · `host_profile` · `token` ·
+`secret` · `key` · `password` · `credential` · `pairing` · `ticket`
+
+Also dropped: any key matching `token`, `secret`, `key`, `password`, `pass`,
+`credential`, or `auth` (substring), and any key with prefixes `http_`,
+`dom_`, `network_`, `vs_`, `vscode_`.
+
+---
+
+## Text and Path Redaction Patterns
+
+Applied (in order) to every `message` string and every allowlisted `attrs`
+string value:
+
+1. **Bearer tokens** — `(?i)\bbearer\s+\S+` → `[REDACTED]`
+2. **URL query-string tokens** — `([?&]\w*(?:token|key|secret|auth)\w*=)[^\s&]+`
+   → `\1[REDACTED]` (parameter name preserved, value scrubbed)
+3. **Windows path usernames** — `(?i)([A-Za-z]:[/\\]Users[/\\])[^/\\\s]+`
+   → `\1[REDACTED]`
+4. **Unix home usernames** — `(/home/)[^/\s]+` → `\1[REDACTED]`
+5. **macOS path usernames** — `(/Users/)[^/\s]+` → `\1[REDACTED]`
+6. **Defence-in-depth** — `browse.core.operator_console.redact_secrets` is
+   applied as a final pass to catch GitHub tokens, AWS keys, OpenAI keys,
+   JWTs, and generic `key=value` assignments.  Import failures are logged at
+   DEBUG and the module-level patterns above still apply.
+
+`message` is capped at **2048 characters** before any redaction pass.
+
+---
+
+## Fail-Closed Behaviour
+
+`redact_entry(entry)` wraps all processing in a `try/except` block.  On any
+unhandled exception:
+
+1. The error is logged via `logging.getLogger("browse.redaction").exception(…)`
+   using only the *type name* of the entry — no field values are included in
+   the log message.
+2. A minimal **sentinel dict** is returned:
+
+   ```json
+   {
+     "idx": <original idx if safe to read, else 0>,
+     "kind": "generic",
+     "level": "error",
+     "source": "unknown",
+     "attrs": {},
+     "redacted": true
+   }
+   ```
+
+This guarantees that callers always receive a dict with `redacted: true` and
+never receive an exception, even when processing malformed or adversarial
+inputs.
+
+---
+
+## Threat Model
+
+### In-scope threats
+
+| Threat | Mitigation |
+|---|---|
+| Bearer / API tokens in log messages | `_BEARER_RE` pattern + `redact_secrets` pass |
+| JWTs embedded in free-text or allowlisted attrs | `redact_secrets` JWT pattern |
+| OS path usernames (Windows `Users\`, Unix `/home/`, macOS `/Users/`) | `_WIN_PATH_RE`, `_UNIX_PATH_RE`, `_MACOS_PATH_RE` |
+| Query-string tokens in `route` attr | Route dropped if `?` present |
+| Sensitive payload keys (`prompt`, `messages`, etc.) | Allowlist-first attrs policy |
+| Host-profile dicts carrying tokens | `host_profile` not in allowlist; nested dicts always dropped |
+| Attacker-controlled field names injecting new top-level keys | Unknown top-level keys dropped |
+| Future field additions bypassing review | Allowlist requires explicit additions |
+| Exception revealing original values in logs | Fail-closed uses `type(entry).__name__` only |
+
+### Out-of-scope (separate controls)
+
+- Transport-layer encryption (TLS) — handled by the HTTP/WebSocket layer.
+- Access control to the debug-log endpoint — handled by `browse/core/auth.py`.
+- Long-term storage retention — handled by the operator/admin configuration.
+- Redaction of already-persisted entries — not retroactive.
+
+---
+
+## Relationship to `operator_console.redact_secrets`
+
+`browse.core.operator_console.redact_secrets` is a **denylist** pattern-
+scanner for raw CLI output streams.  It is *not* replaced or deprecated by
+this module.
+
+`redaction.redact_entry` provides **allowlist-first structured-field
+classification** for `BrowseDebugEntry` dicts.  It calls `redact_secrets`
+internally as a defence-in-depth text pass on string fields, so the two
+controls layer:
+
+```
+raw CLI output  →  redact_secrets (denylist, free-text)
+BrowseDebugEntry →  redact_entry   (allowlist-first, structured)
+                         └── _redact_text() → redact_secrets (defence-in-depth)
+```
+
+Do not remove `redact_secrets`; do not remove `_sanitize_event_value`; do not
+merge this module's allowlist logic back into `operator_console.py`.
+
+---
+
+## #426 Merge-Gate Reconciliation
+
+This module was implemented in parallel with **WBS-101** (which produces
+`docs/DEBUG-LOG-CONTRACT.md`).  The provisional field allowlists above are
+based on the Opus security decision recorded in the WBS-102 context packet.
+
+**Before merging this PR:**
+
+1. Compare `_TOP_LEVEL_KEYS` and `_ATTRS_ALLOWLIST` in `browse/core/redaction.py`
+   against the final field table in `docs/DEBUG-LOG-CONTRACT.md` (WBS-101).
+2. For any field in the contract that is absent from the allowlists here, add
+   it with an explicit validator and a corresponding test case.
+3. For any field in the allowlists here that is absent from the contract,
+   either add it to the contract or remove it from the allowlist.
+4. Update this doc to reference the contract version after reconciliation.
+5. Re-run `python tests/test_browse_redaction.py` and `python test_security.py`
+   to confirm no regressions.
+
+See also: issue [#427](https://github.com/magicpro97/copilot-session-knowledge/issues/427)
+and the blocking issue [#426](https://github.com/magicpro97/copilot-session-knowledge/issues/426).
+
+---
+
+## Testing
+
+```bash
+# Targeted redaction tests (15 required security cases)
+python tests/test_browse_redaction.py
+
+# Or with pytest if available
+python -m pytest tests/test_browse_redaction.py -v
+
+# Security regression suite
+python test_security.py
+
+# Full suite
+python run_all_tests.py
+
+# Syntax check
+python -m py_compile browse/core/redaction.py tests/test_browse_redaction.py
+
+# Ruff lint
+ruff check browse/core/redaction.py tests/test_browse_redaction.py
+```

--- a/tests/test_browse_redaction.py
+++ b/tests/test_browse_redaction.py
@@ -310,9 +310,11 @@ class TestBrowseRedactionCase12NonDictAttrs(unittest.TestCase):
         self.assertTrue(result["redacted"])
 
     def test_none_attrs_allowed(self) -> None:
-        result = redact_entry(_entry(attrs=None))
+        # Include a valid source so that only the attrs=None case is under test.
+        result = redact_entry(_entry(attrs=None, source="cli"))
         # None means attrs not supplied — should not set redacted just for this
         self.assertEqual(result["attrs"], {})
+        self.assertFalse(result["redacted"], "attrs=None must not set redacted True")
 
 
 class TestBrowseRedactionCase13AllowlistedAttrJWT(unittest.TestCase):
@@ -369,7 +371,7 @@ class TestBrowseRedactionCase15RouteQueryString(unittest.TestCase):
         self.assertEqual(result["attrs"]["route"], "/api/sessions")
 
     def test_route_without_query_kept(self) -> None:
-        result = redact_entry(_entry(attrs={"route": "/api/v2/debug-log"}))
+        result = redact_entry(_entry(attrs={"route": "/api/v2/debug-log"}, source="cli"))
         self.assertIn("route", result["attrs"])
         self.assertFalse(result["redacted"])
 
@@ -397,13 +399,15 @@ class TestBrowseRedactionValidators(unittest.TestCase):
         result = redact_entry(_entry(timestamp=ts))
         self.assertEqual(result["timestamp"], ts)
 
-    def test_unknown_level_becomes_info(self) -> None:
-        result = redact_entry(_entry(level="verbose"))
-        self.assertEqual(result["level"], "info")
+    def test_unknown_level_becomes_none(self) -> None:
+        result = redact_entry(_entry(level="verbose", source="cli"))
+        self.assertIsNone(result["level"], "Unknown level must become None")
+        self.assertTrue(result["redacted"], "Unknown level must set redacted True")
 
     def test_unknown_source_becomes_unknown(self) -> None:
         result = redact_entry(_entry(source="custom_source"))
         self.assertEqual(result["source"], "unknown")
+        self.assertTrue(result["redacted"], "Unknown source must set redacted True")
 
     def test_invalid_tool_name_dropped(self) -> None:
         result = redact_entry(_entry(tool_name="bad name with spaces"))
@@ -434,9 +438,9 @@ class TestBrowseRedactionValidators(unittest.TestCase):
         self.assertNotIn("span_id", result)
         self.assertTrue(result["redacted"])
 
-    def test_unknown_status_coerced_to_error(self) -> None:
+    def test_unknown_status_omitted_and_redacted(self) -> None:
         result = redact_entry(_entry(status="unknown_status"))
-        self.assertEqual(result.get("status"), "error")
+        self.assertNotIn("status", result, "Unknown status must be omitted, not coerced")
         self.assertTrue(result["redacted"])
 
     def test_unknown_top_level_key_dropped(self) -> None:
@@ -459,6 +463,225 @@ class TestBrowseRedactionValidators(unittest.TestCase):
             }
         )
         self.assertFalse(result["redacted"], "Clean entry must not be flagged as redacted")
+
+
+class TestBrowseRedactionWBS102Reconciliation(unittest.TestCase):
+    """WBS-102 reconciliation coverage: new kind/source/status/span/duration/level/timestamp rules."""
+
+    # ── kind ──────────────────────────────────────────────────────────────────
+
+    def test_kind_raw_preserved_no_redaction(self) -> None:
+        result = redact_entry({"idx": 0, "kind": "raw", "source": "cli"})
+        self.assertEqual(result["kind"], "raw")
+        self.assertFalse(result["redacted"], "kind=raw with valid source must not be flagged")
+
+    # ── status ────────────────────────────────────────────────────────────────
+
+    def test_status_timeout_omitted_and_redacted(self) -> None:
+        result = redact_entry(_entry(status="timeout"))
+        self.assertNotIn("status", result, "status=timeout must be omitted")
+        self.assertTrue(result["redacted"])
+
+    def test_status_pending_omitted_and_redacted(self) -> None:
+        result = redact_entry(_entry(status="pending"))
+        self.assertNotIn("status", result, "status=pending must be omitted")
+        self.assertTrue(result["redacted"])
+
+    # ── source ────────────────────────────────────────────────────────────────
+
+    def test_source_operator_console_preserved(self) -> None:
+        result = redact_entry(_entry(source="operator_console"))
+        self.assertEqual(result["source"], "operator_console")
+
+    def test_source_hook_runner_preserved(self) -> None:
+        result = redact_entry(_entry(source="hook_runner"))
+        self.assertEqual(result["source"], "hook_runner")
+
+    def test_source_sk_watch_preserved(self) -> None:
+        result = redact_entry(_entry(source="sk_watch"))
+        self.assertEqual(result["source"], "sk_watch")
+
+    def test_missing_source_becomes_unknown_and_redacted(self) -> None:
+        result = redact_entry({"idx": 0, "kind": "generic"})  # no source key
+        self.assertEqual(result["source"], "unknown")
+        self.assertTrue(result["redacted"])
+
+    # ── level ─────────────────────────────────────────────────────────────────
+
+    def test_missing_level_preserves_none_no_redaction_trigger(self) -> None:
+        """Missing level must be None and must NOT by itself trigger redacted=True."""
+        result = redact_entry({"idx": 0, "kind": "generic", "source": "cli"})
+        self.assertIsNone(result["level"])
+        self.assertFalse(result["redacted"], "Missing level alone must not set redacted True")
+
+    # ── span_id ───────────────────────────────────────────────────────────────
+
+    def test_span_id_exactly_16_hex_accepted(self) -> None:
+        result = redact_entry(_entry(span_id="0123456789abcdef"))
+        self.assertEqual(result.get("span_id"), "0123456789abcdef")
+
+    def test_span_id_8_chars_dropped_and_redacted(self) -> None:
+        result = redact_entry(_entry(span_id="01234567"))
+        self.assertNotIn("span_id", result)
+        self.assertTrue(result["redacted"])
+
+    def test_span_id_15_chars_dropped_and_redacted(self) -> None:
+        result = redact_entry(_entry(span_id="0123456789abcde"))
+        self.assertNotIn("span_id", result)
+        self.assertTrue(result["redacted"])
+
+    def test_span_id_17_chars_dropped_and_redacted(self) -> None:
+        result = redact_entry(_entry(span_id="0123456789abcdef0"))
+        self.assertNotIn("span_id", result)
+        self.assertTrue(result["redacted"])
+
+    # ── duration_ms ───────────────────────────────────────────────────────────
+
+    def test_duration_ms_float_accepted(self) -> None:
+        result = redact_entry(_entry(duration_ms=12.5, source="cli"))
+        self.assertEqual(result.get("duration_ms"), 12.5)
+
+    def test_duration_ms_zero_accepted(self) -> None:
+        result = redact_entry(_entry(duration_ms=0, source="cli"))
+        self.assertEqual(result.get("duration_ms"), 0)
+
+    def test_duration_ms_bool_rejected(self) -> None:
+        result = redact_entry(_entry(duration_ms=True))
+        self.assertNotIn("duration_ms", result)
+        self.assertTrue(result["redacted"])
+
+    def test_duration_ms_nan_rejected(self) -> None:
+        result = redact_entry(_entry(duration_ms=float("nan")))
+        self.assertNotIn("duration_ms", result)
+        self.assertTrue(result["redacted"])
+
+    def test_duration_ms_inf_rejected(self) -> None:
+        result = redact_entry(_entry(duration_ms=float("inf")))
+        self.assertNotIn("duration_ms", result)
+        self.assertTrue(result["redacted"])
+
+    # ── idx ───────────────────────────────────────────────────────────────────
+
+    def test_idx_bool_rejected(self) -> None:
+        result = redact_entry({"idx": True, "kind": "generic"})
+        self.assertEqual(result["idx"], 0)
+        self.assertTrue(result["redacted"])
+
+    # ── timestamp ─────────────────────────────────────────────────────────────
+
+    def test_naive_iso_timestamp_dropped_and_redacted(self) -> None:
+        result = redact_entry(_entry(timestamp="2024-01-15T10:30:00"))  # no TZ
+        self.assertIsNone(result.get("timestamp"))
+        self.assertTrue(result["redacted"])
+
+    def test_iso_timestamp_with_offset_kept(self) -> None:
+        ts = "2024-01-15T10:30:00+05:30"
+        result = redact_entry(_entry(timestamp=ts, source="cli"))
+        self.assertEqual(result["timestamp"], ts)
+
+
+class TestBrowseRedactionNonStringMessage(unittest.TestCase):
+    """Finding 1: Non-string message must be stringified AND set redacted=True."""
+
+    def test_int_message_stringified_and_redacted(self) -> None:
+        result = redact_entry(_entry(message=123))
+        self.assertEqual(result.get("message"), "123", "int message must be stringified")
+        self.assertTrue(result["redacted"], "int message must set redacted=True")
+
+    def test_dict_message_stringified_and_redacted(self) -> None:
+        result = redact_entry(_entry(message={"key": "value"}))
+        self.assertIsInstance(result.get("message"), str, "dict message must be stringified")
+        self.assertTrue(result["redacted"], "dict message must set redacted=True")
+
+    def test_list_message_stringified_and_redacted(self) -> None:
+        result = redact_entry(_entry(message=[1, 2, 3]))
+        self.assertIsInstance(result.get("message"), str)
+        self.assertTrue(result["redacted"])
+
+    def test_str_message_clean_not_flagged(self) -> None:
+        """A plain string message that needs no text-redaction must NOT set redacted."""
+        result = redact_entry(_entry(message="hello world", source="cli"))
+        self.assertEqual(result.get("message"), "hello world")
+        self.assertFalse(result["redacted"], "clean string message must not set redacted")
+
+
+class TestBrowseRedactionJWTFallback(unittest.TestCase):
+    """Finding 2: JWT must be redacted even when redact_secrets is unavailable."""
+
+    _JWT = (
+        "eyJhbGciOiJIUzI1NiJ9"
+        ".eyJzdWIiOiIxMjM0NTY3ODkwIn0"
+        ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+
+    def test_jwt_redacted_without_redact_secrets(self) -> None:
+        """JWT in message must be redacted by local _JWT_RE when redact_secrets is unavailable."""
+        import sys
+
+        # Patch sys.modules so any attempt to import browse.core.operator_console
+        # raises ImportError — simulates the module being unavailable.
+        with patch.dict(sys.modules, {"browse.core.operator_console": None}):
+            result = redact_entry(_entry(message=f"token={self._JWT}"))
+        msg = result.get("message", "")
+        self.assertNotIn("eyJ", msg, "JWT header must not appear in output")
+        self.assertIn("[REDACTED]", msg, "JWT must be replaced with [REDACTED]")
+        self.assertTrue(result["redacted"], "JWT in message must set redacted=True")
+
+    def test_jwt_in_message_redacted_normally(self) -> None:
+        """JWT in message must be redacted in the normal (no mock) path too."""
+        result = redact_entry(_entry(message=f"auth header: {self._JWT}"))
+        msg = result.get("message", "")
+        self.assertNotIn(self._JWT, msg)
+        self.assertIn("[REDACTED]", msg)
+        self.assertTrue(result["redacted"])
+
+
+class TestBrowseRedactionRoutePreservedFromTextRedaction(unittest.TestCase):
+    """Finding 3: attrs.route must not be mutated by generic text-redaction patterns,
+    but JWT and Bearer tokens embedded in route strings must still be scrubbed.
+    """
+
+    def test_route_with_users_path_preserved(self) -> None:
+        """/Users/alice/settings is a valid HTTP route; must not trigger redacted."""
+        result = redact_entry(_entry(attrs={"route": "/Users/alice/settings"}, source="cli"))
+        self.assertIn("route", result["attrs"], "route must be present in output")
+        self.assertEqual(
+            result["attrs"]["route"],
+            "/Users/alice/settings",
+            "route value must be unchanged",
+        )
+        self.assertFalse(result["redacted"], "valid route must not set redacted=True")
+
+    def test_route_without_query_still_kept(self) -> None:
+        result = redact_entry(_entry(attrs={"route": "/api/v1/sessions"}, source="cli"))
+        self.assertIn("route", result["attrs"])
+        self.assertEqual(result["attrs"]["route"], "/api/v1/sessions")
+        self.assertFalse(result["redacted"])
+
+    def test_route_with_query_string_still_dropped(self) -> None:
+        """Query-string rejection must still work after the route text-redaction bypass."""
+        result = redact_entry(_entry(attrs={"route": "/Users/alice/settings?token=abc"}))
+        self.assertNotIn("route", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+    def test_route_with_jwt_in_path_segment_redacted(self) -> None:
+        """JWT embedded in a route path segment must be redacted and redacted=True."""
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        route = f"/api/reset/{jwt}"
+        result = redact_entry(_entry(attrs={"route": route}, source="cli"))
+        self.assertIn("route", result["attrs"], "route key must be present (not dropped)")
+        self.assertNotIn(jwt, result["attrs"]["route"], "JWT must not appear in route output")
+        self.assertIn("[REDACTED]", result["attrs"]["route"], "JWT must be replaced with [REDACTED]")
+        self.assertTrue(result["redacted"], "JWT in route must set redacted=True")
+
+    def test_route_with_bearer_token_redacted(self) -> None:
+        """Bearer token embedded in a route string must be redacted and redacted=True."""
+        route = "/api/Bearer secrettoken123"
+        result = redact_entry(_entry(attrs={"route": route}, source="cli"))
+        self.assertIn("route", result["attrs"], "route key must be present (not dropped)")
+        self.assertNotIn("secrettoken123", result["attrs"]["route"], "Bearer token must not appear in route output")
+        self.assertIn("[REDACTED]", result["attrs"]["route"], "Bearer token must be replaced with [REDACTED]")
+        self.assertTrue(result["redacted"], "Bearer token in route must set redacted=True")
 
 
 if __name__ == "__main__":

--- a/tests/test_browse_redaction.py
+++ b/tests/test_browse_redaction.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""tests/test_browse_redaction.py — Security tests for browse.core.redaction.
+
+Covers the 15 required security cases from the WBS-102 / Issue #427 Opus
+security decision:
+
+  1.  Bearer token in message redacted.
+  2.  URL/query token in route dropped.
+  3.  Windows path username redacted.
+  4.  Unix path username redacted.
+  5.  Nested dict/list attrs dropped.
+  6.  Env-var-like keys dropped.
+  7.  Unserializable object fail-closed.
+  8.  Raw prompt/messages dropped.
+  9.  Host profile token-bearing dict dropped.
+  10. Raw file content under unknown key dropped; message truncation respected.
+  11. Unknown kind coerced to `generic`.
+  12. Non-dict attrs coerced to `{}`.
+  13. Allowlisted attr string carrying JWT redacted.
+  14. Malformed session_uuid dropped.
+  15. `route` with query string dropped.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from browse.core.redaction import redact_entry  # noqa: E402
+
+
+def _entry(**kwargs) -> dict:
+    """Return a minimal valid BrowseDebugEntry with any extra fields merged in."""
+    base: dict = {"idx": 0, "kind": "generic"}
+    base.update(kwargs)
+    return base
+
+
+class TestBrowseRedactionCase01BearerToken(unittest.TestCase):
+    """Case 1: Bearer token in message must be redacted."""
+
+    def test_bearer_in_message_redacted(self) -> None:
+        result = redact_entry(_entry(message="Authorization: Bearer supersecrettoken123"))
+        msg = result.get("message", "")
+        self.assertNotIn("supersecrettoken123", msg, "Bearer token must not appear in output")
+        self.assertIn("[REDACTED]", msg, "Placeholder must be present")
+        self.assertTrue(result["redacted"], "redacted flag must be True")
+
+    def test_bearer_case_insensitive(self) -> None:
+        result = redact_entry(_entry(message="auth: bearer abc.def.ghi"))
+        self.assertNotIn("abc.def.ghi", result.get("message", ""))
+        self.assertTrue(result["redacted"])
+
+
+class TestBrowseRedactionCase02URLQueryTokenInRoute(unittest.TestCase):
+    """Case 2: URL/query token in attrs.route must be dropped."""
+
+    def test_route_with_token_query_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"route": "/api/v1?token=secretvalue"}))
+        self.assertNotIn("route", result["attrs"], "route with query must be dropped")
+        self.assertTrue(result["redacted"])
+
+    def test_route_with_api_key_query_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"route": "/search?api_key=xyz789"}))
+        self.assertNotIn("route", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+
+class TestBrowseRedactionCase03WindowsPath(unittest.TestCase):
+    """Case 3: Windows path usernames in message must be redacted."""
+
+    def test_windows_path_username_redacted(self) -> None:
+        result = redact_entry(_entry(message=r"C:\Users\alice\documents\report.pdf"))
+        msg = result.get("message", "")
+        self.assertNotIn("alice", msg, "Username must not appear in output")
+        self.assertIn("[REDACTED]", msg, "Placeholder must be present")
+        self.assertTrue(result["redacted"])
+
+    def test_windows_path_forward_slash_redacted(self) -> None:
+        result = redact_entry(_entry(message="C:/Users/bobsmith/workspace"))
+        msg = result.get("message", "")
+        self.assertNotIn("bobsmith", msg)
+        self.assertIn("[REDACTED]", msg)
+
+
+class TestBrowseRedactionCase04UnixPath(unittest.TestCase):
+    """Case 4: Unix path usernames in message must be redacted."""
+
+    def test_unix_path_username_redacted(self) -> None:
+        result = redact_entry(_entry(message="/home/alice/projects/app.py"))
+        msg = result.get("message", "")
+        self.assertNotIn("alice", msg, "Username must not appear in output")
+        self.assertIn("[REDACTED]", msg, "Placeholder must be present")
+        self.assertTrue(result["redacted"])
+
+    def test_unix_path_preserves_subpath(self) -> None:
+        result = redact_entry(_entry(message="/home/charlie/src/main.py"))
+        msg = result.get("message", "")
+        self.assertNotIn("charlie", msg)
+        # Path after username should still be intact in the scrubbed version
+        self.assertIn("/home/[REDACTED]", msg)
+
+
+class TestBrowseRedactionMacOSPath(unittest.TestCase):
+    """macOS /Users/<name>/... path usernames in message must be redacted.
+
+    Regression test for the finding that _redact_text lacked a macOS pattern
+    and paths like /Users/alice/Documents/file.txt leaked the username.
+    """
+
+    def test_macos_path_username_redacted(self) -> None:
+        result = redact_entry(_entry(message="/Users/alice/Documents/file.txt"))
+        msg = result.get("message", "")
+        self.assertNotIn("alice", msg, "macOS username must not appear in output")
+        self.assertIn("[REDACTED]", msg, "Placeholder must be present")
+        self.assertTrue(result["redacted"])
+
+    def test_macos_path_preserves_subpath_prefix(self) -> None:
+        result = redact_entry(_entry(message="/Users/charlie/src/main.py"))
+        msg = result.get("message", "")
+        self.assertNotIn("charlie", msg)
+        self.assertIn("/Users/[REDACTED]", msg)
+
+    def test_macos_path_mixed_case_username(self) -> None:
+        result = redact_entry(_entry(message="/Users/BobSmith/workspace/project"))
+        msg = result.get("message", "")
+        self.assertNotIn("BobSmith", msg)
+        self.assertIn("[REDACTED]", msg)
+
+    def test_macos_path_in_attrs_string(self) -> None:
+        result = redact_entry(_entry(attrs={"model": "/Users/dave/model.bin"}))
+        val = result["attrs"].get("model", "")
+        self.assertNotIn("dave", val)
+        self.assertIn("[REDACTED]", val)
+        self.assertTrue(result["redacted"])
+
+    def test_windows_users_path_not_double_redacted(self) -> None:
+        """Windows C:/Users/alice/... should be handled by WIN_PATH_RE, not double-scrubbed."""
+        result = redact_entry(_entry(message="C:/Users/alice/docs/file.txt"))
+        msg = result.get("message", "")
+        self.assertNotIn("alice", msg)
+        self.assertIn("[REDACTED]", msg)
+
+
+class TestBrowseRedactionCase05NestedAttrs(unittest.TestCase):
+    """Case 5: Nested dict/list values in attrs must be dropped."""
+
+    def test_nested_dict_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"model": {"name": "gpt-4", "version": 4}}))
+        self.assertNotIn("model", result["attrs"], "Nested dict must be dropped")
+        self.assertTrue(result["redacted"])
+
+    def test_nested_list_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"event_count": [1, 2, 3]}))
+        self.assertNotIn("event_count", result["attrs"], "List value must be dropped")
+        self.assertTrue(result["redacted"])
+
+    def test_scalar_allowed(self) -> None:
+        result = redact_entry(_entry(attrs={"event_count": 42}))
+        self.assertEqual(result["attrs"].get("event_count"), 42, "Scalar int must pass through")
+
+
+class TestBrowseRedactionCase06EnvKeys(unittest.TestCase):
+    """Case 6: Env-var-like and other forbidden keys must be dropped."""
+
+    def test_env_key_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"env": "PATH=/usr/bin:/bin"}))
+        self.assertNotIn("env", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+    def test_environment_key_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"environment": "production"}))
+        self.assertNotIn("environment", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+    def test_cwd_key_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"cwd": "/home/user/project"}))
+        self.assertNotIn("cwd", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+    def test_http_prefix_key_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"http_host": "localhost:8000"}))
+        self.assertNotIn("http_host", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+
+class TestBrowseRedactionCase07FailClosed(unittest.TestCase):
+    """Case 7: Any unexpected error inside redact_entry must fail closed."""
+
+    def test_internal_exception_returns_sentinel(self) -> None:
+        with patch(
+            "browse.core.redaction._redact_entry_impl",
+            side_effect=RuntimeError("simulated internal error"),
+        ):
+            result = redact_entry({"idx": 7, "kind": "tool_call"})
+
+        self.assertTrue(result["redacted"], "Sentinel must have redacted=True")
+        self.assertEqual(result["kind"], "generic", "Sentinel kind must be generic")
+        self.assertEqual(result["level"], "error", "Sentinel level must be error")
+        self.assertIsInstance(result["attrs"], dict, "Sentinel attrs must be dict")
+
+    def test_non_dict_entry_does_not_raise(self) -> None:
+        result = redact_entry("not a dict at all")
+        self.assertIsInstance(result, dict)
+        self.assertTrue(result["redacted"])
+
+    def test_none_entry_does_not_raise(self) -> None:
+        result = redact_entry(None)
+        self.assertIsInstance(result, dict)
+        self.assertTrue(result["redacted"])
+
+
+class TestBrowseRedactionCase08RawPrompt(unittest.TestCase):
+    """Case 8: Raw prompt/messages keys in attrs must be dropped."""
+
+    def test_prompt_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"prompt": "What is 2 + 2?"}))
+        self.assertNotIn("prompt", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+    def test_messages_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"messages": [{"role": "user", "content": "hello"}]}))
+        self.assertNotIn("messages", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+    def test_completion_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"completion": "The answer is 4."}))
+        self.assertNotIn("completion", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+
+class TestBrowseRedactionCase09HostProfile(unittest.TestCase):
+    """Case 9: host_profile token-bearing dicts in attrs must be dropped."""
+
+    def test_host_profile_dict_dropped(self) -> None:
+        result = redact_entry(
+            _entry(
+                attrs={
+                    "host_profile": {"token": "bearer_abc", "url": "https://example.com"},
+                }
+            )
+        )
+        self.assertNotIn("host_profile", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+    def test_token_key_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"token": "abc123"}))
+        self.assertNotIn("token", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+
+class TestBrowseRedactionCase10FileContentAndTruncation(unittest.TestCase):
+    """Case 10: Unknown key dropped; message truncated to MESSAGE_MAX."""
+
+    def test_unknown_key_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"file_content": "a" * 1000}))
+        self.assertNotIn("file_content", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+    def test_message_capped_at_2048(self) -> None:
+        result = redact_entry(_entry(message="x" * 4096))
+        self.assertLessEqual(len(result.get("message", "")), 2048, "message must be capped")
+
+    def test_payload_key_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"payload": "sensitive data"}))
+        self.assertNotIn("payload", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+
+class TestBrowseRedactionCase11UnknownKind(unittest.TestCase):
+    """Case 11: Unknown kind value must be coerced to 'generic'."""
+
+    def test_unknown_kind_coerced(self) -> None:
+        result = redact_entry(_entry(kind="foobar_event"))
+        self.assertEqual(result["kind"], "generic")
+        self.assertTrue(result["redacted"])
+
+    def test_known_kind_preserved(self) -> None:
+        result = redact_entry(_entry(kind="tool_call"))
+        self.assertEqual(result["kind"], "tool_call")
+
+    def test_missing_kind_defaults_to_generic(self) -> None:
+        result = redact_entry({"idx": 0})
+        self.assertEqual(result["kind"], "generic")
+
+
+class TestBrowseRedactionCase12NonDictAttrs(unittest.TestCase):
+    """Case 12: Non-dict attrs must be coerced to {}."""
+
+    def test_string_attrs_coerced(self) -> None:
+        result = redact_entry(_entry(attrs="not a dict"))
+        self.assertEqual(result["attrs"], {})
+        self.assertTrue(result["redacted"])
+
+    def test_list_attrs_coerced(self) -> None:
+        result = redact_entry(_entry(attrs=[{"key": "val"}]))
+        self.assertEqual(result["attrs"], {})
+        self.assertTrue(result["redacted"])
+
+    def test_int_attrs_coerced(self) -> None:
+        result = redact_entry(_entry(attrs=42))
+        self.assertEqual(result["attrs"], {})
+        self.assertTrue(result["redacted"])
+
+    def test_none_attrs_allowed(self) -> None:
+        result = redact_entry(_entry(attrs=None))
+        # None means attrs not supplied — should not set redacted just for this
+        self.assertEqual(result["attrs"], {})
+
+
+class TestBrowseRedactionCase13AllowlistedAttrJWT(unittest.TestCase):
+    """Case 13: Allowlisted attr string carrying a JWT must be redacted."""
+
+    _JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+    def test_jwt_in_model_attr_redacted(self) -> None:
+        result = redact_entry(_entry(attrs={"model": self._JWT}))
+        model_val = result["attrs"].get("model", "")
+        self.assertNotEqual(model_val, self._JWT, "Original JWT must not pass through")
+        self.assertIn("[REDACTED]", model_val, "Placeholder must be present")
+        self.assertTrue(result["redacted"])
+
+    def test_jwt_in_error_category_redacted(self) -> None:
+        result = redact_entry(_entry(attrs={"error_category": self._JWT}))
+        val = result["attrs"].get("error_category", "")
+        self.assertNotEqual(val, self._JWT)
+        self.assertIn("[REDACTED]", val)
+
+
+class TestBrowseRedactionCase14MalformedSessionUUID(unittest.TestCase):
+    """Case 14: Malformed session_uuid must be dropped."""
+
+    def test_malformed_uuid_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"session_uuid": "not-a-uuid"}))
+        self.assertNotIn("session_uuid", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+    def test_partial_uuid_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"session_uuid": "550e8400-e29b-41d4"}))
+        self.assertNotIn("session_uuid", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+    def test_valid_uuid_kept(self) -> None:
+        valid = "550e8400-e29b-41d4-a716-446655440000"
+        result = redact_entry(_entry(attrs={"session_uuid": valid}))
+        self.assertIn("session_uuid", result["attrs"])
+        self.assertEqual(result["attrs"]["session_uuid"], valid)
+
+
+class TestBrowseRedactionCase15RouteQueryString(unittest.TestCase):
+    """Case 15: attrs.route with a query string must be dropped."""
+
+    def test_route_with_query_string_dropped(self) -> None:
+        result = redact_entry(_entry(attrs={"route": "/api/sessions?limit=10"}))
+        self.assertNotIn("route", result["attrs"])
+        self.assertTrue(result["redacted"])
+
+    def test_route_with_fragment_only_kept(self) -> None:
+        # Fragment (#) does not constitute a query string — route is allowed
+        result = redact_entry(_entry(attrs={"route": "/api/sessions"}))
+        self.assertIn("route", result["attrs"])
+        self.assertEqual(result["attrs"]["route"], "/api/sessions")
+
+    def test_route_without_query_kept(self) -> None:
+        result = redact_entry(_entry(attrs={"route": "/api/v2/debug-log"}))
+        self.assertIn("route", result["attrs"])
+        self.assertFalse(result["redacted"])
+
+
+class TestBrowseRedactionValidators(unittest.TestCase):
+    """Additional validator coverage for field rules."""
+
+    def test_idx_negative_coerced_to_zero(self) -> None:
+        result = redact_entry({"idx": -1, "kind": "generic"})
+        self.assertEqual(result["idx"], 0)
+        self.assertTrue(result["redacted"])
+
+    def test_idx_string_coerced_to_zero(self) -> None:
+        result = redact_entry({"idx": "five", "kind": "generic"})
+        self.assertEqual(result["idx"], 0)
+        self.assertTrue(result["redacted"])
+
+    def test_invalid_timestamp_becomes_none(self) -> None:
+        result = redact_entry(_entry(timestamp="not-a-date"))
+        self.assertIsNone(result.get("timestamp"))
+        self.assertTrue(result["redacted"])
+
+    def test_valid_iso_timestamp_kept(self) -> None:
+        ts = "2024-01-15T10:30:00Z"
+        result = redact_entry(_entry(timestamp=ts))
+        self.assertEqual(result["timestamp"], ts)
+
+    def test_unknown_level_becomes_info(self) -> None:
+        result = redact_entry(_entry(level="verbose"))
+        self.assertEqual(result["level"], "info")
+
+    def test_unknown_source_becomes_unknown(self) -> None:
+        result = redact_entry(_entry(source="custom_source"))
+        self.assertEqual(result["source"], "unknown")
+
+    def test_invalid_tool_name_dropped(self) -> None:
+        result = redact_entry(_entry(tool_name="bad name with spaces"))
+        self.assertNotIn("tool_name", result)
+        self.assertTrue(result["redacted"])
+
+    def test_tool_name_with_backslash_dropped(self) -> None:
+        """Backslash must be rejected — docs advertise ^[a-zA-Z0-9_.-]{1,64}$."""
+        result = redact_entry(_entry(tool_name=r"bash\tool"))
+        self.assertNotIn("tool_name", result, "Backslash in tool_name must be dropped")
+        self.assertTrue(result["redacted"])
+
+    def test_valid_tool_name_kept(self) -> None:
+        result = redact_entry(_entry(tool_name="bash_tool"))
+        self.assertEqual(result.get("tool_name"), "bash_tool")
+
+    def test_negative_duration_dropped(self) -> None:
+        result = redact_entry(_entry(duration_ms=-5))
+        self.assertNotIn("duration_ms", result)
+        self.assertTrue(result["redacted"])
+
+    def test_valid_span_id_kept(self) -> None:
+        result = redact_entry(_entry(span_id="0a1b2c3d4e5f0a1b"))
+        self.assertEqual(result.get("span_id"), "0a1b2c3d4e5f0a1b")
+
+    def test_invalid_span_id_dropped(self) -> None:
+        result = redact_entry(_entry(span_id="INVALID-SPAN"))
+        self.assertNotIn("span_id", result)
+        self.assertTrue(result["redacted"])
+
+    def test_unknown_status_coerced_to_error(self) -> None:
+        result = redact_entry(_entry(status="unknown_status"))
+        self.assertEqual(result.get("status"), "error")
+        self.assertTrue(result["redacted"])
+
+    def test_unknown_top_level_key_dropped(self) -> None:
+        result = redact_entry(_entry(raw_prompt="secret prompt text"))
+        self.assertNotIn("raw_prompt", result)
+        self.assertTrue(result["redacted"])
+
+    def test_clean_entry_not_flagged(self) -> None:
+        result = redact_entry(
+            {
+                "idx": 1,
+                "kind": "tool_call",
+                "level": "info",
+                "source": "cli",
+                "message": "Running bash",
+                "tool_name": "bash",
+                "duration_ms": 100,
+                "status": "ok",
+                "attrs": {"event_count": 3, "latency_ms": 42},
+            }
+        )
+        self.assertFalse(result["redacted"], "Clean entry must not be flagged as redacted")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Add a strict allowlist-first `BrowseDebugEntry` redaction helper.
- Add regression coverage for token/query/path/nested-attrs/fail-closed/schema validation cases.
- Document redaction policy, threat model, and #426 contract reconciliation gate.

Closes #427.

## Dependency / merge note
This PR can be reviewed in parallel, but should merge after #426 so the final allowlist and sentinel shape are reconciled against the accepted WBS-101 contract.

## Evidence
- `python tests\test_browse_redaction.py` — 61 tests OK
- `python -m py_compile browse\core\redaction.py tests\test_browse_redaction.py`
- `python test_security.py` — 12 passed, 0 failed
- `python -m ruff check browse\core\redaction.py tests\test_browse_redaction.py`
- `python -m ruff format --check browse\core\redaction.py tests\test_browse_redaction.py`
- Targeted runtime check: macOS `/Users/<name>` path redaction and backslash tool-name rejection OK
- Independent Opus final security review: CLEAN
