### PR TITLE
feat: add operator debug log read API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     registered with `debug=True` — regardless of URL prefix — automatically receives
     Bearer/cookie-only auth, `?token=` rejection (401), static-slot blocking (403), and the
     non-loopback insecure-config 403 rule.  `/api/debug-log/healthz` behaviour is unchanged.
-  - `tests/test_browse_debug_log_api.py`: 32 tests (93 assertions) covering unknown/non-UUID session/run 404
+  - `tests/test_browse_debug_log_api.py`: 36 tests (105 assertions) covering unknown/non-UUID session/run 404
     no leakage; ownership mismatch 404; missing/invalid auth 401; `?token=` rejection 401;
     valid Bearer and cookie 200; static slot 403; pagination (default/explicit/overflow/max
     limit/negative from); kind/level/since filters and bad params; redaction; truncation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Debug-log read API and registry-driven debug auth gate (WBS-104, #429):**
+  - `browse/api/operator.py`: new `GET /api/operator/sessions/{session_id}/runs/{run_id}/debug`
+    endpoint (registered with `debug=True`).  Returns a paginated, redacted `DebugLogResponse`
+    envelope with `schema_version`, `session_id`, `run_id`, `total`, `from`, `limit`,
+    `has_more`, and `events` (array of `BrowseDebugEntry`).  Reads events exclusively from
+    persisted operator run JSON (`get_session` + `get_run_status`); no WBS-103 SQLite storage
+    consulted.  Supports `from`, `limit`, `kind`, `level`, and `since` query parameters with
+    strict validation (bad params → 400 JSON).  Operator events are mapped to BrowseDebugEntry
+    via the WBS-101 taxonomy; `source="operator_console"`, `level=null`, synthetic span_id via
+    `sha1("operator_console:{idx}:1")[:16]`.  Events whose serialized JSON exceeds 8192 bytes
+    receive a truncation marker (`[TRUNCATED sha256=<hex16> bytes=<n>]`) with
+    `attrs.truncated=true` and `attrs.bytes_in=n`.  All entries pass through
+    `browse.core.redaction.redact_entry`; redaction runs on at most `limit` entries (≤100)
+    per request.  Session/run 404 errors include no UUID or path leakage.
+  - `browse/core/registry.py`: generalized `match_route` from hard-coded `{id}` → `session_id`
+    to arbitrary `{name}` named placeholders.  `{id}` still maps to kwarg `session_id` for
+    backward compatibility.  New `_build_route_pattern()` helper splits on `_PLACEHOLDER_RE`
+    and constructs named-group regex patterns.  Multi-placeholder paths such as
+    `/sessions/{session_id}/runs/{run_id}/debug` are fully supported.
+  - `browse/core/server.py`: debug auth gate generalized from prefix `/api/debug-log/` to
+    registry-driven `match_route(path, "GET")` returning `debug_flag=True`.  Any route
+    registered with `debug=True` — regardless of URL prefix — automatically receives
+    Bearer/cookie-only auth, `?token=` rejection (401), static-slot blocking (403), and the
+    non-loopback insecure-config 403 rule.  `/api/debug-log/healthz` behaviour is unchanged.
+  - `tests/test_browse_debug_log_api.py`: 32 tests (93 assertions) covering unknown/non-UUID session/run 404
+    no leakage; ownership mismatch 404; missing/invalid auth 401; `?token=` rejection 401;
+    valid Bearer and cookie 200; static slot 403; pagination (default/explicit/overflow/max
+    limit/negative from); kind/level/since filters and bad params; redaction; truncation
+    indicator; CORS disallowed no ACAO; HEAD status/body; JSON content-type on all responses;
+    performance 100 entries from 1000-event run <200 ms; empty run; schema_version; non-UUID
+    session_id.
+  - `docs/DEBUG-LOG-CONTRACT.md`: updated with WBS-104 section documenting the read API
+    endpoint, auth/status semantics, query parameters, response shape, data source, event
+    mapping, truncation semantics, `since` filter semantics, and registry-driven debug auth
+    gate generalisation.
+
 - **Bounded redacted operator debug-event sidecar (WBS-105, #430):**
   - `browse/core/operator_console.py`:
     - Constants `_MAX_DEBUG_EVENTS = 5000` and `_DEBUG_SOURCE = "operator_console"`.

--- a/browse/api/operator.py
+++ b/browse/api/operator.py
@@ -13,6 +13,8 @@ Endpoints:
   GET   /api/operator/suggest               → path suggestions under ~/
   GET   /api/operator/preview               → file content under ~/
   GET   /api/operator/diff                  → unified diff of two files under ~/
+  GET   /api/operator/sessions/{session_id}/runs/{run_id}/debug
+        → paginated BrowseDebugEntry list (debug=True; Bearer/cookie auth only)
 
 POST body: JSON-encoded, passed as params["_body"][0].
 SSE stream: follows live.py factory(stop_event) → generator pattern.
@@ -20,9 +22,11 @@ Path confinement: all paths are validated to be under ~/; 403 returned otherwise
 """
 
 import base64
+import hashlib as _hashlib
 import json
 import os
 import sys
+from datetime import datetime, timezone
 
 if os.name == "nt":
     for _s in (sys.stdout, sys.stderr):
@@ -577,3 +581,313 @@ def handle_diff(db, params, token, nonce) -> tuple:
         )
 
     return json_ok(result)
+
+
+# ── Debug log read API (WBS-104) ──────────────────────────────────────────────
+
+# Event kind and level enums mirror browse/core/redaction.py allowlists.
+_DEBUG_KIND_ENUM = frozenset(
+    {
+        "session_start",
+        "turn_start",
+        "llm_request",
+        "tool_call",
+        "hook",
+        "subagent",
+        "agent_response",
+        "error",
+        "generic",
+        "raw",
+    }
+)
+_DEBUG_LEVEL_ENUM = frozenset({"debug", "info", "warn", "error"})
+
+# Copilot CLI event-type → BrowseDebugEntry kind taxonomy.
+_EVENT_TYPE_TO_KIND: dict = {
+    "assistant.message": "agent_response",
+    "assistant.message_delta": "agent_response",
+    "tool_call": "tool_call",
+    "tool_result": "tool_call",
+    "session_start": "session_start",
+    "turn_start": "turn_start",
+    "llm_request": "llm_request",
+    "hook": "hook",
+    "subagent": "subagent",
+    "error": "error",
+    "exception": "error",
+}
+
+# Raw event JSON byte limit. Events whose serialized size exceeds this threshold
+# are replaced by a truncation marker; raw content is not exposed.
+_TRUNCATION_BYTES = 8192
+
+# Preview length for the message field (matches _PREVIEW_LEN in timeline.py).
+_DEBUG_MSG_MAX = 200
+
+_NULLABLE_DEBUG_ENTRY_FIELDS = ("tool_name", "duration_ms", "parent_span_id", "status")
+
+
+def _synthetic_span_id(source: str, idx: int, seq: int = 1) -> str:
+    """Return a deterministic 16-char lowercase hex span_id.
+
+    Formula: sha1("{source}:{idx}:{seq}")[:16]; never returns the all-zero sentinel.
+    """
+    candidate = _hashlib.sha1(f"{source}:{idx}:{seq}".encode()).hexdigest()[:16]
+    if candidate == "0000000000000000":
+        return _synthetic_span_id(source, idx, seq + 1)
+    return candidate
+
+
+def _map_operator_event(event: dict) -> dict:
+    """Map one operator-console event dict to a pre-redaction BrowseDebugEntry dict.
+
+    Contract:
+    - ``source`` is always ``"operator_console"``
+    - ``span_id`` is always a synthetic 16-hex value (sha1 formula)
+    - ``timestamp`` is extracted from the inner event when present; never synthesized
+    - ``level`` is always null (operator events carry no severity field)
+    - If serialized event JSON exceeds _TRUNCATION_BYTES, message is replaced with a
+      truncation marker and attrs carry ``truncated=True`` and ``bytes_in=<n>``
+    """
+    idx = int(event.get("idx") or 0)
+    event_type = str(event.get("type") or "raw")
+
+    # Compute raw bytes once for the truncation check and fingerprint.
+    try:
+        raw_blob = json.dumps(event).encode("utf-8", errors="replace")
+        raw_bytes = len(raw_blob)
+    except Exception:
+        raw_blob = b""
+        raw_bytes = 0
+
+    attrs: dict = {}
+    truncated = raw_bytes > _TRUNCATION_BYTES
+
+    if event_type == "raw":
+        text = str(event.get("text") or "")
+        if truncated:
+            sha = _hashlib.sha256(raw_blob).hexdigest()[:16]
+            message = f"[TRUNCATED sha256={sha} bytes={raw_bytes}]"
+            attrs["truncated"] = True
+            attrs["bytes_in"] = raw_bytes
+        else:
+            message = text[:_DEBUG_MSG_MAX]
+
+        return {
+            "idx": idx,
+            "timestamp": None,
+            "kind": "raw",
+            "level": None,
+            "source": "operator_console",
+            "message": message,
+            "span_id": _synthetic_span_id("operator_console", idx),
+            "attrs": attrs,
+        }
+
+    # JSON structured event
+    kind = _EVENT_TYPE_TO_KIND.get(event_type, "generic")
+    inner = event.get("event")
+    if not isinstance(inner, dict):
+        inner = event
+
+    # Timestamp: use first found timestamp-like field from inner event; do NOT synthesize.
+    ts = None
+    for _ts_key in ("timestamp", "ts"):
+        _ts_val = inner.get(_ts_key)
+        if _ts_val and isinstance(_ts_val, str):
+            ts = _ts_val
+            break
+
+    if truncated:
+        sha = _hashlib.sha256(raw_blob).hexdigest()[:16]
+        message = f"[TRUNCATED sha256={sha} bytes={raw_bytes}]"
+        attrs["truncated"] = True
+        attrs["bytes_in"] = raw_bytes
+    else:
+        # Extract human-readable message based on event taxonomy.
+        if event_type in ("assistant.message", "assistant.message_delta"):
+            content = inner.get("content") or inner.get("deltaContent") or ""
+            message = str(content)[:_DEBUG_MSG_MAX]
+        elif event_type in ("tool_call", "tool_result"):
+            tool = (
+                inner.get("toolName") or inner.get("tool_name") or inner.get("name") or inner.get("tool") or event_type
+            )
+            message = str(tool)[:_DEBUG_MSG_MAX]
+        else:
+            text = inner.get("text") or inner.get("message") or inner.get("content") or event_type
+            message = str(text)[:_DEBUG_MSG_MAX]
+
+    return {
+        "idx": idx,
+        "timestamp": ts,
+        "kind": kind,
+        "level": None,
+        "source": "operator_console",
+        "message": message,
+        "span_id": _synthetic_span_id("operator_console", idx),
+        "attrs": attrs,
+    }
+
+
+@route(
+    "/api/operator/sessions/{session_id}/runs/{run_id}/debug",
+    methods=["GET"],
+    debug=True,
+)
+def handle_debug_log(
+    db,
+    params,
+    token,
+    nonce,
+    session_id: str = "",
+    run_id: str = "",
+) -> tuple:
+    """GET /api/operator/sessions/{session_id}/runs/{run_id}/debug — debug log read API.
+
+    Returns a paginated list of BrowseDebugEntry objects for a specific operator
+    session run, sourced from persisted operator run JSON only (no SQLite debug-log
+    storage; WBS-103 SQLite storage has no run_id and no current producers).
+
+    Query parameters:
+      from    int >= 0          (default 0)    — pagination offset
+      limit   1..100            (default 100)  — page size
+      kind    <KIND_ENUM>       (optional)     — filter by event kind
+      level   <LEVEL_ENUM>      (optional)     — filter by severity
+      since   ISO-8601 datetime (optional)     — include only events after this time
+
+    Bad parameters → 400 JSON error.  Unknown session or run → 404 with no ID leakage.
+
+    Response shape:
+      {
+        "schema_version": "1",
+        "session_id": "...",
+        "run_id": "...",
+        "total": N,
+        "from": from,
+        "limit": limit,
+        "has_more": bool,
+        "events": [BrowseDebugEntry, ...]
+      }
+    """
+    from browse.core.redaction import redact_entry  # noqa: PLC0415
+
+    def not_found() -> tuple:
+        return json_error("debug log not found", "NOT_FOUND", 404)
+
+    # ── Validate session / run (404 with no UUID/path leakage) ────────────────
+    session = get_session(session_id)
+    if session is None:
+        return not_found()
+
+    run = get_run_status(run_id)
+    if run is None:
+        return not_found()
+
+    # Strict ownership: run must belong to the given session.
+    if run.get("session_id") != session_id:
+        return not_found()
+
+    # ── Parse and validate query parameters ───────────────────────────────────
+    try:
+        from_idx = int(params.get("from", ["0"])[0] or "0")
+        if from_idx < 0:
+            raise ValueError("from must be >= 0")
+    except (ValueError, TypeError):
+        return json_error("'from' must be a non-negative integer", "BAD_PARAM", 400)
+
+    try:
+        limit = int(params.get("limit", ["100"])[0] or "100")
+        if not (1 <= limit <= 100):
+            raise ValueError("limit out of range")
+    except (ValueError, TypeError):
+        return json_error("'limit' must be an integer between 1 and 100", "BAD_PARAM", 400)
+
+    kind_filter = (params.get("kind", [""])[0] or "").strip() or None
+    if kind_filter and kind_filter not in _DEBUG_KIND_ENUM:
+        return json_error(
+            f"'kind' must be one of: {', '.join(sorted(_DEBUG_KIND_ENUM))}",
+            "BAD_PARAM",
+            400,
+        )
+
+    level_filter = (params.get("level", [""])[0] or "").strip() or None
+    if level_filter and level_filter not in _DEBUG_LEVEL_ENUM:
+        return json_error(
+            f"'level' must be one of: {', '.join(sorted(_DEBUG_LEVEL_ENUM))}",
+            "BAD_PARAM",
+            400,
+        )
+
+    since_filter: datetime | None = None
+    since_str = (params.get("since", [""])[0] or "").strip() or None
+    if since_str:
+        try:
+            since_filter = datetime.fromisoformat(since_str.replace("Z", "+00:00"))
+            if since_filter.tzinfo is None:
+                since_filter = since_filter.replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            return json_error(
+                "'since' must be a valid ISO-8601 datetime string",
+                "BAD_PARAM",
+                400,
+            )
+
+    # ── Retrieve and map events ────────────────────────────────────────────────
+    events_raw = run.get("events") or []
+    if not isinstance(events_raw, list):
+        events_raw = []
+
+    # Map, filter (pre-redaction) — performance: only map what passes filters.
+    mapped: list = []
+    for event in events_raw:
+        if not isinstance(event, dict):
+            continue
+        entry = _map_operator_event(event)
+
+        # Kind filter
+        if kind_filter and entry.get("kind") != kind_filter:
+            continue
+
+        # Level filter (operator entries always have level=null; exclude on mismatch)
+        if level_filter and entry.get("level") != level_filter:
+            continue
+
+        # Since filter: events with no timestamp are excluded when since is set.
+        if since_filter is not None:
+            ts_val = entry.get("timestamp")
+            if not ts_val:
+                continue
+            try:
+                ts = datetime.fromisoformat(str(ts_val).replace("Z", "+00:00"))
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts < since_filter:
+                    continue
+            except (ValueError, TypeError):
+                continue
+
+        mapped.append(entry)
+
+    total = len(mapped)
+
+    # Slice first, then redact — ensures redaction runs at most `limit` entries.
+    page = mapped[from_idx : from_idx + limit]
+    has_more = (from_idx + limit) < total
+
+    redacted = [redact_entry(e) for e in page]
+    for entry in redacted:
+        for field in _NULLABLE_DEBUG_ENTRY_FIELDS:
+            entry.setdefault(field, None)
+
+    return json_ok(
+        {
+            "schema_version": "1",
+            "session_id": session_id,
+            "run_id": run_id,
+            "total": total,
+            "from": from_idx,
+            "limit": limit,
+            "has_more": has_more,
+            "events": redacted,
+        }
+    )

--- a/browse/api/operator.py
+++ b/browse/api/operator.py
@@ -706,11 +706,40 @@ def _map_operator_event(event: dict) -> dict:
     else:
         # Extract human-readable message based on event taxonomy.
         if event_type in ("assistant.message", "assistant.message_delta"):
-            content = inner.get("content") or inner.get("deltaContent") or ""
+            # Check inner-event top-level first, then inner.data, then outer event.data.
+            # Operator-console events may carry content/deltaContent under a nested "data"
+            # sub-object (from _parse_output_event) rather than at the inner event top level.
+            _inner_data = inner.get("data") if isinstance(inner.get("data"), dict) else {}
+            _outer_data = event.get("data") if isinstance(event.get("data"), dict) else {}
+            content = (
+                inner.get("content")
+                or inner.get("deltaContent")
+                or _inner_data.get("content")
+                or _inner_data.get("deltaContent")
+                or _outer_data.get("content")
+                or _outer_data.get("deltaContent")
+                or ""
+            )
             message = str(content)[:_DEBUG_MSG_MAX]
         elif event_type in ("tool_call", "tool_result"):
+            # Check inner-event top-level first, then inner.data, then outer event.data.
+            # Stream events may store tool metadata under a nested "data" object.
+            _inner_data = inner.get("data") if isinstance(inner.get("data"), dict) else {}
+            _outer_data = event.get("data") if isinstance(event.get("data"), dict) else {}
             tool = (
-                inner.get("toolName") or inner.get("tool_name") or inner.get("name") or inner.get("tool") or event_type
+                inner.get("toolName")
+                or inner.get("tool_name")
+                or inner.get("name")
+                or inner.get("tool")
+                or _inner_data.get("toolName")
+                or _inner_data.get("tool_name")
+                or _inner_data.get("name")
+                or _inner_data.get("tool")
+                or _outer_data.get("toolName")
+                or _outer_data.get("tool_name")
+                or _outer_data.get("name")
+                or _outer_data.get("tool")
+                or event_type
             )
             message = str(tool)[:_DEBUG_MSG_MAX]
         else:

--- a/browse/core/registry.py
+++ b/browse/core/registry.py
@@ -18,6 +18,40 @@ ROUTES: list = []
 # reads the per-route debug flag returned by match_route().
 _DEBUG_ROUTES: set = set()
 
+# Compiled regex for detecting {name} placeholders in route paths.
+_PLACEHOLDER_RE = re.compile(r"\{([^}]+)\}")
+
+
+def _build_route_pattern(route_path: str) -> str | None:
+    """Build a regex pattern from route_path containing {name} placeholders.
+
+    Returns a compiled-ready pattern string if any placeholders are found,
+    otherwise returns None (caller should use exact matching).
+
+    Placeholder mapping rules:
+    - ``{id}``        → named group ``session_id``  (backward compatibility)
+    - ``{name}``      → named group ``name``         (arbitrary names)
+
+    Each placeholder matches one or more non-slash characters (``[^/]+``).
+    """
+    if not _PLACEHOLDER_RE.search(route_path):
+        return None
+
+    # split() on the placeholder regex yields alternating literal / name segments:
+    # "/a/{id}/b/{run_id}" → ["/a/", "id", "/b/", "run_id", ""]
+    parts = _PLACEHOLDER_RE.split(route_path)
+    pattern = "^"
+    for i, part in enumerate(parts):
+        if i % 2 == 0:
+            # Literal path segment — escape regex metacharacters
+            pattern += re.escape(part)
+        else:
+            # Placeholder name — map {id} to session_id for backward compat
+            group_name = "session_id" if part == "id" else part
+            pattern += f"(?P<{group_name}>[^/]+)"
+    pattern += "$"
+    return pattern
+
 
 def route(path: str, methods: list | None = None, debug: bool = False):
     """Decorator: @route('/path', methods=['GET'], debug=False) registers handler in ROUTES.
@@ -47,10 +81,11 @@ def match_route(path: str, method: str) -> tuple:
     """
     Returns (handler_fn, kwargs, debug_flag).
     1. Exact match.
-    2. Generic {id} template matching — /session/{id}/suffix, /api/session/{id}/suffix.
-       Check for comment 'Generic {id} template matching' to detect this block.
+    2. Named-placeholder template matching — supports arbitrary {name} patterns
+       including multi-placeholder paths like /sessions/{session_id}/runs/{run_id}/debug.
+       {id} maps to kwargs key ``session_id`` for backward compatibility.
+       Routes are sorted by path length descending so more-specific patterns win.
     3. Prefix fallback for /session/{id} (legacy).
-    kwargs will contain {'session_id': value} for the /session/{id} pattern.
     debug_flag is True when the matched route was registered with debug=True.
 
     Backward compatibility: ROUTES entries may be 3-tuples (legacy direct appends
@@ -67,16 +102,18 @@ def match_route(path: str, method: str) -> tuple:
         if path == route_path and method in route_methods:
             return handler, {}, _debug_flag(entry)
 
-    # Generic {id} template matching — supports /session/{id}/suffix, /api/session/{id}/suffix
-    # Sort by path length descending so more-specific routes (e.g. /session/{id}.md) win over
-    # less-specific ones (e.g. /session/{id}) when both patterns would match.
+    # Named-placeholder template matching — supports /session/{id}/suffix,
+    # /api/session/{id}/suffix, and arbitrary multi-placeholder paths such as
+    # /api/operator/sessions/{session_id}/runs/{run_id}/debug.
+    # Sort by path length descending so more-specific routes (e.g. /session/{id}.md)
+    # win over less-specific ones (e.g. /session/{id}) when both patterns match.
     for entry in sorted(ROUTES, key=lambda r: -len(r[0])):
         route_path, route_methods, handler = entry[0], entry[1], entry[2]
-        if "{id}" in route_path and method in route_methods:
-            pat = "^" + re.escape(route_path).replace("\\{id\\}", "(?P<session_id>[^/]+)") + "$"
+        pat = _build_route_pattern(route_path)
+        if pat is not None and method in route_methods:
             m = re.match(pat, path)
             if m:
-                return handler, {"session_id": m.group("session_id")}, _debug_flag(entry)
+                return handler, m.groupdict(), _debug_flag(entry)
 
     # Prefix pattern for /session/{id} (legacy fallback — catches unknown sub-paths → 400)
     for entry in ROUTES:

--- a/browse/core/server.py
+++ b/browse/core/server.py
@@ -106,6 +106,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
         path = parsed.path
         params = urllib.parse.parse_qs(parsed.query, keep_blank_values=True)
         nonce = generate_nonce()
+        request_method = "GET" if send_body else "HEAD"
         secure_cookie = is_https_request(self.headers)
 
         # /.well-known/browse-host — discovery endpoint; no auth required
@@ -189,16 +190,22 @@ class _BrowseHandler(BaseHTTPRequestHandler):
                     "Vary": "Origin",
                 }
 
-        # ── Debug-log route gate (WBS-103) ────────────────────────────────────
-        # Must precede normal auth check — debug routes use a distinct auth path:
-        # Bearer/cookie only, no ?token=, no open-auth, static-slot → 403.
-        if path.startswith("/api/debug-log/"):
+        # ── Registry-driven debug route gate (WBS-103/WBS-104) ──────────────────
+        # Must precede normal auth check. Any route registered with debug=True uses
+        # a distinct auth path: Bearer/cookie only, no ?token=, no open-auth,
+        # static-slot → 403.  Driven by registry flag rather than a hard-coded URL
+        # prefix so new debug=True routes (e.g. WBS-104 /api/operator/…/debug) are
+        # automatically covered without modifying this dispatcher.
+        _probe_handler, _probe_kwargs, _probe_is_debug = match_route(path, "GET")
+        if _probe_is_debug:
             from browse.core.auth import _is_loopback_host, check_debug_token  # noqa: PLC0415
 
-            _dbg_handler, _dbg_kwargs, _is_debug_route = match_route(path, "GET")
+            _dbg_handler = _probe_handler
+            _dbg_kwargs = _probe_kwargs
 
-            if not _is_debug_route or _dbg_handler is None:
-                # Route not registered (feature disabled) → 404
+            if _dbg_handler is None:
+                # Defensive guard: match_route only sets debug=True for registered
+                # routes, so this branch should never be reached in normal operation.
                 self._send(
                     b"404 Not Found",
                     "text/plain",
@@ -269,7 +276,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
             except Exception as _dbg_exc:
                 _dbg_req_id = str(uuid.uuid4())
                 print(
-                    f"[error] request_id={_dbg_req_id} method=GET path={path} 500: {_dbg_exc}",
+                    f"[error] request_id={_dbg_req_id} method={request_method} path={path} 500: {_dbg_exc}",
                     file=sys.stderr,
                     flush=True,
                 )
@@ -289,7 +296,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
                 cors_headers=cors_resp_headers or None,
             )
             return
-        # ── End debug-log gate ────────────────────────────────────────────────
+        # ── End registry-driven debug gate ───────────────────────────────────
 
         # Auth check (Bearer header, query-string token, or cookie)
         cookie_header = self.headers.get("Cookie", "")
@@ -328,7 +335,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
         params["_session_kind"] = [session_kind]
         if session_kind == "static":
             print(
-                f"[audit] session_kind=static path={path} method=GET",
+                f"[audit] session_kind=static path={path} method={request_method}",
                 file=sys.stderr,
                 flush=True,
             )
@@ -346,7 +353,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
         # Route dispatch: /api/* and .md data exports via registry;
         # everything else is served by the Next.js root app.
         if path.startswith("/api/") or path.endswith(".md"):
-            handler_fn, kwargs, _dbg = match_route(path, "GET")
+            handler_fn, kwargs, _dbg = _probe_handler, _probe_kwargs, _probe_is_debug
             if handler_fn is None:
                 self._send(
                     b"404 Not Found",
@@ -363,7 +370,7 @@ class _BrowseHandler(BaseHTTPRequestHandler):
             except Exception as exc:
                 req_id = str(uuid.uuid4())
                 print(
-                    f"[error] request_id={req_id} method=GET path={path} 500: {exc}",
+                    f"[error] request_id={req_id} method={request_method} path={path} 500: {exc}",
                     file=sys.stderr,
                     flush=True,
                 )
@@ -596,6 +603,71 @@ class _BrowseHandler(BaseHTTPRequestHandler):
                 "Access-Control-Allow-Origin": cors_origin,
                 "Vary": "Origin",
             }
+
+        # Debug routes are read-only. Apply the debug auth guard before normal
+        # mutating auth so query-string tokens/static slots/open-auth cannot be
+        # used against a debug path even when the method is unsupported.
+        _debug_get_handler, _debug_get_kwargs, _debug_path = match_route(path, "GET")
+        if _debug_path:
+            from browse.core.auth import _is_loopback_host, check_debug_token  # noqa: PLC0415
+
+            if _debug_get_handler is None:
+                self._send(
+                    b"404 Not Found",
+                    "text/plain",
+                    404,
+                    nonce,
+                    cors_headers=cors_resp_headers or None,
+                )
+                return
+
+            if params.get("token"):
+                self._send(
+                    b"401 Unauthorized",
+                    "text/plain",
+                    401,
+                    nonce,
+                    cors_headers=cors_resp_headers or None,
+                )
+                return
+
+            from browse.core.pairing import get_static_slot as _dbg_get_static  # noqa: PLC0415
+
+            if _dbg_get_static():
+                self._send(
+                    b"403 Forbidden",
+                    "text/plain",
+                    403,
+                    nonce,
+                    cors_headers=cors_resp_headers or None,
+                )
+                return
+
+            _dbg_valid, _dbg_token_val = check_debug_token(
+                self.token,
+                self.headers.get("Cookie", ""),
+                self.headers.get("Authorization", ""),
+            )
+            if not _dbg_valid:
+                _dbg_host = self.headers.get("Host", "")
+                status = 403 if not self.token and not _is_loopback_host(_dbg_host) else 401
+                self._send(
+                    b"403 Forbidden" if status == 403 else b"401 Unauthorized",
+                    "text/plain",
+                    status,
+                    nonce,
+                    cors_headers=cors_resp_headers or None,
+                )
+                return
+
+            self._send(
+                b"404 Not Found",
+                "text/plain",
+                404,
+                nonce,
+                cors_headers=cors_resp_headers or None,
+            )
+            return
 
         # Auth check (Bearer header, cookie, or query-string token)
         cookie_header = self.headers.get("Cookie", "")

--- a/docs/DEBUG-LOG-CONTRACT.md
+++ b/docs/DEBUG-LOG-CONTRACT.md
@@ -56,7 +56,10 @@ output stream.
 
 ### `DebugLogResponse`
 
-The HTTP response envelope for `GET /api/session/{id}/debug-log`.
+The HTTP response envelope for planned `GET /api/session/{id}/debug-log` consumers.
+For the WBS-104 operator run debug endpoint, see
+[WBS-104 Response Shape](#response-shape); it uses `events` instead of `entries`
+and includes `run_id`, `from`, `limit`, and `has_more`.
 
 | Field | Type | Nullable | Description |
 |---|---|---|---|
@@ -354,8 +357,9 @@ No CSP loosening is applied for debug routes.
 
 The following are explicitly **out of scope** for the current debug-log contract:
 
-1. Full debug-log read/query API (`GET /api/session/{id}/debug-log`) — WBS-103 implemented only the healthz probe and storage layer; the session-scoped read route remains future work.
-2. Frontend UI panel or event row renderer — WBS-104.
+1. Session-scoped debug-log read/query API (`GET /api/session/{id}/debug-log`) — future work.
+   WBS-104 implements the operator-run read endpoint below.
+2. Frontend UI panel or event row renderer — future work.
 3. TypeScript / Zod schema implementation — WBS-106.
 4. SSE streaming of debug log events — WBS-107.
 5. Redaction engine implementation — WBS-102.
@@ -364,6 +368,146 @@ The following are explicitly **out of scope** for the current debug-log contract
 7. Real-time filtering or search — WBS-108+.
 8. Performance benchmarks — WBS-109.
 9. CI integration — WBS-110.
+
+---
+
+## WBS-104 Debug-Log Read API
+
+### Endpoint
+
+```
+GET /api/operator/sessions/{session_id}/runs/{run_id}/debug
+```
+
+**Registered with `debug=True`** — uses the same Bearer/cookie-only auth gate as
+`/api/debug-log/healthz`.  Query-string `?token=` is rejected with `401`.
+
+### Auth and Status Semantics
+
+| Condition | Response |
+|---|---|
+| Route not registered | `404 Not Found` (falls through to regular 404 dispatch) |
+| `?token=` query-string auth present | `401 Unauthorized` |
+| Static/demo slot active | `403 Forbidden` |
+| Non-loopback host, no server token configured | `403 Forbidden` |
+| Missing or invalid Bearer/cookie token | `401 Unauthorized` |
+| Valid Bearer header or session cookie | `200 OK` |
+| Unknown `session_id` (or not a valid UUID4) | `404 application/json` |
+| Unknown `run_id` | `404 application/json` |
+| `run.session_id != session_id` (ownership mismatch) | `404 application/json` |
+| Bad query parameter | `400 application/json` |
+
+**No UUID / path leakage** — 404 error bodies never echo back the session_id, run_id,
+or any filesystem path.
+
+### Query Parameters
+
+| Parameter | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `from` | integer | `0` | `>= 0` | Pagination offset (zero-based) |
+| `limit` | integer | `100` | `1..100` | Page size |
+| `kind` | string | — | one of `_KIND_ENUM` | Filter by event kind |
+| `level` | string | — | one of `_LEVEL_ENUM` | Filter by severity level |
+| `since` | string | — | parseable ISO-8601 | Include only events with `timestamp >= since` |
+
+Bad parameter values → `400 application/json` with `{"error": "...", "code": "BAD_PARAM"}`.
+
+### Response Shape
+
+```json
+{
+  "schema_version": "1",
+  "session_id": "<uuid>",
+  "run_id": "<uuid>",
+  "total": 42,
+  "from": 0,
+  "limit": 100,
+  "has_more": false,
+  "events": [<BrowseDebugEntry>, ...]
+}
+```
+
+`total` is the count **after** filters are applied but **before** pagination.
+`has_more` is `true` when `from + limit < total`.
+`events` contains at most `limit` entries, starting from the `from` index of the
+filtered result set.  All entries pass through `browse.core.redaction.redact_entry`
+before being returned.
+Operator-console entries return nullable `tool_name`, `duration_ms`,
+`parent_span_id`, and `status` keys explicitly as `null` when no source value is
+available.
+
+### Data Source
+
+Entries are read from persisted operator run JSON `run["events"]` only:
+- `get_session(session_id)` — validates the session exists
+- `get_run_status(run_id)` — loads from `_ACTIVE_RUNS` memory or `~/.copilot/session-state/operator-console/runs/{session_id}/{run_id}.json`
+- Strict `run["session_id"] == session_id` ownership check before reading events
+
+**No WBS-103 SQLite debug-log storage is consulted** — that store has no `run_id`
+key and no current producers.
+
+**No WBS-105 sidecar source yet** — this endpoint intentionally does not read
+`run["debug_events"]`.  Reconciling the sidecar with the read endpoint is a
+follow-up for #434, because the sidecar currently has different span-id,
+timestamp, nullable-field, and cap semantics.
+
+### Operator Event → BrowseDebugEntry Mapping
+
+| Operator event `type` | `BrowseDebugEntry.kind` |
+|---|---|
+| `"raw"` (non-JSON line) | `"raw"` |
+| `"assistant.message"`, `"assistant.message_delta"` | `"agent_response"` |
+| `"tool_call"`, `"tool_result"` | `"tool_call"` |
+| `"session_start"` | `"session_start"` |
+| `"turn_start"` | `"turn_start"` |
+| `"llm_request"` | `"llm_request"` |
+| `"hook"` | `"hook"` |
+| `"subagent"` | `"subagent"` |
+| `"error"`, `"exception"` | `"error"` |
+| any other `type` | `"generic"` |
+
+**Fixed fields for all operator events:**
+- `source` = `"operator_console"`
+- `level` = `null` (operator events carry no severity field)
+- `timestamp` = extracted from inner event `timestamp`/`ts` field; `null` when absent
+- `span_id` = `synthetic_span_id("operator_console", idx, 1)` (see
+  [Synthetic Span-ID Rule](#synthetic-span-id-rule))
+
+### Large-Event Truncation
+
+If the serialized JSON bytes of a raw operator event exceed **8192 bytes**:
+
+- `message` is replaced with: `[TRUNCATED sha256=<hex16> bytes=<n>]`
+- `attrs.truncated` = `true`
+- `attrs.bytes_in` = `<n>` (original byte count)
+- Raw event content is **never** included in the response
+
+Both `truncated` and `bytes_in` are in the `attrs` allowlist and survive the
+redaction pass.
+
+### `since` Filter Semantics
+
+Events with `timestamp = null` are **excluded** when the `since` parameter is
+provided.  If the timestamp cannot be parsed as ISO-8601, the event is also
+excluded.
+
+### Registry-Driven Debug Auth Gate (WBS-104 Generalisation)
+
+`browse/core/server.py` no longer hard-codes the `/api/debug-log/` URL prefix.
+The gate is now driven by `match_route(path, "GET")` returning `debug_flag=True`.
+Any route registered with `debug=True` — regardless of path prefix — automatically
+receives Bearer/cookie-only auth, `?token=` rejection, static-slot blocking, and the
+non-loopback insecure-config 403 rule.
+
+The `/api/debug-log/healthz` behaviour is unchanged.
+
+### Performance
+
+The implementation slices the filtered entry list **before** calling `redact_entry`,
+so at most `limit` (default 100, max 100) entries are redacted per request.
+
+A performance test (`tests/test_browse_debug_log_api.py::DB26`) verifies that
+100 entries are served from a 1000-event run in under 200 ms.
 
 ---
 

--- a/tests/test_browse_debug_log_api.py
+++ b/tests/test_browse_debug_log_api.py
@@ -1,0 +1,815 @@
+#!/usr/bin/env python3
+"""tests/test_browse_debug_log_api.py — HTTP tests for WBS-104 debug-log read API.
+
+GET /api/operator/sessions/{session_id}/runs/{run_id}/debug
+
+Tests:
+  DB1:  Unknown session_id → 404 with no UUID leakage
+  DB2:  Unknown run_id → 404 with no UUID leakage
+  DB3:  Mismatched run (run belongs to different session) → 404
+  DB4:  Missing auth → 401
+  DB5:  Invalid Bearer → 401
+  DB6:  ?token= query-string auth → 401 (rejected for debug routes)
+  DB7:  Valid Bearer → 200 with correct response shape
+  DB8:  Valid cookie → 200
+  DB9:  Static slot active → 403
+  DB10: Default pagination (limit=100, from=0, has_more=False for small run)
+  DB11: Explicit limit and from
+  DB12: from exceeds total → 200, empty events, has_more=False
+  DB13: limit out of range (>100) → 400
+  DB14: from < 0 → 400
+  DB15: kind filter — valid kind matches only matching events
+  DB16: kind filter — invalid kind → 400
+  DB17: level filter — valid (returns 0 events since operator events have level=null)
+  DB18: level filter — invalid → 400
+  DB19: since filter — valid ISO-8601 filters events without timestamp
+  DB20: since filter — invalid datetime string → 400
+  DB21: Redaction: redacted=False for clean entry, redacted=True for dirty entry
+  DB22: Truncation indicator: event >8192 bytes → truncation marker in message + attrs
+  DB23: CORS disallowed origin → no ACAO header on 200 response
+  DB24: HEAD request → correct status, no body
+  DB25: Content-Type is application/json for all responses
+  DB26: Performance: 100 entries from 1000-event run in under 200ms
+  DB27: Empty run → total=0, has_more=False, events=[]
+  DB28: schema_version field is "1"
+  DB29: Non-UUID session_id → 404 (get_session returns None for invalid IDs)
+  DB30: Unknown session/run/mismatched run use uniform 404 code/message
+  DB31: Non-loopback with no server token → 403 on new debug path
+  DB32: Mutating method with ?token= on debug path → 401 before normal auth
+"""
+
+import hashlib
+import http.client
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import browse.core.registry as registry_mod  # noqa: E402
+
+# Set up isolated operator state dir before importing operator_console
+_TEST_STATE_DIR = Path(tempfile.mkdtemp())
+os.environ["COPILOT_OPERATOR_STATE"] = str(_TEST_STATE_DIR)
+
+import sqlite3  # noqa: E402
+
+import browse.api.operator  # noqa: E402 — registers all operator routes incl. debug
+import browse.routes.health  # noqa: E402 — healthz route
+from browse.core.operator_console import (  # noqa: E402
+    _ACTIVE_RUNS,
+    _RUNS_LOCK,
+    _is_valid_id,
+    create_session,
+    get_run_status,
+    get_session,
+)
+from browse.core.server import _make_handler_class  # noqa: E402
+
+_PASS = 0
+_FAIL = 0
+
+_TOKEN = "test-debug-api-token-wbs104"
+_ALLOWED_ORIGIN = "https://agents.linhngo.dev"
+_DISALLOWED_ORIGIN = "https://evil.example.com"
+
+
+def test(name: str, expr: bool) -> None:
+    global _PASS, _FAIL
+    if expr:
+        _PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        _FAIL += 1
+        print(f"  FAIL  {name}")
+
+
+# ── Server helpers ─────────────────────────────────────────────────────────────
+
+
+def _make_test_db() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.executescript("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            summary TEXT DEFAULT '',
+            repository TEXT DEFAULT '',
+            branch TEXT DEFAULT '',
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT ''
+        );
+    """)
+    db.commit()
+    return db
+
+
+def _make_test_server(token: str = _TOKEN) -> tuple:
+    """Spin up a ThreadingHTTPServer on loopback and return (server, port)."""
+    db = _make_test_db()
+    HandlerClass = _make_handler_class(db, token)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), HandlerClass)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server, server.server_address[1]
+
+
+# ── Data helpers ───────────────────────────────────────────────────────────────
+
+
+def _make_session() -> str:
+    """Create a real session in the test state dir. Returns session_id."""
+    session = create_session(name="test-session-wbs104", model="", mode="")
+    return session["id"]
+
+
+def _make_run(session_id: str, events: list | None = None) -> str:
+    """Inject a fake in-memory run (already persisted via JSON). Returns run_id."""
+    run_id = str(uuid.uuid4())
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).isoformat()
+    run = {
+        "id": run_id,
+        "session_id": session_id,
+        "prompt": "test prompt",
+        "status": "done",
+        "started_at": now,
+        "finished_at": now,
+        "exit_code": 0,
+        "resume_used": False,
+        "events": events if events is not None else [],
+    }
+    with _RUNS_LOCK:
+        _ACTIVE_RUNS[run_id] = run
+    return run_id
+
+
+def _bearer(port: int, path: str, token: str = _TOKEN, extra_headers: dict | None = None) -> http.client.HTTPResponse:
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    hdrs = {"Authorization": f"Bearer {token}"}
+    if extra_headers:
+        hdrs.update(extra_headers)
+    conn.request("GET", path, headers=hdrs)
+    return conn.getresponse()
+
+
+def _debug_path(session_id: str, run_id: str, qs: str = "") -> str:
+    base = f"/api/operator/sessions/{session_id}/runs/{run_id}/debug"
+    return base + (f"?{qs}" if qs else "")
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+
+def test_unknown_session_404():
+    """DB1: Unknown session_id → 404, no UUID in body."""
+    server, port = _make_test_server()
+    try:
+        fake_session = str(uuid.uuid4())
+        fake_run = str(uuid.uuid4())
+        resp = _bearer(port, _debug_path(fake_session, fake_run))
+        body = resp.read()
+        test("DB1 status 404", resp.status == 404)
+        # Ensure no UUID leakage in error body
+        data = json.loads(body)
+        test("DB1 no session_id in error", fake_session not in json.dumps(data))
+        test("DB1 no run_id in error", fake_run not in json.dumps(data))
+    finally:
+        server.shutdown()
+
+
+def test_unknown_run_404():
+    """DB2: Valid session but unknown run → 404."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        fake_run = str(uuid.uuid4())
+        resp = _bearer(port, _debug_path(sid, fake_run))
+        body = resp.read()
+        test("DB2 status 404", resp.status == 404)
+        data = json.loads(body)
+        test("DB2 no run_id in error", fake_run not in json.dumps(data))
+    finally:
+        server.shutdown()
+
+
+def test_mismatched_run_404():
+    """DB3: Run exists but belongs to different session → 404."""
+    server, port = _make_test_server()
+    try:
+        sid1 = _make_session()
+        sid2 = _make_session()
+        run_id = _make_run(sid1, events=[])
+
+        # Query run_id under sid2 (different session)
+        resp = _bearer(port, _debug_path(sid2, run_id))
+        body = resp.read()
+        test("DB3 status 404", resp.status == 404)
+    finally:
+        server.shutdown()
+
+
+def test_missing_auth_401():
+    """DB4: No Authorization header → 401."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid)
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", _debug_path(sid, run_id))
+        resp = conn.getresponse()
+        resp.read()
+        test("DB4 status 401", resp.status == 401)
+    finally:
+        server.shutdown()
+
+
+def test_invalid_bearer_401():
+    """DB5: Wrong Bearer token → 401."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid)
+        resp = _bearer(port, _debug_path(sid, run_id), token="wrong-token")
+        resp.read()
+        test("DB5 status 401", resp.status == 401)
+    finally:
+        server.shutdown()
+
+
+def test_query_token_rejected_401():
+    """DB6: ?token= query-string auth → 401 (rejected for debug routes)."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid)
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", _debug_path(sid, run_id, qs=f"token={_TOKEN}"))
+        resp = conn.getresponse()
+        resp.read()
+        test("DB6 status 401", resp.status == 401)
+    finally:
+        server.shutdown()
+
+
+def test_valid_bearer_200():
+    """DB7: Valid Bearer → 200 with correct response shape."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(
+            sid,
+            events=[
+                {"type": "raw", "idx": 0, "text": "hello world"},
+                {"type": "assistant.message", "idx": 1, "event": {"type": "assistant.message", "content": "Hi"}},
+            ],
+        )
+        resp = _bearer(port, _debug_path(sid, run_id))
+        body = resp.read()
+        test("DB7 status 200", resp.status == 200)
+        ct = resp.getheader("Content-Type", "")
+        test("DB7 content-type JSON", "application/json" in ct)
+        data = json.loads(body)
+        test("DB7 schema_version=1", data.get("schema_version") == "1")
+        test("DB7 session_id matches", data.get("session_id") == sid)
+        test("DB7 run_id matches", data.get("run_id") == run_id)
+        test("DB7 total present", isinstance(data.get("total"), int))
+        test("DB7 from present", "from" in data)
+        test("DB7 limit present", "limit" in data)
+        test("DB7 has_more present", "has_more" in data)
+        test("DB7 events is list", isinstance(data.get("events"), list))
+        test("DB7 total == 2", data.get("total") == 2)
+        test("DB7 events len == 2", len(data["events"]) == 2)
+        for field in ("tool_name", "duration_ms", "parent_span_id", "status"):
+            test(
+                f"DB7 nullable {field} present as null",
+                all(event.get(field, "missing") is None for event in data["events"]),
+            )
+    finally:
+        server.shutdown()
+
+
+def test_valid_cookie_200():
+    """DB8: Valid browse_token cookie → 200."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", _debug_path(sid, run_id), headers={"Cookie": f"browse_token={_TOKEN}"})
+        resp = conn.getresponse()
+        body = resp.read()
+        test("DB8 status 200", resp.status == 200)
+        data = json.loads(body)
+        test("DB8 schema_version present", data.get("schema_version") == "1")
+    finally:
+        server.shutdown()
+
+
+def test_static_slot_403():
+    """DB9: Static slot active → 403."""
+    import browse.core.pairing as _pairing
+
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+        original = _pairing._static_slot
+        _pairing._static_slot = {"token": "demo-tok", "label": "demo"}
+        try:
+            resp = _bearer(port, _debug_path(sid, run_id))
+            resp.read()
+            test("DB9 status 403", resp.status == 403)
+        finally:
+            _pairing._static_slot = original
+    finally:
+        server.shutdown()
+
+
+def test_default_pagination():
+    """DB10: Default pagination — from=0, limit=100, has_more=False for small run."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        evts = [{"type": "raw", "idx": i, "text": f"line {i}"} for i in range(5)]
+        run_id = _make_run(sid, events=evts)
+        resp = _bearer(port, _debug_path(sid, run_id))
+        data = json.loads(resp.read())
+        test("DB10 status 200", resp.status == 200)
+        test("DB10 from=0", data.get("from") == 0)
+        test("DB10 limit=100", data.get("limit") == 100)
+        test("DB10 has_more=False", data.get("has_more") is False)
+        test("DB10 total=5", data.get("total") == 5)
+        test("DB10 events len=5", len(data["events"]) == 5)
+    finally:
+        server.shutdown()
+
+
+def test_explicit_limit_and_from():
+    """DB11: Explicit limit=2, from=1 → page of 2 starting at index 1."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        evts = [{"type": "raw", "idx": i, "text": f"line {i}"} for i in range(5)]
+        run_id = _make_run(sid, events=evts)
+        resp = _bearer(port, _debug_path(sid, run_id, qs="limit=2&from=1"))
+        data = json.loads(resp.read())
+        test("DB11 status 200", resp.status == 200)
+        test("DB11 from=1", data.get("from") == 1)
+        test("DB11 limit=2", data.get("limit") == 2)
+        test("DB11 has_more=True", data.get("has_more") is True)
+        test("DB11 events len=2", len(data["events"]) == 2)
+        test("DB11 total=5", data.get("total") == 5)
+    finally:
+        server.shutdown()
+
+
+def test_from_exceeds_total():
+    """DB12: from > total → 200, empty events, has_more=False."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[{"type": "raw", "idx": 0, "text": "x"}])
+        resp = _bearer(port, _debug_path(sid, run_id, qs="from=999"))
+        data = json.loads(resp.read())
+        test("DB12 status 200", resp.status == 200)
+        test("DB12 events empty", data.get("events") == [])
+        test("DB12 has_more=False", data.get("has_more") is False)
+        test("DB12 total=1", data.get("total") == 1)
+    finally:
+        server.shutdown()
+
+
+def test_limit_out_of_range_400():
+    """DB13: limit=101 → 400."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+        resp = _bearer(port, _debug_path(sid, run_id, qs="limit=101"))
+        resp.read()
+        test("DB13 status 400", resp.status == 400)
+
+        resp2 = _bearer(port, _debug_path(sid, run_id, qs="limit=0"))
+        resp2.read()
+        test("DB13 limit=0 also 400", resp2.status == 400)
+    finally:
+        server.shutdown()
+
+
+def test_from_negative_400():
+    """DB14: from=-1 → 400."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+        resp = _bearer(port, _debug_path(sid, run_id, qs="from=-1"))
+        resp.read()
+        test("DB14 status 400", resp.status == 400)
+    finally:
+        server.shutdown()
+
+
+def test_kind_filter():
+    """DB15: kind=raw → only raw events returned."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        evts = [
+            {"type": "raw", "idx": 0, "text": "raw line"},
+            {"type": "assistant.message", "idx": 1, "event": {"type": "assistant.message", "content": "Hi"}},
+            {"type": "raw", "idx": 2, "text": "another raw"},
+        ]
+        run_id = _make_run(sid, events=evts)
+        resp = _bearer(port, _debug_path(sid, run_id, qs="kind=raw"))
+        data = json.loads(resp.read())
+        test("DB15 status 200", resp.status == 200)
+        test("DB15 total=2 (raw only)", data.get("total") == 2)
+        test("DB15 all kinds raw", all(e["kind"] == "raw" for e in data["events"]))
+    finally:
+        server.shutdown()
+
+
+def test_kind_filter_invalid_400():
+    """DB16: kind=invalid → 400."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+        resp = _bearer(port, _debug_path(sid, run_id, qs="kind=not_a_kind"))
+        resp.read()
+        test("DB16 status 400", resp.status == 400)
+    finally:
+        server.shutdown()
+
+
+def test_level_filter_returns_zero():
+    """DB17: level=info → 0 events (operator events always have level=null)."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        evts = [{"type": "raw", "idx": 0, "text": "x"}]
+        run_id = _make_run(sid, events=evts)
+        resp = _bearer(port, _debug_path(sid, run_id, qs="level=info"))
+        data = json.loads(resp.read())
+        test("DB17 status 200", resp.status == 200)
+        test("DB17 total=0 (null level filtered)", data.get("total") == 0)
+    finally:
+        server.shutdown()
+
+
+def test_level_filter_invalid_400():
+    """DB18: level=critical → 400."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+        resp = _bearer(port, _debug_path(sid, run_id, qs="level=critical"))
+        resp.read()
+        test("DB18 status 400", resp.status == 400)
+    finally:
+        server.shutdown()
+
+
+def test_since_filter():
+    """DB19: since= filters events without timestamp (raw events have null ts)."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        evts = [
+            {"type": "raw", "idx": 0, "text": "no ts"},  # will be excluded (no timestamp)
+            {
+                "type": "assistant.message",
+                "idx": 1,
+                "event": {
+                    "type": "assistant.message",
+                    "timestamp": "2025-01-02T00:00:00Z",
+                    "content": "after",
+                },
+            },
+            {
+                "type": "assistant.message",
+                "idx": 2,
+                "event": {
+                    "type": "assistant.message",
+                    "timestamp": "2024-12-31T00:00:00Z",
+                    "content": "before",
+                },
+            },
+        ]
+        run_id = _make_run(sid, events=evts)
+        resp = _bearer(port, _debug_path(sid, run_id, qs="since=2025-01-01T00%3A00%3A00Z"))
+        data = json.loads(resp.read())
+        test("DB19 status 200", resp.status == 200)
+        # Only the 2025-01-02 event passes; raw and 2024-12-31 are excluded
+        test("DB19 total=1", data.get("total") == 1)
+        test("DB19 event content", data["events"][0].get("message") == "after")
+    finally:
+        server.shutdown()
+
+
+def test_since_invalid_400():
+    """DB20: since=not-a-date → 400."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+        resp = _bearer(port, _debug_path(sid, run_id, qs="since=not-a-date"))
+        resp.read()
+        test("DB20 status 400", resp.status == 400)
+    finally:
+        server.shutdown()
+
+
+def test_redaction():
+    """DB21: redacted=False for clean entry, redacted=True for entry with bearer token in message."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        evts = [
+            {"type": "raw", "idx": 0, "text": "clean message"},
+            {"type": "raw", "idx": 1, "text": "Bearer ghp_abc123secrettoken message"},
+        ]
+        run_id = _make_run(sid, events=evts)
+        resp = _bearer(port, _debug_path(sid, run_id))
+        data = json.loads(resp.read())
+        test("DB21 status 200", resp.status == 200)
+        events = data["events"]
+        test("DB21 clean entry redacted=False", events[0].get("redacted") is False)
+        test("DB21 dirty entry redacted=True", events[1].get("redacted") is True)
+        # Bearer token must not appear in the response
+        resp_str = json.dumps(data)
+        test("DB21 no bearer token in response", "ghp_abc123secrettoken" not in resp_str)
+    finally:
+        server.shutdown()
+
+
+def test_truncation_indicator():
+    """DB22: Event >8192 bytes → truncation marker in message, attrs.truncated=True, attrs.bytes_in=N."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        # Build a raw event whose JSON serialization exceeds 8192 bytes
+        large_text = "A" * 9000
+        evts = [{"type": "raw", "idx": 0, "text": large_text}]
+        raw_bytes = len(json.dumps(evts[0]).encode("utf-8"))
+        run_id = _make_run(sid, events=evts)
+
+        resp = _bearer(port, _debug_path(sid, run_id))
+        data = json.loads(resp.read())
+        test("DB22 status 200", resp.status == 200)
+        entry = data["events"][0]
+        msg = entry.get("message", "")
+        expected_sha = hashlib.sha256(json.dumps(evts[0]).encode("utf-8", errors="replace")).hexdigest()[:16]
+        test("DB22 message starts with [TRUNCATED", msg.startswith("[TRUNCATED sha256="))
+        test("DB22 sha fingerprints same bytes as bytes_in", f"sha256={expected_sha}" in msg)
+        test("DB22 attrs.truncated=True", entry.get("attrs", {}).get("truncated") is True)
+        bytes_in = entry.get("attrs", {}).get("bytes_in")
+        test("DB22 attrs.bytes_in == raw_bytes", bytes_in == raw_bytes)
+        test("DB22 large text not in message", large_text[:100] not in msg)
+    finally:
+        server.shutdown()
+
+
+def test_cors_disallowed_no_acao():
+    """DB23: Disallowed Origin → no ACAO header."""
+    os.environ["BROWSE_CORS_ORIGINS"] = _ALLOWED_ORIGIN
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+        resp = _bearer(
+            port,
+            _debug_path(sid, run_id),
+            extra_headers={"Origin": _DISALLOWED_ORIGIN},
+        )
+        resp.read()
+        acao = resp.getheader("Access-Control-Allow-Origin", "")
+        test("DB23 no ACAO for disallowed origin", acao == "")
+    finally:
+        server.shutdown()
+        os.environ.pop("BROWSE_CORS_ORIGINS", None)
+
+
+def test_head_request():
+    """DB24: HEAD → correct status, empty body."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[{"type": "raw", "idx": 0, "text": "x"}])
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "HEAD",
+            _debug_path(sid, run_id),
+            headers={"Authorization": f"Bearer {_TOKEN}"},
+        )
+        resp = conn.getresponse()
+        body = resp.read()
+        test("DB24 HEAD status 200", resp.status == 200)
+        test("DB24 HEAD body empty", body == b"")
+        ct = resp.getheader("Content-Type", "")
+        test("DB24 HEAD content-type JSON", "application/json" in ct)
+    finally:
+        server.shutdown()
+
+
+def test_content_type_json():
+    """DB25: All responses carry application/json content-type."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+
+        # 200 response
+        resp = _bearer(port, _debug_path(sid, run_id))
+        resp.read()
+        test("DB25 200 content-type", "application/json" in resp.getheader("Content-Type", ""))
+
+        # 400 response
+        resp2 = _bearer(port, _debug_path(sid, run_id, qs="limit=999"))
+        resp2.read()
+        test("DB25 400 content-type", "application/json" in resp2.getheader("Content-Type", ""))
+
+        # 404 response
+        resp3 = _bearer(port, _debug_path(str(uuid.uuid4()), str(uuid.uuid4())))
+        resp3.read()
+        test("DB25 404 content-type", "application/json" in resp3.getheader("Content-Type", ""))
+    finally:
+        server.shutdown()
+
+
+def test_performance_100_of_1000():
+    """DB26: Serve 100 entries from a 1000-event run in <200ms."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        evts = [{"type": "raw", "idx": i, "text": f"line {i} " + "x" * 80} for i in range(1000)]
+        run_id = _make_run(sid, events=evts)
+
+        start = time.monotonic()
+        resp = _bearer(port, _debug_path(sid, run_id, qs="limit=100&from=0"))
+        data = json.loads(resp.read())
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        test("DB26 status 200", resp.status == 200)
+        test("DB26 100 events returned", len(data.get("events", [])) == 100)
+        test("DB26 total=1000", data.get("total") == 1000)
+        test(f"DB26 elapsed {elapsed_ms:.0f}ms < 200ms", elapsed_ms < 200)
+    finally:
+        server.shutdown()
+
+
+def test_empty_run():
+    """DB27: Run with no events → total=0, has_more=False, events=[]."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+        resp = _bearer(port, _debug_path(sid, run_id))
+        data = json.loads(resp.read())
+        test("DB27 status 200", resp.status == 200)
+        test("DB27 total=0", data.get("total") == 0)
+        test("DB27 has_more=False", data.get("has_more") is False)
+        test("DB27 events=[]", data.get("events") == [])
+    finally:
+        server.shutdown()
+
+
+def test_schema_version():
+    """DB28: schema_version is always '1'."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+        resp = _bearer(port, _debug_path(sid, run_id))
+        data = json.loads(resp.read())
+        test("DB28 schema_version=1", data.get("schema_version") == "1")
+    finally:
+        server.shutdown()
+
+
+def test_non_uuid_session_404():
+    """DB29: Non-UUID session_id → 404 (get_session returns None for invalid IDs)."""
+    server, port = _make_test_server()
+    try:
+        resp = _bearer(port, "/api/operator/sessions/not-a-uuid/runs/also-not-uuid/debug")
+        body = resp.read()
+        test("DB29 status 404", resp.status == 404)
+        # No path or ID leakage
+        data = json.loads(body)
+        test("DB29 no path in error", "not-a-uuid" not in json.dumps(data))
+    finally:
+        server.shutdown()
+
+
+def test_uniform_404_error_code():
+    """DB30: All negative lookup cases use the same non-enumerating 404 code/message."""
+    server, port = _make_test_server()
+    try:
+        fake_session = str(uuid.uuid4())
+        fake_run = str(uuid.uuid4())
+        sid1 = _make_session()
+        sid2 = _make_session()
+        run_id = _make_run(sid1, events=[])
+
+        cases = [
+            _debug_path(fake_session, fake_run),
+            _debug_path(sid1, fake_run),
+            _debug_path(sid2, run_id),
+        ]
+        payloads = []
+        for path in cases:
+            resp = _bearer(port, path)
+            payloads.append(json.loads(resp.read()))
+            test("DB30 status 404", resp.status == 404)
+        codes = {p.get("code") for p in payloads}
+        errors = {p.get("error") for p in payloads}
+        test("DB30 single 404 code", codes == {"NOT_FOUND"})
+        test("DB30 single 404 message", errors == {"debug log not found"})
+    finally:
+        server.shutdown()
+
+
+def test_non_loopback_no_token_403():
+    """DB31: Non-loopback Host with no server token is rejected by the debug gate."""
+    server, port = _make_test_server(token="")
+    try:
+        path = _debug_path(str(uuid.uuid4()), str(uuid.uuid4()))
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", path, headers={"Host": "agents.example.com"})
+        resp = conn.getresponse()
+        resp.read()
+        test("DB31 status 403", resp.status == 403)
+    finally:
+        server.shutdown()
+
+
+def test_mutating_query_token_rejected_401():
+    """DB32: POST to a debug path still rejects ?token= before normal auth."""
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(sid, events=[])
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("POST", _debug_path(sid, run_id, qs=f"token={_TOKEN}"), body="")
+        resp = conn.getresponse()
+        resp.read()
+        test("DB32 status 401", resp.status == 401)
+    finally:
+        server.shutdown()
+
+
+# ── Runner ─────────────────────────────────────────────────────────────────────
+
+
+if __name__ == "__main__":
+    print("\n── WBS-104 Debug Log API Tests ──────────────────────────────────────")
+    test_unknown_session_404()
+    test_unknown_run_404()
+    test_mismatched_run_404()
+    test_missing_auth_401()
+    test_invalid_bearer_401()
+    test_query_token_rejected_401()
+    test_valid_bearer_200()
+    test_valid_cookie_200()
+    test_static_slot_403()
+    test_default_pagination()
+    test_explicit_limit_and_from()
+    test_from_exceeds_total()
+    test_limit_out_of_range_400()
+    test_from_negative_400()
+    test_kind_filter()
+    test_kind_filter_invalid_400()
+    test_level_filter_returns_zero()
+    test_level_filter_invalid_400()
+    test_since_filter()
+    test_since_invalid_400()
+    test_redaction()
+    test_truncation_indicator()
+    test_cors_disallowed_no_acao()
+    test_head_request()
+    test_content_type_json()
+    test_performance_100_of_1000()
+    test_empty_run()
+    test_schema_version()
+    test_non_uuid_session_404()
+    test_uniform_404_error_code()
+    test_non_loopback_no_token_403()
+    test_mutating_query_token_rejected_401()
+
+    print(f"\n{'=' * 50}")
+    print(f"Results: {_PASS} passed, {_FAIL} failed")
+    if _FAIL:
+        sys.exit(1)

--- a/tests/test_browse_debug_log_api.py
+++ b/tests/test_browse_debug_log_api.py
@@ -36,6 +36,10 @@ Tests:
   DB30: Unknown session/run/mismatched run use uniform 404 code/message
   DB31: Non-loopback with no server token → 403 on new debug path
   DB32: Mutating method with ?token= on debug path → 401 before normal auth
+  DB33: Nested inner.data content extraction for assistant.message (comment #1 fix)
+  DB34: Outer event["data"] deltaContent extraction for assistant.message_delta (#1 fix)
+  DB35: Nested inner.data toolName extraction for tool_call (comment #2 fix)
+  DB36: Outer event["data"] name extraction for tool_call (comment #2 fix)
 """
 
 import hashlib
@@ -57,10 +61,10 @@ if os.name == "nt":
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import browse.core.registry as registry_mod  # noqa: E402
-
-# Set up isolated operator state dir before importing operator_console
-_TEST_STATE_DIR = Path(tempfile.mkdtemp())
+# Set up isolated operator state dir before importing operator_console.
+# Use TemporaryDirectory so the dir is cleaned up when the module is unloaded (no leak).
+_TEST_STATE_DIR_HANDLE = tempfile.TemporaryDirectory()
+_TEST_STATE_DIR = Path(_TEST_STATE_DIR_HANDLE.name)
 os.environ["COPILOT_OPERATOR_STATE"] = str(_TEST_STATE_DIR)
 
 import sqlite3  # noqa: E402
@@ -70,7 +74,6 @@ import browse.routes.health  # noqa: E402 — healthz route
 from browse.core.operator_console import (  # noqa: E402
     _ACTIVE_RUNS,
     _RUNS_LOCK,
-    _is_valid_id,
     create_session,
     get_run_status,
     get_session,
@@ -771,6 +774,146 @@ def test_mutating_query_token_rejected_401():
         server.shutdown()
 
 
+def test_nested_inner_data_content_extraction():
+    """DB33: assistant.message with content in inner.event.data (not top-level inner).
+
+    Verifies comment #1 fix: _map_operator_event checks inner.data.content before
+    falling back, so content is not lost when Copilot CLI emits data.content rather
+    than a top-level content key.
+    """
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        # Content nested under event.event.data — NOT at event.event top-level.
+        run_id = _make_run(
+            sid,
+            events=[
+                {
+                    "type": "assistant.message",
+                    "idx": 0,
+                    "event": {
+                        "type": "assistant.message",
+                        "data": {"content": "nested-data-content"},
+                    },
+                }
+            ],
+        )
+        resp = _bearer(port, _debug_path(sid, run_id))
+        data = json.loads(resp.read())
+        test("DB33 status 200", resp.status == 200)
+        events = data.get("events", [])
+        test("DB33 one event", len(events) == 1)
+        test(
+            "DB33 message = nested-data-content",
+            events[0].get("message") == "nested-data-content",
+        )
+    finally:
+        server.shutdown()
+
+
+def test_outer_data_delta_content_extraction():
+    """DB34: assistant.message_delta with deltaContent in outer event["data"].
+
+    Verifies comment #1 fix: _map_operator_event checks outer event.data.deltaContent
+    (promoted to the top-level "data" key by _parse_output_event) so stream delta
+    previews are not silently lost.
+    """
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        # deltaContent stored at outer event["data"] level (no top-level inner key).
+        run_id = _make_run(
+            sid,
+            events=[
+                {
+                    "type": "assistant.message_delta",
+                    "idx": 0,
+                    "event": {"type": "assistant.message_delta"},
+                    "data": {"deltaContent": "outer-delta-content"},
+                }
+            ],
+        )
+        resp = _bearer(port, _debug_path(sid, run_id))
+        data = json.loads(resp.read())
+        test("DB34 status 200", resp.status == 200)
+        events = data.get("events", [])
+        test("DB34 one event", len(events) == 1)
+        test(
+            "DB34 message = outer-delta-content",
+            events[0].get("message") == "outer-delta-content",
+        )
+    finally:
+        server.shutdown()
+
+
+def test_nested_inner_data_tool_name_extraction():
+    """DB35: tool_call with toolName in inner.event.data (nested data sub-object).
+
+    Verifies comment #2 fix: _map_operator_event checks inner.data.toolName so
+    tool-call previews degrade to event_type only when no tool name exists anywhere.
+    """
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(
+            sid,
+            events=[
+                {
+                    "type": "tool_call",
+                    "idx": 0,
+                    "event": {
+                        "type": "tool_call",
+                        "data": {"toolName": "nested-tool-name"},
+                    },
+                }
+            ],
+        )
+        resp = _bearer(port, _debug_path(sid, run_id))
+        data = json.loads(resp.read())
+        test("DB35 status 200", resp.status == 200)
+        events = data.get("events", [])
+        test("DB35 one event", len(events) == 1)
+        test(
+            "DB35 message = nested-tool-name",
+            events[0].get("message") == "nested-tool-name",
+        )
+    finally:
+        server.shutdown()
+
+
+def test_outer_data_tool_name_extraction():
+    """DB36: tool_call with name in outer event["data"] (top-level stored data key).
+
+    Verifies comment #2 fix: _map_operator_event checks outer event.data.name so
+    tool-call previews work when tool metadata lives at the outer envelope level.
+    """
+    server, port = _make_test_server()
+    try:
+        sid = _make_session()
+        run_id = _make_run(
+            sid,
+            events=[
+                {
+                    "type": "tool_call",
+                    "idx": 0,
+                    "event": {"type": "tool_call"},
+                    "data": {"name": "outer-tool-name"},
+                }
+            ],
+        )
+        resp = _bearer(port, _debug_path(sid, run_id))
+        data = json.loads(resp.read())
+        test("DB36 status 200", resp.status == 200)
+        events = data.get("events", [])
+        test("DB36 one event", len(events) == 1)
+        test(
+            "DB36 message = outer-tool-name",
+            events[0].get("message") == "outer-tool-name",
+        )
+    finally:
+        server.shutdown()
+
+
 # ── Runner ─────────────────────────────────────────────────────────────────────
 
 
@@ -808,6 +951,10 @@ if __name__ == "__main__":
     test_uniform_404_error_code()
     test_non_loopback_no_token_403()
     test_mutating_query_token_rejected_401()
+    test_nested_inner_data_content_extraction()
+    test_outer_data_delta_content_extraction()
+    test_nested_inner_data_tool_name_extraction()
+    test_outer_data_tool_name_extraction()
 
     print(f"\n{'=' * 50}")
     print(f"Results: {_PASS} passed, {_FAIL} failed")


### PR DESCRIPTION
## Summary
- Adds `GET /api/operator/sessions/{session_id}/runs/{run_id}/debug` as a registry-driven debug route with Bearer/cookie-only access.
- Maps persisted operator run `events` into paginated, redacted `BrowseDebugEntry` responses with strict filters and uniform 404s.
- Generalizes route placeholders/debug gates and documents the WBS-104 response shape plus the WBS-105 sidecar follow-up boundary.
- Fixes review findings for nested/outer operator event `data` envelopes and test tempdir cleanup.

## Verification
- `python tests\test_browse_debug_log_api.py` -> 105 passed, 0 failed
- `python tests\test_browse_operator_debug_events.py` -> 204 passed, 0 failed
- `python tests\test_browse_debug_log_transport.py` -> 26 passed, 0 failed
- `python tests\test_browse_core_registry.py` -> 34 passed, 0 failed
- `python test_security.py` -> 12 passed, 0 failed
- `python test_fixes.py` -> 226 passed, 0 failed
- `python -m ruff check browse\core\registry.py browse\core\server.py browse\api\operator.py tests\test_browse_debug_log_api.py` -> clean
- `python -m ruff format --check browse\core\registry.py browse\core\server.py browse\api\operator.py tests\test_browse_debug_log_api.py` -> clean
- `git diff --check` -> clean
- PR #444 head `b751250`: GitHub Actions quality-gates, e2e-smoke, browse-ui, remote-terminal, Windows onboarding smoke, and Python platform safety (ubuntu/macos/windows) completed successfully.

Independent reviews: WBS-104 code review CLEAN, browser security review CLEAN, whole-app impact findings fixed, final code review CLEAN, post-review patch code-review CLEAN. Opus decision: keep WBS-104 sourcing from `run["events"]`; defer `run["debug_events"]` reconciliation to #434.

Closes #429