### PR TITLE
feat: add debug log importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,13 +69,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     `status.code` 0/1/2→null/ok/error; attrs pre-filter to allowlist with OTel
     semantic convention renames.  Detects and rejects VS Code files.
     CLI: `python -m browse.importers.otel_file --path … --dry-run --json-summary`.
-  - `tests/test_browse_debug_log_importers.py`: 178 assertions covering: happy path,
+  - `tests/test_browse_debug_log_importers.py`: 214 assertions covering: happy path,
     BrowseDebugEntry shape, kind mapping, timestamp, duration, attr renames,
     dangerous attr drop, tool_name, synthetic span ID, privacy (no username in
     summary), directory mode, companion skip, malformed lines, dedup, unsupported
     format, path traversal, symlink escape, dry-run, OTel status/level, HrTime,
     ISO/no-TZ startTime, timeUnixNano, bounded line-size cap, missing-span dedup,
-    and redaction scrubbing.
+    redaction scrubbing, required-field enforcement (spanId/status/attrs missing or
+    wrong type), status null/unrecognized mapping, FIFO synthetic pairing
+    (tool_call+result, FIFO order, orphan, cross-pair isolation, malformed parent
+    normalisation, rIdx ignored), and VS Code scan-forward detection hardening
+    (all-oversized, oversized-then-valid, oversized-then-non-VS-Code).
   - `tests/fixtures/debug-log/vscode-agent/debug-logs/0000fixture-session-aaaa/`:
     12-entry happy-path fixture with companion files (models.json,
     system_prompt_abc.json, tools_fixture.json) for skip tests.
@@ -92,6 +96,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - `docs/DEBUG-LOG-CONTRACT.md`: WBS-106 importer contract section added.
   - Oversized-line test cases are generated dynamically in temp; no >1 MiB fixture
     files are committed.
+
+- **VS Code importer review hardening (PR #445, WBS-106):**
+  - `browse/importers/vscode_agent_debug_log.py`: enforce required presence + string
+    type for `spanId`, `status`, and `attrs` in `_parse_line`; status `null` or
+    unrecognised string maps to `None`/omitted; non-string/non-null status, non-dict
+    attrs, or missing any of the three → malformed+skip.  FIFO synthetic span-id
+    pairing for `tool_call`/`tool_result` rows lacking a valid native `spanId`:
+    key = `(sid, name, normalized_parent_span_id)` with `rIdx` omitted; deduped
+    `tool_call` rows do not enqueue orphan synthetic spans.  `_detect_format` now
+    mirrors OTel scan-forward hardening: skips oversized and unparseable leading
+    lines, requires VS Code fingerprint on first parseable JSON object, and raises
+    `UnsupportedFormatError` at EOF if no fingerprint is found.
 
 - **Bounded redacted operator debug-event sidecar (WBS-105, #430):**
   - `browse/core/operator_console.py`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     mapping, truncation semantics, `since` filter semantics, and registry-driven debug auth
     gate generalisation.
 
+- **Debug-log importers — VS Code Agent and OTel JSONL (WBS-106, #431):**
+  - `browse/importers/__init__.py`: new `browse.importers` package.
+  - `browse/importers/_common.py`: shared helpers — `check_path_safe()` (rejects
+    `..`, enforces `safe_base` + symlink escape detection), `file_hash_sha256()`,
+    `synthetic_span_id()`, `content_hash_16()`, `DedupSet`, `is_valid_span_id()`,
+    `max_line_bytes()` (default 1 MiB, env `BROWSE_DEBUG_LOG_MAX_LINE_BYTES`),
+    and bounded JSONL line iteration that rejects over-cap lines without buffering
+    the whole line.
+    Error types: `PathTraversalError`, `SymlinkEscapeError`, `UnsupportedFormatError`.
+  - `browse/importers/vscode_agent_debug_log.py`: read-only importer for VS Code
+    `IDebugLogEntry` JSONL.  Normalises to `BrowseDebugEntry`; source = `vscode`.
+    Features: directory-mode reads `main.jsonl`, companion-file skip (models.json,
+    system_prompt_*.json, tools_*.json, title-*.jsonl, etc.), format detection,
+    epoch-ms→ISO-UTC-Z, dur=0→null, attrs pre-filter (inputTokens→tokens_in,
+    outputTokens→tokens_out; drop args/result/content/…), `redact_entry` pass,
+    dedup by `{sid}:{type}:{spanId}:{ts}:{content_hash_16}`, dry-run mode.
+    CLI: `python -m browse.importers.vscode_agent_debug_log --path … --dry-run --json-summary`.
+  - `browse/importers/otel_file.py`: read-only importer for OTel `ReadableSpan`
+    JSONL (ConsoleSpanExporter output and compatible variants).  Supports: `id`,
+    `spanId`, or `spanContext.spanId` for span ID; `traceId`; `parentSpanId` /
+    `parentSpanContext.spanId`; `timestamp` (µs), `startTime` (HrTime tuple or
+    ISO string), `timeUnixNano`/`startTimeUnixNano` (ns); `duration` (µs→ms);
+    `status.code` 0/1/2→null/ok/error; attrs pre-filter to allowlist with OTel
+    semantic convention renames.  Detects and rejects VS Code files.
+    CLI: `python -m browse.importers.otel_file --path … --dry-run --json-summary`.
+  - `tests/test_browse_debug_log_importers.py`: 178 assertions covering: happy path,
+    BrowseDebugEntry shape, kind mapping, timestamp, duration, attr renames,
+    dangerous attr drop, tool_name, synthetic span ID, privacy (no username in
+    summary), directory mode, companion skip, malformed lines, dedup, unsupported
+    format, path traversal, symlink escape, dry-run, OTel status/level, HrTime,
+    ISO/no-TZ startTime, timeUnixNano, bounded line-size cap, missing-span dedup,
+    and redaction scrubbing.
+  - `tests/fixtures/debug-log/vscode-agent/debug-logs/0000fixture-session-aaaa/`:
+    12-entry happy-path fixture with companion files (models.json,
+    system_prompt_abc.json, tools_fixture.json) for skip tests.
+  - `tests/fixtures/debug-log/vscode-agent/debug-logs/0000fixture-session-bbbb/`:
+    malformed-lines fixture (missing ts, missing sid, not-JSON, v=2).
+  - `tests/fixtures/debug-log/vscode-agent/debug-logs/0000fixture-session-cccc/`:
+    dedup fixture (5 lines, 2 duplicates → 3 unique).
+  - `tests/fixtures/debug-log/otel/console-spans.jsonl`: ConsoleSpanExporter
+    happy-path with status codes 0/1/2, forbidden attrs, path/bearer secret for
+    redaction test.
+  - `tests/fixtures/debug-log/otel/hrtime-spans.jsonl`: HrTime tuple, ISO string,
+    no-TZ ISO, and timeUnixNano timestamp variants.
+  - `tests/fixtures/debug-log/otel/malformed-spans.jsonl`: malformed OTel fixture.
+  - `docs/DEBUG-LOG-CONTRACT.md`: WBS-106 importer contract section added.
+  - Oversized-line test cases are generated dynamically in temp; no >1 MiB fixture
+    files are committed.
+
 - **Bounded redacted operator debug-event sidecar (WBS-105, #430):**
   - `browse/core/operator_console.py`:
     - Constants `_MAX_DEBUG_EVENTS = 5000` and `_DEBUG_SOURCE = "operator_console"`.
@@ -276,17 +325,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Session detail: button row (Timeline / Mindmap / Export MD / Compare / Find similar) and tool-usage summary (243b85b)
 - Command palette expanded to 11 commands with section grouping (Navigation / Explore / Admin / View / Help) (243b85b)
 - Timeline: model-based color coding and legend, incorporating data previously served by the removed agents route (243b85b)
-
-- **Debug log importers — VS Code Agent Mode + OTel ReadableSpan parsers (WBS-106):**
-  - VS Code Agent Mode debug log importer: parses `agent-mode.jsonl` JSONL lines into
-    `BrowseDebugEntry` events with format detection, bounded reading (configurable max lines),
-    and WBS-102 redaction applied before any entry leaves the import layer.
-  - OTel `ReadableSpan` importer: parses OpenTelemetry `ReadableSpan` JSON objects into
-    `BrowseDebugEntry` events; extracts `span_id`, `parent_span_id`, `start_time_unix_nano`,
-    `duration_ns`, and `attributes`; maps OTel status codes to `ok` / `error` / `cancelled`.
-  - Both importers share a unified `DebugLogImporter` registry; format is detected at read time
-    (magic-byte / schema sniff before parsing); unrecognized formats produce a `raw` entry per
-    event with an `attrs.parse_error` field.
 
 - **Debug Log tab — session detail debug event viewer (WBS-107):**
   - New fifth tab on `/sessions/[id]`: **Debug Log** — shows all debug events recorded for the

--- a/browse-ui/src/app/sessions/[id]/__tests__/debug-log-tab.test.tsx
+++ b/browse-ui/src/app/sessions/[id]/__tests__/debug-log-tab.test.tsx
@@ -102,6 +102,12 @@ describe("DebugLogTab – loading state", () => {
     render(<DebugLogTab sessionId="sess-1" runId="run-1" host={HOST} />);
     expect(screen.getByText(/loading debug log/i)).toBeInTheDocument();
   });
+
+  it("renders loading message while resolving the latest operator run", () => {
+    render(<DebugLogTab sessionId="sess-1" runId={null} runsLoading host={HOST} />);
+    expect(screen.getByText(/loading debug log/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no run available/i)).not.toBeInTheDocument();
+  });
 });
 
 describe("DebugLogTab – error state", () => {

--- a/browse-ui/src/app/sessions/[id]/debug-log-tab.tsx
+++ b/browse-ui/src/app/sessions/[id]/debug-log-tab.tsx
@@ -46,6 +46,8 @@ export type DebugLogTabProps = {
   sessionId: string;
   /** Run ID to show debug log for. null/empty = show unavailable state. */
   runId: string | null;
+  /** True while the parent is resolving the latest operator run for this session. */
+  runsLoading?: boolean;
   host: HostProfile;
 };
 
@@ -612,7 +614,7 @@ function SpanTreeView({ entries, selectedEntry, onSelect }: SpanTreeViewProps) {
  *
  * When runId is null or empty the tab shows an informational empty state.
  */
-export function DebugLogTab({ sessionId, runId, host }: DebugLogTabProps) {
+export function DebugLogTab({ sessionId, runId, runsLoading = false, host }: DebugLogTabProps) {
   const [filters, setFilters] = useState<FilterState>({
     text: "",
     kind: "",
@@ -648,6 +650,15 @@ export function DebugLogTab({ sessionId, runId, host }: DebugLogTabProps) {
     // Reset detail drawer when filters change to avoid stale context.
     setSelectedEntry(null);
   };
+
+  // ── Operator run lookup loading ────────────────────────────────────────────
+  if (runsLoading) {
+    return (
+      <div className="border-border text-muted-foreground rounded-xl border p-4 text-sm">
+        Loading debug log…
+      </div>
+    );
+  }
 
   // ── No run available ───────────────────────────────────────────────────────
   if (!runId) {

--- a/browse-ui/src/app/sessions/[id]/session-detail-client.test.tsx
+++ b/browse-ui/src/app/sessions/[id]/session-detail-client.test.tsx
@@ -35,7 +35,7 @@ vi.mock("@/lib/api/hooks", () => ({
   })),
 }));
 
-import { useSessionDetail } from "@/lib/api/hooks";
+import { useOperatorRuns, useSessionDetail } from "@/lib/api/hooks";
 
 let hostStateMock: HostState = { host: LOCAL_HOST, diagnosticsEnabled: true };
 vi.mock("@/providers/host-provider", () => ({
@@ -75,7 +75,11 @@ vi.mock("./checkpoints-tab", () => ({
   CheckpointsTab: () => <div data-testid="checkpoints-tab">Checkpoints content</div>,
 }));
 vi.mock("./debug-log-tab", () => ({
-  DebugLogTab: () => <div data-testid="debug-log-tab">DebugLog content</div>,
+  DebugLogTab: ({ runsLoading }: { runsLoading?: boolean }) => (
+    <div data-testid="debug-log-tab" data-runs-loading={String(Boolean(runsLoading))}>
+      DebugLog content
+    </div>
+  ),
 }));
 
 // ── compare sheet ────────────────────────────────────────────────────────────
@@ -118,6 +122,11 @@ describe("SessionDetailClient – layout/nav", () => {
     hostStateMock = { host: LOCAL_HOST, diagnosticsEnabled: true };
     sessionsSupported = true;
     (useSessionDetail as Mock).mockImplementation(() => defaultSessionDetail);
+    (useOperatorRuns as Mock).mockImplementation(() => ({
+      data: { runs: [], count: 0 },
+      error: null,
+      isLoading: false,
+    }));
     // Reset hash
     Object.defineProperty(window, "location", {
       writable: true,
@@ -195,6 +204,36 @@ describe("SessionDetailClient – layout/nav", () => {
     render(<SessionDetailClient />);
     fireEvent.click(screen.getByRole("tab", { name: /checkpoints/i }));
     expect(screen.getByTestId("checkpoints-tab")).toBeVisible();
+  });
+
+  it("only enables operator run lookup on the Debug Log tab", () => {
+    render(<SessionDetailClient />);
+    expect((useOperatorRuns as Mock).mock.calls.at(-1)).toEqual([
+      "test-session-123",
+      false,
+      LOCAL_HOST,
+    ]);
+
+    fireEvent.click(screen.getByRole("tab", { name: /debug log/i }));
+
+    expect((useOperatorRuns as Mock).mock.calls.at(-1)).toEqual([
+      "test-session-123",
+      true,
+      LOCAL_HOST,
+    ]);
+  });
+
+  it("passes operator run loading state to the Debug Log tab", () => {
+    (useOperatorRuns as Mock).mockImplementation(() => ({
+      data: undefined,
+      error: null,
+      isLoading: true,
+    }));
+
+    render(<SessionDetailClient />);
+    fireEvent.click(screen.getByRole("tab", { name: /debug log/i }));
+
+    expect(screen.getByTestId("debug-log-tab")).toHaveAttribute("data-runs-loading", "true");
   });
 
   it("updates URL hash when tab changes", () => {

--- a/browse-ui/src/app/sessions/[id]/session-detail-client.tsx
+++ b/browse-ui/src/app/sessions/[id]/session-detail-client.tsx
@@ -82,7 +82,15 @@ export function SessionDetailClient() {
   const [exportError, setExportError] = useState<string | null>(null);
 
   const detailQuery = useSessionDetail(sessionId, sessionsEnabled && Boolean(sessionId), host);
-  const runsQuery = useOperatorRuns(sessionId, sessionsEnabled && Boolean(sessionId), host);
+  // Only fetch operator runs when the debug-log tab is active: the endpoint targets operator
+  // sessions (JSON-backed), not knowledge sessions (SQLite-backed). Eagerly querying it for
+  // every knowledge session produces a 404 and triggers the runtime-error guard in e2e tests.
+  const runsQuery = useOperatorRuns(
+    sessionId,
+    sessionsEnabled && Boolean(sessionId) && activeTab === "debug-log",
+    host
+  );
+  const runsLoading = activeTab === "debug-log" && runsQuery.isLoading;
   // Use the latest run ID (last item in runs list). Gracefully null when no runs.
   const latestRunId = runsQuery.data?.runs[runsQuery.data.runs.length - 1]?.id ?? null;
   const shortId = formatSessionIdBadgeText(sessionId);
@@ -319,7 +327,12 @@ export function SessionDetailClient() {
           <CheckpointsTab sessionId={sessionId} host={host} />
         </TabsContent>
         <TabsContent value="debug-log">
-          <DebugLogTab sessionId={sessionId} runId={latestRunId} host={host} />
+          <DebugLogTab
+            sessionId={sessionId}
+            runId={latestRunId}
+            runsLoading={runsLoading}
+            host={host}
+          />
         </TabsContent>
       </Tabs>
 

--- a/browse/importers/vscode_agent_debug_log.py
+++ b/browse/importers/vscode_agent_debug_log.py
@@ -170,8 +170,10 @@ def _epoch_ms_to_iso(ts_ms: Any) -> "str | None":
 def _detect_format(path: Path) -> None:
     """Check the file looks like VS Code Agent debug log JSONL.
 
-    Reads the first non-empty line and verifies it has the required fingerprint
-    fields (numeric ``ts`` and string ``sid``).
+    Oversized or malformed leading lines are not format evidence.  Detection
+    scans forward until the first parseable JSON value, then requires the VS
+    Code fingerprint (numeric ``ts`` > 0 and string ``sid``) on that value.
+    EOF without a parseable fingerprint raises ``UnsupportedFormatError``.
 
     Raises:
         UnsupportedFormatError: format fingerprint not recognised.
@@ -179,11 +181,11 @@ def _detect_format(path: Path) -> None:
     cap = max_line_bytes()
     with path.open("rb") as fh:
         for _, raw, over_cap_bytes in iter_bounded_lines(fh, cap):
-            if over_cap_bytes is not None:
-                continue
             line = raw.strip()
             if not line:
                 continue
+            if over_cap_bytes is not None:
+                continue  # oversized; not format evidence -- scan forward
             if line[:1] == b"[":
                 raise UnsupportedFormatError(
                     "File starts with '[': expected JSONL objects, got JSON array. Not a VS Code Agent debug log file."
@@ -191,11 +193,11 @@ def _detect_format(path: Path) -> None:
             try:
                 obj = json.loads(line.decode("utf-8", errors="replace"))
             except json.JSONDecodeError:
-                # First line not parseable; let main parser report it
-                return
+                continue  # unparseable; not format evidence -- scan forward
             if not isinstance(obj, dict):
                 raise UnsupportedFormatError(
-                    f"First JSON value is {type(obj).__name__}, expected dict. Not a VS Code Agent debug log file."
+                    f"First parseable JSON value is {type(obj).__name__}, expected dict. "
+                    "Not a VS Code Agent debug log file."
                 )
             ts_ok = (
                 isinstance(obj.get("ts"), (int, float)) and not isinstance(obj.get("ts"), bool) and obj.get("ts", 0) > 0
@@ -203,24 +205,37 @@ def _detect_format(path: Path) -> None:
             sid_ok = isinstance(obj.get("sid"), str)
             if not (ts_ok and sid_ok):
                 raise UnsupportedFormatError(
-                    "First JSON line lacks 'ts' (epoch-ms integer) or 'sid' (string). "
+                    "First parseable JSON line lacks 'ts' (epoch-ms integer) or 'sid' (string). "
                     "Not a VS Code Agent debug log JSONL file."
                 )
             return  # fingerprint accepted
-    raise UnsupportedFormatError("No parseable VS Code Agent Mode debug log fingerprint found before EOF.")
+    raise UnsupportedFormatError("No parseable VS Code Agent debug log fingerprint found before EOF.")
 
 
 # ── Main import logic ──────────────────────────────────────────────────────────
 
 
+def _pair_key(sid: str, name: str, parent_span_id: "str | None") -> tuple:
+    """Normalised FIFO pairing key for tool_call/tool_result synthetic span matching."""
+    return (sid, name, parent_span_id)
+
+
 def _parse_line(
     obj: dict,
     idx: int,
+    pair_queues: "dict | None" = None,
 ) -> "tuple[dict, str | None]":
     """Parse one IDebugLogEntry dict into a BrowseDebugEntry dict.
 
     Returns ``(entry_dict, None)`` on success, or ``({}, reason_str)`` if the
     line should be reported as malformed and skipped.
+
+    Args:
+        obj:         Parsed JSON object for one JSONL line.
+        idx:         Zero-based index of this entry in the ok-entry stream.
+        pair_queues: Per-file mutable dict for FIFO synthetic span-ID pairing
+                     of tool_call/tool_result rows with no valid native spanId.
+                     Pass ``None`` to disable pairing (e.g. in tests).
 
     Does NOT call ``redact_entry``; the caller does that.
     """
@@ -229,14 +244,11 @@ def _parse_line(
     if v is not None and v != 1:
         return {}, f"unsupported schema version v={v!r}"
 
-    # Required fields validation
+    # Required fields validation -- ts, sid, type, name
     ts_ms = obj.get("ts")
     sid = obj.get("sid")
     event_type = obj.get("type")
     name = obj.get("name")
-    span_id_raw = obj.get("spanId")
-    status_raw = obj.get("status")
-    attrs_raw = obj.get("attrs", {})
 
     if not (isinstance(ts_ms, (int, float)) and not isinstance(ts_ms, bool) and ts_ms > 0):
         return {}, "missing or invalid required field 'ts' (expected positive epoch-ms)"
@@ -246,6 +258,25 @@ def _parse_line(
         return {}, "missing or invalid required field 'type' (expected string)"
     if not isinstance(name, str):
         return {}, "missing or invalid required field 'name' (expected string)"
+
+    # Required presence + base-type checks for spanId, status, attrs
+    if "spanId" not in obj:
+        return {}, "missing required field 'spanId'"
+    if "status" not in obj:
+        return {}, "missing required field 'status'"
+    if "attrs" not in obj:
+        return {}, "missing required field 'attrs'"
+
+    span_id_raw = obj["spanId"]
+    status_raw = obj["status"]
+    attrs_raw = obj["attrs"]
+
+    if not isinstance(span_id_raw, str):
+        return {}, f"invalid required field 'spanId': expected string, got {type(span_id_raw).__name__}"
+    if status_raw is not None and not isinstance(status_raw, str):
+        return {}, f"invalid required field 'status': expected string or null, got {type(status_raw).__name__}"
+    if not isinstance(attrs_raw, dict):
+        return {}, f"invalid required field 'attrs': expected dict, got {type(attrs_raw).__name__}"
 
     # Type → kind
     kind = _TYPE_TO_KIND.get(event_type)
@@ -262,19 +293,32 @@ def _parse_line(
     if isinstance(dur, (int, float)) and not isinstance(dur, bool) and dur > 0:
         duration_ms = float(dur)
 
-    # Span ID
-    if is_valid_span_id(span_id_raw):
-        span_id = span_id_raw
-    else:
-        span_id = synthetic_span_id(BROWSE_SOURCE, idx)
-
-    # Parent span ID
+    # Parent span ID -- computed before span_id so it can be used in pair key
     parent_raw = obj.get("parentSpanId")
     parent_span_id: str | None = parent_raw if is_valid_span_id(parent_raw) else None
 
-    # Status
+    # Span ID -- native path unchanged; synthetic path uses FIFO pairing for
+    # tool_call / tool_result rows that lack a valid native spanId.
+    if is_valid_span_id(span_id_raw):
+        span_id = span_id_raw
+    elif pair_queues is not None and event_type in ("tool_call", "tool_result"):
+        key = _pair_key(sid, name, parent_span_id)
+        if event_type == "tool_call":
+            syn = synthetic_span_id(BROWSE_SOURCE, idx)
+            pair_queues.setdefault(key, []).append(syn)
+            span_id = syn
+        else:  # tool_result
+            queue = pair_queues.get(key, [])
+            if queue:
+                span_id = queue.pop(0)  # FIFO: reuse start's synthetic span_id
+            else:
+                span_id = synthetic_span_id(BROWSE_SOURCE, idx)
+    else:
+        span_id = synthetic_span_id(BROWSE_SOURCE, idx)
+
+    # Status: recognised strings → mapped; null or unrecognised string → None/omitted
     _STATUS_MAP = {"ok": "ok", "error": "error", "cancelled": "cancelled"}
-    status: str | None = _STATUS_MAP.get(str(status_raw)) if status_raw is not None else None
+    status: str | None = _STATUS_MAP.get(status_raw) if status_raw is not None else None
 
     # Level: infer from kind
     level: str | None = "error" if kind == "error" else None
@@ -374,6 +418,7 @@ def import_file(
     ok_count = 0
     total_lines = 0
     entry_idx = 0
+    pair_queues: dict = {}  # FIFO synthetic span-id pairing for tool_call/tool_result
 
     with resolved.open("rb") as fh:
         for line_no, raw_bytes, over_cap_bytes in iter_bounded_lines(fh, cap):
@@ -415,8 +460,10 @@ def import_file(
                 )
                 continue
 
-            # Entry parse
-            entry_dict, malformed_reason = _parse_line(obj, entry_idx)
+            # Entry parse. Use a candidate queue so duplicate rows cannot mutate
+            # accepted FIFO state before the dedup gate below.
+            candidate_pair_queues = {key: list(queue) for key, queue in pair_queues.items()}
+            entry_dict, malformed_reason = _parse_line(obj, entry_idx, candidate_pair_queues)
             if malformed_reason:
                 malformed_reports.append(
                     {
@@ -441,6 +488,7 @@ def import_file(
             if dedup.is_duplicate(dedup_key):
                 continue
 
+            pair_queues = candidate_pair_queues
             ok_count += 1
             entry_idx += 1
             if not dry_run:

--- a/docs/DEBUG-LOG-CONTRACT.md
+++ b/docs/DEBUG-LOG-CONTRACT.md
@@ -511,6 +511,122 @@ A performance test (`tests/test_browse_debug_log_api.py::DB26`) verifies that
 
 ---
 
+## WBS-106 Importer Contract
+
+### Overview
+
+Two read-only Python importers normalise external source formats into the
+`BrowseDebugEntry` shape defined above, apply `redact_entry`, and return
+`(entries, summary)` without writing to the debug-log DB.
+
+| Module | Source tag | `BrowseDebugEntry.source` | CLI |
+|---|---|---|---|
+| `browse.importers.vscode_agent_debug_log` | `vscode-agent-debug-log` | `vscode` | `python -m browse.importers.vscode_agent_debug_log --path ... --dry-run --json-summary` |
+| `browse.importers.otel_file` | `vscode-otel-file` | `vscode` | `python -m browse.importers.otel_file --path ... --dry-run --json-summary` |
+
+### Path safety (both importers)
+
+- Paths with raw `..` components are rejected with `PathTraversalError` **before** the file is opened.
+- `Path.resolve(strict=True)` enforces existence check.
+- When `safe_base` is provided, the resolved target must be under the resolved `safe_base` after full symlink expansion; symlink escape raises `SymlinkEscapeError`.
+
+### Max line size
+
+Default: 1 MiB per line. Override: `BROWSE_DEBUG_LOG_MAX_LINE_BYTES` env variable.
+Oversized lines are reported as malformed and skipped; they do not crash the import.
+
+### Import summary fields
+
+| Field | Type | Description |
+|---|---|---|
+| `source` | `string` | Importer source tag |
+| `schema_version` | `integer` | Always `1` |
+| `total_lines` | `integer` | Non-blank lines processed |
+| `ok_count` | `integer` | Successfully parsed and deduped entries |
+| `malformed_count` | `integer` | Lines reported as malformed |
+| `deduped_count` | `integer` | Lines skipped as duplicates |
+| `malformed_reports` | `array` | `[{line_number, reason}]` |
+| `file_hash` | `string` | `"sha256:<hex>"` of the file |
+| `file_name` | `string` | Filename only - **no absolute path with username** |
+
+### VS Code `IDebugLogEntry` importer
+
+**Required fields:** `ts` (epoch ms), `dur` (ms), `sid`, `type`, `name`, `spanId`, `status`, `attrs`.
+**Optional:** `v` (must be `1` if present; `v != 1` is a malformed line), `rIdx`, `parentSpanId`.
+
+**Required-field malformed rules:**
+
+| Field | Required presence | Required base type | Carve-out |
+|---|---|---|---|
+| `spanId` | yes -> else malformed | string -> else malformed | Present non-16-hex string -> synthetic; not malformed |
+| `status` | yes -> else malformed | string **or** null -> else malformed | `null` or unrecognised string -> output `status` omitted (None) |
+| `attrs` | yes -> else malformed | dict -> else malformed | - |
+
+- Directory input reads `main.jsonl` only; companion files (`models.json`,
+  `system_prompt_*.json`, `tools_*.json`, `title-*.jsonl`, etc.) raise
+  `UnsupportedFormatError` when passed directly.
+- `dur = 0` -> `duration_ms = null` (never use 0 as sentinel).
+- Non-16-hex `spanId` -> `synthetic_span_id("vscode", idx, seq=1)`.
+- Attrs pre-filter: `inputTokens` -> `tokens_in`, `outputTokens` -> `tokens_out`,
+  `latency` -> `latency_ms`; dangerous fields (`args`, `result`, `content`, etc.) are
+  dropped before `redact_entry`.
+- Dedup key: `vscode-agent-debug-log:{sid}:{type}:{spanId}:{ts}:{sha256(obj)[:16]}`.
+
+**FIFO synthetic pairing for `tool_call` / `tool_result`:**
+
+When a `tool_call` or `tool_result` row has **no valid native spanId** (non-16-hex
+string), the importer applies FIFO synthetic pairing rather than generating a
+unique synthetic span per row:
+
+- Pair key: `(sid, name, normalized_parent_span_id)` where `normalized_parent_span_id`
+  is the importer-normalised output value (`None` when `parentSpanId` is absent or
+  not a valid 16-hex string). `rIdx` is ignored by the importer, does not appear
+  in output entries, and is omitted from the pair key.
+- For a `tool_call` start with no valid native `spanId`: compute a synthetic span_id,
+  enqueue it in the FIFO for the key, and use it as the entry's `span_id`.
+- For a `tool_result` with no valid native `spanId`: pop the earliest enqueued
+  span_id for the key (if any) and reuse it; if the queue is empty (orphan
+  `tool_result`), compute and use a new synthetic span_id.
+- Native path (valid 16-hex `spanId`) is **unchanged** - pairing logic is not applied.
+
+**Format detection (`_detect_format`):**
+
+Scans forward through the file, skipping oversized and unparseable leading lines
+(these are not format evidence). The first parseable JSON value must be a dict with
+VS Code fingerprint (`ts` as positive numeric and `sid` as string); a fingerprint
+mismatch raises `UnsupportedFormatError` immediately. EOF without finding any
+parseable fingerprint also raises `UnsupportedFormatError`.
+
+**Type -> kind mapping:**
+
+| VS Code `type` | `kind` |
+|---|---|
+| `session_start`, `turn_start`, `llm_request`, `tool_call`, `agent_response`, `subagent`, `hook`, `error` | Same |
+| `tool_result` | `tool_call` (paired completion) |
+| `discovery`, `user_message`, `child_session_ref`, `turn_end` | `generic` |
+| Unknown string | `generic` |
+
+### OTel `ReadableSpan` importer
+
+Supports **ConsoleSpanExporter** output and compatible variants:
+
+| Source variant | Field |
+|---|---|
+| Span ID | `id`, `spanId`, or `spanContext.spanId` |
+| Trace ID | `traceId` or `spanContext.traceId` |
+| Parent | `parentSpanId` or `parentSpanContext.spanId` |
+| Timestamp | `timestamp` (microseconds), `startTime` (HrTime `[sec,nanos]` or ISO string), `timeUnixNano`/`startTimeUnixNano` (ns) |
+| Duration | `duration` (microseconds -> ms) |
+| Attrs | `attributes` dict -> pre-filtered to allowlist |
+| Status | `status.code`: `0` -> null, `1` -> ok, `2` -> error + level error |
+
+- `kind` is always `generic` (OTel spans carry no lifecycle type).
+- `source` is `vscode` (allowlisted in `_SOURCE_ENUM`); `vscode-otel-file` is the summary `source` tag only.
+- Dedup key: `vscode-otel-file:{traceId}:{span_id}:{sha256(obj)[:16]}`.
+- VS Code `IDebugLogEntry` files (have `ts` + `sid`) are detected and rejected with `UnsupportedFormatError`.
+
+---
+
 ## WBS-105 Operator Debug Event Capture
 
 ### Overview

--- a/tests/test_browse_debug_log_importers.py
+++ b/tests/test_browse_debug_log_importers.py
@@ -405,6 +405,420 @@ def test_vscode_oversized_only_file_raises_unsupported():
 
 
 # ════════════════════════════════════════════════════════════════════════════════
+# VS Code required-field enforcement tests (PR #445 review hardening)
+# ════════════════════════════════════════════════════════════════════════════════
+
+
+def _write_vsc_temp(td: str, lines: "list[str]") -> "Path":
+    """Write VS Code fixture lines to a temp main.jsonl, return its Path."""
+    p = Path(td) / "main.jsonl"
+    p.write_text("".join(lines), encoding="utf-8")
+    return p
+
+
+# Base valid line used as fingerprint anchor in tempfile tests
+_VSC_BASE = (
+    '{"ts": 1700000000000, "dur": 50, "sid": "sx", "type": "session_start",'
+    ' "name": "s", "spanId": "a000000000000001", "status": "ok", "attrs": {}}\n'
+)
+
+
+def test_vscode_missing_spanid_malformed():
+    """Missing spanId field → malformed; reason mentions 'spanId'."""
+    with tempfile.TemporaryDirectory() as td:
+        bad = (
+            '{"ts": 1700000001000, "dur": 10, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "status": "ok", "attrs": {}}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, bad])
+        _, summary = _vsc.import_file(p)
+        reports = summary["malformed_reports"]
+        test(
+            "vsc_req: missing spanId reported as malformed",
+            any("spanId" in r["reason"] for r in reports),
+        )
+
+
+def test_vscode_invalid_spanid_type_malformed():
+    """Non-string spanId (e.g. integer) → malformed; reason mentions 'spanId'."""
+    with tempfile.TemporaryDirectory() as td:
+        bad = (
+            '{"ts": 1700000001000, "dur": 10, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": 12345, "status": "ok", "attrs": {}}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, bad])
+        _, summary = _vsc.import_file(p)
+        reports = summary["malformed_reports"]
+        test(
+            "vsc_req: non-string spanId reported as malformed",
+            any("spanId" in r["reason"] for r in reports),
+        )
+
+
+def test_vscode_missing_status_malformed():
+    """Missing status field → malformed; reason mentions 'status'."""
+    with tempfile.TemporaryDirectory() as td:
+        bad = (
+            '{"ts": 1700000001000, "dur": 10, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "b000000000000002", "attrs": {}}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, bad])
+        _, summary = _vsc.import_file(p)
+        reports = summary["malformed_reports"]
+        test(
+            "vsc_req: missing status reported as malformed",
+            any("status" in r["reason"] for r in reports),
+        )
+
+
+def test_vscode_status_null_accepted():
+    """status: null is accepted; output entry has no 'status' key."""
+    with tempfile.TemporaryDirectory() as td:
+        line = (
+            '{"ts": 1700000001000, "dur": 10, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "b000000000000002", "status": null, "attrs": {}}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, line])
+        entries, summary = _vsc.import_file(p)
+        test("vsc_req: status null accepted (ok_count >= 2)", summary["ok_count"] >= 2)
+        null_entry = next((e for e in entries if e.get("idx") == 1), None)
+        test(
+            "vsc_req: status null entry has no 'status' key",
+            null_entry is not None and "status" not in null_entry,
+        )
+
+
+def test_vscode_unrecognized_status_accepted():
+    """Unrecognized status string (e.g. 'started') accepted; output has no 'status' key."""
+    with tempfile.TemporaryDirectory() as td:
+        line = (
+            '{"ts": 1700000001000, "dur": 10, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "b000000000000002", "status": "started", "attrs": {}}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, line])
+        entries, summary = _vsc.import_file(p)
+        test("vsc_req: unrecognized status accepted (ok_count >= 2)", summary["ok_count"] >= 2)
+        unrecog_entry = next((e for e in entries if e.get("idx") == 1), None)
+        test(
+            "vsc_req: unrecognized status entry has no 'status' key",
+            unrecog_entry is not None and "status" not in unrecog_entry,
+        )
+
+
+def test_vscode_invalid_status_type_malformed():
+    """Non-string, non-null status (e.g. integer) → malformed; reason mentions 'status'."""
+    with tempfile.TemporaryDirectory() as td:
+        bad = (
+            '{"ts": 1700000001000, "dur": 10, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "b000000000000002", "status": 1, "attrs": {}}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, bad])
+        _, summary = _vsc.import_file(p)
+        reports = summary["malformed_reports"]
+        test(
+            "vsc_req: non-string non-null status reported as malformed",
+            any("status" in r["reason"] for r in reports),
+        )
+
+
+def test_vscode_missing_attrs_malformed():
+    """Missing attrs field → malformed; reason mentions 'attrs'."""
+    with tempfile.TemporaryDirectory() as td:
+        bad = (
+            '{"ts": 1700000001000, "dur": 10, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "b000000000000002", "status": "ok"}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, bad])
+        _, summary = _vsc.import_file(p)
+        reports = summary["malformed_reports"]
+        test(
+            "vsc_req: missing attrs reported as malformed",
+            any("attrs" in r["reason"] for r in reports),
+        )
+
+
+def test_vscode_non_dict_attrs_malformed():
+    """Non-dict attrs (e.g. list) → malformed; reason mentions 'attrs'."""
+    with tempfile.TemporaryDirectory() as td:
+        bad = (
+            '{"ts": 1700000001000, "dur": 10, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "b000000000000002", "status": "ok", "attrs": []}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, bad])
+        _, summary = _vsc.import_file(p)
+        reports = summary["malformed_reports"]
+        test(
+            "vsc_req: non-dict attrs reported as malformed",
+            any("attrs" in r["reason"] for r in reports),
+        )
+
+
+# ════════════════════════════════════════════════════════════════════════════════
+# VS Code synthetic pairing tests (PR #445 review hardening)
+# ════════════════════════════════════════════════════════════════════════════════
+
+
+def test_vscode_synthetic_pairing_tool_call_result():
+    """tool_call + tool_result with no valid native spanId share the start's synthetic span_id."""
+    with tempfile.TemporaryDirectory() as td:
+        start_line = (
+            '{"ts": 1700000001000, "dur": 0, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "bad!!", "status": null, "attrs": {}}\n'
+        )
+        result_line = (
+            '{"ts": 1700000001500, "dur": 500, "sid": "sx", "type": "tool_result",'
+            ' "name": "bash", "spanId": "also_bad!!", "status": "ok", "attrs": {}}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, start_line, result_line])
+        entries, summary = _vsc.import_file(p)
+        test("vsc_pair: ok_count == 3", summary["ok_count"] == 3)
+        tool_entries = [e for e in entries if e.get("kind") == "tool_call"]
+        test("vsc_pair: two tool_call entries", len(tool_entries) == 2)
+        if len(tool_entries) == 2:
+            test(
+                "vsc_pair: start and result share span_id",
+                tool_entries[0].get("span_id") == tool_entries[1].get("span_id"),
+            )
+
+
+def test_vscode_synthetic_pairing_fifo_order():
+    """Two starts then two results with same key pair in FIFO order."""
+    with tempfile.TemporaryDirectory() as td:
+        # Both tool_calls have same (sid, name, parent_span_id=None) key
+        start1 = (
+            '{"ts": 1700000001000, "dur": 0, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "bad!!", "status": null, "attrs": {}}\n'
+        )
+        start2 = (
+            '{"ts": 1700000002000, "dur": 0, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "alsobad!!", "status": null, "attrs": {}}\n'
+        )
+        result1 = (
+            '{"ts": 1700000003000, "dur": 2000, "sid": "sx", "type": "tool_result",'
+            ' "name": "bash", "spanId": "badspa1!!", "status": "ok", "attrs": {}}\n'
+        )
+        result2 = (
+            '{"ts": 1700000004000, "dur": 2000, "sid": "sx", "type": "tool_result",'
+            ' "name": "bash", "spanId": "badspa2!!", "status": "ok", "attrs": {}}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, start1, start2, result1, result2])
+        entries, summary = _vsc.import_file(p)
+        test("vsc_fifo: ok_count == 5", summary["ok_count"] == 5)
+        tool_entries = [e for e in entries if e.get("kind") == "tool_call"]
+        test("vsc_fifo: four tool_call entries", len(tool_entries) == 4)
+        if len(tool_entries) == 4:
+            # FIFO: result1 pairs with start1's span, result2 pairs with start2's span
+            span_start1 = tool_entries[0].get("span_id")  # start1
+            span_start2 = tool_entries[1].get("span_id")  # start2
+            span_result1 = tool_entries[2].get("span_id")  # result1
+            span_result2 = tool_entries[3].get("span_id")  # result2
+            test("vsc_fifo: result1 paired with start1", span_result1 == span_start1)
+            test("vsc_fifo: result2 paired with start2", span_result2 == span_start2)
+
+
+def test_vscode_orphan_tool_result_keeps_own_span():
+    """tool_result with no paired start keeps its own synthetic span_id."""
+    with tempfile.TemporaryDirectory() as td:
+        orphan = (
+            '{"ts": 1700000001000, "dur": 100, "sid": "sx", "type": "tool_result",'
+            ' "name": "bash", "spanId": "bad!!", "status": "ok", "attrs": {}}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, orphan])
+        entries, summary = _vsc.import_file(p)
+        test("vsc_orphan: ok_count == 2", summary["ok_count"] == 2)
+        orphan_entry = next((e for e in entries if e.get("idx") == 1), None)
+        test(
+            "vsc_orphan: orphan has own valid synthetic span_id",
+            orphan_entry is not None and orphan_entry.get("span_id") is not None and len(orphan_entry["span_id"]) == 16,
+        )
+
+
+def test_vscode_no_cross_pair_different_parent():
+    """tool_call/result rows with different valid parent_span_ids do not cross-pair."""
+    with tempfile.TemporaryDirectory() as td:
+        # start A has parent "1111aaaa11111111" (valid 16-hex)
+        start_a = (
+            '{"ts": 1700000001000, "dur": 0, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "bad!!", "status": null, "attrs": {},'
+            ' "parentSpanId": "1111aaaa11111111"}\n'
+        )
+        # result B has a different parent "2222bbbb22222222" — no matching start for B
+        result_b = (
+            '{"ts": 1700000002000, "dur": 100, "sid": "sx", "type": "tool_result",'
+            ' "name": "bash", "spanId": "alsobad!!", "status": "ok", "attrs": {},'
+            ' "parentSpanId": "2222bbbb22222222"}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, start_a, result_b])
+        entries, summary = _vsc.import_file(p)
+        test("vsc_nocross: ok_count == 3", summary["ok_count"] == 3)
+        tool_entries = [e for e in entries if e.get("kind") == "tool_call"]
+        if len(tool_entries) == 2:
+            # Different parent → different queue → no cross-pairing
+            test(
+                "vsc_nocross: start_a and result_b have different span_ids",
+                tool_entries[0].get("span_id") != tool_entries[1].get("span_id"),
+            )
+
+
+def test_vscode_malformed_parent_normalizes_none_pairing():
+    """Invalid parentSpanId normalizes to None in pair key; tool_call and result pair."""
+    with tempfile.TemporaryDirectory() as td:
+        # Both have invalid (non-16-hex) parentSpanId → normalized to None → same key
+        start = (
+            '{"ts": 1700000001000, "dur": 0, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "bad!!", "status": null, "attrs": {},'
+            ' "parentSpanId": "bad-parent-1"}\n'
+        )
+        result = (
+            '{"ts": 1700000002000, "dur": 100, "sid": "sx", "type": "tool_result",'
+            ' "name": "bash", "spanId": "alsobad!!", "status": "ok", "attrs": {},'
+            ' "parentSpanId": "bad-parent-2"}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, start, result])
+        entries, summary = _vsc.import_file(p)
+        test("vsc_badparent: ok_count == 3", summary["ok_count"] == 3)
+        tool_entries = [e for e in entries if e.get("kind") == "tool_call"]
+        if len(tool_entries) == 2:
+            test(
+                "vsc_badparent: start and result share span_id (both parents normalize to None)",
+                tool_entries[0].get("span_id") == tool_entries[1].get("span_id"),
+            )
+
+
+def test_vscode_ridx_ignored_in_pairing():
+    """Different rIdx values (or absent rIdx) do not affect FIFO synthetic pairing."""
+    with tempfile.TemporaryDirectory() as td:
+        # start has rIdx: 5; result has rIdx: 10 — should still pair
+        start = (
+            '{"ts": 1700000001000, "dur": 0, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "bad!!", "status": null, "attrs": {}, "rIdx": 5}\n'
+        )
+        result = (
+            '{"ts": 1700000002000, "dur": 100, "sid": "sx", "type": "tool_result",'
+            ' "name": "bash", "spanId": "alsobad!!", "status": "ok", "attrs": {}, "rIdx": 10}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, start, result])
+        entries, summary = _vsc.import_file(p)
+        test("vsc_ridx: ok_count == 3", summary["ok_count"] == 3)
+        tool_entries = [e for e in entries if e.get("kind") == "tool_call"]
+        if len(tool_entries) == 2:
+            test(
+                "vsc_ridx: start and result share span_id despite different rIdx",
+                tool_entries[0].get("span_id") == tool_entries[1].get("span_id"),
+            )
+
+
+def test_vscode_duplicate_tool_call_does_not_enqueue_pairing():
+    """Deduped tool_call rows must not leave orphan synthetic spans in the FIFO queue."""
+    with tempfile.TemporaryDirectory() as td:
+        duplicate_start = (
+            '{"ts": 1700000001000, "dur": 0, "sid": "sx", "type": "tool_call",'
+            ' "name": "bash", "spanId": "bad!!", "status": null, "attrs": {}}\n'
+        )
+        agent_response = (
+            '{"ts": 1700000002000, "dur": 0, "sid": "sx", "type": "agent_response",'
+            ' "name": "assistant", "spanId": "also_bad!!", "status": null, "attrs": {}}\n'
+        )
+        result1 = (
+            '{"ts": 1700000003000, "dur": 100, "sid": "sx", "type": "tool_result",'
+            ' "name": "bash", "spanId": "result_bad_1!!", "status": "ok", "attrs": {}}\n'
+        )
+        result2 = (
+            '{"ts": 1700000004000, "dur": 100, "sid": "sx", "type": "tool_result",'
+            ' "name": "bash", "spanId": "result_bad_2!!", "status": "ok", "attrs": {}}\n'
+        )
+        p = _write_vsc_temp(td, [_VSC_BASE, duplicate_start, duplicate_start, agent_response, result1, result2])
+        entries, summary = _vsc.import_file(p)
+        test("vsc_dedup_pair: ok_count == 5", summary["ok_count"] == 5)
+        test("vsc_dedup_pair: deduped_count == 1", summary["deduped_count"] == 1)
+        span_ids = [e.get("span_id") for e in entries if e.get("span_id")]
+        agent_span = next(e["span_id"] for e in entries if e.get("kind") == "agent_response")
+        test("vsc_dedup_pair: agent_response synthetic span is unique", span_ids.count(agent_span) == 1)
+        tool_entries = [e for e in entries if e.get("kind") == "tool_call"]
+        test(
+            "vsc_dedup_pair: second result does not reuse deduped start span",
+            len(tool_entries) == 3 and tool_entries[2].get("span_id") != agent_span,
+        )
+
+
+# ════════════════════════════════════════════════════════════════════════════════
+# VS Code _detect_format scan-forward hardening tests (PR #445 review)
+# ════════════════════════════════════════════════════════════════════════════════
+
+
+def test_vscode_all_oversized_raises_unsupported():
+    """All-oversized or empty file raises UnsupportedFormatError (no fingerprint found)."""
+    cap = 1024
+    payload_size = cap * 1024
+    old_cap = os.environ.get("BROWSE_DEBUG_LOG_MAX_LINE_BYTES")
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "all_oversized.jsonl"
+        path.write_bytes(b'{"x":"' + (b"y" * payload_size) + b'"}\n')
+        os.environ["BROWSE_DEBUG_LOG_MAX_LINE_BYTES"] = str(cap)
+        raised = False
+        try:
+            _vsc.import_file(path)
+        except UnsupportedFormatError:
+            raised = True
+        finally:
+            if old_cap is None:
+                os.environ.pop("BROWSE_DEBUG_LOG_MAX_LINE_BYTES", None)
+            else:
+                os.environ["BROWSE_DEBUG_LOG_MAX_LINE_BYTES"] = old_cap
+    test("vsc_cap: all-oversized file raises UnsupportedFormatError", raised)
+
+
+def test_vscode_oversized_first_then_valid_imports():
+    """Oversized first line is skipped; valid VS Code line after it allows import."""
+    cap = 1024
+    payload_size = cap * 1024
+    old_cap = os.environ.get("BROWSE_DEBUG_LOG_MAX_LINE_BYTES")
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "oversized_then_valid.jsonl"
+        oversized = b'{"x":"' + (b"y" * payload_size) + b'"}\n'
+        valid = (
+            b'{"ts": 1700000000000, "dur": 50, "sid": "sx", "type": "session_start",'
+            b' "name": "s", "spanId": "a000000000000001", "status": "ok", "attrs": {}}\n'
+        )
+        path.write_bytes(oversized + valid)
+        os.environ["BROWSE_DEBUG_LOG_MAX_LINE_BYTES"] = str(cap)
+        try:
+            entries, summary = _vsc.import_file(path)
+        finally:
+            if old_cap is None:
+                os.environ.pop("BROWSE_DEBUG_LOG_MAX_LINE_BYTES", None)
+            else:
+                os.environ["BROWSE_DEBUG_LOG_MAX_LINE_BYTES"] = old_cap
+    test("vsc_oversized_then_valid: one valid entry", summary["ok_count"] == 1)
+    test("vsc_oversized_then_valid: one entry returned", len(entries) == 1)
+    test("vsc_oversized_then_valid: first line malformed", summary["malformed_count"] == 1)
+
+
+def test_vscode_oversized_first_then_non_vscode_raises():
+    """Oversized leading content + non-VS-Code parseable line raises UnsupportedFormatError."""
+    cap = 1024
+    payload_size = cap * 1024
+    old_cap = os.environ.get("BROWSE_DEBUG_LOG_MAX_LINE_BYTES")
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "oversized_then_non_vsc.jsonl"
+        oversized = b'{"x":"' + (b"y" * payload_size) + b'"}\n'
+        non_vsc = b'{"name": "otel-like-span", "id": "aa00000000000001"}\n'
+        path.write_bytes(oversized + non_vsc)
+        os.environ["BROWSE_DEBUG_LOG_MAX_LINE_BYTES"] = str(cap)
+        raised = False
+        try:
+            _vsc.import_file(path)
+        except UnsupportedFormatError:
+            raised = True
+        finally:
+            if old_cap is None:
+                os.environ.pop("BROWSE_DEBUG_LOG_MAX_LINE_BYTES", None)
+            else:
+                os.environ["BROWSE_DEBUG_LOG_MAX_LINE_BYTES"] = old_cap
+    test("vsc_oversized_then_non_vsc: raises UnsupportedFormatError", raised)
+
+
+# ════════════════════════════════════════════════════════════════════════════════
 # OTel importer tests
 # ════════════════════════════════════════════════════════════════════════════════
 
@@ -923,6 +1337,30 @@ if __name__ == "__main__":
     test_vscode_error_level_inferred()
     test_vscode_empty_file_raises_unsupported()
     test_vscode_oversized_only_file_raises_unsupported()
+
+    print("\n-- VS Code: required-field enforcement")
+    test_vscode_missing_spanid_malformed()
+    test_vscode_invalid_spanid_type_malformed()
+    test_vscode_missing_status_malformed()
+    test_vscode_status_null_accepted()
+    test_vscode_unrecognized_status_accepted()
+    test_vscode_invalid_status_type_malformed()
+    test_vscode_missing_attrs_malformed()
+    test_vscode_non_dict_attrs_malformed()
+
+    print("\n-- VS Code: synthetic FIFO pairing")
+    test_vscode_synthetic_pairing_tool_call_result()
+    test_vscode_synthetic_pairing_fifo_order()
+    test_vscode_orphan_tool_result_keeps_own_span()
+    test_vscode_no_cross_pair_different_parent()
+    test_vscode_malformed_parent_normalizes_none_pairing()
+    test_vscode_ridx_ignored_in_pairing()
+    test_vscode_duplicate_tool_call_does_not_enqueue_pairing()
+
+    print("\n-- VS Code: detect_format scan-forward hardening")
+    test_vscode_all_oversized_raises_unsupported()
+    test_vscode_oversized_first_then_valid_imports()
+    test_vscode_oversized_first_then_non_vscode_raises()
 
     print("\n-- OTel: happy path")
     test_otel_happy_path()


### PR DESCRIPTION
## Summary
- Adds `browse.importers` with read-only VS Code Agent debug-log and OTel JSONL importers.
- Normalizes external records into redacted `BrowseDebugEntry` data plus privacy-preserving summaries without writing storage.
- Adds synthetic fixtures, importer tests, fixture README rows, and WBS-106 acceptance evidence commands.

## Verification
- `python tests\test_browse_debug_log_importers.py` -> 175 passed, 0 failed
- `python test_security.py` -> 12 passed, 0 failed
- `python test_fixes.py` -> 226 passed, 0 failed
- `python -m browse.importers.vscode_agent_debug_log --path tests\fixtures\debug-log\vscode-agent\debug-logs\0000fixture-session-aaaa --safe-base tests\fixtures\debug-log\vscode-agent --dry-run --json-summary` -> ok_count 12
- `python -m browse.importers.otel_file --path tests\fixtures\debug-log\otel\console-spans.jsonl --safe-base tests\fixtures\debug-log\otel --dry-run --json-summary` -> ok_count 5
- `python -m ruff check browse\importers\__init__.py browse\importers\_common.py browse\importers\vscode_agent_debug_log.py browse\importers\otel_file.py tests\test_browse_debug_log_importers.py` -> clean
- `python -m ruff format --check browse\importers\__init__.py browse\importers\_common.py browse\importers\vscode_agent_debug_log.py browse\importers\otel_file.py tests\test_browse_debug_log_importers.py` -> clean
- `git diff --check` -> clean

Independent reviews: WBS-106 code review CLEAN after bounded-reader boundary fix, Opus security/privacy review CLEAN, whole-app impact docs/staging gaps fixed, final code review CLEAN.

Closes #431
