### PR TITLE
feat: add secure debug log storage plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Debug-log separate SQLite storage and healthz probe (WBS-103, #428):**
+  - `browse/core/debug_log_storage.py`: new isolated debug-log store — separate SQLite DB at
+    `~/.copilot/operator-console/debug-log/debug-log.db` (outside session-state and `knowledge.db`).
+    WAL/NORMAL pragmas; redaction before insert (JSON-only); deterministic age-then-size pruning;
+    optional background retention thread; explicit shutdown, no `atexit`/signal handlers.
+  - `browse/routes/debug_log.py`: `GET /api/debug-log/healthz` — safe probe route (enabled only);
+    returns `ok`, `enabled`, and `retention` config; no paths, event counts, or session content.
+  - `browse/__init__.py`: new CLI flags and env vars:
+    `--debug-log` / `BROWSE_DEBUG_LOG_ENABLED=1` (disabled by default);
+    `--debug-log-dir` / `BROWSE_DEBUG_LOG_DIR`;
+    `--debug-log-max-age-seconds` / `BROWSE_DEBUG_LOG_MAX_AGE_S` (default 86400);
+    `--debug-log-max-bytes` / `BROWSE_DEBUG_LOG_MAX_BYTES` (default 52428800);
+    `--debug-log-retention-interval` / `BROWSE_DEBUG_LOG_RETENTION_INTERVAL_S` (default 300);
+    `--debug-log-ephemeral` / `BROWSE_DEBUG_LOG_EPHEMERAL`.
+  - `browse/core/server.py`: debug-log gate — disabled route → 404; `?token=` rejected with 401;
+    static/demo mode → 403; non-loopback with no server token → 403; auth via `check_debug_token`
+    (Bearer/cookie only, no open-auth); inherits `/api` CORS/PNA/Vary policy.
+  - `tests/test_browse_debug_log_storage.py`, `tests/test_browse_debug_log_transport.py`,
+    `tests/test_browse_debug_log_exclusion.py`: isolation verified — default path outside
+    session-state; `.db` ignored by watcher; sync auto-detect excludes `operator-console/`;
+    session export body excludes debug-log content.
+  - `docs/DEBUG-LOG-CONTRACT.md`: updated to document WBS-103 storage/transport contract.
+
 - **Explicit improvement signal tracking (#126):**
   - `migrate.py` v24: new `improvement_signals` table in the session knowledge DB — stores explicit user-reported `missed_match`, `wrong_skill`, and `outdated_skill` signals linked to session IDs, with `consumed` tracking and indexes on `consumed`, `signal_type`, `created_at`, and `mentioned_skill`.
   - `improvement-signals.py`: new standalone stdlib-only script exposing `record`, `list`, `consume`, and `stats` subcommands. Supports `--format json` throughout. Fail-open on missing DB. Creates the table itself if migration has not yet run.

--- a/browse/__init__.py
+++ b/browse/__init__.py
@@ -672,6 +672,61 @@ def main() -> None:
             "Exits after removal — does NOT start a server."
         ),
     )
+    # ── Debug-log storage flags (WBS-103) ─────────────────────────────────────
+    p.add_argument(
+        "--debug-log",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable debug-log storage and the /api/debug-log/healthz probe route. "
+            "Disabled by default.  Also enabled via BROWSE_DEBUG_LOG_ENABLED=1. "
+            "Debug routes require Bearer or cookie auth — ?token= is rejected. "
+            "See docs/DEBUG-LOG-CONTRACT.md for the full contract."
+        ),
+    )
+    p.add_argument(
+        "--debug-log-dir",
+        metavar="DIR",
+        default="",
+        help=(
+            "Directory for the debug-log SQLite DB (default: "
+            "~/.copilot/operator-console/debug-log/). "
+            "Also configurable via BROWSE_DEBUG_LOG_DIR."
+        ),
+    )
+    p.add_argument(
+        "--debug-log-max-age-seconds",
+        type=int,
+        default=0,
+        metavar="SECONDS",
+        help="Max age in seconds for debug-log events (default: 86400). "
+             "Also via BROWSE_DEBUG_LOG_MAX_AGE_S.",
+    )
+    p.add_argument(
+        "--debug-log-max-bytes",
+        type=int,
+        default=0,
+        metavar="BYTES",
+        help="Max total size in bytes for debug-log events (default: 52428800). "
+             "Also via BROWSE_DEBUG_LOG_MAX_BYTES.",
+    )
+    p.add_argument(
+        "--debug-log-retention-interval",
+        type=int,
+        default=0,
+        metavar="SECONDS",
+        help="Interval in seconds between retention runs (default: 300). "
+             "Also via BROWSE_DEBUG_LOG_RETENTION_INTERVAL_S.",
+    )
+    p.add_argument(
+        "--debug-log-ephemeral",
+        action="store_true",
+        default=False,
+        help=(
+            "Remove the debug-log DB and WAL/SHM files on shutdown. "
+            "Also via BROWSE_DEBUG_LOG_EPHEMERAL=1."
+        ),
+    )
     args = p.parse_args()
 
     # --install-launcher: one-shot install — exit after writing launcher files.
@@ -993,6 +1048,35 @@ def main() -> None:
     if not args.no_tunnel:
         stop_tunnel = _start_cloudflared(local_base_url, token, token_env_source=token_env_source)
 
+    # ── Debug-log storage initialization (WBS-103) ────────────────────────────
+    # Check both CLI flag and env variable; set env so is_enabled() returns True.
+    _dl_enabled = args.debug_log or os.environ.get(
+        "BROWSE_DEBUG_LOG_ENABLED", ""
+    ).strip().lower() in ("1", "true", "yes")
+    if _dl_enabled:
+        os.environ["BROWSE_DEBUG_LOG_ENABLED"] = "1"
+        from browse.core.debug_log_storage import (  # noqa: PLC0415
+            init_storage as _dl_init,
+            start_retention_thread as _dl_start,
+        )
+        import browse.routes.debug_log  # noqa: F401 — registers /api/debug-log/healthz
+
+        _dl_db_path = (
+            Path(args.debug_log_dir) / "debug-log.db"
+            if args.debug_log_dir
+            else None
+        )
+        # init_storage raises OSError/sqlite3.OperationalError on failure (no silent fallback)
+        _dl_init(
+            db_path=_dl_db_path,
+            max_age_s=args.debug_log_max_age_seconds or None,
+            max_bytes=args.debug_log_max_bytes or None,
+            retention_interval_s=args.debug_log_retention_interval or None,
+            ephemeral=args.debug_log_ephemeral or None,
+        )
+        _dl_start()
+        print("[debug-log] storage initialized; /api/debug-log/healthz registered.", flush=True)
+
     try:
         server.serve_forever()
     except KeyboardInterrupt:
@@ -1001,3 +1085,8 @@ def main() -> None:
         stop_tunnel()
         server.server_close()
         db.close()
+        # Explicit shutdown — NO atexit, NO signal handler (WBS-103)
+        if _dl_enabled:
+            from browse.core.debug_log_storage import shutdown_storage as _dl_shutdown  # noqa: PLC0415
+
+            _dl_shutdown()

--- a/browse/__init__.py
+++ b/browse/__init__.py
@@ -1055,11 +1055,13 @@ def main() -> None:
     ).strip().lower() in ("1", "true", "yes")
     if _dl_enabled:
         os.environ["BROWSE_DEBUG_LOG_ENABLED"] = "1"
+        import browse.routes.debug_log  # noqa: F401 — registers /api/debug-log/healthz
         from browse.core.debug_log_storage import (  # noqa: PLC0415
             init_storage as _dl_init,
+        )
+        from browse.core.debug_log_storage import (
             start_retention_thread as _dl_start,
         )
-        import browse.routes.debug_log  # noqa: F401 — registers /api/debug-log/healthz
 
         _dl_db_path = (
             Path(args.debug_log_dir) / "debug-log.db"

--- a/browse/__init__.py
+++ b/browse/__init__.py
@@ -699,16 +699,14 @@ def main() -> None:
         type=int,
         default=0,
         metavar="SECONDS",
-        help="Max age in seconds for debug-log events (default: 86400). "
-             "Also via BROWSE_DEBUG_LOG_MAX_AGE_S.",
+        help="Max age in seconds for debug-log events (default: 86400). Also via BROWSE_DEBUG_LOG_MAX_AGE_S.",
     )
     p.add_argument(
         "--debug-log-max-bytes",
         type=int,
         default=0,
         metavar="BYTES",
-        help="Max total size in bytes for debug-log events (default: 52428800). "
-             "Also via BROWSE_DEBUG_LOG_MAX_BYTES.",
+        help="Max total size in bytes for debug-log events (default: 52428800). Also via BROWSE_DEBUG_LOG_MAX_BYTES.",
     )
     p.add_argument(
         "--debug-log-retention-interval",
@@ -716,16 +714,13 @@ def main() -> None:
         default=0,
         metavar="SECONDS",
         help="Interval in seconds between retention runs (default: 300). "
-             "Also via BROWSE_DEBUG_LOG_RETENTION_INTERVAL_S.",
+        "Also via BROWSE_DEBUG_LOG_RETENTION_INTERVAL_S.",
     )
     p.add_argument(
         "--debug-log-ephemeral",
         action="store_true",
         default=False,
-        help=(
-            "Remove the debug-log DB and WAL/SHM files on shutdown. "
-            "Also via BROWSE_DEBUG_LOG_EPHEMERAL=1."
-        ),
+        help=("Remove the debug-log DB and WAL/SHM files on shutdown. Also via BROWSE_DEBUG_LOG_EPHEMERAL=1."),
     )
     args = p.parse_args()
 
@@ -1050,9 +1045,11 @@ def main() -> None:
 
     # ── Debug-log storage initialization (WBS-103) ────────────────────────────
     # Check both CLI flag and env variable; set env so is_enabled() returns True.
-    _dl_enabled = args.debug_log or os.environ.get(
-        "BROWSE_DEBUG_LOG_ENABLED", ""
-    ).strip().lower() in ("1", "true", "yes")
+    _dl_enabled = args.debug_log or os.environ.get("BROWSE_DEBUG_LOG_ENABLED", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
     if _dl_enabled:
         os.environ["BROWSE_DEBUG_LOG_ENABLED"] = "1"
         import browse.routes.debug_log  # noqa: F401 — registers /api/debug-log/healthz
@@ -1063,11 +1060,7 @@ def main() -> None:
             start_retention_thread as _dl_start,
         )
 
-        _dl_db_path = (
-            Path(args.debug_log_dir) / "debug-log.db"
-            if args.debug_log_dir
-            else None
-        )
+        _dl_db_path = Path(args.debug_log_dir) / "debug-log.db" if args.debug_log_dir else None
         # init_storage raises OSError/sqlite3.OperationalError on failure (no silent fallback)
         _dl_init(
             db_path=_dl_db_path,

--- a/browse/core/auth.py
+++ b/browse/core/auth.py
@@ -184,7 +184,7 @@ def check_debug_token(token: str, cookie_header: str, auth_header: str) -> "tupl
 
     # Bearer header: authoritative, no fallback on failure
     if auth_header and auth_header.startswith("Bearer "):
-        provided = auth_header[len("Bearer "):].strip()
+        provided = auth_header[len("Bearer ") :].strip()
         if provided:
             try:
                 if hmac.compare_digest(provided.encode("utf-8"), token.encode("utf-8")):
@@ -209,7 +209,6 @@ def check_debug_token(token: str, cookie_header: str, auth_header: str) -> "tupl
                 pass
 
     return False, ""
-
 
 
 # ── Loopback / open-auth guard (WBS-087) ─────────────────────────────────────

--- a/browse/core/auth.py
+++ b/browse/core/auth.py
@@ -163,6 +163,55 @@ def check_origin(request_headers: object, host: str) -> tuple:
     return False, is_https
 
 
+# ── Debug-log token auth (WBS-103) ────────────────────────────────────────────
+
+
+def check_debug_token(token: str, cookie_header: str, auth_header: str) -> "tuple[bool, str]":
+    """Check debug-log authentication: Bearer header or cookie only.
+
+    No query-string / params auth accepted.
+    Empty server *token* always returns (False, '') — debug endpoints are
+    never open-auth.
+
+    Returns (valid: bool, token_val: str).
+
+    Priority: Bearer header > cookie.
+    If a Bearer header is present and fails, fails closed with no cookie
+    fallback (matching the strict-auth pattern of check_token for Bearer).
+    """
+    if not token:
+        return False, ""
+
+    # Bearer header: authoritative, no fallback on failure
+    if auth_header and auth_header.startswith("Bearer "):
+        provided = auth_header[len("Bearer "):].strip()
+        if provided:
+            try:
+                if hmac.compare_digest(provided.encode("utf-8"), token.encode("utf-8")):
+                    return True, provided
+            except Exception:
+                pass
+        return False, ""
+
+    # Cookie fallback (no Bearer header present)
+    if cookie_header:
+        jar = http.cookies.SimpleCookie()
+        try:
+            jar.load(cookie_header)
+        except Exception:
+            pass
+        morsel = jar.get("browse_token")
+        if morsel:
+            try:
+                if hmac.compare_digest(morsel.value.encode("utf-8"), token.encode("utf-8")):
+                    return True, morsel.value
+            except Exception:
+                pass
+
+    return False, ""
+
+
+
 # ── Loopback / open-auth guard (WBS-087) ─────────────────────────────────────
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "127.0.0.0"})

--- a/browse/core/debug_log_storage.py
+++ b/browse/core/debug_log_storage.py
@@ -1,0 +1,378 @@
+"""browse/core/debug_log_storage.py — Local-only bounded debug-log storage.
+
+Feature-disabled by default.  Enable via --debug-log CLI flag or
+BROWSE_DEBUG_LOG_ENABLED=1.
+
+Storage location:
+  Path.home() / '.copilot' / 'operator-console' / 'debug-log' / 'debug-log.db'
+Override directory with BROWSE_DEBUG_LOG_DIR env variable.
+
+This module is intentionally isolated from knowledge.db and session-state:
+  - Not under session-state directory
+  - Not in knowledge.db
+  - Excluded from sync, export, watch, and index pipelines
+
+No third-party dependencies — stdlib only.  Python 3.10+.
+No atexit.  No signal handlers.  Use shutdown_storage() explicitly.
+"""
+
+import json
+import logging
+import os
+import sqlite3
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+_log = logging.getLogger("browse.debug_log_storage")
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+
+DEFAULT_MAX_AGE_S: int = 24 * 3600          # 24 hours
+DEFAULT_MAX_BYTES: int = 50 * 1024 * 1024   # 50 MB
+DEFAULT_RETENTION_INTERVAL_S: int = 300     # 5 minutes
+
+_DB_FILENAME = "debug-log.db"
+
+
+# ── Env helpers ───────────────────────────────────────────────────────────────
+
+
+def _env_int(name: str, default: int, aliases: tuple = ()) -> int:
+    """Read an integer env variable with optional aliases, fallback to *default*."""
+    for key in (name,) + aliases:
+        v = os.environ.get(key, "").strip()
+        if v:
+            try:
+                return int(v)
+            except ValueError:
+                _log.warning("Invalid integer for %s=%r; using default %d", key, v, default)
+    return default
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Read a boolean env variable (1/true/yes → True)."""
+    v = os.environ.get(name, "").strip().lower()
+    if v in ("1", "true", "yes"):
+        return True
+    if v in ("0", "false", "no"):
+        return False
+    return default
+
+
+# ── Public path helpers ───────────────────────────────────────────────────────
+
+
+def default_debug_log_path() -> Path:
+    """Return the default debug-log DB path (outside session-state).
+
+    Default: Path.home() / '.copilot' / 'operator-console' / 'debug-log' / 'debug-log.db'
+    Override directory with BROWSE_DEBUG_LOG_DIR.
+    """
+    d = os.environ.get("BROWSE_DEBUG_LOG_DIR", "").strip()
+    if d:
+        return Path(d) / _DB_FILENAME
+    return Path.home() / ".copilot" / "operator-console" / "debug-log" / _DB_FILENAME
+
+
+def is_enabled() -> bool:
+    """Return True when the debug-log feature is enabled via env."""
+    return _env_bool("BROWSE_DEBUG_LOG_ENABLED")
+
+
+# ── Module-level state ────────────────────────────────────────────────────────
+
+_lock = threading.Lock()
+_conn: "sqlite3.Connection | None" = None
+_db_path: "Path | None" = None
+_max_age_s: int = DEFAULT_MAX_AGE_S
+_max_bytes: int = DEFAULT_MAX_BYTES
+_retention_interval_s: int = DEFAULT_RETENTION_INTERVAL_S
+_ephemeral: bool = False
+_stop_event: threading.Event = threading.Event()
+_thread: "threading.Thread | None" = None
+
+
+# ── Schema ────────────────────────────────────────────────────────────────────
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS debug_log_events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_ns      INTEGER NOT NULL,
+    session_id TEXT NOT NULL,
+    idx        INTEGER NOT NULL,
+    kind       TEXT NOT NULL,
+    payload    TEXT NOT NULL,
+    byte_len   INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_debug_session ON debug_log_events (session_id, idx);
+CREATE INDEX IF NOT EXISTS idx_debug_ts ON debug_log_events (ts_ns);
+CREATE TABLE IF NOT EXISTS debug_log_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+INSERT OR IGNORE INTO debug_log_meta (key, value) VALUES ('schema_version', '1');
+"""
+
+
+def _open_storage_conn(db_path: Path) -> sqlite3.Connection:
+    """Open a WAL+NORMAL SQLite connection to the debug-log DB.
+
+    Raises OSError / sqlite3.OperationalError on failure — no silent fallback.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path), check_same_thread=False, timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.executescript(_SCHEMA_SQL)
+    conn.commit()
+    return conn
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def init_storage(
+    db_path: "Path | None" = None,
+    max_age_s: "int | None" = None,
+    max_bytes: "int | None" = None,
+    retention_interval_s: "int | None" = None,
+    ephemeral: "bool | None" = None,
+) -> None:
+    """Initialize the debug-log storage module.
+
+    Must be called before append_event / prune_now / shutdown_storage.
+    Raises OSError / sqlite3.OperationalError on DB open failure (no silent
+    fallback).  Safe to call again after shutdown_storage().
+
+    Parameter values take precedence over the corresponding env variables.
+    """
+    global _conn, _db_path, _max_age_s, _max_bytes, _retention_interval_s, _ephemeral
+
+    with _lock:
+        if _conn is not None:
+            return  # already initialized
+
+        resolved_path = db_path if db_path is not None else default_debug_log_path()
+        resolved_max_age = (
+            max_age_s
+            if max_age_s is not None
+            else _env_int(
+                "BROWSE_DEBUG_LOG_MAX_AGE_S",
+                DEFAULT_MAX_AGE_S,
+                aliases=("BROWSE_DEBUG_LOG_MAX_AGE_SECONDS",),
+            )
+        )
+        resolved_max_bytes = (
+            max_bytes
+            if max_bytes is not None
+            else _env_int("BROWSE_DEBUG_LOG_MAX_BYTES", DEFAULT_MAX_BYTES)
+        )
+        resolved_interval = (
+            retention_interval_s
+            if retention_interval_s is not None
+            else _env_int(
+                "BROWSE_DEBUG_LOG_RETENTION_INTERVAL_S",
+                DEFAULT_RETENTION_INTERVAL_S,
+                aliases=("BROWSE_DEBUG_LOG_RETENTION_INTERVAL_SECONDS",),
+            )
+        )
+        resolved_ephemeral = (
+            ephemeral if ephemeral is not None else _env_bool("BROWSE_DEBUG_LOG_EPHEMERAL")
+        )
+
+        # Open DB — errors propagate, no silent fallback
+        conn = _open_storage_conn(resolved_path)
+
+        _conn = conn
+        _db_path = resolved_path
+        _max_age_s = resolved_max_age
+        _max_bytes = resolved_max_bytes
+        _retention_interval_s = resolved_interval
+        _ephemeral = resolved_ephemeral
+
+
+def start_retention_thread() -> None:
+    """Start the background retention daemon thread.
+
+    Must be called after init_storage().  No-op if thread already running.
+    """
+    global _thread
+
+    with _lock:
+        if _thread is not None and _thread.is_alive():
+            return
+
+    def _loop() -> None:
+        interval = _retention_interval_s
+        while not _stop_event.is_set():
+            try:
+                prune_now()
+            except Exception:
+                _log.exception("[debug_log] retention loop error")
+            _stop_event.wait(interval)
+
+    t = threading.Thread(target=_loop, daemon=True, name="debug-log-retention")
+    with _lock:
+        _thread = t
+    t.start()
+
+
+def get_config() -> dict:
+    """Return the current storage configuration (thread-safe snapshot)."""
+    with _lock:
+        return {
+            "max_age_seconds": _max_age_s,
+            "max_bytes": _max_bytes,
+            "interval_seconds": _retention_interval_s,
+        }
+
+
+def append_event(session_id: str, idx: int, kind: str, payload: Any) -> None:
+    """Append a debug-log event after redaction.
+
+    *payload* is passed through browse.core.redaction.redact_entry; the
+    resulting dict must contain a ``redacted`` key, else ValueError is raised.
+    Stores the redacted JSON payload only.
+
+    Raises RuntimeError if storage not initialized.
+    Raises ValueError if redact_entry result is missing the ``redacted`` key.
+    """
+    from browse.core.redaction import redact_entry  # noqa: PLC0415
+
+    redacted_dict = redact_entry(payload)
+    if "redacted" not in redacted_dict:
+        raise ValueError(
+            "redact_entry result missing 'redacted' key; refusing to store unsafe payload"
+        )
+
+    payload_json = json.dumps(redacted_dict, ensure_ascii=False)
+    byte_len = len(payload_json.encode("utf-8"))
+    ts_ns = time.time_ns()
+
+    with _lock:
+        if _conn is None:
+            raise RuntimeError(
+                "debug_log_storage not initialized; call init_storage() first"
+            )
+        _conn.execute(
+            "INSERT INTO debug_log_events (ts_ns, session_id, idx, kind, payload, byte_len)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (ts_ns, session_id, idx, kind, payload_json, byte_len),
+        )
+        _conn.commit()
+
+
+def prune_now(
+    conn: "sqlite3.Connection | None" = None,
+    now_ns: "int | None" = None,
+) -> dict:
+    """Prune age-expired rows, then enforce size cap.
+
+    Deletes rows older than max_age_s, then deletes oldest rows by (ts_ns, id)
+    in deterministic chunks until SUM(byte_len) <= max_bytes.
+
+    Returns stats dict: {deleted_age, deleted_size, remaining}.
+    """
+    if now_ns is None:
+        now_ns = time.time_ns()
+
+    with _lock:
+        c = conn if conn is not None else _conn
+        if c is None:
+            return {"deleted_age": 0, "deleted_size": 0, "remaining": 0}
+
+        age_cutoff_ns = now_ns - int(_max_age_s * 1_000_000_000)
+
+        # Delete age-expired rows
+        cur = c.execute(
+            "DELETE FROM debug_log_events WHERE ts_ns < ?",
+            (age_cutoff_ns,),
+        )
+        deleted_age = cur.rowcount
+
+        # Enforce size cap: delete oldest rows in chunks until under limit
+        deleted_size = 0
+        _CHUNK = 100
+        while True:
+            row = c.execute("SELECT SUM(byte_len) FROM debug_log_events").fetchone()
+            total = int(row[0] or 0)
+            if total <= _max_bytes:
+                break
+            ids = [
+                r[0]
+                for r in c.execute(
+                    "SELECT id FROM debug_log_events ORDER BY ts_ns ASC, id ASC LIMIT ?",
+                    (_CHUNK,),
+                ).fetchall()
+            ]
+            if not ids:
+                break
+            placeholders = ",".join("?" * len(ids))
+            cur2 = c.execute(
+                f"DELETE FROM debug_log_events WHERE id IN ({placeholders})",
+                ids,
+            )
+            deleted_size += cur2.rowcount
+
+        c.commit()
+
+        remaining_row = c.execute("SELECT COUNT(*) FROM debug_log_events").fetchone()
+        remaining = int(remaining_row[0] if remaining_row else 0)
+
+    return {"deleted_age": deleted_age, "deleted_size": deleted_size, "remaining": remaining}
+
+
+def shutdown_storage() -> None:
+    """Stop the retention thread, close the DB, and optionally remove DB files.
+
+    Idempotent — safe to call multiple times or without prior init_storage().
+    Joins the retention thread with a 2-second timeout.
+    Does NOT use atexit or signal handlers.
+
+    If ephemeral mode is active, removes the DB file and WAL/SHM siblings.
+    """
+    global _conn, _db_path, _thread, _stop_event
+
+    # Signal the retention thread to stop
+    _stop_event.set()
+
+    # Join with bounded timeout (outside lock to avoid deadlock)
+    with _lock:
+        t = _thread
+    if t is not None:
+        t.join(timeout=2.0)
+
+    with _lock:
+        conn = _conn
+        path = _db_path
+        eph = _ephemeral
+        _conn = None
+        _db_path = None
+        _thread = None
+
+    if conn is not None:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    if eph and path is not None:
+        for suffix in ("", "-wal", "-shm"):
+            try:
+                p = Path(str(path) + suffix)
+                if p.exists():
+                    p.unlink()
+            except Exception:
+                pass
+
+    # Reset stop event so module can be re-initialized (important for tests)
+    _stop_event = threading.Event()

--- a/browse/core/debug_log_storage.py
+++ b/browse/core/debug_log_storage.py
@@ -35,9 +35,9 @@ _log = logging.getLogger("browse.debug_log_storage")
 
 # ── Defaults ──────────────────────────────────────────────────────────────────
 
-DEFAULT_MAX_AGE_S: int = 24 * 3600          # 24 hours
-DEFAULT_MAX_BYTES: int = 50 * 1024 * 1024   # 50 MB
-DEFAULT_RETENTION_INTERVAL_S: int = 300     # 5 minutes
+DEFAULT_MAX_AGE_S: int = 24 * 3600  # 24 hours
+DEFAULT_MAX_BYTES: int = 50 * 1024 * 1024  # 50 MB
+DEFAULT_RETENTION_INTERVAL_S: int = 300  # 5 minutes
 
 _DB_FILENAME = "debug-log.db"
 
@@ -172,9 +172,7 @@ def init_storage(
             )
         )
         resolved_max_bytes = (
-            max_bytes
-            if max_bytes is not None
-            else _env_int("BROWSE_DEBUG_LOG_MAX_BYTES", DEFAULT_MAX_BYTES)
+            max_bytes if max_bytes is not None else _env_int("BROWSE_DEBUG_LOG_MAX_BYTES", DEFAULT_MAX_BYTES)
         )
         resolved_interval = (
             retention_interval_s
@@ -185,9 +183,7 @@ def init_storage(
                 aliases=("BROWSE_DEBUG_LOG_RETENTION_INTERVAL_SECONDS",),
             )
         )
-        resolved_ephemeral = (
-            ephemeral if ephemeral is not None else _env_bool("BROWSE_DEBUG_LOG_EPHEMERAL")
-        )
+        resolved_ephemeral = ephemeral if ephemeral is not None else _env_bool("BROWSE_DEBUG_LOG_EPHEMERAL")
 
         # Open DB — errors propagate, no silent fallback
         conn = _open_storage_conn(resolved_path)
@@ -257,9 +253,7 @@ def append_event(session_id: str, idx: int, kind: str, payload: Any) -> None:
 
     redacted_dict = redact_entry(payload)
     if "redacted" not in redacted_dict:
-        raise ValueError(
-            "redact_entry result missing 'redacted' key; refusing to store unsafe payload"
-        )
+        raise ValueError("redact_entry result missing 'redacted' key; refusing to store unsafe payload")
 
     payload_json = json.dumps(redacted_dict, ensure_ascii=False)
     byte_len = len(payload_json.encode("utf-8"))
@@ -267,12 +261,9 @@ def append_event(session_id: str, idx: int, kind: str, payload: Any) -> None:
 
     with _lock:
         if _conn is None:
-            raise RuntimeError(
-                "debug_log_storage not initialized; call init_storage() first"
-            )
+            raise RuntimeError("debug_log_storage not initialized; call init_storage() first")
         _conn.execute(
-            "INSERT INTO debug_log_events (ts_ns, session_id, idx, kind, payload, byte_len)"
-            " VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO debug_log_events (ts_ns, session_id, idx, kind, payload, byte_len) VALUES (?, ?, ?, ?, ?, ?)",
             (ts_ns, session_id, idx, kind, payload_json, byte_len),
         )
         _conn.commit()

--- a/browse/core/debug_log_storage.py
+++ b/browse/core/debug_log_storage.py
@@ -210,15 +210,22 @@ def start_retention_thread() -> None:
     with _lock:
         if _thread is not None and _thread.is_alive():
             return
+        # Capture the stop event under the lock so the thread holds a stable
+        # reference to this specific Event for its entire lifetime.  If
+        # shutdown_storage() times out on join and then replaces the
+        # module-level _stop_event with a fresh unset Event, the thread still
+        # observes the *original* (signalled) event and exits rather than
+        # running as an untracked zombie against a re-initialized connection.
+        stop = _stop_event
 
     def _loop() -> None:
         interval = _retention_interval_s
-        while not _stop_event.is_set():
+        while not stop.is_set():
             try:
                 prune_now()
             except Exception:
                 _log.exception("[debug_log] retention loop error")
-            _stop_event.wait(interval)
+            stop.wait(interval)
 
     t = threading.Thread(target=_loop, daemon=True, name="debug-log-retention")
     with _lock:

--- a/browse/core/registry.py
+++ b/browse/core/registry.py
@@ -10,17 +10,27 @@ if os.name == "nt":
         if hasattr(_s, "reconfigure"):
             _s.reconfigure(encoding="utf-8", errors="replace")
 
-# Global route table: list of (path_pattern, methods, handler_fn)
+# Global route table: list of (path_pattern, methods, handler_fn, debug)
+# debug=True routes receive distinct auth gating in the server dispatcher.
 ROUTES: list = []
 
+# Set of paths registered with debug=True (used by server for fast lookup).
+_DEBUG_ROUTES: set = set()
 
-def route(path: str, methods: list | None = None):
-    """Decorator: @route('/path', methods=['GET']) registers handler in ROUTES."""
+
+def route(path: str, methods: list | None = None, debug: bool = False):
+    """Decorator: @route('/path', methods=['GET'], debug=False) registers handler in ROUTES.
+
+    debug=True marks a route as a debug-log endpoint that requires separate
+    auth gating (Bearer/cookie only, no ?token=, no open-auth).
+    """
     if methods is None:
         methods = ["GET"]
 
     def decorator(fn: Callable) -> Callable:
-        ROUTES.append((path, [m.upper() for m in methods], fn))
+        ROUTES.append((path, [m.upper() for m in methods], fn, debug))
+        if debug:
+            _DEBUG_ROUTES.add(path)
         return fn
 
     return decorator
@@ -28,34 +38,44 @@ def route(path: str, methods: list | None = None):
 
 def match_route(path: str, method: str) -> tuple:
     """
-    Returns (handler_fn, kwargs).
+    Returns (handler_fn, kwargs, debug_flag).
     1. Exact match.
     2. Generic {id} template matching — /session/{id}/suffix, /api/session/{id}/suffix.
        Check for comment 'Generic {id} template matching' to detect this block.
     3. Prefix fallback for /session/{id} (legacy).
     kwargs will contain {'session_id': value} for the /session/{id} pattern.
+    debug_flag is True when the matched route was registered with debug=True.
+
+    Backward compatibility: ROUTES entries may be 3-tuples (legacy direct appends
+    in tests); those are treated as debug=False.
     """
     method = method.upper()
 
+    def _debug_flag(entry: tuple) -> bool:
+        return bool(entry[3]) if len(entry) > 3 else False
+
     # Exact match
-    for route_path, route_methods, handler in ROUTES:
+    for entry in ROUTES:
+        route_path, route_methods, handler = entry[0], entry[1], entry[2]
         if path == route_path and method in route_methods:
-            return handler, {}
+            return handler, {}, _debug_flag(entry)
 
     # Generic {id} template matching — supports /session/{id}/suffix, /api/session/{id}/suffix
     # Sort by path length descending so more-specific routes (e.g. /session/{id}.md) win over
     # less-specific ones (e.g. /session/{id}) when both patterns would match.
-    for route_path, route_methods, handler in sorted(ROUTES, key=lambda r: -len(r[0])):
+    for entry in sorted(ROUTES, key=lambda r: -len(r[0])):
+        route_path, route_methods, handler = entry[0], entry[1], entry[2]
         if "{id}" in route_path and method in route_methods:
             pat = "^" + re.escape(route_path).replace("\\{id\\}", "(?P<session_id>[^/]+)") + "$"
             m = re.match(pat, path)
             if m:
-                return handler, {"session_id": m.group("session_id")}
+                return handler, {"session_id": m.group("session_id")}, _debug_flag(entry)
 
     # Prefix pattern for /session/{id} (legacy fallback — catches unknown sub-paths → 400)
-    for route_path, route_methods, handler in ROUTES:
+    for entry in ROUTES:
+        route_path, route_methods, handler = entry[0], entry[1], entry[2]
         if route_path == "/session/{id}" and path.startswith("/session/") and method in route_methods:
             session_id = path[len("/session/") :]
-            return handler, {"session_id": session_id}
+            return handler, {"session_id": session_id}, _debug_flag(entry)
 
-    return None, {}
+    return None, {}, False

--- a/browse/core/registry.py
+++ b/browse/core/registry.py
@@ -14,7 +14,8 @@ if os.name == "nt":
 # debug=True routes receive distinct auth gating in the server dispatcher.
 ROUTES: list = []
 
-# Set of paths registered with debug=True (used by server for fast lookup).
+# Set of paths registered with debug=True. Exposed for test reset; the dispatcher
+# reads the per-route debug flag returned by match_route().
 _DEBUG_ROUTES: set = set()
 
 
@@ -26,9 +27,15 @@ def route(path: str, methods: list | None = None, debug: bool = False):
     """
     if methods is None:
         methods = ["GET"]
+    upper_methods = [m.upper() for m in methods]
+    if debug and upper_methods != ["GET"]:
+        raise ValueError(
+            f"debug=True routes must be GET-only (got {upper_methods} for {path}); "
+            "debug-log endpoints are read-only by contract (WBS-103)."
+        )
 
     def decorator(fn: Callable) -> Callable:
-        ROUTES.append((path, [m.upper() for m in methods], fn, debug))
+        ROUTES.append((path, upper_methods, fn, debug))
         if debug:
             _DEBUG_ROUTES.add(path)
         return fn

--- a/browse/core/server.py
+++ b/browse/core/server.py
@@ -193,8 +193,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
         # Must precede normal auth check — debug routes use a distinct auth path:
         # Bearer/cookie only, no ?token=, no open-auth, static-slot → 403.
         if path.startswith("/api/debug-log/"):
-            from browse.core.auth import _is_loopback_host  # noqa: PLC0415
-            from browse.core.auth import check_debug_token  # noqa: PLC0415
+            from browse.core.auth import _is_loopback_host, check_debug_token  # noqa: PLC0415
 
             _dbg_handler, _dbg_kwargs, _is_debug_route = match_route(path, "GET")
 

--- a/browse/core/server.py
+++ b/browse/core/server.py
@@ -114,7 +114,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
             discovery_cors: dict = {}
             if cors_ok:
                 discovery_cors = {"Access-Control-Allow-Origin": cors_origin, "Vary": "Origin"}
-            handler_fn, kwargs = match_route(path, "GET")
+            handler_fn, kwargs, _dbg = match_route(path, "GET")
             if handler_fn:
                 body, ct, status = handler_fn(self.db, params, self.token, nonce, **kwargs)
             else:
@@ -128,7 +128,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
             healthz_cors: dict = {}
             if cors_ok:
                 healthz_cors = {"Access-Control-Allow-Origin": cors_origin, "Vary": "Origin"}
-            handler_fn, kwargs = match_route(path, "GET")
+            handler_fn, kwargs, _dbg = match_route(path, "GET")
             if handler_fn:
                 body, ct, status = handler_fn(self.db, params, "", nonce, **kwargs)
             else:
@@ -189,6 +189,88 @@ class _BrowseHandler(BaseHTTPRequestHandler):
                     "Vary": "Origin",
                 }
 
+        # ── Debug-log route gate (WBS-103) ────────────────────────────────────
+        # Must precede normal auth check — debug routes use a distinct auth path:
+        # Bearer/cookie only, no ?token=, no open-auth, static-slot → 403.
+        if path.startswith("/api/debug-log/"):
+            from browse.core.auth import _is_loopback_host  # noqa: PLC0415
+            from browse.core.auth import check_debug_token  # noqa: PLC0415
+
+            _dbg_handler, _dbg_kwargs, _is_debug_route = match_route(path, "GET")
+
+            if not _is_debug_route or _dbg_handler is None:
+                # Route not registered (feature disabled) → 404
+                self._send(
+                    b"404 Not Found", "text/plain", 404, nonce,
+                    cors_headers=cors_resp_headers or None, send_body=send_body,
+                )
+                return
+
+            # Reject ?token= query-string auth for debug routes
+            if params.get("token"):
+                self._send(
+                    b"401 Unauthorized", "text/plain", 401, nonce,
+                    cors_headers=cors_resp_headers or None, send_body=send_body,
+                )
+                return
+
+            # Static/demo slot active → 403 (debug not available in demo mode)
+            from browse.core.pairing import get_static_slot as _dbg_get_static  # noqa: PLC0415
+            if _dbg_get_static():
+                self._send(
+                    b"403 Forbidden", "text/plain", 403, nonce,
+                    cors_headers=cors_resp_headers or None, send_body=send_body,
+                )
+                return
+
+            # Debug token auth (Bearer or cookie; empty server token → False)
+            _dbg_cookie = self.headers.get("Cookie", "")
+            _dbg_auth_hdr = self.headers.get("Authorization", "")
+            _dbg_valid, _dbg_token_val = check_debug_token(
+                self.token, _dbg_cookie, _dbg_auth_hdr
+            )
+
+            if not _dbg_valid:
+                # Non-loopback + no server token configured → 403 (insecure config)
+                _dbg_host = self.headers.get("Host", "")
+                if not self.token and not _is_loopback_host(_dbg_host):
+                    self._send(
+                        b"403 Forbidden", "text/plain", 403, nonce,
+                        cors_headers=cors_resp_headers or None, send_body=send_body,
+                    )
+                else:
+                    self._send(
+                        b"401 Unauthorized", "text/plain", 401, nonce,
+                        cors_headers=cors_resp_headers or None, send_body=send_body,
+                    )
+                return
+
+            # Dispatch debug handler
+            try:
+                body, ct, status = _dbg_handler(
+                    self.db, params, _dbg_token_val, nonce, **_dbg_kwargs
+                )
+            except Exception as _dbg_exc:
+                _dbg_req_id = str(uuid.uuid4())
+                print(
+                    f"[error] request_id={_dbg_req_id} method=GET path={path} 500: {_dbg_exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                traceback.print_exc(file=sys.stderr)
+                body = b"500 Internal Server Error"
+                ct = "text/plain"
+                status = 500
+                cors_resp_headers = dict(cors_resp_headers)
+                cors_resp_headers["X-Request-ID"] = _dbg_req_id
+
+            self._send(
+                body, ct, status, nonce,
+                send_body=send_body, cors_headers=cors_resp_headers or None,
+            )
+            return
+        # ── End debug-log gate ────────────────────────────────────────────────
+
         # Auth check (Bearer header, query-string token, or cookie)
         cookie_header = self.headers.get("Cookie", "")
         auth_header = self.headers.get("Authorization", "")
@@ -244,7 +326,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
         # Route dispatch: /api/* and .md data exports via registry;
         # everything else is served by the Next.js root app.
         if path.startswith("/api/") or path.endswith(".md"):
-            handler_fn, kwargs = match_route(path, "GET")
+            handler_fn, kwargs, _dbg = match_route(path, "GET")
             if handler_fn is None:
                 self._send(
                     b"404 Not Found",
@@ -475,7 +557,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
                 return
             _body_bytes = self.rfile.read(_cl) if _cl > 0 else b""
             params["_body"] = [_body_bytes.decode("utf-8", errors="replace")]
-            handler_fn, kwargs = match_route(path, method)
+            handler_fn, kwargs, _dbg = match_route(path, method)
             if handler_fn:
                 body, ct, status = handler_fn(self.db, params, self.token, nonce, **kwargs)
             else:
@@ -574,7 +656,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
         params["_user_agent"] = [self.headers.get("User-Agent", "")]
 
         # Route dispatch
-        handler_fn, kwargs = match_route(path, method)
+        handler_fn, kwargs, _dbg = match_route(path, method)
         if handler_fn is None:
             self._send(
                 b"404 Not Found",

--- a/browse/core/server.py
+++ b/browse/core/server.py
@@ -200,55 +200,72 @@ class _BrowseHandler(BaseHTTPRequestHandler):
             if not _is_debug_route or _dbg_handler is None:
                 # Route not registered (feature disabled) → 404
                 self._send(
-                    b"404 Not Found", "text/plain", 404, nonce,
-                    cors_headers=cors_resp_headers or None, send_body=send_body,
+                    b"404 Not Found",
+                    "text/plain",
+                    404,
+                    nonce,
+                    cors_headers=cors_resp_headers or None,
+                    send_body=send_body,
                 )
                 return
 
             # Reject ?token= query-string auth for debug routes
             if params.get("token"):
                 self._send(
-                    b"401 Unauthorized", "text/plain", 401, nonce,
-                    cors_headers=cors_resp_headers or None, send_body=send_body,
+                    b"401 Unauthorized",
+                    "text/plain",
+                    401,
+                    nonce,
+                    cors_headers=cors_resp_headers or None,
+                    send_body=send_body,
                 )
                 return
 
             # Static/demo slot active → 403 (debug not available in demo mode)
             from browse.core.pairing import get_static_slot as _dbg_get_static  # noqa: PLC0415
+
             if _dbg_get_static():
                 self._send(
-                    b"403 Forbidden", "text/plain", 403, nonce,
-                    cors_headers=cors_resp_headers or None, send_body=send_body,
+                    b"403 Forbidden",
+                    "text/plain",
+                    403,
+                    nonce,
+                    cors_headers=cors_resp_headers or None,
+                    send_body=send_body,
                 )
                 return
 
             # Debug token auth (Bearer or cookie; empty server token → False)
             _dbg_cookie = self.headers.get("Cookie", "")
             _dbg_auth_hdr = self.headers.get("Authorization", "")
-            _dbg_valid, _dbg_token_val = check_debug_token(
-                self.token, _dbg_cookie, _dbg_auth_hdr
-            )
+            _dbg_valid, _dbg_token_val = check_debug_token(self.token, _dbg_cookie, _dbg_auth_hdr)
 
             if not _dbg_valid:
                 # Non-loopback + no server token configured → 403 (insecure config)
                 _dbg_host = self.headers.get("Host", "")
                 if not self.token and not _is_loopback_host(_dbg_host):
                     self._send(
-                        b"403 Forbidden", "text/plain", 403, nonce,
-                        cors_headers=cors_resp_headers or None, send_body=send_body,
+                        b"403 Forbidden",
+                        "text/plain",
+                        403,
+                        nonce,
+                        cors_headers=cors_resp_headers or None,
+                        send_body=send_body,
                     )
                 else:
                     self._send(
-                        b"401 Unauthorized", "text/plain", 401, nonce,
-                        cors_headers=cors_resp_headers or None, send_body=send_body,
+                        b"401 Unauthorized",
+                        "text/plain",
+                        401,
+                        nonce,
+                        cors_headers=cors_resp_headers or None,
+                        send_body=send_body,
                     )
                 return
 
             # Dispatch debug handler
             try:
-                body, ct, status = _dbg_handler(
-                    self.db, params, _dbg_token_val, nonce, **_dbg_kwargs
-                )
+                body, ct, status = _dbg_handler(self.db, params, _dbg_token_val, nonce, **_dbg_kwargs)
             except Exception as _dbg_exc:
                 _dbg_req_id = str(uuid.uuid4())
                 print(
@@ -264,8 +281,12 @@ class _BrowseHandler(BaseHTTPRequestHandler):
                 cors_resp_headers["X-Request-ID"] = _dbg_req_id
 
             self._send(
-                body, ct, status, nonce,
-                send_body=send_body, cors_headers=cors_resp_headers or None,
+                body,
+                ct,
+                status,
+                nonce,
+                send_body=send_body,
+                cors_headers=cors_resp_headers or None,
             )
             return
         # ── End debug-log gate ────────────────────────────────────────────────

--- a/browse/routes/debug_log.py
+++ b/browse/routes/debug_log.py
@@ -1,0 +1,42 @@
+"""browse/routes/debug_log.py — Debug-log probe route (WBS-103).
+
+Registered only when the debug-log feature is enabled:
+  - CLI flag --debug-log, or
+  - BROWSE_DEBUG_LOG_ENABLED=1
+
+All auth/CORS gating is handled in the server dispatcher
+(browse/core/server.py, _handle_get_like debug-log gate).  This module only
+produces safe probe responses: no filesystem paths, no session content, no
+event counts.
+"""
+
+import json
+import os
+import sys
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+from browse.core.registry import route
+
+
+@route("/api/debug-log/healthz", methods=["GET"], debug=True)
+def handle_debug_log_healthz(db, params, token, nonce) -> tuple:
+    """Return a safe probe payload: ok / enabled / retention config only.
+
+    Never reveals filesystem paths, session content, or event counts.
+    """
+    from browse.core.debug_log_storage import get_config, is_enabled  # noqa: PLC0415
+
+    cfg = get_config()
+    payload = json.dumps(
+        {
+            "ok": True,
+            "enabled": is_enabled(),
+            "retention": cfg,
+        },
+        ensure_ascii=False,
+    )
+    return payload.encode("utf-8"), "application/json", 200

--- a/docs/DEBUG-LOG-CONTRACT.md
+++ b/docs/DEBUG-LOG-CONTRACT.md
@@ -1,8 +1,8 @@
 # Agent Debug Log Browse Contract
 
 **Schema version:** `1`
-**Status:** Draft — WBS-101
-**Blocks:** WBS-103 (backend route), WBS-104/WBS-105 (UI), WBS-106 (TS/Zod schemas)
+**Status:** WBS-101 complete; WBS-103 storage/transport complete
+**Blocks:** WBS-104/WBS-105 (UI), WBS-106 (TS/Zod schemas)
 **Redaction policy:** See [Security & Redaction](#security--redaction) — WBS-102
 
 ---
@@ -171,7 +171,7 @@ the formula for its own `span_id`; it simply inherits the start row's value.
 - Full raw prompt text, tool input/output payloads, and assistant response bodies are **excluded**
   from the default `BrowseDebugEntry` contract.
 - If the UI requires full content, a separate `GET /api/session/{id}/debug-log/{idx}/raw`
-  endpoint is reserved for WBS-103 design.
+  endpoint is reserved for a future WBS iteration beyond WBS-103.
 
 ---
 
@@ -230,17 +230,137 @@ This contract defines only the **boundary**:
 
 ---
 
+## WBS-103 Storage and Transport Contract
+
+### Feature gating
+
+The debug-log feature is **disabled by default**. Enable via:
+
+- CLI flag `--debug-log`, or
+- environment variable `BROWSE_DEBUG_LOG_ENABLED=1`
+
+When disabled, `/api/debug-log/healthz` returns **404**. No DB is opened, no events are stored.
+
+### Storage location and isolation
+
+| Property | Value |
+|---|---|
+| Default DB path | `~/.copilot/operator-console/debug-log/debug-log.db` |
+| Override directory | `--debug-log-dir <dir>` / `BROWSE_DEBUG_LOG_DIR` |
+| SQLite pragmas | `journal_mode=WAL`, `synchronous=NORMAL` |
+| Relation to `knowledge.db` | **Separate DB**; never merged or co-located |
+| Relation to session-state | Path is outside `~/.copilot/session-state/` by default |
+
+**Isolation guarantees (verified by `tests/test_browse_debug_log_exclusion.py`):**
+
+- `watch-sessions.py` ignores `.db` files by extension — `debug-log.db` is never indexed.
+- `sync-knowledge.py` auto-detect targets only `knowledge.db` paths; `operator-console/` is excluded.
+- `build-session-index.py` has no reference to `operator-console` or `debug-log`.
+- Session export body (`/session/{id}.md`) excludes `debug-log`/`operator-console` content.
+
+### CLI flags and environment variables
+
+| CLI flag | Env variable | Default | Description |
+|---|---|---|---|
+| `--debug-log` | `BROWSE_DEBUG_LOG_ENABLED=1` | disabled | Enable feature |
+| `--debug-log-dir` | `BROWSE_DEBUG_LOG_DIR` | `~/.copilot/operator-console/debug-log/` | Storage directory |
+| `--debug-log-max-age-seconds` | `BROWSE_DEBUG_LOG_MAX_AGE_S` | `86400` (24 h) | Max event age in seconds |
+| `--debug-log-max-bytes` | `BROWSE_DEBUG_LOG_MAX_BYTES` | `52428800` (50 MiB) | Max total DB payload bytes |
+| `--debug-log-retention-interval` | `BROWSE_DEBUG_LOG_RETENTION_INTERVAL_S` | `300` (5 min) | Retention daemon poll interval |
+| `--debug-log-ephemeral` | `BROWSE_DEBUG_LOG_EPHEMERAL=1` | off | Remove DB + WAL/SHM on clean shutdown |
+
+### Storage schema (`debug_log_storage.py`)
+
+```sql
+CREATE TABLE debug_log_events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_ns      INTEGER NOT NULL,
+    session_id TEXT NOT NULL,
+    idx        INTEGER NOT NULL,
+    kind       TEXT NOT NULL,
+    payload    TEXT NOT NULL,   -- redacted JSON only
+    byte_len   INTEGER NOT NULL
+);
+CREATE TABLE debug_log_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+-- schema_version = '1'
+```
+
+### Retention and pruning
+
+Pruning is deterministic and runs in two ordered passes:
+
+1. **Age pass** — delete rows where `ts_ns < now_ns - (max_age_s × 1 000 000 000)`.
+2. **Size pass** — while `SUM(byte_len) > max_bytes`, delete the oldest 100 rows by `(ts_ns ASC, id ASC)`.
+
+The optional background retention thread polls every `retention_interval_s` seconds.
+`shutdown_storage()` stops the thread (2-second join), closes the DB, and optionally removes files.
+**No `atexit` handlers; no signal handlers.** Clean shutdown must be triggered explicitly from `main`'s
+`finally` block. SIGKILL / process kill can leave `debug-log.db`, `-wal`, and `-shm` files on disk.
+
+### Payload serialization
+
+`append_event()` passes every payload through `browse.core.redaction.redact_entry` before insert.
+Only the **redacted JSON string** is stored; unredacted data is never written to the DB.
+If `redact_entry` returns a dict without a `redacted` key, the insert is refused with `ValueError`.
+
+### `/api/debug-log/healthz` endpoint
+
+| Property | Value |
+|---|---|
+| Method | `GET` |
+| Path | `/api/debug-log/healthz` |
+| Registered when | feature enabled only |
+| Response `Content-Type` | `application/json` |
+
+**Response body (non-sensitive only):**
+
+```json
+{
+  "ok": true,
+  "enabled": true,
+  "retention": {
+    "max_age_seconds": 86400,
+    "max_bytes": 52428800,
+    "interval_seconds": 300
+  }
+}
+```
+
+The response **never** includes filesystem paths, event counts, session content, or stored debug data.
+
+### Authentication and status semantics
+
+| Condition | Response |
+|---|---|
+| Feature disabled (route not registered) | `404 Not Found` |
+| Feature enabled; `?token=` query-string auth present | `401 Unauthorized` (query-string auth rejected for debug routes) |
+| Feature enabled; static/demo slot active | `403 Forbidden` |
+| Feature enabled; non-loopback host with no server token configured | `403 Forbidden` |
+| Feature enabled; missing or invalid Bearer/cookie token | `401 Unauthorized` |
+| Feature enabled; valid Bearer header or session cookie | `200 OK` |
+
+Auth is handled by `check_debug_token()` in `browse/core/auth.py`: Bearer header > cookie; empty
+server token always returns `(False, "")` — **no open-auth debug route**.
+
+### Transport security
+
+`/api/debug-log/*` inherits the same CORS/PNA/Vary policy as all `/api` routes:
+allowlisted `Origin` only; `Vary: Origin` set; Private Network Access preflight supported.
+No CSP loosening is applied for debug routes.
+
+---
+
 ## Non-Goals
 
-The following are explicitly **out of scope** for this contract (WBS-101):
+The following are explicitly **out of scope** for the current debug-log contract:
 
-1. Backend HTTP route implementation (`GET /api/session/{id}/debug-log`) — WBS-103.
+1. Full debug-log read/query API (`GET /api/session/{id}/debug-log`) — WBS-103 implemented only the healthz probe and storage layer; the session-scoped read route remains future work.
 2. Frontend UI panel or event row renderer — WBS-104/WBS-105.
 3. TypeScript / Zod schema implementation — WBS-106.
 4. SSE streaming of debug log events — WBS-107.
 5. Redaction engine implementation — WBS-102.
-6. Persistence or indexing of debug log entries — existing `event_offsets` table handles raw
-   indexing; WBS-101 does not change the DB schema.
+6. Syncing or indexing debug-log entries into `knowledge.db` / session-state — WBS-103 persistence
+   stays in the isolated local debug-log DB only.
 7. Real-time filtering or search — WBS-108+.
 8. Performance benchmarks — WBS-109.
 9. CI integration — WBS-110.

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -564,7 +564,7 @@ def run_all_tests() -> int:
     import browse.routes.session_compare  # noqa: F401 — registers @route
     from browse.core.registry import match_route as _match_route
 
-    h20, kw20 = _match_route("/compare", "GET")
+    h20, kw20, _dbg20 = _match_route("/compare", "GET")
     test("T20: /compare route registered", h20 is not None)
 
     # Form fallback when params are empty

--- a/tests/test_browse_agents.py
+++ b/tests/test_browse_agents.py
@@ -67,23 +67,23 @@ def run_all_tests() -> int:
     # The old /session/{id}/agents routes are gone. /session/{id} is a wildcard
     # that may absorb "abc/agents" as a session_id — that's fine. What matters is
     # that no dedicated agents handler is registered.
-    handler_html, kw_html = match_route("/session/abc/agents", "GET")
+    handler_html, kw_html, _dbg_html = match_route("/session/abc/agents", "GET")
     # Either not found, or falls through to session_detail (not an agents handler)
     test("T3: /session/{id}/agents → no dedicated agents handler",
          handler_html is None or handler_html is handle_session_detail)
 
-    handler_api, _ = match_route("/api/session/abc/agents", "GET")
+    handler_api, _, _dbg_api = match_route("/api/session/abc/agents", "GET")
     test("T3: /api/session/{id}/agents → not registered (None)", handler_api is None)
 
     # Verify /session/{id}/timeline still works (no regression)
     from browse.routes.timeline import handle_session_timeline
-    handler_tl, kwargs_tl = match_route("/session/abc-123/timeline", "GET")
+    handler_tl, kwargs_tl, _dbg_tl = match_route("/session/abc-123/timeline", "GET")
     test("T3: /session/{id}/timeline still resolves", handler_tl is handle_session_timeline)
     test("T3: timeline session_id extracted", kwargs_tl.get("session_id") == "abc-123")
 
     # Verify /session/{id} still works (no regression)
     from browse.routes.session_detail import handle_session_detail
-    handler3, kwargs3 = match_route("/session/abc-123-def", "GET")
+    handler3, kwargs3, _dbg3 = match_route("/session/abc-123-def", "GET")
     test("T3: /session/{id} still resolves to session_detail", handler3 is handle_session_detail)
     test("T3: /session/{id} session_id correct", kwargs3.get("session_id") == "abc-123-def")
 

--- a/tests/test_browse_core_registry.py
+++ b/tests/test_browse_core_registry.py
@@ -31,12 +31,16 @@ def test(name: str, expr: bool) -> None:
 def _with_clean_routes(fn):
     """Run fn with a clean ROUTES list, restoring original after."""
     original = list(registry_mod.ROUTES)
+    original_debug = set(registry_mod._DEBUG_ROUTES)
     registry_mod.ROUTES.clear()
+    registry_mod._DEBUG_ROUTES.clear()
     try:
         fn()
     finally:
         registry_mod.ROUTES.clear()
+        registry_mod._DEBUG_ROUTES.clear()
         registry_mod.ROUTES.extend(original)
+        registry_mod._DEBUG_ROUTES.update(original_debug)
 
 
 # ── @route decorator ──────────────────────────────────────────────────────────
@@ -79,6 +83,7 @@ def test_route_decorator_multiple_methods():
 
 def test_route_decorator_returns_fn():
     """Decorator should return the original function unchanged."""
+
     def _inner():
         def original():
             return "original"
@@ -86,6 +91,72 @@ def test_route_decorator_returns_fn():
         decorated = registry_mod.route("/noop", methods=["GET"])(original)
         test("route_decorator: returns fn", decorated is original)
         test("route_decorator: fn callable", decorated() == "original")
+
+    _with_clean_routes(_inner)
+
+
+def test_debug_route_accepts_get_only():
+    """debug=True routes are GET-only and match with debug=True."""
+
+    def _inner():
+        @registry_mod.route("/api/debug-log/test", methods=["GET"], debug=True)
+        def _handler():
+            pass
+
+        fn, kwargs, dbg = registry_mod.match_route("/api/debug-log/test", "GET")
+        test("debug_route_get: handler found", fn is _handler)
+        test("debug_route_get: no kwargs", kwargs == {})
+        test("debug_route_get: debug True", dbg is True)
+        test(
+            "debug_route_get: debug path tracked",
+            "/api/debug-log/test" in registry_mod._DEBUG_ROUTES,
+        )
+
+    _with_clean_routes(_inner)
+
+
+def test_debug_route_default_methods_ok():
+    """debug=True without methods defaults to GET and is accepted."""
+
+    def _inner():
+        @registry_mod.route("/api/debug-log/default", debug=True)
+        def _handler():
+            pass
+
+        fn, _, dbg = registry_mod.match_route("/api/debug-log/default", "GET")
+        test("debug_route_default: handler found", fn is _handler)
+        test("debug_route_default: debug True", dbg is True)
+
+    _with_clean_routes(_inner)
+
+
+def test_debug_route_rejects_post():
+    """debug=True rejects mutating-only routes instead of silently bypassing debug auth."""
+
+    def _inner():
+        try:
+            registry_mod.route("/api/debug-log/post", methods=["POST"], debug=True)(lambda: None)
+            test("debug_route_post: rejected", False)
+        except ValueError as exc:
+            message = str(exc)
+            test("debug_route_post: rejected", True)
+            test("debug_route_post: mentions GET-only", "GET-only" in message)
+            test("debug_route_post: mentions path", "/api/debug-log/post" in message)
+
+    _with_clean_routes(_inner)
+
+
+def test_debug_route_rejects_mixed_methods():
+    """debug=True rejects mixed GET+mutating routes."""
+
+    def _inner():
+        try:
+            registry_mod.route("/api/debug-log/mixed", methods=["GET", "POST"], debug=True)(lambda: None)
+            test("debug_route_mixed: rejected", False)
+        except ValueError as exc:
+            message = str(exc)
+            test("debug_route_mixed: rejected", True)
+            test("debug_route_mixed: mentions WBS-103", "WBS-103" in message)
 
     _with_clean_routes(_inner)
 
@@ -208,6 +279,10 @@ if __name__ == "__main__":
     test_route_decorator_default_methods()
     test_route_decorator_multiple_methods()
     test_route_decorator_returns_fn()
+    test_debug_route_accepts_get_only()
+    test_debug_route_default_methods_ok()
+    test_debug_route_rejects_post()
+    test_debug_route_rejects_mixed_methods()
     test_match_route_exact()
     test_match_route_no_match()
     test_match_route_method_mismatch()

--- a/tests/test_browse_core_registry.py
+++ b/tests/test_browse_core_registry.py
@@ -98,18 +98,20 @@ def test_match_route_exact():
             pass
 
         registry_mod.ROUTES.append(("/exact/path", ["GET"], _handler))
-        fn, kwargs = registry_mod.match_route("/exact/path", "GET")
+        fn, kwargs, dbg = registry_mod.match_route("/exact/path", "GET")
         test("match_exact: handler found", fn is _handler)
         test("match_exact: no kwargs", kwargs == {})
+        test("match_exact: debug False", dbg is False)
 
     _with_clean_routes(_inner)
 
 
 def test_match_route_no_match():
     def _inner():
-        fn, kwargs = registry_mod.match_route("/nonexistent", "GET")
+        fn, kwargs, dbg = registry_mod.match_route("/nonexistent", "GET")
         test("match_none: fn is None", fn is None)
         test("match_none: empty kwargs", kwargs == {})
+        test("match_none: debug False", dbg is False)
 
     _with_clean_routes(_inner)
 
@@ -120,7 +122,7 @@ def test_match_route_method_mismatch():
             pass
 
         registry_mod.ROUTES.append(("/path", ["GET"], _handler))
-        fn, kwargs = registry_mod.match_route("/path", "POST")
+        fn, kwargs, dbg = registry_mod.match_route("/path", "POST")
         test("match_method_mismatch: no match", fn is None)
 
     _with_clean_routes(_inner)
@@ -133,7 +135,7 @@ def test_match_route_method_case_insensitive():
             pass
 
         registry_mod.ROUTES.append(("/path", ["GET"], _handler))
-        fn, kwargs = registry_mod.match_route("/path", "get")
+        fn, kwargs, dbg = registry_mod.match_route("/path", "get")
         test("match_case: lowercase method matches", fn is _handler)
 
     _with_clean_routes(_inner)
@@ -145,7 +147,7 @@ def test_match_route_id_template():
             pass
 
         registry_mod.ROUTES.append(("/session/{id}", ["GET"], _handler))
-        fn, kwargs = registry_mod.match_route("/session/abc123", "GET")
+        fn, kwargs, dbg = registry_mod.match_route("/session/abc123", "GET")
         test("match_id: handler found", fn is _handler)
         test("match_id: session_id extracted", kwargs.get("session_id") == "abc123")
 
@@ -159,7 +161,7 @@ def test_match_route_id_template_complex():
             pass
 
         registry_mod.ROUTES.append(("/api/session/{id}/details", ["GET"], _handler))
-        fn, kwargs = registry_mod.match_route("/api/session/sess-xyz/details", "GET")
+        fn, kwargs, dbg = registry_mod.match_route("/api/session/sess-xyz/details", "GET")
         test("match_id_complex: handler found", fn is _handler)
         test("match_id_complex: session_id", kwargs.get("session_id") == "sess-xyz")
 
@@ -177,7 +179,7 @@ def test_match_route_more_specific_wins():
 
         registry_mod.ROUTES.append(("/session/{id}", ["GET"], _short))
         registry_mod.ROUTES.append(("/session/{id}.md", ["GET"], _long))
-        fn, kwargs = registry_mod.match_route("/session/abc.md", "GET")
+        fn, kwargs, dbg = registry_mod.match_route("/session/abc.md", "GET")
         test("match_specific: longer route wins", fn is _long)
 
     _with_clean_routes(_inner)
@@ -193,8 +195,8 @@ def test_match_route_multiple_routes():
 
         registry_mod.ROUTES.append(("/route/one", ["GET"], _h1))
         registry_mod.ROUTES.append(("/route/two", ["GET"], _h2))
-        fn1, _ = registry_mod.match_route("/route/one", "GET")
-        fn2, _ = registry_mod.match_route("/route/two", "GET")
+        fn1, _, _dbg1 = registry_mod.match_route("/route/one", "GET")
+        fn2, _, _dbg2 = registry_mod.match_route("/route/two", "GET")
         test("match_multi: first route", fn1 is _h1)
         test("match_multi: second route", fn2 is _h2)
 

--- a/tests/test_browse_debug_log_exclusion.py
+++ b/tests/test_browse_debug_log_exclusion.py
@@ -15,6 +15,7 @@ Verifies that the debug-log DB is correctly isolated from all other pipelines:
 import os
 import sys
 import tempfile
+import types
 from pathlib import Path
 
 if os.name == "nt":
@@ -285,12 +286,13 @@ def test_build_session_index_no_debug_log_ref():
 
 def test_session_export_no_debug_log():
     """Session export (*.md route) output does not include debug-log path or content."""
-    import sqlite3
-    from browse.core.server import _make_handler_class
-    from http.server import ThreadingHTTPServer
     import http.client
-    import threading
     import json
+    import sqlite3
+    import threading
+    from http.server import ThreadingHTTPServer
+
+    from browse.core.server import _make_handler_class
 
     db = sqlite3.connect(":memory:", check_same_thread=False)
     db.row_factory = sqlite3.Row
@@ -375,7 +377,6 @@ class _WatchSigsHelper:
 
 
 # Monkey-patch the helper module reference used by test_watch_get_file_signatures_ignores_db_files
-import types
 _shim = types.ModuleType("watch_sessions_import_helper")
 _shim.get_file_signatures_fn = None
 sys.modules["watch_sessions_import_helper"] = _shim
@@ -419,6 +420,6 @@ if __name__ == "__main__":
     print("\n-- session export exclusion")
     test_session_export_no_debug_log()
 
-    print(f"\n==================================================")
+    print("\n==================================================")
     print(f"Results: {_PASS} passed, {_FAIL} failed")
     sys.exit(0 if _FAIL == 0 else 1)

--- a/tests/test_browse_debug_log_exclusion.py
+++ b/tests/test_browse_debug_log_exclusion.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""test_browse_debug_log_exclusion.py — Isolation tests for WBS-103 debug-log storage.
+
+Verifies that the debug-log DB is correctly isolated from all other pipelines:
+  - default_debug_log_path() is NOT under session-state
+  - default_debug_log_path() is NOT knowledge.db
+  - watch-sessions.py get_file_signatures ignores .db files by extension
+  - sync-knowledge.py auto-detect never includes operator-console path
+  - build-session-index.py does not reference operator-console or debug-log dir
+  - BROWSE_DEBUG_LOG_DIR override still produces a path with debug-log.db filename
+  - debug-log.db would not be picked up even if placed inside a watched dir
+    (extension filter)
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+_PASS = 0
+_FAIL = 0
+
+
+def test(name: str, expr: bool) -> None:
+    global _PASS, _FAIL
+    if expr:
+        _PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        _FAIL += 1
+        print(f"  FAIL  {name}")
+
+
+# ── default_debug_log_path isolation ─────────────────────────────────────────
+
+def test_default_path_not_under_session_state():
+    """default_debug_log_path() must not resolve to a path under session-state."""
+    from browse.core.debug_log_storage import default_debug_log_path
+
+    old = os.environ.pop("BROWSE_DEBUG_LOG_DIR", None)
+    try:
+        p = default_debug_log_path()
+        path_str = str(p).replace("\\", "/").lower()
+        test(
+            "isolation: default path not under session-state",
+            "session-state" not in path_str,
+        )
+        test(
+            "isolation: default path not under knowledge.db parent",
+            "knowledge.db" not in path_str,
+        )
+        test(
+            "isolation: default path is under operator-console",
+            "operator-console" in path_str,
+        )
+        test(
+            "isolation: default path is under debug-log subdir",
+            "debug-log" in path_str,
+        )
+        test(
+            "isolation: default path filename is debug-log.db",
+            p.name == "debug-log.db",
+        )
+    finally:
+        if old is not None:
+            os.environ["BROWSE_DEBUG_LOG_DIR"] = old
+
+
+def test_default_path_not_knowledge_db():
+    """default_debug_log_path() must not equal the knowledge.db path."""
+    from browse.core.debug_log_storage import default_debug_log_path
+
+    old = os.environ.pop("BROWSE_DEBUG_LOG_DIR", None)
+    try:
+        p = default_debug_log_path()
+        # Common knowledge.db location
+        session_state = Path.home() / ".copilot" / "session-state"
+        knowledge_db = session_state / "knowledge.db"
+        test(
+            "isolation: default path != knowledge.db",
+            p.resolve() != knowledge_db.resolve(),
+        )
+    finally:
+        if old is not None:
+            os.environ["BROWSE_DEBUG_LOG_DIR"] = old
+
+
+# ── watch-sessions.py extension filter ───────────────────────────────────────
+
+def test_watch_get_file_signatures_ignores_db_files():
+    """get_file_signatures only picks up *.md, *.txt, *.jsonl — ignores *.db."""
+    from watch_sessions_import_helper import get_file_signatures_fn
+
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        session_dir = base / "fake-session-uuid"
+        session_dir.mkdir()
+
+        # Create files in the watched directory
+        (session_dir / "SUMMARY.md").write_text("test")
+        (session_dir / "notes.txt").write_text("test")
+        (session_dir / "events.jsonl").write_text("{}")
+        db_file = session_dir / "debug-log.db"
+        db_file.write_bytes(b"SQLite format 3\x00")
+
+        sigs = get_file_signatures_fn([base])
+
+        sigs_paths = list(sigs.keys())
+        test(
+            "watch_sigs: *.md file is tracked",
+            any("SUMMARY.md" in p for p in sigs_paths),
+        )
+        test(
+            "watch_sigs: *.txt file is tracked",
+            any("notes.txt" in p for p in sigs_paths),
+        )
+        test(
+            "watch_sigs: *.jsonl file is tracked",
+            any("events.jsonl" in p for p in sigs_paths),
+        )
+        test(
+            "watch_sigs: debug-log.db NOT tracked",
+            not any("debug-log.db" in p for p in sigs_paths),
+        )
+        test(
+            "watch_sigs: *.db files NOT tracked",
+            not any(p.endswith(".db") for p in sigs_paths),
+        )
+
+
+def _import_get_file_signatures():
+    """Import get_file_signatures from watch-sessions.py without running main."""
+    import importlib.util
+    repo = Path(__file__).parent.parent
+    spec = importlib.util.spec_from_file_location(
+        "watch_sessions", repo / "watch-sessions.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # Avoid executing the __main__ block
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod.get_file_signatures
+
+
+def test_watch_get_file_signatures_via_direct_import():
+    """get_file_signatures ignores .db files — verified by direct import."""
+    try:
+        fn = _import_get_file_signatures()
+    except Exception as e:
+        test("watch_direct_import: can import get_file_signatures", False)
+        print(f"    Import error: {e}")
+        return
+
+    test("watch_direct_import: can import get_file_signatures", True)
+
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        session_dir = base / "session-abc123"
+        session_dir.mkdir()
+
+        (session_dir / "doc.md").write_text("hello")
+        (session_dir / "debug-log.db").write_bytes(b"\x00" * 16)
+        (session_dir / "debug-log.db-wal").write_bytes(b"\x00" * 8)
+
+        sigs = fn([base])
+        paths = list(sigs.keys())
+
+        test(
+            "watch_direct: doc.md tracked",
+            any("doc.md" in p for p in paths),
+        )
+        test(
+            "watch_direct: debug-log.db not tracked",
+            not any("debug-log.db" in p for p in paths),
+        )
+        test(
+            "watch_direct: debug-log.db-wal not tracked",
+            not any("debug-log.db-wal" in p for p in paths),
+        )
+
+
+# ── sync-knowledge.py auto-detect ────────────────────────────────────────────
+
+def test_sync_autodetect_source():
+    """sync-knowledge.py auto-detect source: only targets knowledge.db paths."""
+    import importlib.util
+    repo = Path(__file__).parent.parent
+    spec = importlib.util.spec_from_file_location(
+        "sync_knowledge", repo / "sync-knowledge.py"
+    )
+    try:
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    except Exception as e:
+        test("sync_autodetect: can import sync-knowledge.py", False)
+        print(f"    Import error: {e}")
+        return
+
+    test("sync_autodetect: can import sync-knowledge.py", True)
+
+    # The auto-detect function should exist
+    fn = getattr(mod, "get_auto_detect_sources", None) or getattr(mod, "_auto_detect_sources", None)
+    if fn is None:
+        # Try searching for any function that discovers source paths
+        for attr_name in dir(mod):
+            attr = getattr(mod, attr_name, None)
+            if callable(attr) and "detect" in attr_name.lower():
+                fn = attr
+                break
+
+    if fn is None:
+        # Just verify the module source doesn't hardcode operator-console
+        source_code = (repo / "sync-knowledge.py").read_text(encoding="utf-8")
+        test(
+            "sync_autodetect: source does not reference operator-console",
+            "operator-console" not in source_code,
+        )
+        test(
+            "sync_autodetect: source does not reference debug-log",
+            "debug-log" not in source_code,
+        )
+        return
+
+    try:
+        sources = fn() or []
+        paths_str = [str(p) for p in sources]
+        test(
+            "sync_autodetect: no operator-console in detected sources",
+            not any("operator-console" in p for p in paths_str),
+        )
+        test(
+            "sync_autodetect: no debug-log in detected sources",
+            not any("debug-log" in p for p in paths_str),
+        )
+    except Exception as e:
+        # Auto-detect may fail in test env (no real WSL etc.) — just verify source
+        source_code = (repo / "sync-knowledge.py").read_text(encoding="utf-8")
+        test(
+            "sync_autodetect: source does not reference operator-console",
+            "operator-console" not in source_code,
+        )
+        test(
+            "sync_autodetect: source does not reference debug-log",
+            "debug-log" not in source_code,
+        )
+
+
+# ── build-session-index.py isolation ─────────────────────────────────────────
+
+def test_build_session_index_no_debug_log_ref():
+    """build-session-index.py source does not reference debug-log or operator-console."""
+    repo = Path(__file__).parent.parent
+    bsi = repo / "build-session-index.py"
+    if not bsi.exists():
+        test("bsi_isolation: build-session-index.py not found (skip)", True)
+        return
+
+    src = bsi.read_text(encoding="utf-8")
+    test(
+        "bsi_isolation: no 'operator-console' in source",
+        "operator-console" not in src,
+    )
+    test(
+        "bsi_isolation: no 'debug-log' in source",
+        "debug-log" not in src,
+    )
+    test(
+        "bsi_isolation: only indexes knowledge.db",
+        "knowledge.db" in src or "SK_DB_PATH" in src,
+    )
+
+
+# ── Session export exclusion ──────────────────────────────────────────────────
+
+def test_session_export_no_debug_log():
+    """Session export (*.md route) output does not include debug-log path or content."""
+    import sqlite3
+    from browse.core.server import _make_handler_class
+    from http.server import ThreadingHTTPServer
+    import http.client
+    import threading
+    import json
+
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.executescript("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            summary TEXT DEFAULT '',
+            repository TEXT DEFAULT '',
+            branch TEXT DEFAULT '',
+            path TEXT DEFAULT '',
+            source TEXT DEFAULT '',
+            event_count_estimate INTEGER DEFAULT 0,
+            fts_indexed_at TEXT DEFAULT NULL,
+            file_mtime TEXT DEFAULT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT ''
+        );
+        CREATE TABLE IF NOT EXISTS documents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            seq INTEGER DEFAULT 0,
+            title TEXT DEFAULT '',
+            doc_type TEXT DEFAULT ''
+        );
+        CREATE TABLE IF NOT EXISTS sections (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            document_id INTEGER,
+            section_name TEXT DEFAULT '',
+            content TEXT DEFAULT ''
+        );
+    """)
+    db.execute(
+        "INSERT INTO sessions (id, summary, source) VALUES ('export-test', 'export isolation test', 'test')"
+    )
+    db.commit()
+
+    # Import export route to register it
+    import browse.routes.session_export  # noqa: F401
+
+    HandlerClass = _make_handler_class(db, "export-token")
+    server = ThreadingHTTPServer(("127.0.0.1", 0), HandlerClass)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    port = server.server_address[1]
+
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "GET",
+            "/session/export-test.md",
+            headers={"Authorization": "Bearer export-token"},
+        )
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8", errors="replace")
+
+        test("export_isolation: status 200", resp.status == 200)
+        test(
+            "export_isolation: no debug-log in body",
+            "debug-log" not in body.lower(),
+        )
+        test(
+            "export_isolation: no operator-console in body",
+            "operator-console" not in body.lower(),
+        )
+    finally:
+        server.shutdown()
+
+
+# ── Helper shim for watch-sessions import ────────────────────────────────────
+# We use a simple direct-import approach instead of a shim module.
+
+class _WatchSigsHelper:
+    """Lazy import helper for get_file_signatures from watch-sessions.py."""
+    _fn = None
+
+    @classmethod
+    def get(cls):
+        if cls._fn is not None:
+            return cls._fn
+        cls._fn = _import_get_file_signatures()
+        return cls._fn
+
+
+# Monkey-patch the helper module reference used by test_watch_get_file_signatures_ignores_db_files
+import types
+_shim = types.ModuleType("watch_sessions_import_helper")
+_shim.get_file_signatures_fn = None
+sys.modules["watch_sessions_import_helper"] = _shim
+
+
+def _init_shim():
+    try:
+        sys.modules["watch_sessions_import_helper"].get_file_signatures_fn = \
+            _import_get_file_signatures()
+        return True
+    except Exception as e:
+        print(f"  [warn] Could not import watch-sessions.py: {e}")
+        return False
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    print("\n=== debug_log exclusion / isolation tests ===\n")
+
+    shim_ok = _init_shim()
+
+    print("-- default_debug_log_path isolation")
+    test_default_path_not_under_session_state()
+    test_default_path_not_knowledge_db()
+
+    print("\n-- watch-sessions extension filter")
+    if shim_ok:
+        test_watch_get_file_signatures_ignores_db_files()
+        test_watch_get_file_signatures_via_direct_import()
+    else:
+        # Shim failed — run only the direct-import variant
+        test_watch_get_file_signatures_via_direct_import()
+
+    print("\n-- sync-knowledge auto-detect")
+    test_sync_autodetect_source()
+
+    print("\n-- build-session-index isolation")
+    test_build_session_index_no_debug_log_ref()
+
+    print("\n-- session export exclusion")
+    test_session_export_no_debug_log()
+
+    print(f"\n==================================================")
+    print(f"Results: {_PASS} passed, {_FAIL} failed")
+    sys.exit(0 if _FAIL == 0 else 1)

--- a/tests/test_browse_debug_log_storage.py
+++ b/tests/test_browse_debug_log_storage.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""test_browse_debug_log_storage.py — Unit tests for browse/core/debug_log_storage.py.
+
+Covers:
+  - Schema initialized correctly (tables + meta row)
+  - append_event calls redaction and stores redacted JSON
+  - Query orders by idx (session_id + idx index)
+  - Age prune deletes expired rows
+  - Size prune deletes oldest rows until under cap
+  - No-op prune on empty DB
+  - Ephemeral shutdown removes db/-wal/-shm
+  - Non-ephemeral shutdown persists DB
+  - shutdown_storage idempotent / safe without prior init
+  - Retention thread starts and stops
+  - Retention loop deletes expired rows
+  - Default path is outside session-state directory
+  - init_storage raises on bad path (no silent fallback)
+  - Re-init after shutdown works (stop_event is reset)
+  - get_config returns correct snapshot
+"""
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import browse.core.debug_log_storage as _dls  # noqa: E402
+
+_PASS = 0
+_FAIL = 0
+
+
+def test(name: str, expr: bool) -> None:
+    global _PASS, _FAIL
+    if expr:
+        _PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        _FAIL += 1
+        print(f"  FAIL  {name}")
+
+
+def _reset():
+    """Ensure storage is fully shut down and module state is clean."""
+    _dls.shutdown_storage()
+
+
+# ── Schema initialization ─────────────────────────────────────────────────────
+
+def test_schema_tables_exist():
+    """init_storage creates debug_log_events and debug_log_meta tables."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "test.db"
+        _reset()
+        _dls.init_storage(db_path=db_path)
+        try:
+            with _dls._lock:
+                c = _dls._conn
+                tables = {
+                    r[0] for r in c.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table'"
+                    ).fetchall()
+                }
+            test("schema: debug_log_events table exists", "debug_log_events" in tables)
+            test("schema: debug_log_meta table exists", "debug_log_meta" in tables)
+        finally:
+            _reset()
+
+
+def test_schema_meta_version():
+    """init_storage inserts schema_version=1 into debug_log_meta."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "test.db"
+        _reset()
+        _dls.init_storage(db_path=db_path)
+        try:
+            with _dls._lock:
+                c = _dls._conn
+                row = c.execute(
+                    "SELECT value FROM debug_log_meta WHERE key='schema_version'"
+                ).fetchone()
+            test("schema: meta schema_version row exists", row is not None)
+            test("schema: schema_version == '1'", row is not None and row[0] == "1")
+        finally:
+            _reset()
+
+
+# ── append_event ──────────────────────────────────────────────────────────────
+
+def test_append_event_stores_redacted():
+    """append_event calls redact_entry and stores the redacted JSON payload."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "test.db"
+        _reset()
+        _dls.init_storage(db_path=db_path)
+        try:
+            _dls.append_event("sess-abc", 0, "tool_call", {"tool": "bash", "cmd": "ls"})
+            with _dls._lock:
+                c = _dls._conn
+                rows = c.execute(
+                    "SELECT session_id, idx, kind, payload, byte_len FROM debug_log_events"
+                ).fetchall()
+            test("append: one row inserted", len(rows) == 1)
+            row = rows[0]
+            test("append: session_id correct", row[0] == "sess-abc")
+            test("append: idx correct", row[1] == 0)
+            test("append: kind correct", row[2] == "tool_call")
+            parsed = json.loads(row[3])
+            test("append: payload has 'redacted' key", "redacted" in parsed)
+            test("append: byte_len positive", row[4] > 0)
+        finally:
+            _reset()
+
+
+def test_append_event_not_initialized():
+    """append_event raises RuntimeError when storage not initialized."""
+    _reset()
+    try:
+        _dls.append_event("s", 0, "kind", {})
+        test("append_uninit: raises RuntimeError", False)
+    except RuntimeError:
+        test("append_uninit: raises RuntimeError", True)
+    except Exception:
+        test("append_uninit: raises RuntimeError", False)
+
+
+def test_append_event_multiple_ordered_by_idx():
+    """Multiple appends for same session are ordered by idx."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "test.db"
+        _reset()
+        _dls.init_storage(db_path=db_path)
+        try:
+            for i in range(5):
+                _dls.append_event("sess-order", i, "kind", {"n": i})
+            with _dls._lock:
+                c = _dls._conn
+                rows = c.execute(
+                    "SELECT idx FROM debug_log_events"
+                    " WHERE session_id='sess-order'"
+                    " ORDER BY session_id, idx"
+                ).fetchall()
+            idxs = [r[0] for r in rows]
+            test("append_order: five rows", len(idxs) == 5)
+            test("append_order: ordered 0..4", idxs == [0, 1, 2, 3, 4])
+        finally:
+            _reset()
+
+
+# ── prune_now — age ───────────────────────────────────────────────────────────
+
+def test_prune_age_deletes_expired():
+    """prune_now deletes rows older than max_age_s."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "test.db"
+        _reset()
+        _dls.init_storage(db_path=db_path, max_age_s=10, max_bytes=10 * 1024 * 1024)
+        try:
+            conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+
+            now_ns = time.time_ns()
+            old_ns = now_ns - 20 * 1_000_000_000  # 20 s ago → expired
+            fresh_ns = now_ns - 1 * 1_000_000_000  # 1 s ago → fresh
+
+            conn.execute(
+                "INSERT INTO debug_log_events (ts_ns, session_id, idx, kind, payload, byte_len)"
+                " VALUES (?, 'a', 0, 'k', '{}', 2)",
+                (old_ns,),
+            )
+            conn.execute(
+                "INSERT INTO debug_log_events (ts_ns, session_id, idx, kind, payload, byte_len)"
+                " VALUES (?, 'b', 0, 'k', '{}', 2)",
+                (fresh_ns,),
+            )
+            conn.commit()
+
+            stats = _dls.prune_now(conn=conn, now_ns=now_ns)
+
+            test("prune_age: deleted_age == 1", stats["deleted_age"] == 1)
+            test("prune_age: remaining == 1", stats["remaining"] == 1)
+            remaining = conn.execute(
+                "SELECT session_id FROM debug_log_events"
+            ).fetchall()
+            test("prune_age: kept fresh row", remaining[0][0] == "b")
+            conn.close()
+        finally:
+            _reset()
+
+
+def test_prune_noop_empty_db():
+    """prune_now on empty DB returns zero counts."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "test.db"
+        _reset()
+        _dls.init_storage(db_path=db_path)
+        try:
+            stats = _dls.prune_now()
+            test("prune_noop: deleted_age == 0", stats["deleted_age"] == 0)
+            test("prune_noop: deleted_size == 0", stats["deleted_size"] == 0)
+            test("prune_noop: remaining == 0", stats["remaining"] == 0)
+        finally:
+            _reset()
+
+
+# ── prune_now — size cap ──────────────────────────────────────────────────────
+
+def test_prune_size_deletes_oldest_over_cap():
+    """prune_now deletes oldest rows when total bytes exceed max_bytes."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "test.db"
+        _reset()
+        # max_bytes=30: three 10-byte rows → over cap; should prune oldest
+        _dls.init_storage(db_path=db_path, max_age_s=9999999, max_bytes=30)
+        try:
+            conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            now_ns = time.time_ns()
+            for i in range(4):
+                conn.execute(
+                    "INSERT INTO debug_log_events"
+                    " (ts_ns, session_id, idx, kind, payload, byte_len)"
+                    " VALUES (?, 's', ?, 'k', '{}', 10)",
+                    (now_ns + i, i),
+                )
+            conn.commit()
+
+            # 4 rows × 10 bytes = 40 bytes; cap is 30 → need to delete ≥1
+            stats = _dls.prune_now(conn=conn, now_ns=now_ns + 9999999 * 1_000_000_000)
+            remaining_rows = conn.execute(
+                "SELECT COUNT(*) FROM debug_log_events"
+            ).fetchone()[0]
+            total_bytes = conn.execute(
+                "SELECT SUM(byte_len) FROM debug_log_events"
+            ).fetchone()[0] or 0
+            conn.close()
+
+            test("prune_size: deleted_size > 0", stats["deleted_size"] > 0)
+            test("prune_size: total_bytes <= max_bytes", total_bytes <= 30)
+            test("prune_size: remaining <= 3", remaining_rows <= 3)
+        finally:
+            _reset()
+
+
+# ── shutdown_storage ──────────────────────────────────────────────────────────
+
+def test_shutdown_ephemeral_removes_files():
+    """Ephemeral shutdown removes the db file (and WAL/SHM if present)."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "ephemeral.db"
+        _reset()
+        _dls.init_storage(db_path=db_path, ephemeral=True)
+        assert db_path.exists(), "DB file should exist after init"
+        _dls.shutdown_storage()
+
+        test("ephemeral_shutdown: db removed", not db_path.exists())
+        # WAL/SHM may or may not exist; just confirm no exception was raised
+        test("ephemeral_shutdown: no exception", True)
+
+
+def test_shutdown_non_ephemeral_persists_db():
+    """Non-ephemeral shutdown leaves the DB file on disk."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "persist.db"
+        _reset()
+        _dls.init_storage(db_path=db_path, ephemeral=False)
+        _dls.shutdown_storage()
+
+        test("persist_shutdown: db file still exists", db_path.exists())
+
+
+def test_shutdown_idempotent():
+    """shutdown_storage is safe to call multiple times."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "idem.db"
+        _reset()
+        _dls.init_storage(db_path=db_path)
+        _dls.shutdown_storage()
+        try:
+            _dls.shutdown_storage()
+            _dls.shutdown_storage()
+            test("shutdown_idempotent: no exception on repeated call", True)
+        except Exception as e:
+            test("shutdown_idempotent: no exception on repeated call", False)
+            print(f"    Exception: {e}")
+
+
+def test_shutdown_safe_without_init():
+    """shutdown_storage is safe to call when init_storage was never called."""
+    _reset()
+    try:
+        _dls.shutdown_storage()
+        test("shutdown_no_init: no exception", True)
+    except Exception as e:
+        test("shutdown_no_init: no exception", False)
+        print(f"    Exception: {e}")
+
+
+# ── Re-init after shutdown ────────────────────────────────────────────────────
+
+def test_reinit_after_shutdown():
+    """init_storage can be called again after shutdown_storage (stop_event reset)."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "reinit.db"
+        _reset()
+        _dls.init_storage(db_path=db_path)
+        _dls.shutdown_storage()
+
+        try:
+            _dls.init_storage(db_path=db_path)
+            test("reinit: second init succeeds", True)
+            with _dls._lock:
+                c = _dls._conn
+                test("reinit: connection is live", c is not None)
+        except Exception as e:
+            test("reinit: second init succeeds", False)
+            print(f"    Exception: {e}")
+        finally:
+            _reset()
+
+
+# ── Retention thread ──────────────────────────────────────────────────────────
+
+def test_retention_thread_starts():
+    """start_retention_thread spawns a live daemon thread."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "thread.db"
+        _reset()
+        _dls.init_storage(db_path=db_path, retention_interval_s=60)
+        _dls.start_retention_thread()
+        try:
+            with _dls._lock:
+                t = _dls._thread
+            test("retention_thread: thread is not None", t is not None)
+            test("retention_thread: thread is alive", t is not None and t.is_alive())
+            test("retention_thread: daemon=True", t is not None and t.daemon)
+        finally:
+            _reset()
+
+
+def test_retention_thread_stops_on_shutdown():
+    """shutdown_storage signals and joins the retention thread."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "tstop.db"
+        _reset()
+        _dls.init_storage(db_path=db_path, retention_interval_s=60)
+        _dls.start_retention_thread()
+
+        with _dls._lock:
+            t = _dls._thread
+        assert t is not None and t.is_alive()
+
+        _dls.shutdown_storage()
+        # Give thread up to 3s to exit (shutdown joins with 2s timeout)
+        t.join(timeout=3.0)
+        test("retention_thread_stop: thread not alive after shutdown", not t.is_alive())
+
+
+def test_retention_thread_prunes():
+    """Retention thread calls prune_now and deletes expired rows."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "prune_thread.db"
+        _reset()
+        # Very short max_age (1s) and fast interval (0.1s) so thread prunes quickly
+        _dls.init_storage(
+            db_path=db_path,
+            max_age_s=1,
+            max_bytes=10 * 1024 * 1024,
+            retention_interval_s=1,
+        )
+        try:
+            # Insert an event with ts_ns far in the past
+            old_ns = time.time_ns() - 5 * 1_000_000_000
+            with _dls._lock:
+                c = _dls._conn
+                c.execute(
+                    "INSERT INTO debug_log_events"
+                    " (ts_ns, session_id, idx, kind, payload, byte_len)"
+                    " VALUES (?, 'x', 0, 'k', '{}', 2)",
+                    (old_ns,),
+                )
+                c.commit()
+
+            _dls.start_retention_thread()
+            # Wait up to 3s for the thread to prune
+            deadline = time.time() + 3.0
+            remaining = 1
+            while time.time() < deadline:
+                with _dls._lock:
+                    c2 = _dls._conn
+                    if c2 is not None:
+                        remaining = c2.execute(
+                            "SELECT COUNT(*) FROM debug_log_events"
+                        ).fetchone()[0]
+                if remaining == 0:
+                    break
+                time.sleep(0.1)
+
+            test("retention_loop: expired row pruned by thread", remaining == 0)
+        finally:
+            _reset()
+
+
+# ── get_config ────────────────────────────────────────────────────────────────
+
+def test_get_config_returns_snapshot():
+    """get_config returns max_age_seconds, max_bytes, interval_seconds."""
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "cfg.db"
+        _reset()
+        _dls.init_storage(
+            db_path=db_path,
+            max_age_s=3600,
+            max_bytes=1024,
+            retention_interval_s=120,
+        )
+        try:
+            cfg = _dls.get_config()
+            test("get_config: max_age_seconds == 3600", cfg["max_age_seconds"] == 3600)
+            test("get_config: max_bytes == 1024", cfg["max_bytes"] == 1024)
+            test("get_config: interval_seconds == 120", cfg["interval_seconds"] == 120)
+        finally:
+            _reset()
+
+
+# ── Default path / path isolation ─────────────────────────────────────────────
+
+def test_default_path_outside_session_state():
+    """default_debug_log_path() must NOT be under the session-state directory."""
+    old_env = os.environ.pop("BROWSE_DEBUG_LOG_DIR", None)
+    try:
+        p = _dls.default_debug_log_path()
+        path_str = str(p).lower()
+        # Must not be under session-state worktree or knowledge.db location
+        test(
+            "default_path: not under session-state",
+            "session-state" not in path_str,
+        )
+        # Must be under .copilot/operator-console
+        test(
+            "default_path: under .copilot/operator-console",
+            ".copilot" in path_str and "operator-console" in path_str,
+        )
+        test("default_path: filename is debug-log.db", p.name == "debug-log.db")
+    finally:
+        if old_env is not None:
+            os.environ["BROWSE_DEBUG_LOG_DIR"] = old_env
+
+
+def test_default_path_override_via_env():
+    """BROWSE_DEBUG_LOG_DIR env overrides default_debug_log_path()."""
+    with tempfile.TemporaryDirectory() as td:
+        old_env = os.environ.get("BROWSE_DEBUG_LOG_DIR")
+        os.environ["BROWSE_DEBUG_LOG_DIR"] = td
+        try:
+            p = _dls.default_debug_log_path()
+            test("default_path_env: uses BROWSE_DEBUG_LOG_DIR", str(p).startswith(td))
+            test("default_path_env: filename is debug-log.db", p.name == "debug-log.db")
+        finally:
+            if old_env is None:
+                os.environ.pop("BROWSE_DEBUG_LOG_DIR", None)
+            else:
+                os.environ["BROWSE_DEBUG_LOG_DIR"] = old_env
+
+
+def test_init_raises_on_bad_path():
+    """init_storage raises OSError or sqlite3.Error on an unwritable path."""
+    _reset()
+    bad_path = Path("/nonexistent/deeply/nested/path/that/cannot/exist/db.db")
+    if os.name == "nt":
+        bad_path = Path("Z:\\nonexistent\\path\\db.db")
+    try:
+        _dls.init_storage(db_path=bad_path)
+        test("init_bad_path: raises on bad path", False)
+    except (OSError, sqlite3.OperationalError, sqlite3.DatabaseError):
+        test("init_bad_path: raises on bad path", True)
+    except Exception as e:
+        # Accept any exception that indicates failure (not silent success)
+        test("init_bad_path: raises on bad path", True)
+        print(f"    (raised {type(e).__name__}: {e})")
+    finally:
+        _reset()
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    print("\n=== debug_log_storage unit tests ===\n")
+
+    print("-- Schema")
+    test_schema_tables_exist()
+    test_schema_meta_version()
+
+    print("\n-- append_event")
+    test_append_event_stores_redacted()
+    test_append_event_not_initialized()
+    test_append_event_multiple_ordered_by_idx()
+
+    print("\n-- prune_now (age)")
+    test_prune_age_deletes_expired()
+    test_prune_noop_empty_db()
+
+    print("\n-- prune_now (size cap)")
+    test_prune_size_deletes_oldest_over_cap()
+
+    print("\n-- shutdown_storage")
+    test_shutdown_ephemeral_removes_files()
+    test_shutdown_non_ephemeral_persists_db()
+    test_shutdown_idempotent()
+    test_shutdown_safe_without_init()
+
+    print("\n-- Re-init after shutdown")
+    test_reinit_after_shutdown()
+
+    print("\n-- Retention thread")
+    test_retention_thread_starts()
+    test_retention_thread_stops_on_shutdown()
+    test_retention_thread_prunes()
+
+    print("\n-- get_config")
+    test_get_config_returns_snapshot()
+
+    print("\n-- Default path / isolation")
+    test_default_path_outside_session_state()
+    test_default_path_override_via_env()
+    test_init_raises_on_bad_path()
+
+    print(f"\n==================================================")
+    print(f"Results: {_PASS} passed, {_FAIL} failed")
+    sys.exit(0 if _FAIL == 0 else 1)

--- a/tests/test_browse_debug_log_storage.py
+++ b/tests/test_browse_debug_log_storage.py
@@ -367,6 +367,50 @@ def test_retention_thread_stops_on_shutdown():
         test("retention_thread_stop: thread not alive after shutdown", not t.is_alive())
 
 
+def test_retention_thread_not_revived_by_stop_event_reset():
+    """Retention thread cannot become a zombie when _stop_event is reassigned.
+
+    Regression test for WBS-103: start_retention_thread() must capture the
+    stop Event in a closure (not look it up via module-global each iteration).
+    If shutdown_storage() times out on join and replaces _stop_event with a
+    fresh unset Event, the thread must still observe the *original* (signalled)
+    Event and exit — not continue running against a reinitialized connection.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "zombie.db"
+        _reset()
+        _dls.init_storage(db_path=db_path, retention_interval_s=60)
+        _dls.start_retention_thread()
+
+        with _dls._lock:
+            t = _dls._thread
+        # Capture the event the thread was started with (same object the
+        # fixed _loop closure holds).
+        original_stop = _dls._stop_event
+
+        assert t is not None and t.is_alive(), "thread should be alive before test"
+
+        # Step 1: signal the original event (as shutdown_storage() does).
+        original_stop.set()
+
+        # Step 2: replace the module-level _stop_event with a fresh unset
+        # Event, exactly as shutdown_storage() does after a timed-out join.
+        _dls._stop_event = threading.Event()  # new, unset — must NOT revive thread
+
+        # Step 3: the thread must exit because its closure still holds
+        # original_stop (which is set), not the fresh replacement.
+        t.join(timeout=3.0)
+        test(
+            "zombie_prevention: thread exits when original stop event is set "
+            "even after module-level _stop_event is replaced with new unset event",
+            not t.is_alive(),
+        )
+
+        # Clean module state for subsequent tests (_thread still points to
+        # the now-dead thread; shutdown_storage handles that gracefully).
+        _reset()
+
+
 def test_retention_thread_prunes():
     """Retention thread calls prune_now and deletes expired rows."""
     with tempfile.TemporaryDirectory() as td:
@@ -526,6 +570,7 @@ if __name__ == "__main__":
     print("\n-- Retention thread")
     test_retention_thread_starts()
     test_retention_thread_stops_on_shutdown()
+    test_retention_thread_not_revived_by_stop_event_reset()
     test_retention_thread_prunes()
 
     print("\n-- get_config")
@@ -536,6 +581,6 @@ if __name__ == "__main__":
     test_default_path_override_via_env()
     test_init_raises_on_bad_path()
 
-    print(f"\n==================================================")
+    print("\n==================================================")
     print(f"Results: {_PASS} passed, {_FAIL} failed")
     sys.exit(0 if _FAIL == 0 else 1)

--- a/tests/test_browse_debug_log_transport.py
+++ b/tests/test_browse_debug_log_transport.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""test_browse_debug_log_transport.py — Transport/HTTP tests for /api/debug-log/* (WBS-103).
+
+Covers:
+  - Disabled route → 404 (route not registered)
+  - Enabled + ?token= → 401 (no query-string auth for debug routes)
+  - Enabled + valid Bearer → 200
+  - Enabled + invalid Bearer → 401
+  - Enabled + valid cookie → 200
+  - Enabled + missing auth → 401
+  - Static slot active → 403
+  - Allowlisted Origin gets exact ACAO + Vary
+  - Disallowed Origin gets no ACAO header
+  - OPTIONS allowlisted Origin → CORS headers returned
+  - OPTIONS disallowed Origin → 403, no ACAO
+  - Response body does NOT expose filesystem paths, session content, or counts
+  - CSP: no unsafe-inline in script-src for JSON debug response
+"""
+
+import http.client
+import importlib
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import threading
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import browse.core.debug_log_storage as _dls  # noqa: E402
+import browse.core.registry as registry_mod  # noqa: E402
+from browse.core.server import _make_handler_class  # noqa: E402
+
+_PASS = 0
+_FAIL = 0
+
+_ALLOWED_ORIGIN = "https://agents.linhngo.dev"
+_DISALLOWED_ORIGIN = "https://evil.example.com"
+_TOKEN = "test-secret-debug-token"
+
+
+def test(name: str, expr: bool) -> None:
+    global _PASS, _FAIL
+    if expr:
+        _PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        _FAIL += 1
+        print(f"  FAIL  {name}")
+
+
+def _make_test_db() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.executescript("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            summary TEXT DEFAULT '',
+            repository TEXT DEFAULT '',
+            branch TEXT DEFAULT '',
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT ''
+        );
+    """)
+    db.commit()
+    return db
+
+
+def _make_test_server(token: str = "") -> tuple:
+    """Spin up a ThreadingHTTPServer on loopback and return (server, port)."""
+    db = _make_test_db()
+    HandlerClass = _make_handler_class(db, token)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), HandlerClass)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server, server.server_address[1]
+
+
+def _with_clean_routes(fn):
+    """Run fn with a clean ROUTES list, restoring original after."""
+    original = list(registry_mod.ROUTES)
+    original_debug = set(registry_mod._DEBUG_ROUTES)
+    registry_mod.ROUTES.clear()
+    registry_mod._DEBUG_ROUTES.clear()
+    try:
+        fn()
+    finally:
+        registry_mod.ROUTES.clear()
+        registry_mod._DEBUG_ROUTES.clear()
+        registry_mod.ROUTES.extend(original)
+        registry_mod._DEBUG_ROUTES.update(original_debug)
+
+
+def _reset_storage():
+    """Shut down debug_log_storage if initialized."""
+    _dls.shutdown_storage()
+
+
+# ── Disabled: route not registered → 404 ─────────────────────────────────────
+
+def test_disabled_route_returns_404():
+    """When debug_log route is NOT imported, /api/debug-log/healthz → 404."""
+    def _inner():
+        # Do NOT import debug_log route; ROUTES is clean
+        server, port = _make_test_server(token=_TOKEN)
+        try:
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request(
+                "GET",
+                "/api/debug-log/healthz",
+                headers={"Authorization": f"Bearer {_TOKEN}"},
+            )
+            resp = conn.getresponse()
+            resp.read()
+            test("disabled_404: status 404", resp.status == 404)
+        finally:
+            server.shutdown()
+
+    _with_clean_routes(_inner)
+
+
+# ── Enabled helpers ───────────────────────────────────────────────────────────
+
+def _setup_enabled(td: str):
+    """Import debug_log route, init storage in td, return (server, port)."""
+    _reset_storage()
+    db_path = Path(td) / "debug-log.db"
+    _dls.init_storage(db_path=db_path)
+
+    # Ensure route is registered (import triggers @route decorator)
+    import browse.routes.debug_log  # noqa: F401
+    importlib.reload(browse.routes.debug_log)
+
+    # Also ensure healthz and other standard routes exist for server
+    import browse.routes.health  # noqa: F401
+
+    server, port = _make_test_server(token=_TOKEN)
+    return server, port
+
+
+# ── Auth: ?token= rejected ────────────────────────────────────────────────────
+
+def test_query_token_rejected():
+    """?token= query-string auth → 401 for debug routes."""
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            server, port = _setup_enabled(td)
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request("GET", f"/api/debug-log/healthz?token={_TOKEN}")
+                resp = conn.getresponse()
+                resp.read()
+                test("query_token_rejected: status 401", resp.status == 401)
+            finally:
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+
+
+# ── Auth: valid Bearer → 200 ──────────────────────────────────────────────────
+
+def test_valid_bearer_200():
+    """Valid Bearer token → 200 with JSON body."""
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            server, port = _setup_enabled(td)
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request(
+                    "GET",
+                    "/api/debug-log/healthz",
+                    headers={"Authorization": f"Bearer {_TOKEN}"},
+                )
+                resp = conn.getresponse()
+                body = resp.read()
+                test("valid_bearer: status 200", resp.status == 200)
+                ct = resp.getheader("Content-Type", "")
+                test("valid_bearer: JSON content-type", "application/json" in ct)
+                parsed = json.loads(body)
+                test("valid_bearer: ok == True", parsed.get("ok") is True)
+                test("valid_bearer: 'enabled' key present", "enabled" in parsed)
+                test("valid_bearer: 'retention' key present", "retention" in parsed)
+            finally:
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+
+
+# ── Auth: invalid Bearer → 401 ────────────────────────────────────────────────
+
+def test_invalid_bearer_401():
+    """Invalid Bearer token → 401."""
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            server, port = _setup_enabled(td)
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request(
+                    "GET",
+                    "/api/debug-log/healthz",
+                    headers={"Authorization": "Bearer wrong-token"},
+                )
+                resp = conn.getresponse()
+                resp.read()
+                test("invalid_bearer: status 401", resp.status == 401)
+            finally:
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+
+
+# ── Auth: valid cookie → 200 ──────────────────────────────────────────────────
+
+def test_valid_cookie_200():
+    """Valid browse_token cookie → 200."""
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            server, port = _setup_enabled(td)
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request(
+                    "GET",
+                    "/api/debug-log/healthz",
+                    headers={"Cookie": f"browse_token={_TOKEN}"},
+                )
+                resp = conn.getresponse()
+                body = resp.read()
+                test("valid_cookie: status 200", resp.status == 200)
+                parsed = json.loads(body)
+                test("valid_cookie: ok == True", parsed.get("ok") is True)
+            finally:
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+
+
+# ── Auth: missing auth → 401 ──────────────────────────────────────────────────
+
+def test_missing_auth_401():
+    """No auth headers → 401 (loopback host + token configured)."""
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            server, port = _setup_enabled(td)
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request("GET", "/api/debug-log/healthz")
+                resp = conn.getresponse()
+                resp.read()
+                test("missing_auth: status 401", resp.status == 401)
+            finally:
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+
+
+# ── Static slot active → 403 ──────────────────────────────────────────────────
+
+def test_static_slot_403():
+    """Static/demo slot active → 403 regardless of auth."""
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            import browse.core.pairing as _pairing  # noqa: F401
+
+            server, port = _setup_enabled(td)
+            try:
+                # Inject a fake static slot directly into module-level variable
+                original_slot = _pairing._static_slot
+                _pairing._static_slot = {"token": "demo-token", "label": "demo"}
+
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request(
+                    "GET",
+                    "/api/debug-log/healthz",
+                    headers={"Authorization": f"Bearer {_TOKEN}"},
+                )
+                resp = conn.getresponse()
+                resp.read()
+                test("static_slot_403: status 403", resp.status == 403)
+            finally:
+                _pairing._static_slot = original_slot
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+
+
+# ── CORS: allowlisted Origin → ACAO + Vary ────────────────────────────────────
+
+def test_cors_allowed_origin_acao():
+    """Allowlisted Origin on GET /api/debug-log/healthz → ACAO + Vary: Origin."""
+    os.environ["BROWSE_CORS_ORIGINS"] = _ALLOWED_ORIGIN
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            server, port = _setup_enabled(td)
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request(
+                    "GET",
+                    "/api/debug-log/healthz",
+                    headers={
+                        "Authorization": f"Bearer {_TOKEN}",
+                        "Origin": _ALLOWED_ORIGIN,
+                    },
+                )
+                resp = conn.getresponse()
+                resp.read()
+                test("cors_allowed: status 200", resp.status == 200)
+                acao = resp.getheader("Access-Control-Allow-Origin", "")
+                test("cors_allowed: ACAO == allowed origin", acao == _ALLOWED_ORIGIN)
+                vary = resp.getheader("Vary", "")
+                test("cors_allowed: Vary includes Origin", "Origin" in vary)
+            finally:
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+    os.environ.pop("BROWSE_CORS_ORIGINS", None)
+
+
+def test_cors_disallowed_origin_no_acao():
+    """Disallowed Origin on GET /api/debug-log/healthz → no ACAO header."""
+    os.environ["BROWSE_CORS_ORIGINS"] = _ALLOWED_ORIGIN
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            server, port = _setup_enabled(td)
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request(
+                    "GET",
+                    "/api/debug-log/healthz",
+                    headers={
+                        "Authorization": f"Bearer {_TOKEN}",
+                        "Origin": _DISALLOWED_ORIGIN,
+                    },
+                )
+                resp = conn.getresponse()
+                resp.read()
+                # Response may be 200 (auth passed) but must have no ACAO
+                acao = resp.getheader("Access-Control-Allow-Origin", "")
+                test("cors_disallowed: no ACAO header", acao == "")
+            finally:
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+    os.environ.pop("BROWSE_CORS_ORIGINS", None)
+
+
+# ── OPTIONS preflight ─────────────────────────────────────────────────────────
+
+def test_options_allowed_origin_cors():
+    """OPTIONS /api/debug-log/healthz with allowlisted Origin → CORS preflight headers."""
+    os.environ["BROWSE_CORS_ORIGINS"] = _ALLOWED_ORIGIN
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            server, port = _setup_enabled(td)
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request(
+                    "OPTIONS",
+                    "/api/debug-log/healthz",
+                    headers={
+                        "Origin": _ALLOWED_ORIGIN,
+                        "Access-Control-Request-Method": "GET",
+                        "Access-Control-Request-Headers": "Authorization",
+                    },
+                )
+                resp = conn.getresponse()
+                resp.read()
+                # OPTIONS on /api/* with allowlisted origin → 204
+                test("options_allowed: status 2xx", resp.status in (200, 204))
+                acao = resp.getheader("Access-Control-Allow-Origin", "")
+                test("options_allowed: ACAO present", acao == _ALLOWED_ORIGIN)
+            finally:
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+    os.environ.pop("BROWSE_CORS_ORIGINS", None)
+
+
+def test_options_disallowed_origin_403():
+    """OPTIONS /api/debug-log/healthz with disallowed Origin → 403, no ACAO."""
+    os.environ["BROWSE_CORS_ORIGINS"] = _ALLOWED_ORIGIN
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            server, port = _setup_enabled(td)
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request(
+                    "OPTIONS",
+                    "/api/debug-log/healthz",
+                    headers={
+                        "Origin": _DISALLOWED_ORIGIN,
+                        "Access-Control-Request-Method": "GET",
+                    },
+                )
+                resp = conn.getresponse()
+                resp.read()
+                test("options_disallowed: status 403", resp.status == 403)
+                acao = resp.getheader("Access-Control-Allow-Origin", "")
+                test("options_disallowed: no ACAO", acao == "")
+            finally:
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+    os.environ.pop("BROWSE_CORS_ORIGINS", None)
+
+
+# ── Response body safety ──────────────────────────────────────────────────────
+
+def test_response_no_filesystem_paths():
+    """Healthz response body contains no filesystem paths or session content."""
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            server, port = _setup_enabled(td)
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request(
+                    "GET",
+                    "/api/debug-log/healthz",
+                    headers={"Authorization": f"Bearer {_TOKEN}"},
+                )
+                resp = conn.getresponse()
+                body = resp.read().decode("utf-8", errors="replace")
+                # Must not expose filesystem path from temp dir
+                test(
+                    "safe_body: no temp dir path in body",
+                    td.replace("\\", "/") not in body.replace("\\", "/"),
+                )
+                # Must not expose session data
+                test("safe_body: no 'session_id' in body", "session_id" not in body)
+                test("safe_body: no 'knowledge' in body", "knowledge" not in body)
+                # Valid JSON
+                parsed = json.loads(body)
+                test("safe_body: ok key present", "ok" in parsed)
+                test("safe_body: retention has expected keys", all(
+                    k in parsed.get("retention", {})
+                    for k in ("max_age_seconds", "max_bytes", "interval_seconds")
+                ))
+            finally:
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+
+
+# ── CSP header ────────────────────────────────────────────────────────────────
+
+def test_no_unsafe_inline_in_csp():
+    """Debug-log healthz response CSP does not include unsafe-inline in script-src."""
+    with tempfile.TemporaryDirectory() as td:
+        def _inner():
+            server, port = _setup_enabled(td)
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request(
+                    "GET",
+                    "/api/debug-log/healthz",
+                    headers={"Authorization": f"Bearer {_TOKEN}"},
+                )
+                resp = conn.getresponse()
+                resp.read()
+                csp = resp.getheader("Content-Security-Policy", "")
+                if csp:
+                    # Find the script-src directive
+                    directives = {
+                        d.strip().split()[0]: d.strip()
+                        for d in csp.split(";")
+                        if d.strip()
+                    }
+                    script_src = directives.get("script-src", "")
+                    test(
+                        "csp_debug: script-src has no unsafe-inline",
+                        "'unsafe-inline'" not in script_src,
+                    )
+                else:
+                    # No CSP → JSON API routes may omit CSP; just record as pass
+                    test("csp_debug: no CSP on JSON route (acceptable)", True)
+            finally:
+                server.shutdown()
+                _reset_storage()
+        _with_clean_routes(_inner)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    print("\n=== debug_log transport tests ===\n")
+
+    print("-- Disabled (route not registered)")
+    test_disabled_route_returns_404()
+
+    print("\n-- Auth gating")
+    test_query_token_rejected()
+    test_valid_bearer_200()
+    test_invalid_bearer_401()
+    test_valid_cookie_200()
+    test_missing_auth_401()
+
+    print("\n-- Static slot")
+    test_static_slot_403()
+
+    print("\n-- CORS (actual GET)")
+    test_cors_allowed_origin_acao()
+    test_cors_disallowed_origin_no_acao()
+
+    print("\n-- OPTIONS preflight")
+    test_options_allowed_origin_cors()
+    test_options_disallowed_origin_403()
+
+    print("\n-- Response body safety")
+    test_response_no_filesystem_paths()
+
+    print("\n-- CSP")
+    test_no_unsafe_inline_in_csp()
+
+    print(f"\n==================================================")
+    print(f"Results: {_PASS} passed, {_FAIL} failed")
+    sys.exit(0 if _FAIL == 0 else 1)

--- a/tests/test_browse_debug_log_transport.py
+++ b/tests/test_browse_debug_log_transport.py
@@ -518,6 +518,6 @@ if __name__ == "__main__":
     print("\n-- CSP")
     test_no_unsafe_inline_in_csp()
 
-    print(f"\n==================================================")
+    print("\n==================================================")
     print(f"Results: {_PASS} passed, {_FAIL} failed")
     sys.exit(0 if _FAIL == 0 else 1)

--- a/tests/test_browse_pairing.py
+++ b/tests/test_browse_pairing.py
@@ -8,8 +8,8 @@ issue #59 (static pairing slot / demo mode).
 import io
 import json
 import sys
-import time
 import threading
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -144,8 +144,8 @@ def test_verify_expired_ticket():
     token = "tok"
     base_url = "http://127.0.0.1:8765"
     # Manually craft an old ticket
-    import hmac as _hmac
     import hashlib as _hashlib
+    import hmac as _hmac
     import secrets as _secrets
 
     old_time = int(time.time()) - 400  # 400s ago
@@ -301,6 +301,7 @@ def test_static_slot_ticket_url():
 def test_static_slot_ticket_stays_valid_beyond_default_qr_window():
     """Static slot ticket keeps its signed TTL instead of expiring after 5 minutes."""
     from unittest.mock import patch
+
     import browse.core.pairing as pairing_mod
 
     terminate_static_slot()
@@ -324,8 +325,8 @@ def test_render_terminal_qr_url_box_fallback():
     is absent.  We temporarily mock ``qrcode`` as unavailable to force the box
     path, then verify the output contains the URL and the expected instructions.
     """
-    import io
     import sys
+
     from browse.core.pairing import _print_url_box
 
     url = "browse://connect?ticket=dGVzdAo"
@@ -349,8 +350,8 @@ def test_render_terminal_qr_dispatches():
     Confirms the runtime fallback chain (qrcode → URL-in-box) is solid and
     provides end-to-end proof that the terminal QR path does not crash.
     """
-    import io
     import sys
+
     from browse.core.pairing import render_terminal_qr
 
     url = "browse://connect?ticket=dGVzdHRlc3Q"
@@ -384,6 +385,7 @@ def test_render_terminal_qr_dispatches():
 def test_pairing_verify_endpoint_valid():
     """POST /api/operator/pairing/verify returns valid=true for a fresh ticket."""
     import sqlite3
+
     from browse.api.pairing import handle_verify_pairing_ticket
 
     token = "api_test_token_abc"
@@ -406,6 +408,7 @@ def test_pairing_verify_endpoint_wrong_token():
     """POST /api/operator/pairing/verify returns valid=false for wrong server token."""
     import json
     import sqlite3
+
     from browse.api.pairing import handle_verify_pairing_ticket
 
     ticket_url = create_pairing_ticket("correct_token", "http://127.0.0.1:9999")
@@ -422,6 +425,7 @@ def test_pairing_verify_endpoint_wrong_token():
 def test_pairing_verify_endpoint_missing_ticket():
     """POST /api/operator/pairing/verify returns 400 when ticket is absent."""
     import json
+
     from browse.api.pairing import handle_verify_pairing_ticket
 
     body = json.dumps({"other_field": "value"})
@@ -433,6 +437,7 @@ def test_pairing_verify_endpoint_missing_ticket():
 def test_pairing_verify_endpoint_invalid_max_age_falls_back():
     """POST /api/operator/pairing/verify does not 500 on malformed max_age_seconds."""
     import json
+
     from browse.api.pairing import handle_verify_pairing_ticket
 
     token = "api_test_token_abc"
@@ -453,6 +458,7 @@ def test_pairing_verify_endpoint_invalid_max_age_falls_back():
 def test_static_slot_api_get():
     """GET /api/operator/pairing/static returns active=false when no slot."""
     import json
+
     from browse.api.pairing import handle_get_static_slot
 
     terminate_static_slot()
@@ -465,6 +471,7 @@ def test_static_slot_api_get():
 def test_static_slot_api_get_active():
     """GET /api/operator/pairing/static returns full info when slot is active."""
     import json
+
     from browse.api.pairing import handle_get_static_slot
 
     terminate_static_slot()
@@ -484,6 +491,7 @@ def test_static_slot_api_get_active():
 def test_static_slot_api_terminate():
     """DELETE /api/operator/pairing/static terminates active slot."""
     import json
+
     from browse.api.pairing import handle_terminate_static_slot
 
     terminate_static_slot()
@@ -498,6 +506,7 @@ def test_static_slot_api_terminate():
 def test_static_slot_api_terminate_idempotent():
     """DELETE /api/operator/pairing/static returns terminated=false when no slot."""
     import json
+
     from browse.api.pairing import handle_terminate_static_slot
 
     terminate_static_slot()
@@ -509,6 +518,7 @@ def test_static_slot_api_terminate_idempotent():
 def test_static_slot_api_refresh():
     """POST /api/operator/pairing/static/refresh terminates old slot and creates new one."""
     import json
+
     from browse.api.pairing import handle_refresh_static_slot
 
     terminate_static_slot()
@@ -538,6 +548,7 @@ def test_static_slot_api_refresh():
 def test_static_slot_api_terminate_forbidden_for_static_session():
     """DELETE /api/operator/pairing/static rejects static-slot callers."""
     import json
+
     from browse.api.pairing import handle_terminate_static_slot
 
     terminate_static_slot()
@@ -558,6 +569,7 @@ def test_static_slot_api_terminate_forbidden_for_static_session():
 def test_static_slot_api_refresh_forbidden_for_static_session():
     """POST /api/operator/pairing/static/refresh rejects static-slot callers."""
     import json
+
     from browse.api.pairing import handle_refresh_static_slot
 
     terminate_static_slot()
@@ -636,7 +648,8 @@ def test_static_token_reaches_real_server_auth_path():
     db = sqlite3.connect(":memory:")
 
     # Register a test route under /api/ so the server dispatches it via registry.
-    from browse.core.registry import ROUTES, route as _route
+    from browse.core.registry import ROUTES
+    from browse.core.registry import route as _route
 
     _route_path = "/api/test/static-session-kind-echo"
 
@@ -688,7 +701,7 @@ def test_static_token_reaches_real_server_auth_path():
         db.close()
         terminate_static_slot()
         # Remove test route from global ROUTES to avoid polluting other tests.
-        ROUTES[:] = [(p, m, h) for p, m, h in ROUTES if p != _route_path]
+        ROUTES[:] = [r for r in ROUTES if r[0] != _route_path]
 
 
 # ── Open verify endpoint – request-path proof (#58) ───────────────────────────
@@ -703,6 +716,7 @@ def test_open_verify_endpoint_real_server():
     import sqlite3
     import urllib.request
     from http.server import ThreadingHTTPServer
+
     from browse.core.server import _make_handler_class
     from browse.routes import discovery as _disc  # noqa: F401 — register routes
 

--- a/tests/test_session_export.py
+++ b/tests/test_session_export.py
@@ -79,8 +79,8 @@ def run_all_tests() -> int:
     # T2: match_route returns handler + session_id kwarg
     print("\n-- T2: match_route extracts session_id")
     from browse.core.registry import match_route
-    handler, kw = match_route("/session/abc123.md", "GET")
-    api_handler, api_kw = match_route("/api/session/abc123/export", "GET")
+    handler, kw, _dbg = match_route("/session/abc123.md", "GET")
+    api_handler, api_kw, _dbg_api = match_route("/api/session/abc123/export", "GET")
     test("T2: legacy handler is not None", handler is not None)
     test("T2: legacy session_id kwarg == 'abc123'", kw.get("session_id") == "abc123")
     test("T2: API handler is not None", api_handler is not None)


### PR DESCRIPTION
## Summary
- Adds WBS-103 local-only debug-log SQLite storage outside session-state/knowledge.db.
- Adds debug-log health probe `GET /api/debug-log/healthz` with Bearer/cookie-only auth, disabled-by-default registration, query-token rejection, static/demo guard, and `/api` CORS/PNA/Vary reuse.
- Adds retention, shutdown, sync/export/watch exclusion tests, docs contract, and changelog entry.

## Local verification
- `python tests\\test_browse_debug_log_storage.py` -> 44 passed
- `python tests\\test_browse_debug_log_transport.py` -> 26 passed
- `python tests\\test_browse_debug_log_exclusion.py` -> 24 passed
- `python tests\\test_browse_pairing.py` -> 114 passed
- `python test_security.py` -> 12 passed
- `python test_fixes.py` -> 226 passed
- `python run_all_tests.py` -> 142/142 passed
- `ruff check` on changed Python files -> passed
- `git diff --check` -> exit 0

Closes #428.