### PR TITLE
feat: add Rust browse debug log importers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,6 +57,19 @@ watch-sessions.py  ──→  Incremental re-indexing (adaptive polling)
 above remain on disk, are invoked by operators manually, and are referenced by name in `sk watch`
 recovery hints. None of these scripts are candidates for deletion as a consequence of wave20.
 
+## Native Rust Browse Importers
+
+`sk-rust/src/browse/importers/` contains a native Rust parity port for the debug-log
+importers documented in `docs/DEBUG-LOG-CONTRACT.md`: VS Code Agent Debug Log
+JSONL and OTel `ReadableSpan` JSONL. The port includes shared path-safety,
+bounded-line reading, SHA-1 synthetic span IDs, dedup hashing, and redaction
+helpers that mirror the production Python importers.
+
+This is parser-only infrastructure. It has no Browse DB persistence and no CLI
+subcommand yet, so the Python modules remain the production callable importer
+surface. The Rust port is kept compiled and tested in `sk-rust` so a later
+operator command can wire it in without changing the data contract.
+
 ## Python Lint Surface Inventory
 
 This is the canonical inventory for Python Ruff coverage. Keep it in sync with

--- a/docs/DEBUG-LOG-CONTRACT.md
+++ b/docs/DEBUG-LOG-CONTRACT.md
@@ -515,7 +515,7 @@ A performance test (`tests/test_browse_debug_log_api.py::DB26`) verifies that
 
 ### Overview
 
-Two read-only Python importers normalise external source formats into the
+The production read-only Python importers normalise external source formats into the
 `BrowseDebugEntry` shape defined above, apply `redact_entry`, and return
 `(entries, summary)` without writing to the debug-log DB.
 
@@ -523,6 +523,12 @@ Two read-only Python importers normalise external source formats into the
 |---|---|---|---|
 | `browse.importers.vscode_agent_debug_log` | `vscode-agent-debug-log` | `vscode` | `python -m browse.importers.vscode_agent_debug_log --path ... --dry-run --json-summary` |
 | `browse.importers.otel_file` | `vscode-otel-file` | `vscode` | `python -m browse.importers.otel_file --path ... --dry-run --json-summary` |
+
+Issue #455 adds a native Rust parser port under `sk-rust/src/browse/importers/`
+for the same VS Code Agent Debug Log and OTel `ReadableSpan` formats. The Rust
+port mirrors the contracts below and has Rust golden coverage, but it is not yet
+the production CLI/DB persistence path; Python remains the callable importer
+surface until a follow-up wires Rust importers into an operator command.
 
 ### Path safety (both importers)
 
@@ -821,6 +827,9 @@ The canonical implementation references are:
   read endpoint (WBS-104).
 - **`browse/core/debug_log_storage.py`** — isolated SQLite debug-log store (WBS-103).
 - **`browse/core/operator_console.py`** — bounded sidecar capture (WBS-105).
+- **`sk-rust/src/browse/importers/`** — native Rust parser parity port for VS Code
+  Agent Debug Log and OTel `ReadableSpan` inputs (issue #455; no DB persistence
+  or CLI entry point yet).
 
 For the commit hash, run `git log --oneline -1` in the repo root after the WBS-110 merge commit
 lands.

--- a/sk-rust/Cargo.lock
+++ b/sk-rust/Cargo.lock
@@ -1408,6 +1408,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1453,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "tokio",
 ]

--- a/sk-rust/Cargo.toml
+++ b/sk-rust/Cargo.toml
@@ -36,10 +36,12 @@ anyhow  = "1"
 chrono  = { version = "0.4", features = ["serde"] }
 ctrlc   = "3"
 
-# Optional — compiled-in only when the matching native-* feature is enabled.
-notify  = { version = "6",    optional = true }
+# Always-on — low overhead, used across browse importers and other native commands.
 regex   = "1"
 sha1    = "0.10"
+
+# Optional — compiled-in only when the matching native-* feature is enabled.
+notify  = { version = "6",    optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"], optional = true }
 tokio   = { version = "1",    features = ["rt-multi-thread", "macros"], optional = true }
 

--- a/sk-rust/Cargo.toml
+++ b/sk-rust/Cargo.toml
@@ -12,7 +12,7 @@ default = ["native-embed", "native-sync", "native-extract"]
 native-embed   = ["dep:reqwest", "dep:tokio"]
 native-sync    = ["dep:reqwest", "dep:tokio"]
 native-watch   = ["dep:notify"]
-native-hooks   = ["dep:regex"]
+native-hooks   = []
 # Wave-14/16/17/19: hot-path classification/write loop, deterministic relation
 # extraction, native residual helpers, and SEMANTIC_PROXIMITY (TF-IDF cosine).
 # In scope: knowledge_entries write, ke_fts sync, knowledge_relations for
@@ -20,7 +20,7 @@ native-hooks   = ["dep:regex"]
 #   backfill_affected_files, infer_task_ids, confidence decay.
 # Python `extract-knowledge.py` remains for manual/fallback use but is no
 #   longer auto-spawned on the successful native watch path.
-native-extract = ["dep:regex"]
+native-extract = []
 
 [dependencies]
 clap      = { version = "4",    features = ["derive"] }
@@ -38,7 +38,8 @@ ctrlc   = "3"
 
 # Optional — compiled-in only when the matching native-* feature is enabled.
 notify  = { version = "6",    optional = true }
-regex   = { version = "1",    optional = true }
+regex   = "1"
+sha1    = "0.10"
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"], optional = true }
 tokio   = { version = "1",    features = ["rt-multi-thread", "macros"], optional = true }
 

--- a/sk-rust/src/browse/importers/common.rs
+++ b/sk-rust/src/browse/importers/common.rs
@@ -242,15 +242,18 @@ pub fn synthetic_span_id(source: &str, idx: u64) -> String {
     synthetic_span_id_seq(source, idx, 1)
 }
 
-fn synthetic_span_id_seq(source: &str, idx: u64, seq: u64) -> String {
-    let input = format!("{source}:{idx}:{seq}");
-    let hash = Sha1::digest(input.as_bytes());
-    let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
-    let candidate = &hex[..16];
-    if candidate == "0000000000000000" {
-        return synthetic_span_id_seq(source, idx, seq + 1);
+fn synthetic_span_id_seq(source: &str, idx: u64, start_seq: u64) -> String {
+    let mut seq = start_seq;
+    loop {
+        let input = format!("{source}:{idx}:{seq}");
+        let hash = Sha1::digest(input.as_bytes());
+        let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
+        let candidate = &hex[..16];
+        if candidate != "0000000000000000" {
+            return candidate.to_string();
+        }
+        seq += 1;
     }
-    candidate.to_string()
 }
 
 // ── Content hash for dedup ────────────────────────────────────────────────────

--- a/sk-rust/src/browse/importers/common.rs
+++ b/sk-rust/src/browse/importers/common.rs
@@ -1,0 +1,550 @@
+//! Shared path-safety, dedup, hashing, and span-ID helpers.
+//!
+//! Ports `browse/importers/_common.py`.  No third-party dependencies beyond
+//! `sha1` and `sha2` (already in Cargo.toml).
+
+use std::collections::{BTreeMap, HashSet};
+use std::io::{BufRead, Read};
+use std::path::{Path, PathBuf};
+
+use sha1::{Digest, Sha1};
+use sha2::Sha256;
+
+// ── Line size cap ─────────────────────────────────────────────────────────────
+
+const DEFAULT_MAX_LINE_BYTES: usize = 1024 * 1024; // 1 MiB
+
+/// Return the configured max bytes per raw JSONL line (default 1 MiB).
+///
+/// Override via `BROWSE_DEBUG_LOG_MAX_LINE_BYTES` environment variable.
+pub fn max_line_bytes() -> usize {
+    if let Ok(val) = std::env::var("BROWSE_DEBUG_LOG_MAX_LINE_BYTES") {
+        if let Ok(n) = val.trim().parse::<usize>() {
+            return n.max(1);
+        }
+    }
+    DEFAULT_MAX_LINE_BYTES
+}
+
+// ── Bounded line iterator ─────────────────────────────────────────────────────
+
+/// A single yielded item from [`iter_bounded_lines`].
+pub struct BoundedLine {
+    /// 1-based line number.
+    pub line_no: usize,
+    /// The line bytes (up to `cap + 1` bytes; may lack trailing `\n` if oversized).
+    pub bytes: Vec<u8>,
+    /// When `Some(n)`, the line was oversized; `n` is the total bytes consumed.
+    pub oversize_total: Option<usize>,
+}
+
+/// Yield JSONL lines without buffering any single line beyond `cap + 1` bytes.
+///
+/// Over-long lines are consumed to the next newline in bounded chunks so the
+/// reader position is always advanced correctly.
+///
+/// Mirrors Python `iter_bounded_lines(fh, cap)`.
+pub fn iter_bounded_lines<R: Read>(reader: R, cap: usize) -> BoundedLineIter<R> {
+    BoundedLineIter {
+        inner: std::io::BufReader::new(reader),
+        cap,
+        line_no: 0,
+    }
+}
+
+pub struct BoundedLineIter<R> {
+    inner: std::io::BufReader<R>,
+    cap: usize,
+    line_no: usize,
+}
+
+impl<R: Read> Iterator for BoundedLineIter<R> {
+    type Item = BoundedLine;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let cap = self.cap;
+        // Read up to cap+1 bytes stopping at newline.
+        let mut buf = Vec::with_capacity(cap + 2);
+        let n = read_up_to(&mut self.inner, &mut buf, cap + 1);
+        if n == 0 {
+            return None;
+        }
+        self.line_no += 1;
+
+        let ends_with_newline = buf.last() == Some(&b'\n');
+
+        if buf.len() <= cap || ends_with_newline {
+            // Normal line (fits or exactly ends at newline boundary).
+            return Some(BoundedLine {
+                line_no: self.line_no,
+                bytes: buf,
+                oversize_total: None,
+            });
+        }
+
+        // Oversized: keep preview, consume rest of line.
+        let preview = buf.clone();
+        let mut total = buf.len();
+        loop {
+            let mut tail = Vec::with_capacity(cap + 1);
+            let k = read_up_to(&mut self.inner, &mut tail, cap);
+            if k == 0 {
+                break;
+            }
+            total += k;
+            if tail.last() == Some(&b'\n') {
+                break;
+            }
+        }
+        Some(BoundedLine {
+            line_no: self.line_no,
+            bytes: preview,
+            oversize_total: Some(total),
+        })
+    }
+}
+
+/// Read up to `limit` bytes from `reader`, stopping (and including) the first
+/// `\n` encountered.  Returns bytes actually read.
+fn read_up_to<R: BufRead>(reader: &mut R, buf: &mut Vec<u8>, limit: usize) -> usize {
+    let start = buf.len();
+    let mut remaining = limit;
+    while remaining > 0 {
+        let available = match reader.fill_buf() {
+            Ok([]) => break,
+            Ok(b) => b,
+            Err(_) => break,
+        };
+        let take = available.len().min(remaining);
+        // Find newline position within the slice we're going to take.
+        let newline_pos = available[..take].iter().position(|&b| b == b'\n');
+        let end = newline_pos.map(|p| p + 1).unwrap_or(take);
+        buf.extend_from_slice(&available[..end]);
+        reader.consume(end);
+        remaining -= end;
+        if newline_pos.is_some() {
+            break;
+        }
+    }
+    buf.len() - start
+}
+
+// ── Error types ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq)]
+pub enum PathCheckError {
+    /// Path contains raw `..` component or escapes safe_base.
+    Traversal(String),
+    /// A symlink component resolved outside safe_base.
+    SymlinkEscape(String),
+    /// Path does not exist.
+    NotFound(String),
+}
+
+impl std::fmt::Display for PathCheckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PathCheckError::Traversal(s) => write!(f, "Path traversal: {s}"),
+            PathCheckError::SymlinkEscape(s) => write!(f, "Symlink escape: {s}"),
+            PathCheckError::NotFound(s) => write!(f, "Path not found: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for PathCheckError {}
+
+// ── Path safety ────────────────────────────────────────────────────────────────
+
+/// Validate that `path` is safe to read.
+///
+/// 1. Reject raw `..` components in the unresolved path.
+/// 2. Canonicalise (returns `NotFound` if absent).
+/// 3. If `safe_base` is given, require the canonical path to be under it;
+///    distinguishes symlink escape when a symlink component is detected.
+pub fn check_path_safe(path: &Path, safe_base: Option<&Path>) -> Result<PathBuf, PathCheckError> {
+    // 1. Reject raw '..' components.
+    for component in path.components() {
+        use std::path::Component;
+        if matches!(component, Component::ParentDir) {
+            return Err(PathCheckError::Traversal(format!(
+                "Path contains traversal component '..': {}",
+                path.display()
+            )));
+        }
+    }
+
+    // 2. Canonicalise (strict: requires existence).
+    let resolved = path
+        .canonicalize()
+        .map_err(|_| PathCheckError::NotFound(format!("Path not found: {}", path.display())))?;
+
+    // 3. Safe-base containment.
+    if let Some(base) = safe_base {
+        let base_resolved = base.canonicalize().map_err(|_| {
+            PathCheckError::NotFound(format!("safe_base not found: {}", base.display()))
+        })?;
+        if !resolved.starts_with(&base_resolved) {
+            // Detect whether any component of the original path is a symlink.
+            if has_symlink_component(path) {
+                return Err(PathCheckError::SymlinkEscape(format!(
+                    "Symlink at {} resolves outside safe_base {}",
+                    path.display(),
+                    base_resolved.display()
+                )));
+            }
+            return Err(PathCheckError::Traversal(format!(
+                "Path {} is outside safe_base {}",
+                resolved.display(),
+                base_resolved.display()
+            )));
+        }
+    }
+
+    Ok(resolved)
+}
+
+/// Return `true` if any prefix of `path` is a symlink.
+fn has_symlink_component(path: &Path) -> bool {
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        current.push(component);
+        if current.is_symlink() {
+            return true;
+        }
+    }
+    false
+}
+
+// ── File hash ─────────────────────────────────────────────────────────────────
+
+/// Return `"sha256:<hex>"` of the file at `path`, reading in 64 KiB chunks.
+pub fn file_hash_sha256(path: &Path) -> std::io::Result<String> {
+    let mut hasher = Sha256::new();
+    let mut file = std::fs::File::open(path)?;
+    let mut buf = [0u8; 65536];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+// ── Synthetic span ID ─────────────────────────────────────────────────────────
+
+/// Return a 16-char lowercase hex span-ID.
+///
+/// Mirrors Python: `hashlib.sha1(f"{source}:{idx}:{seq}").hexdigest()[:16]`
+/// with all-zero retry (`seq` incremented until result ≠ `"0000000000000000"`).
+pub fn synthetic_span_id(source: &str, idx: u64) -> String {
+    synthetic_span_id_seq(source, idx, 1)
+}
+
+fn synthetic_span_id_seq(source: &str, idx: u64, seq: u64) -> String {
+    let input = format!("{source}:{idx}:{seq}");
+    let hash = Sha1::digest(input.as_bytes());
+    let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
+    let candidate = &hex[..16];
+    if candidate == "0000000000000000" {
+        return synthetic_span_id_seq(source, idx, seq + 1);
+    }
+    candidate.to_string()
+}
+
+// ── Content hash for dedup ────────────────────────────────────────────────────
+
+/// Return the first 16 hex chars of SHA-256 of the canonical JSON of `value`.
+///
+/// Canonical form matches Python's
+/// `json.dumps(obj, sort_keys=True, ensure_ascii=True, separators=(",", ":"))`:
+/// - Keys sorted lexicographically at every nesting level.
+/// - No whitespace.
+/// - Non-ASCII characters escaped as `\uXXXX`.
+pub fn content_hash_16(value: &serde_json::Value) -> String {
+    let canon = canonical_json(value);
+    let hash = Sha256::digest(canon.as_bytes());
+    let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
+    hex[..16].to_string()
+}
+
+/// Produce canonical JSON matching Python's `json.dumps(sort_keys=True,
+/// ensure_ascii=True, separators=(",",":"))`.
+pub fn canonical_json(value: &serde_json::Value) -> String {
+    use serde_json::Value;
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => if *b { "true" } else { "false" }.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => encode_json_string(s),
+        Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(canonical_json).collect();
+            format!("[{}]", items.join(","))
+        }
+        Value::Object(map) => {
+            // Sort keys lexicographically (BTreeMap preserves insertion order
+            // only; collect into sorted structure).
+            let sorted: BTreeMap<&str, &Value> = map.iter().map(|(k, v)| (k.as_str(), v)).collect();
+            let pairs: Vec<String> = sorted
+                .iter()
+                .map(|(k, v)| format!("{}:{}", encode_json_string(k), canonical_json(v)))
+                .collect();
+            format!("{{{}}}", pairs.join(","))
+        }
+    }
+}
+
+/// Encode a Rust string as a JSON string with `ensure_ascii=True` (non-ASCII
+/// characters are emitted as `\uXXXX` escape sequences).
+fn encode_json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str(r#"\""#),
+            '\\' => out.push_str(r"\\"),
+            '\n' => out.push_str(r"\n"),
+            '\r' => out.push_str(r"\r"),
+            '\t' => out.push_str(r"\t"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c if c.is_ascii() => out.push(c),
+            c => {
+                // Non-ASCII: emit as \uXXXX (or surrogate pair for > U+FFFF).
+                let code = c as u32;
+                if code <= 0xFFFF {
+                    out.push_str(&format!("\\u{:04x}", code));
+                } else {
+                    // Surrogate pair encoding (matches Python's ensure_ascii).
+                    let code = code - 0x10000;
+                    let high = 0xD800 + (code >> 10);
+                    let low = 0xDC00 + (code & 0x3FF);
+                    out.push_str(&format!("\\u{:04x}\\u{:04x}", high, low));
+                }
+            }
+        }
+    }
+    out.push('"');
+    out
+}
+
+// ── Dedup set ─────────────────────────────────────────────────────────────────
+
+/// Track seen dedup keys and count duplicates.
+#[derive(Default)]
+pub struct DedupSet {
+    seen: HashSet<String>,
+    pub deduped: usize,
+}
+
+impl DedupSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return `true` (and increment counter) if `key` was already seen.
+    pub fn is_duplicate(&mut self, key: &str) -> bool {
+        if self.seen.contains(key) {
+            self.deduped += 1;
+            true
+        } else {
+            self.seen.insert(key.to_string());
+            false
+        }
+    }
+}
+
+// ── Span ID validation ────────────────────────────────────────────────────────
+
+/// Return `true` iff `s` is a 16-char lowercase hex string.
+pub fn is_valid_span_id(s: &str) -> bool {
+    s.len() == 16 && s.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    // ── synthetic_span_id ─────────────────────────────────────────────────────
+
+    #[test]
+    fn synthetic_span_id_known_value_vscode_0() {
+        // Python: hashlib.sha1(b"vscode:0:1").hexdigest()[:16] = "88fdec75ea74c57f"
+        let id = synthetic_span_id("vscode", 0);
+        assert_eq!(id.len(), 16, "span id must be 16 chars");
+        assert!(
+            id.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')),
+            "span id must be lowercase hex: {id}"
+        );
+        assert_eq!(id, "88fdec75ea74c57f");
+    }
+
+    #[test]
+    fn synthetic_span_id_known_value_otel_5() {
+        // Python: hashlib.sha1(b"otel:5:1").hexdigest()[:16] = "27ce4d26fcc7932d"
+        let id = synthetic_span_id("otel", 5);
+        assert_eq!(id.len(), 16);
+        assert_eq!(id, "27ce4d26fcc7932d");
+    }
+
+    #[test]
+    fn synthetic_span_id_never_all_zero() {
+        // For any reasonable source/idx combination the result should be non-zero.
+        // We can't easily force the all-zero case, but we can verify the normal path.
+        for idx in 0u64..10 {
+            let id = synthetic_span_id("test", idx);
+            assert_ne!(id, "0000000000000000", "span_id must never be all-zero");
+        }
+    }
+
+    // ── content_hash_16 ───────────────────────────────────────────────────────
+
+    #[test]
+    fn content_hash_16_empty_object() {
+        // Python: content_hash_16({}) = sha256(b"{}").hexdigest()[:16] = "44136fa355b3678a"
+        let val = serde_json::json!({});
+        assert_eq!(content_hash_16(&val), "44136fa355b3678a");
+    }
+
+    #[test]
+    fn content_hash_16_sorted_keys() {
+        // Python: json.dumps({"b":1,"a":2}, sort_keys=True, ...) = '{"a":2,"b":1}'
+        // sha256(b'{"a":2,"b":1}').hexdigest()[:16] = "d3626ac30a87e6f7"
+        let val = serde_json::json!({"b": 1, "a": 2});
+        assert_eq!(content_hash_16(&val), "d3626ac30a87e6f7");
+    }
+
+    #[test]
+    fn content_hash_16_ensure_ascii_non_ascii() {
+        // Python encodes non-ASCII as \uXXXX with ensure_ascii=True.
+        // "café" → "caf\u00e9"
+        let val = serde_json::json!("café");
+        let canon = canonical_json(&val);
+        assert_eq!(canon, r#""caf\u00e9""#);
+    }
+
+    // ── is_valid_span_id ──────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_span_id_accepts_16_lower_hex() {
+        assert!(is_valid_span_id("0123456789abcdef"));
+        assert!(is_valid_span_id("aaaaaaaaaaaaaaaa"));
+        assert!(is_valid_span_id("0000000000000000"));
+    }
+
+    #[test]
+    fn valid_span_id_rejects_uppercase() {
+        assert!(!is_valid_span_id("0123456789ABCDEF"));
+    }
+
+    #[test]
+    fn valid_span_id_rejects_wrong_length() {
+        assert!(!is_valid_span_id("0123456789abcde")); // 15 chars
+        assert!(!is_valid_span_id("0123456789abcdef0")); // 17 chars
+        assert!(!is_valid_span_id(""));
+    }
+
+    // ── DedupSet ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn dedup_set_counts_duplicates() {
+        let mut d = DedupSet::new();
+        assert!(!d.is_duplicate("a"));
+        assert!(!d.is_duplicate("b"));
+        assert!(d.is_duplicate("a"));
+        assert_eq!(d.deduped, 1);
+        assert!(d.is_duplicate("b"));
+        assert_eq!(d.deduped, 2);
+    }
+
+    // ── iter_bounded_lines ────────────────────────────────────────────────────
+
+    #[test]
+    fn bounded_lines_normal_lines() {
+        let data = b"line1\nline2\nline3\n";
+        let lines: Vec<_> = iter_bounded_lines(Cursor::new(data), 100).collect();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0].bytes, b"line1\n");
+        assert_eq!(lines[0].oversize_total, None);
+        assert_eq!(lines[1].line_no, 2);
+    }
+
+    #[test]
+    fn bounded_lines_oversized_line_reported() {
+        // cap = 9; first line is "0123456789\n" = 11 bytes > cap+1=10 without trailing newline.
+        // second line "normal\n" = 7 bytes < cap+1=10, fits normally.
+        let data = b"0123456789\nnormal\n";
+        let lines: Vec<_> = iter_bounded_lines(Cursor::new(data), 9).collect();
+        // First line is oversized.
+        assert!(
+            lines[0].oversize_total.is_some(),
+            "first line should be oversized"
+        );
+        // Preview is cap+1 = 10 bytes.
+        assert_eq!(lines[0].bytes.len(), 10);
+        // Second line is normal (7 bytes ≤ cap+1=10 and ends with newline).
+        assert_eq!(lines[1].bytes, b"normal\n");
+        assert_eq!(lines[1].oversize_total, None);
+    }
+
+    #[test]
+    fn bounded_lines_eof_without_trailing_newline() {
+        let data = b"only";
+        let lines: Vec<_> = iter_bounded_lines(Cursor::new(data), 100).collect();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].bytes, b"only");
+        assert_eq!(lines[0].oversize_total, None);
+    }
+
+    // ── check_path_safe ───────────────────────────────────────────────────────
+
+    #[test]
+    fn path_safe_rejects_dotdot() {
+        let p = Path::new("foo/../bar");
+        let result = check_path_safe(p, None);
+        assert!(matches!(result, Err(PathCheckError::Traversal(_))));
+    }
+
+    #[test]
+    fn path_safe_accepts_existing_file() {
+        // Use Cargo.toml as a known-existing file.
+        let manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+        let result = check_path_safe(&manifest, None);
+        assert!(result.is_ok(), "should accept existing file: {result:?}");
+    }
+
+    #[test]
+    fn path_safe_rejects_outside_base() {
+        let manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+        // Use a safe_base that definitely does NOT contain Cargo.toml.
+        let tmp_base = std::env::temp_dir();
+        let result = check_path_safe(&manifest, Some(&tmp_base));
+        assert!(
+            matches!(result, Err(PathCheckError::Traversal(_))),
+            "expected Traversal, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn path_safe_accepts_file_under_base() {
+        let base = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let target = base.join("Cargo.toml");
+        let result = check_path_safe(&target, Some(base));
+        assert!(result.is_ok(), "should accept file under base: {result:?}");
+    }
+
+    // ── file_hash_sha256 ──────────────────────────────────────────────────────
+
+    #[test]
+    fn file_hash_sha256_produces_sha256_prefix() {
+        let manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+        let hash = file_hash_sha256(&manifest).expect("should hash Cargo.toml");
+        assert!(hash.starts_with("sha256:"), "hash: {hash}");
+        assert_eq!(hash.len(), 7 + 64); // "sha256:" + 64 hex chars
+    }
+}

--- a/sk-rust/src/browse/importers/mod.rs
+++ b/sk-rust/src/browse/importers/mod.rs
@@ -1,0 +1,398 @@
+//! Native Rust port of `browse/importers/` Python package.
+//!
+//! Exposes shared helpers (`common`, `redaction`) and the importer trait surface
+//! needed by parser agents.  Parsers (`otel`, `vscode_debug`) are in sibling
+//! modules and may be stubs until their respective parser agents land.
+
+pub mod common;
+pub mod otel;
+pub mod redaction;
+pub mod vscode_debug;
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+// ── Core entry type ───────────────────────────────────────────────────────────
+
+/// Post-redaction `BrowseDebugEntry` envelope.
+///
+/// Serialisation mirrors Python `redact_entry` output exactly:
+/// - `timestamp` and `level` are always emitted (null when absent/invalid).
+/// - `message`, `tool_name`, `duration_ms`, `span_id`, `parent_span_id`, and
+///   `status` are omitted when `None` (Python only sets them when present).
+/// - `redacted` is always emitted (Python always sets `out["redacted"]`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BrowseDebugEntry {
+    pub idx: u64,
+    /// Always serialised; null when absent or invalid in source.
+    pub timestamp: Option<String>,
+    pub kind: String,
+    /// Always serialised; null when absent or invalid in source.
+    pub level: Option<String>,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_span_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Flat scalar map; values are JSON primitives (no nested objects/arrays).
+    pub attrs: HashMap<String, serde_json::Value>,
+    /// Set to `true` whenever any field was dropped or transformed by redaction.
+    /// Always serialised (Python always emits `"redacted": true/false`).
+    pub redacted: bool,
+}
+
+impl Default for BrowseDebugEntry {
+    fn default() -> Self {
+        Self {
+            idx: 0,
+            timestamp: None,
+            kind: "generic".to_string(),
+            level: None,
+            source: "unknown".to_string(),
+            message: None,
+            tool_name: None,
+            duration_ms: None,
+            span_id: None,
+            parent_span_id: None,
+            status: None,
+            attrs: HashMap::new(),
+            redacted: false,
+        }
+    }
+}
+
+// ── Error / result types ──────────────────────────────────────────────────────
+
+/// Describes a malformed record encountered during import.
+///
+/// JSON field names mirror the Python `malformed_reports` envelope:
+/// `line_number` and `reason`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MalformedReport {
+    pub line_number: usize,
+    /// Human-readable description of why the record was rejected.
+    pub reason: String,
+}
+
+/// Summary returned by each importer after processing a file.
+///
+/// Field names and types exactly match the Python `summary` dict:
+/// `source`, `schema_version`, `total_lines`, `ok_count`, `malformed_count`,
+/// `deduped_count`, `malformed_reports`, `file_hash`, `file_name`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ImportSummary {
+    /// Source tag: `"vscode-agent-debug-log"` or `"vscode-otel-file"`.
+    pub source: String,
+    /// Always `1` (schema version).
+    pub schema_version: u32,
+    /// Non-blank lines seen (mirrors Python `total_lines`).
+    pub total_lines: u64,
+    /// Successfully imported entries.
+    pub ok_count: u64,
+    /// Number of malformed records (`len(malformed_reports)` in Python).
+    pub malformed_count: u64,
+    /// Duplicate entries dropped.
+    pub deduped_count: u64,
+    /// Per-line malformed reports.
+    pub malformed_reports: Vec<MalformedReport>,
+    /// `"sha256:<hex>"` of the file.
+    pub file_hash: String,
+    /// Basename only — no absolute path.
+    pub file_name: String,
+}
+
+impl ImportSummary {
+    /// Convenience constructor for parsers.
+    pub fn new(
+        source: impl Into<String>,
+        file_hash: impl Into<String>,
+        file_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            schema_version: 1,
+            total_lines: 0,
+            ok_count: 0,
+            malformed_count: 0,
+            deduped_count: 0,
+            malformed_reports: Vec::new(),
+            file_hash: file_hash.into(),
+            file_name: file_name.into(),
+        }
+    }
+}
+
+/// Errors produced by importers.
+///
+/// Variants map 1-to-1 with Python exceptions in `browse/importers/_common.py`:
+/// - `PathTraversalError` → `PathTraversal`
+/// - `SymlinkEscapeError` → `SymlinkEscape`
+/// - `FileNotFoundError` → `FileNotFound`
+/// - `UnsupportedFormatError` → `UnsupportedFormat`
+/// - `IOError` → `Io`
+#[derive(Debug)]
+pub enum ImportError {
+    Io(std::io::Error),
+    /// `..` component or path escapes safe_base (Python `PathTraversalError`).
+    PathTraversal(String),
+    /// Symlink resolves outside safe_base (Python `SymlinkEscapeError`).
+    SymlinkEscape(String),
+    /// File does not exist (Python `FileNotFoundError`).
+    FileNotFound(String),
+    /// File format is not parseable as the expected type (Python `UnsupportedFormatError`).
+    UnsupportedFormat(String),
+    /// Unexpected internal error.
+    Other(String),
+}
+
+impl fmt::Display for ImportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ImportError::Io(e) => write!(f, "I/O error: {e}"),
+            ImportError::PathTraversal(s) => write!(f, "Path traversal: {s}"),
+            ImportError::SymlinkEscape(s) => write!(f, "Symlink escape: {s}"),
+            ImportError::FileNotFound(s) => write!(f, "File not found: {s}"),
+            ImportError::UnsupportedFormat(s) => write!(f, "Unsupported format: {s}"),
+            ImportError::Other(s) => write!(f, "Import error: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for ImportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        if let ImportError::Io(e) = self {
+            Some(e)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<std::io::Error> for ImportError {
+    fn from(e: std::io::Error) -> Self {
+        ImportError::Io(e)
+    }
+}
+
+impl From<common::PathCheckError> for ImportError {
+    fn from(e: common::PathCheckError) -> Self {
+        match e {
+            common::PathCheckError::Traversal(s) => ImportError::PathTraversal(s),
+            common::PathCheckError::SymlinkEscape(s) => ImportError::SymlinkEscape(s),
+            common::PathCheckError::NotFound(s) => ImportError::FileNotFound(s),
+        }
+    }
+}
+
+// ── Importer trait ────────────────────────────────────────────────────────────
+
+/// Common interface for all browse-debug-log importers.
+pub trait Importer {
+    /// Parse *path* and return redacted entries plus an import summary.
+    ///
+    /// `safe_base` limits which directories the file may reside in; pass
+    /// `None` to skip containment checking (test-only).
+    ///
+    /// When `dry_run` is `true` the returned entries `Vec` is empty (mirroring
+    /// Python's `import_file(…, dry_run=True)` contract).
+    fn import(
+        &self,
+        path: &Path,
+        safe_base: Option<&Path>,
+        dry_run: bool,
+    ) -> Result<(Vec<BrowseDebugEntry>, ImportSummary), ImportError>;
+}
+
+// ── Concrete importer stubs (to be filled in by parser agents) ────────────────
+
+/// Importer for OTel JSONL span files.
+pub struct OtelImporter;
+
+/// Importer for VS Code agent debug-log files.
+pub struct VscodeDebugImporter;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── MalformedReport serialisation ─────────────────────────────────────────
+
+    #[test]
+    fn malformed_report_serialises_line_number_field() {
+        let r = MalformedReport {
+            line_number: 42,
+            reason: "bad JSON".to_string(),
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(
+            v["line_number"], 42,
+            "field must be 'line_number', not 'line_no'"
+        );
+        assert_eq!(v["reason"], "bad JSON");
+        assert!(v.get("line_no").is_none(), "old 'line_no' must not appear");
+    }
+
+    // ── ImportSummary serialisation ───────────────────────────────────────────
+
+    #[test]
+    fn import_summary_serialises_python_envelope_fields() {
+        let summary = ImportSummary {
+            source: "vscode-agent-debug-log".to_string(),
+            schema_version: 1,
+            total_lines: 10,
+            ok_count: 8,
+            malformed_count: 2,
+            deduped_count: 1,
+            malformed_reports: vec![
+                MalformedReport {
+                    line_number: 3,
+                    reason: "JSON parse error".to_string(),
+                },
+                MalformedReport {
+                    line_number: 7,
+                    reason: "missing field 'name'".to_string(),
+                },
+            ],
+            file_hash: "sha256:abcdef1234567890".to_string(),
+            file_name: "main.jsonl".to_string(),
+        };
+        let v = serde_json::to_value(&summary).unwrap();
+        assert_eq!(v["source"], "vscode-agent-debug-log");
+        assert_eq!(v["schema_version"], 1);
+        assert_eq!(v["total_lines"], 10);
+        assert_eq!(v["ok_count"], 8);
+        assert_eq!(v["malformed_count"], 2);
+        assert_eq!(v["deduped_count"], 1);
+        assert_eq!(v["file_hash"], "sha256:abcdef1234567890");
+        assert_eq!(v["file_name"], "main.jsonl");
+        let reports = v["malformed_reports"].as_array().unwrap();
+        assert_eq!(reports.len(), 2);
+        assert_eq!(reports[0]["line_number"], 3);
+        assert_eq!(reports[1]["line_number"], 7);
+        // Old Python-mismatched fields must not appear
+        assert!(v.get("entries_imported").is_none());
+        assert!(v.get("entries_skipped").is_none());
+        assert!(v.get("malformed").is_none());
+    }
+
+    // ── BrowseDebugEntry serialisation ────────────────────────────────────────
+
+    #[test]
+    fn entry_omits_none_optional_fields() {
+        let e = BrowseDebugEntry {
+            idx: 1,
+            timestamp: None,
+            kind: "generic".to_string(),
+            level: None,
+            source: "vscode".to_string(),
+            message: None,
+            tool_name: None,
+            duration_ms: None,
+            span_id: None,
+            parent_span_id: None,
+            status: None,
+            attrs: HashMap::new(),
+            redacted: false,
+        };
+        let v = serde_json::to_value(&e).unwrap();
+        // message / tool_name / duration_ms / span_id / parent_span_id / status must be absent
+        assert!(
+            v.get("message").is_none(),
+            "message must be absent when None"
+        );
+        assert!(
+            v.get("tool_name").is_none(),
+            "tool_name must be absent when None"
+        );
+        assert!(
+            v.get("duration_ms").is_none(),
+            "duration_ms must be absent when None"
+        );
+        assert!(
+            v.get("span_id").is_none(),
+            "span_id must be absent when None"
+        );
+        assert!(
+            v.get("parent_span_id").is_none(),
+            "parent_span_id must be absent when None"
+        );
+        assert!(v.get("status").is_none(), "status must be absent when None");
+        // timestamp and level must be present (as null) — Python always emits them
+        assert_eq!(v["timestamp"], json!(null));
+        assert_eq!(v["level"], json!(null));
+        // redacted must always be present
+        assert_eq!(v["redacted"], false);
+    }
+
+    #[test]
+    fn entry_includes_optional_fields_when_set() {
+        let mut attrs = HashMap::new();
+        attrs.insert("tokens_in".to_string(), json!(100));
+        let e = BrowseDebugEntry {
+            idx: 5,
+            timestamp: Some("2024-01-01T00:00:00.000Z".to_string()),
+            kind: "tool_call".to_string(),
+            level: Some("info".to_string()),
+            source: "cli".to_string(),
+            message: Some("hello".to_string()),
+            tool_name: Some("read_file".to_string()),
+            duration_ms: Some(12.5),
+            span_id: Some("0123456789abcdef".to_string()),
+            parent_span_id: Some("fedcba9876543210".to_string()),
+            status: Some("ok".to_string()),
+            attrs,
+            redacted: true,
+        };
+        let v = serde_json::to_value(&e).unwrap();
+        assert_eq!(v["idx"], 5);
+        assert_eq!(v["timestamp"], "2024-01-01T00:00:00.000Z");
+        assert_eq!(v["kind"], "tool_call");
+        assert_eq!(v["level"], "info");
+        assert_eq!(v["source"], "cli");
+        assert_eq!(v["message"], "hello");
+        assert_eq!(v["tool_name"], "read_file");
+        assert_eq!(v["duration_ms"], 12.5);
+        assert_eq!(v["span_id"], "0123456789abcdef");
+        assert_eq!(v["parent_span_id"], "fedcba9876543210");
+        assert_eq!(v["status"], "ok");
+        assert_eq!(v["attrs"]["tokens_in"], 100);
+        assert_eq!(v["redacted"], true);
+    }
+
+    #[test]
+    fn entry_redacted_false_always_serialised() {
+        let e = BrowseDebugEntry::default();
+        let v = serde_json::to_value(&e).unwrap();
+        // redacted: false must be present even when false
+        assert_eq!(v["redacted"], false);
+    }
+
+    // ── ImportError from PathCheckError ──────────────────────────────────────
+
+    #[test]
+    fn import_error_from_path_check_error() {
+        use crate::browse::importers::common::PathCheckError;
+        let e: ImportError = PathCheckError::Traversal("..".to_string()).into();
+        assert!(matches!(e, ImportError::PathTraversal(_)));
+
+        let e: ImportError = PathCheckError::SymlinkEscape("link".to_string()).into();
+        assert!(matches!(e, ImportError::SymlinkEscape(_)));
+
+        let e: ImportError = PathCheckError::NotFound("missing".to_string()).into();
+        assert!(matches!(e, ImportError::FileNotFound(_)));
+    }
+}

--- a/sk-rust/src/browse/importers/otel.rs
+++ b/sk-rust/src/browse/importers/otel.rs
@@ -1,0 +1,1088 @@
+//! OTel JSONL span importer.
+//!
+//! Ports `browse/importers/otel_file.py` — ReadableSpan JSONL files produced by
+//! ConsoleSpanExporter or compatible OTel exporters.
+//!
+//! Source tag  : `vscode-otel-file`
+//! Entry source: `vscode`
+//! Schema      : 1
+
+use std::path::Path;
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde_json::Value;
+
+use super::common::{
+    check_path_safe, content_hash_16, file_hash_sha256, is_valid_span_id, iter_bounded_lines,
+    max_line_bytes, synthetic_span_id, DedupSet,
+};
+use super::redaction::redact_entry;
+use super::{BrowseDebugEntry, ImportError, ImportSummary, Importer, MalformedReport};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const SOURCE_TAG: &str = "vscode-otel-file";
+const BROWSE_SOURCE: &str = "vscode";
+const SCHEMA_VERSION: u32 = 1;
+
+// ── Attr rename / drop tables ─────────────────────────────────────────────────
+
+/// OTel semantic-convention key → BrowseDebugEntry allowlist key.
+/// Mirrors Python `_OTEL_ATTR_RENAMES`.
+const ATTR_RENAMES: &[(&str, &str)] = &[
+    ("http.status_code", "status_code"),
+    ("gen_ai.usage.input_tokens", "tokens_in"),
+    ("gen_ai.usage.output_tokens", "tokens_out"),
+    ("gen_ai.request.model", "model"),
+    ("model", "model"),
+    ("latency_ms", "latency_ms"),
+    ("tokens_in", "tokens_in"),
+    ("tokens_out", "tokens_out"),
+    ("status_code", "status_code"),
+    ("exit_code", "exit_code"),
+    ("event_count", "event_count"),
+    ("bytes_in", "bytes_in"),
+    ("bytes_out", "bytes_out"),
+    ("attempt", "attempt"),
+    ("cache_hit", "cache_hit"),
+    ("truncated", "truncated"),
+    ("error_category", "error_category"),
+    ("queue_depth", "queue_depth"),
+];
+
+/// Sensitive / PII keys that must be dropped before redaction.
+/// Mirrors Python `_OTEL_UNSAFE_ATTR_DROP`.
+const ATTR_DROP: &[&str] = &[
+    "gen_ai.prompt",
+    "gen_ai.completion",
+    "gen_ai.system",
+    "http.url",
+    "http.request.body",
+    "http.response.body",
+    "http.request_content_length",
+    "db.statement",
+    "messaging.message.body",
+    "messaging.message.payload",
+    "content",
+    "args",
+    "result",
+    "messages",
+    "prompt",
+    "completion",
+    "systemPromptFile",
+    "toolsFile",
+    "rpc.request.body",
+    "rpc.response.body",
+];
+
+// ── Attr mapping ──────────────────────────────────────────────────────────────
+
+/// Pre-filter OTel attributes: drop unsafe keys, rename to allowlist keys.
+///
+/// Unknown keys are dropped silently (redact_entry also filters).
+/// Mirrors Python `_map_otel_attrs`.
+fn map_otel_attrs(raw: &Value) -> serde_json::Map<String, Value> {
+    let map = match raw {
+        Value::Object(m) => m,
+        _ => return serde_json::Map::new(),
+    };
+    let mut out = serde_json::Map::new();
+    for (k, v) in map {
+        if ATTR_DROP.contains(&k.as_str()) {
+            continue;
+        }
+        if let Some(&(_src, dst)) = ATTR_RENAMES.iter().find(|(src, _)| *src == k.as_str()) {
+            out.insert(dst.to_string(), v.clone());
+        }
+        // Unknown keys: silently drop
+    }
+    out
+}
+
+// ── Field extraction helpers ──────────────────────────────────────────────────
+
+/// Try to extract a valid 16-hex span ID from various field layouts.
+/// Mirrors Python `_extract_span_id`.
+fn extract_span_id(obj: &serde_json::Map<String, Value>) -> Option<String> {
+    for key in &["id", "spanId"] {
+        if let Some(Value::String(s)) = obj.get(*key) {
+            if is_valid_span_id(s) {
+                return Some(s.clone());
+            }
+        }
+    }
+    if let Some(Value::Object(ctx)) = obj.get("spanContext") {
+        if let Some(Value::String(s)) = ctx.get("spanId") {
+            if is_valid_span_id(s) {
+                return Some(s.clone());
+            }
+        }
+    }
+    None
+}
+
+/// Return the raw span-id field string for dedup without synthetic fallback.
+/// Mirrors Python `_extract_raw_span_key`.
+fn extract_raw_span_key(obj: &serde_json::Map<String, Value>) -> String {
+    for key in &["id", "spanId"] {
+        if let Some(Value::String(s)) = obj.get(*key) {
+            return s.clone();
+        }
+    }
+    if let Some(Value::Object(ctx)) = obj.get("spanContext") {
+        if let Some(Value::String(s)) = ctx.get("spanId") {
+            return s.clone();
+        }
+    }
+    String::new()
+}
+
+/// Try to extract a trace ID string from various field layouts.
+/// Mirrors Python `_extract_trace_id`.
+fn extract_trace_id(obj: &serde_json::Map<String, Value>) -> Option<String> {
+    if let Some(Value::String(s)) = obj.get("traceId") {
+        if !s.is_empty() {
+            return Some(s.clone());
+        }
+    }
+    if let Some(Value::Object(ctx)) = obj.get("spanContext") {
+        if let Some(Value::String(s)) = ctx.get("traceId") {
+            if !s.is_empty() {
+                return Some(s.clone());
+            }
+        }
+    }
+    None
+}
+
+/// Try to extract a valid parent span ID.
+/// Mirrors Python `_extract_parent_span_id`.
+fn extract_parent_span_id(obj: &serde_json::Map<String, Value>) -> Option<String> {
+    if let Some(Value::String(s)) = obj.get("parentSpanId") {
+        if is_valid_span_id(s) {
+            return Some(s.clone());
+        }
+    }
+    if let Some(Value::Object(ctx)) = obj.get("parentSpanContext") {
+        if let Some(Value::String(s)) = ctx.get("spanId") {
+            if is_valid_span_id(s) {
+                return Some(s.clone());
+            }
+        }
+    }
+    None
+}
+
+/// Format a `DateTime<Utc>` as `YYYY-MM-DDTHH:MM:SS.sssZ` (Python isoformat milliseconds).
+fn dt_to_iso(dt: DateTime<Utc>) -> String {
+    dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()
+}
+
+/// Return `Some(f64)` for a JSON number that is not a bool.
+fn as_numeric_non_bool(v: &Value) -> Option<f64> {
+    match v {
+        Value::Bool(_) => None,
+        Value::Number(n) => n.as_f64(),
+        _ => None,
+    }
+}
+
+/// Convert a Unix timestamp in fractional seconds to `DateTime<Utc>`.
+fn float_secs_to_utc(secs: f64) -> Option<DateTime<Utc>> {
+    if !secs.is_finite() {
+        return None;
+    }
+    let sec_i64 = secs.floor() as i64;
+    let frac = secs - secs.floor();
+    let nanos = (frac * 1_000_000_000.0).round() as u32;
+    let nanos = nanos.min(999_999_999);
+    DateTime::from_timestamp(sec_i64, nanos)
+}
+
+/// Parse an ISO 8601 UTC string to `DateTime<Utc>`.
+///
+/// Formats tried (matching Python `_extract_timestamp`):
+/// - `YYYY-MM-DDTHH:MM:SS.ffffffZ`
+/// - `YYYY-MM-DDTHH:MM:SSZ`
+/// - `YYYY-MM-DDTHH:MM:SS.ffffff+00:00`
+/// - `YYYY-MM-DDTHH:MM:SS+00:00`
+/// - `YYYY-MM-DDTHH:MM:SS.ffffff` (no TZ, assumed UTC)
+/// - `YYYY-MM-DDTHH:MM:SS` (no TZ, assumed UTC)
+fn parse_iso_string(s: &str) -> Option<DateTime<Utc>> {
+    // Formats with Z suffix
+    for fmt in &["%Y-%m-%dT%H:%M:%S%.fZ", "%Y-%m-%dT%H:%M:%SZ"] {
+        if let Ok(ndt) = NaiveDateTime::parse_from_str(s, fmt) {
+            return Some(ndt.and_utc());
+        }
+    }
+    // Formats with +00:00 suffix: strip suffix, then parse naive
+    if let Some(stripped) = s.strip_suffix("+00:00") {
+        for fmt in &["%Y-%m-%dT%H:%M:%S%.f", "%Y-%m-%dT%H:%M:%S"] {
+            if let Ok(ndt) = NaiveDateTime::parse_from_str(stripped, fmt) {
+                return Some(ndt.and_utc());
+            }
+        }
+    }
+    // No timezone: assume UTC
+    for fmt in &["%Y-%m-%dT%H:%M:%S%.f", "%Y-%m-%dT%H:%M:%S"] {
+        if let Ok(ndt) = NaiveDateTime::parse_from_str(s, fmt) {
+            return Some(ndt.and_utc());
+        }
+    }
+    None
+}
+
+/// Convert timestamp to ISO-8601 UTC Z string from various encodings.
+/// Mirrors Python `_extract_timestamp`.
+fn extract_timestamp(obj: &serde_json::Map<String, Value>) -> Option<String> {
+    // 1. numeric `timestamp` (microseconds — ConsoleSpanExporter default)
+    if let Some(ts) = obj.get("timestamp") {
+        if let Some(n) = as_numeric_non_bool(ts) {
+            if n > 0.0 {
+                if let Some(dt) = float_secs_to_utc(n / 1_000_000.0) {
+                    return Some(dt_to_iso(dt));
+                }
+            }
+        }
+    }
+
+    // 2. startTime as HrTime [sec, nanos] or ISO string
+    if let Some(st) = obj.get("startTime") {
+        match st {
+            Value::Array(arr) if arr.len() == 2 => {
+                if let (Some(sec), Some(ns)) =
+                    (as_numeric_non_bool(&arr[0]), as_numeric_non_bool(&arr[1]))
+                {
+                    let total = sec + ns / 1_000_000_000.0;
+                    if let Some(dt) = float_secs_to_utc(total) {
+                        return Some(dt_to_iso(dt));
+                    }
+                }
+            }
+            Value::String(s) if !s.is_empty() => {
+                if let Some(dt) = parse_iso_string(s) {
+                    return Some(dt_to_iso(dt));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // 3. timeUnixNano / startTimeUnixNano (nanoseconds integer)
+    for key in &["timeUnixNano", "startTimeUnixNano"] {
+        if let Some(v) = obj.get(*key) {
+            if let Some(n) = as_numeric_non_bool(v) {
+                if n > 0.0 {
+                    if let Some(dt) = float_secs_to_utc(n / 1_000_000_000.0) {
+                        return Some(dt_to_iso(dt));
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Convert duration from µs integer to milliseconds float.
+/// Mirrors Python `_extract_duration_ms`.
+fn extract_duration_ms(obj: &serde_json::Map<String, Value>) -> Option<f64> {
+    if let Some(d) = obj.get("duration") {
+        if let Some(n) = as_numeric_non_bool(d) {
+            if n > 0.0 {
+                return Some(n / 1000.0);
+            }
+        }
+    }
+    None
+}
+
+/// Return `(status, level)` from `status.code`.
+///
+/// code 0 → (None, None); code 1 → ("ok", None); code 2 → ("error", "error")
+/// Mirrors Python `_extract_status`.
+fn extract_status(obj: &serde_json::Map<String, Value>) -> (Option<String>, Option<String>) {
+    if let Some(Value::Object(status_obj)) = obj.get("status") {
+        match status_obj.get("code") {
+            Some(Value::Number(n)) if n.as_f64() == Some(1.0) => {
+                return (Some("ok".to_string()), None)
+            }
+            Some(Value::Number(n)) if n.as_f64() == Some(2.0) => {
+                return (Some("error".to_string()), Some("error".to_string()))
+            }
+            _ => {}
+        }
+    }
+    (None, None)
+}
+
+// ── Format detection ──────────────────────────────────────────────────────────
+
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "NoneType",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "float",
+        Value::String(_) => "str",
+        Value::Array(_) => "list",
+        Value::Object(_) => "dict",
+    }
+}
+
+/// Check the file looks like OTel ReadableSpan JSONL.
+///
+/// Mirrors Python `_detect_format`.
+fn detect_format(path: &Path) -> Result<(), ImportError> {
+    let cap = max_line_bytes();
+    let file = std::fs::File::open(path).map_err(ImportError::Io)?;
+
+    for line in iter_bounded_lines(file, cap) {
+        // Strip trailing \r\n and check blank
+        let rstrip = line
+            .bytes
+            .iter()
+            .rev()
+            .take_while(|&&b| b == b'\n' || b == b'\r')
+            .count();
+        let stripped = &line.bytes[..line.bytes.len() - rstrip];
+        if stripped.is_empty() {
+            continue;
+        }
+        // Oversized lines are not format evidence
+        if line.oversize_total.is_some() {
+            continue;
+        }
+        // Bare JSON array
+        if stripped.first() == Some(&b'[') {
+            return Err(ImportError::UnsupportedFormat(
+                "File starts with '[': expected JSONL objects, got JSON array. \
+                 Not an OTel ReadableSpan file."
+                    .to_string(),
+            ));
+        }
+        let line_str = String::from_utf8_lossy(stripped);
+        let obj: Value = match serde_json::from_str(line_str.trim()) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let map = match &obj {
+            Value::Object(m) => m,
+            _ => {
+                return Err(ImportError::UnsupportedFormat(format!(
+                    "First parseable JSON value is {}, expected dict.",
+                    json_type_name(&obj)
+                )));
+            }
+        };
+        // Guard against VS Code IDebugLogEntry (has numeric 'ts' + string 'sid')
+        let is_vscode = matches!(map.get("ts"), Some(Value::Number(_)))
+            && matches!(map.get("sid"), Some(Value::String(_)));
+        if is_vscode {
+            return Err(ImportError::UnsupportedFormat(
+                "File appears to be a VS Code Agent debug log (has 'ts' + 'sid'). \
+                 Use browse.importers.vscode_agent_debug_log instead."
+                    .to_string(),
+            ));
+        }
+        let has_name = map.contains_key("name");
+        let has_span = matches!(map.get("id"), Some(Value::String(_)))
+            || matches!(map.get("spanId"), Some(Value::String(_)))
+            || matches!(map.get("spanContext"), Some(Value::Object(_)))
+            || matches!(map.get("traceId"), Some(Value::String(_)));
+        if !(has_name && has_span) {
+            return Err(ImportError::UnsupportedFormat(
+                "First parseable JSON line lacks OTel ReadableSpan fingerprint \
+                 ('name' + span ID or traceId field). \
+                 Not an OTel ReadableSpan JSONL file."
+                    .to_string(),
+            ));
+        }
+        return Ok(()); // fingerprint accepted
+    }
+
+    Err(ImportError::UnsupportedFormat(
+        "No parseable OTel ReadableSpan fingerprint found before EOF.".to_string(),
+    ))
+}
+
+// ── Single-line parser ────────────────────────────────────────────────────────
+
+struct ParsedSpan {
+    /// Raw entry JSON ready for `redact_entry`.
+    entry: Value,
+    /// Trace ID extracted for dedup key (may be empty).
+    trace_id: String,
+    /// Raw span key for dedup (first string of id/spanId/spanContext.spanId).
+    raw_span_key: String,
+}
+
+/// Parse one OTel ReadableSpan dict into a raw entry Value.
+///
+/// Returns `Ok(ParsedSpan)` on success or `Err(reason)` for malformed lines.
+/// Mirrors Python `_parse_line`.
+fn parse_line(obj: serde_json::Map<String, Value>, idx: u64) -> Result<ParsedSpan, String> {
+    let name = match obj.get("name") {
+        Some(Value::String(s)) if !s.is_empty() => s.clone(),
+        _ => return Err("missing or empty required field 'name'".to_string()),
+    };
+
+    let span_id = extract_span_id(&obj).unwrap_or_else(|| synthetic_span_id(BROWSE_SOURCE, idx));
+    let trace_id = extract_trace_id(&obj).unwrap_or_default();
+    let raw_span_key = extract_raw_span_key(&obj);
+    let parent_span_id = extract_parent_span_id(&obj);
+    let timestamp = extract_timestamp(&obj);
+    let duration_ms = extract_duration_ms(&obj);
+    let (status, level) = extract_status(&obj);
+
+    // Attrs: prefer "attributes", fallback "attrs"
+    let raw_attrs = obj
+        .get("attributes")
+        .or_else(|| obj.get("attrs"))
+        .unwrap_or(&Value::Null);
+    let mapped_attrs = map_otel_attrs(raw_attrs);
+
+    let mut entry = serde_json::Map::new();
+    entry.insert("idx".to_string(), Value::Number(idx.into()));
+    entry.insert(
+        "timestamp".to_string(),
+        timestamp.map(Value::String).unwrap_or(Value::Null),
+    );
+    entry.insert("kind".to_string(), Value::String("generic".to_string()));
+    entry.insert(
+        "level".to_string(),
+        level.map(Value::String).unwrap_or(Value::Null),
+    );
+    entry.insert(
+        "source".to_string(),
+        Value::String(BROWSE_SOURCE.to_string()),
+    );
+    entry.insert("message".to_string(), Value::String(name));
+    entry.insert("attrs".to_string(), Value::Object(mapped_attrs));
+    entry.insert("span_id".to_string(), Value::String(span_id));
+
+    if let Some(parent) = parent_span_id {
+        entry.insert("parent_span_id".to_string(), Value::String(parent));
+    }
+    if let Some(d) = duration_ms {
+        if let Some(n) = serde_json::Number::from_f64(d) {
+            entry.insert("duration_ms".to_string(), Value::Number(n));
+        }
+    }
+    if let Some(s) = status {
+        entry.insert("status".to_string(), Value::String(s));
+    }
+
+    Ok(ParsedSpan {
+        entry: Value::Object(entry),
+        trace_id,
+        raw_span_key,
+    })
+}
+
+// ── Importer implementation ───────────────────────────────────────────────────
+
+impl Importer for super::OtelImporter {
+    /// Parse an OTel ReadableSpan JSONL file.
+    ///
+    /// Mirrors `browse/importers/otel_file.py::import_file`.
+    fn import(
+        &self,
+        path: &Path,
+        safe_base: Option<&Path>,
+        dry_run: bool,
+    ) -> Result<(Vec<BrowseDebugEntry>, ImportSummary), ImportError> {
+        // ── Path safety ───────────────────────────────────────────────────────
+        let resolved = check_path_safe(path, safe_base)?;
+        if resolved.is_dir() {
+            return Err(ImportError::UnsupportedFormat(
+                "OTel importer expects a file path, not a directory.".to_string(),
+            ));
+        }
+
+        // ── Format detection ──────────────────────────────────────────────────
+        detect_format(&resolved)?;
+
+        // ── File hash ─────────────────────────────────────────────────────────
+        let file_hash = file_hash_sha256(&resolved).map_err(ImportError::Io)?;
+        let file_name = resolved
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+
+        // ── Parse ─────────────────────────────────────────────────────────────
+        let cap = max_line_bytes();
+        let mut dedup = DedupSet::new();
+        let mut entries: Vec<BrowseDebugEntry> = Vec::new();
+        let mut malformed_reports: Vec<MalformedReport> = Vec::new();
+        let mut ok_count: u64 = 0;
+        let mut total_lines: u64 = 0;
+        let mut entry_idx: u64 = 0;
+
+        let file = std::fs::File::open(&resolved).map_err(ImportError::Io)?;
+        for line in iter_bounded_lines(file, cap) {
+            // Strip trailing \r\n, skip blank lines silently
+            let rstrip = line
+                .bytes
+                .iter()
+                .rev()
+                .take_while(|&&b| b == b'\n' || b == b'\r')
+                .count();
+            let stripped_len = line.bytes.len() - rstrip;
+            if stripped_len == 0 {
+                continue;
+            }
+
+            total_lines += 1;
+
+            // Line size cap
+            if let Some(total) = line.oversize_total {
+                malformed_reports.push(MalformedReport {
+                    line_number: line.line_no,
+                    reason: format!("line exceeds max byte cap ({} > {} bytes)", total, cap),
+                });
+                continue;
+            }
+
+            // JSON parse (decode with replacement chars, strip all whitespace)
+            let line_str = String::from_utf8_lossy(&line.bytes);
+            let line_str = line_str.trim();
+            let obj: Value = match serde_json::from_str(line_str) {
+                Ok(v) => v,
+                Err(e) => {
+                    malformed_reports.push(MalformedReport {
+                        line_number: line.line_no,
+                        reason: format!("JSON parse error: {e}"),
+                    });
+                    continue;
+                }
+            };
+            let map = match obj {
+                Value::Object(m) => m,
+                other => {
+                    malformed_reports.push(MalformedReport {
+                        line_number: line.line_no,
+                        reason: format!("line is {}, expected JSON object", json_type_name(&other)),
+                    });
+                    continue;
+                }
+            };
+
+            // Preserve original object for content-hash dedup
+            let orig_obj = Value::Object(map.clone());
+
+            match parse_line(map, entry_idx) {
+                Err(reason) => {
+                    malformed_reports.push(MalformedReport {
+                        line_number: line.line_no,
+                        reason,
+                    });
+                    continue;
+                }
+                Ok(parsed) => {
+                    // Dedup key: SOURCE_TAG:traceId:rawSpanKey:contentHash16
+                    let dedup_key = format!(
+                        "{}:{}:{}:{}",
+                        SOURCE_TAG,
+                        parsed.trace_id,
+                        parsed.raw_span_key,
+                        content_hash_16(&orig_obj),
+                    );
+                    if dedup.is_duplicate(&dedup_key) {
+                        continue;
+                    }
+
+                    let redacted = redact_entry(&parsed.entry);
+                    ok_count += 1;
+                    entry_idx += 1;
+                    if !dry_run {
+                        entries.push(redacted);
+                    }
+                }
+            }
+        }
+
+        let malformed_count = malformed_reports.len() as u64;
+        let summary = ImportSummary {
+            source: SOURCE_TAG.to_string(),
+            schema_version: SCHEMA_VERSION,
+            total_lines,
+            ok_count,
+            malformed_count,
+            deduped_count: dedup.deduped as u64,
+            malformed_reports,
+            file_hash,
+            file_name,
+        };
+
+        Ok((entries, summary))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::browse::importers::Importer;
+    use std::io::Write;
+
+    fn fixture_root() -> std::path::PathBuf {
+        // Cargo.toml lives in sk-rust/; parent is the repo root.
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("tests/fixtures/debug-log")
+    }
+
+    fn otel_fixture(name: &str) -> std::path::PathBuf {
+        fixture_root().join("otel").join(name)
+    }
+
+    fn import_file(path: &std::path::Path) -> (Vec<BrowseDebugEntry>, ImportSummary) {
+        super::super::OtelImporter
+            .import(path, None, false)
+            .expect("import should succeed")
+    }
+
+    // ── Happy path: console-spans.jsonl ──────────────────────────────────────
+
+    #[test]
+    fn console_spans_summary_ok() {
+        let path = otel_fixture("console-spans.jsonl");
+        let (_entries, summary) = import_file(&path);
+        assert_eq!(summary.source, "vscode-otel-file");
+        assert_eq!(summary.schema_version, 1);
+        assert_eq!(summary.ok_count, 5, "expected 5 ok entries");
+        assert_eq!(summary.total_lines, 5, "expected 5 non-blank lines");
+        assert_eq!(summary.malformed_count, 0);
+        assert_eq!(summary.deduped_count, 0);
+        assert!(
+            summary.file_hash.starts_with("sha256:"),
+            "file_hash should start with sha256:"
+        );
+        assert_eq!(summary.file_name, "console-spans.jsonl");
+    }
+
+    #[test]
+    fn console_spans_entry_count() {
+        let path = otel_fixture("console-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        assert_eq!(entries.len(), 5);
+    }
+
+    #[test]
+    fn console_spans_source_is_vscode() {
+        let path = otel_fixture("console-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        for e in &entries {
+            assert_eq!(e.source, "vscode", "all entries should have source=vscode");
+        }
+    }
+
+    #[test]
+    fn console_spans_status_mapping() {
+        let path = otel_fixture("console-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        // Line 1: code=1 → status "ok", level None
+        assert_eq!(entries[0].status.as_deref(), Some("ok"));
+        assert_eq!(entries[0].level, None);
+        // Line 2: code=2 → status "error", level "error"
+        assert_eq!(entries[1].status.as_deref(), Some("error"));
+        assert_eq!(entries[1].level.as_deref(), Some("error"));
+        // Line 3: code=0 → no status
+        assert_eq!(entries[2].status, None);
+        assert_eq!(entries[2].level, None);
+    }
+
+    #[test]
+    fn console_spans_parent_span() {
+        let path = otel_fixture("console-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        // Line 2 has parentSpanContext.spanId = "aa00000000000001"
+        assert_eq!(
+            entries[1].parent_span_id.as_deref(),
+            Some("aa00000000000001")
+        );
+        // Line 1 has no parent
+        assert_eq!(entries[0].parent_span_id, None);
+        // Line 4 has parentSpanId = "cc00000000000003"
+        assert_eq!(
+            entries[3].parent_span_id.as_deref(),
+            Some("cc00000000000003")
+        );
+    }
+
+    #[test]
+    fn console_spans_duration_ms() {
+        let path = otel_fixture("console-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        // Line 1: duration 1500000 µs → 1500.0 ms
+        assert!((entries[0].duration_ms.unwrap() - 1500.0).abs() < 1e-9);
+        // Line 4: duration 0 → None (not positive)
+        assert_eq!(entries[3].duration_ms, None);
+    }
+
+    #[test]
+    fn console_spans_attr_rename_tokens() {
+        let path = otel_fixture("console-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        // Line 1: gen_ai.usage.input_tokens → tokens_in, gen_ai.usage.output_tokens → tokens_out
+        let attrs = &entries[0].attrs;
+        assert_eq!(attrs.get("tokens_in"), Some(&serde_json::json!(512)));
+        assert_eq!(attrs.get("tokens_out"), Some(&serde_json::json!(128)));
+    }
+
+    #[test]
+    fn console_spans_unsafe_attr_dropped() {
+        let path = otel_fixture("console-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        // Line 4: gen_ai.prompt = "must-be-dropped" should be absent
+        let attrs = &entries[3].attrs;
+        assert!(
+            attrs.get("gen_ai.prompt").is_none(),
+            "gen_ai.prompt must be dropped"
+        );
+        // error_category should be present (renamed to itself)
+        assert_eq!(
+            attrs.get("error_category"),
+            Some(&serde_json::json!("io_error"))
+        );
+    }
+
+    #[test]
+    fn console_spans_redaction_bearer_path() {
+        let path = otel_fixture("console-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        // Line 5 message contains "bearer supersecret" and Windows path → redacted
+        let msg = entries[4].message.as_deref().unwrap_or("");
+        assert!(
+            !msg.contains("supersecret"),
+            "bearer token must be redacted; got: {msg}"
+        );
+        assert!(
+            !msg.contains("alice"),
+            "path username must be redacted; got: {msg}"
+        );
+        assert!(entries[4].redacted, "entry 5 must be marked redacted");
+    }
+
+    // ── HrTime / ISO / timeUnixNano fixture ───────────────────────────────────
+
+    #[test]
+    fn hrtime_spans_summary() {
+        let path = otel_fixture("hrtime-spans.jsonl");
+        let (entries, summary) = import_file(&path);
+        assert_eq!(summary.ok_count, 4);
+        assert_eq!(entries.len(), 4);
+        assert_eq!(summary.malformed_count, 0);
+    }
+
+    #[test]
+    fn hrtime_spans_hrtime_timestamp() {
+        let path = otel_fixture("hrtime-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        // Line 1: startTime=[1700000, 500000000] → sec=1700000 + 0.5
+        let ts = entries[0].timestamp.as_deref().unwrap_or("");
+        assert!(!ts.is_empty(), "hrtime span should have timestamp");
+        assert!(ts.ends_with('Z'), "timestamp must end with Z");
+    }
+
+    #[test]
+    fn hrtime_spans_iso_z_timestamp() {
+        let path = otel_fixture("hrtime-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        // Line 2: startTime="2024-01-15T10:00:00.000Z"
+        let ts = entries[1].timestamp.as_deref().unwrap_or("");
+        assert!(
+            ts.starts_with("2024-01-15T10:00:00"),
+            "expected ISO Z; got: {ts}"
+        );
+    }
+
+    #[test]
+    fn hrtime_spans_iso_notz_timestamp() {
+        let path = otel_fixture("hrtime-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        // Line 3: startTime="2024-01-15T10:00:01.500" (no TZ, assume UTC)
+        let ts = entries[2].timestamp.as_deref().unwrap_or("");
+        assert!(
+            ts.starts_with("2024-01-15T10:00:01"),
+            "expected parsed no-TZ ISO; got: {ts}"
+        );
+    }
+
+    #[test]
+    fn hrtime_spans_timeunixnano_timestamp() {
+        let path = otel_fixture("hrtime-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        // Line 4: timeUnixNano=1700000002000000000 → 1700000002 seconds
+        let ts = entries[3].timestamp.as_deref().unwrap_or("");
+        assert!(!ts.is_empty(), "timeUnixNano span should have timestamp");
+        assert!(ts.ends_with('Z'));
+    }
+
+    #[test]
+    fn hrtime_spans_tokensin_tokens_out_rename() {
+        let path = otel_fixture("hrtime-spans.jsonl");
+        let (entries, _) = import_file(&path);
+        // Line 4 has tokens_in=64, tokens_out=32 (already allowlist names)
+        let attrs = &entries[3].attrs;
+        assert_eq!(attrs.get("tokens_in"), Some(&serde_json::json!(64)));
+        assert_eq!(attrs.get("tokens_out"), Some(&serde_json::json!(32)));
+    }
+
+    // ── Malformed fixture ─────────────────────────────────────────────────────
+
+    #[test]
+    fn malformed_fixture_counts() {
+        let path = otel_fixture("malformed-spans.jsonl");
+        let (entries, summary) = import_file(&path);
+        // Line 1: valid
+        // Line 2: "this is not json" → JSON parse error
+        // Line 3: missing name → malformed
+        // Line 4: valid
+        assert_eq!(summary.ok_count, 2, "expected 2 ok entries");
+        assert_eq!(summary.malformed_count, 2, "expected 2 malformed");
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn malformed_fixture_reports_reason() {
+        let path = otel_fixture("malformed-spans.jsonl");
+        let (_, summary) = import_file(&path);
+        let reasons: Vec<&str> = summary
+            .malformed_reports
+            .iter()
+            .map(|r| r.reason.as_str())
+            .collect();
+        assert!(
+            reasons.iter().any(|r| r.starts_with("JSON parse error")),
+            "expected JSON parse error; got: {reasons:?}"
+        );
+        assert!(
+            reasons
+                .iter()
+                .any(|r| r.contains("missing or empty required field 'name'")),
+            "expected missing name error; got: {reasons:?}"
+        );
+    }
+
+    // ── Synthetic span ID ─────────────────────────────────────────────────────
+
+    #[test]
+    fn missing_span_id_gets_synthetic() {
+        let jsonl = r#"{"name":"no-id","traceId":"aaaaaaaaaaaaaaaa"}"#;
+        let tmpdir = std::env::temp_dir();
+        let path = tmpdir.join("otel_test_synthetic_span.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", jsonl).unwrap();
+        drop(f);
+
+        let (entries, summary) = super::super::OtelImporter
+            .import(&path, None, false)
+            .expect("should succeed");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(summary.ok_count, 1);
+        let span = entries[0].span_id.as_deref().unwrap_or("");
+        assert_eq!(span.len(), 16, "synthetic span_id must be 16 chars");
+        assert!(
+            span.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')),
+            "synthetic span_id must be lowercase hex: {span}"
+        );
+    }
+
+    // ── Dedup ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn dedup_identical_lines() {
+        let line = r#"{"name":"dup","id":"aa00000000000001","traceId":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","timestamp":1700000000000000}"#;
+        let tmpdir = std::env::temp_dir();
+        let path = tmpdir.join("otel_test_dedup.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", line).unwrap();
+        writeln!(f, "{}", line).unwrap();
+        drop(f);
+
+        let (entries, summary) = super::super::OtelImporter
+            .import(&path, None, false)
+            .expect("should succeed");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(
+            summary.ok_count, 1,
+            "second identical line should be deduped"
+        );
+        assert_eq!(summary.deduped_count, 1);
+        assert_eq!(entries.len(), 1);
+    }
+
+    // ── Oversized line ────────────────────────────────────────────────────────
+
+    #[test]
+    fn oversized_line_is_malformed() {
+        // Build a line that genuinely exceeds the 1 MiB default cap so we do not
+        // need to touch BROWSE_DEBUG_LOG_MAX_LINE_BYTES (env-var mutation causes
+        // race conditions when tests run in parallel).
+        let cap = super::super::common::max_line_bytes();
+        let valid = r#"{"name":"ok","id":"aa00000000000001","traceId":"aaaa"}"#;
+        // Oversized line: JSON prefix so it would parse if small, padded past cap.
+        let padding = " ".repeat(cap + 2);
+        let big = format!(r#"{{"name":"x","id":"bb00000000000002"{}  }}"#, padding);
+        assert!(big.len() > cap, "test setup: big line must exceed cap");
+
+        let tmpdir = std::env::temp_dir();
+        let path = tmpdir.join("otel_test_oversized_real.jsonl");
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            writeln!(f, "{}", valid).unwrap();
+            writeln!(f, "{}", big).unwrap();
+        }
+
+        let (entries, summary) = super::super::OtelImporter
+            .import(&path, None, false)
+            .expect("import should succeed");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(entries.len(), 1, "only the valid line should be imported");
+        assert_eq!(
+            summary.malformed_count, 1,
+            "oversized line should be reported malformed"
+        );
+        let reason = &summary.malformed_reports[0].reason;
+        assert!(
+            reason.contains("line exceeds max byte cap"),
+            "unexpected reason: {reason}"
+        );
+    }
+
+    // ── Unsupported format: VS Code debug log ─────────────────────────────────
+
+    #[test]
+    fn vscode_format_rejected() {
+        let line = r#"{"ts":1700000000,"sid":"session-123","msg":"hello"}"#;
+        let tmpdir = std::env::temp_dir();
+        let path = tmpdir.join("otel_test_vscode_reject.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", line).unwrap();
+        drop(f);
+
+        let result = super::super::OtelImporter.import(&path, None, false);
+        std::fs::remove_file(&path).ok();
+
+        assert!(
+            matches!(result, Err(ImportError::UnsupportedFormat(_))),
+            "VS Code format should be rejected"
+        );
+    }
+
+    // ── Unsupported format: JSON array ────────────────────────────────────────
+
+    #[test]
+    fn json_array_rejected() {
+        let tmpdir = std::env::temp_dir();
+        let path = tmpdir.join("otel_test_array_reject.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, r#"[{{"name":"x","id":"aa00000000000001"}}]"#).unwrap();
+        drop(f);
+
+        let result = super::super::OtelImporter.import(&path, None, false);
+        std::fs::remove_file(&path).ok();
+
+        assert!(
+            matches!(result, Err(ImportError::UnsupportedFormat(_))),
+            "JSON array should be rejected"
+        );
+    }
+
+    // ── Directory path rejected ───────────────────────────────────────────────
+
+    #[test]
+    fn directory_path_rejected() {
+        let tmpdir = std::env::temp_dir();
+        let result = super::super::OtelImporter.import(&tmpdir, None, false);
+        assert!(
+            matches!(result, Err(ImportError::UnsupportedFormat(_))),
+            "directory should return UnsupportedFormat"
+        );
+    }
+
+    // ── Path traversal rejected ───────────────────────────────────────────────
+
+    #[test]
+    fn path_traversal_rejected() {
+        let path = std::path::Path::new("some/../file.jsonl");
+        let result = super::super::OtelImporter.import(path, None, false);
+        assert!(
+            matches!(result, Err(ImportError::PathTraversal(_))),
+            "path traversal should be rejected"
+        );
+    }
+
+    // ── Safe-base containment ─────────────────────────────────────────────────
+
+    #[test]
+    fn safe_base_rejects_outside_file() {
+        let path = otel_fixture("console-spans.jsonl");
+        let base = std::env::temp_dir(); // fixture is not under temp_dir
+        let result = super::super::OtelImporter.import(&path, Some(&base), false);
+        assert!(
+            matches!(
+                result,
+                Err(ImportError::PathTraversal(_)) | Err(ImportError::SymlinkEscape(_))
+            ),
+            "file outside safe_base should be rejected: {result:?}"
+        );
+    }
+
+    // ── Dry run ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn dry_run_returns_empty_entries_with_counts() {
+        let path = otel_fixture("console-spans.jsonl");
+        let (entries, summary) = super::super::OtelImporter
+            .import(&path, None, true)
+            .expect("dry run should succeed");
+        assert!(entries.is_empty(), "dry_run must return empty entries vec");
+        assert_eq!(summary.ok_count, 5, "dry_run must still count ok entries");
+        assert_eq!(summary.total_lines, 5);
+    }
+
+    // ── Timestamp: numeric microseconds ──────────────────────────────────────
+
+    #[test]
+    fn timestamp_microseconds_correct_format() {
+        // 1700000000000000 µs = 1700000000 s = 2023-11-14T22:13:20.000Z
+        let line = r#"{"name":"ts-test","id":"aa00000000000001","traceId":"aaaa","timestamp":1700000000000000}"#;
+        let tmpdir = std::env::temp_dir();
+        let path = tmpdir.join("otel_test_ts_us.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", line).unwrap();
+        drop(f);
+
+        let (entries, _) = super::super::OtelImporter
+            .import(&path, None, false)
+            .expect("should succeed");
+        std::fs::remove_file(&path).ok();
+
+        let ts = entries[0].timestamp.as_deref().unwrap_or("");
+        assert_eq!(ts, "2023-11-14T22:13:20.000Z", "unexpected timestamp: {ts}");
+    }
+
+    // ── EOF without fingerprint ───────────────────────────────────────────────
+
+    #[test]
+    fn eof_without_fingerprint() {
+        let tmpdir = std::env::temp_dir();
+        let path = tmpdir.join("otel_test_empty.jsonl");
+        std::fs::write(&path, b"\n\n").unwrap();
+
+        let result = super::super::OtelImporter.import(&path, None, false);
+        std::fs::remove_file(&path).ok();
+
+        assert!(
+            matches!(result, Err(ImportError::UnsupportedFormat(_))),
+            "empty file should be UnsupportedFormat"
+        );
+    }
+}

--- a/sk-rust/src/browse/importers/redaction.rs
+++ b/sk-rust/src/browse/importers/redaction.rs
@@ -1,0 +1,840 @@
+//! Allowlist-first `BrowseDebugEntry` redaction.
+//!
+//! Ports `browse/core/redaction.py`.  No third-party dependencies beyond
+//! `regex` (always-on in Cargo.toml) and `serde_json`.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde_json::Value;
+
+use super::BrowseDebugEntry;
+
+// ── Limits ────────────────────────────────────────────────────────────────────
+
+const MESSAGE_MAX: usize = 2048;
+
+// ── Enum allowlists ───────────────────────────────────────────────────────────
+
+const KIND_ENUM: &[&str] = &[
+    "session_start",
+    "turn_start",
+    "llm_request",
+    "tool_call",
+    "hook",
+    "subagent",
+    "agent_response",
+    "error",
+    "generic",
+    "raw",
+];
+
+const LEVEL_ENUM: &[&str] = &["debug", "info", "warn", "error"];
+
+const SOURCE_ENUM: &[&str] = &[
+    "cli",
+    "hook",
+    "browse",
+    "vscode",
+    "operator_console",
+    "hook_runner",
+    "sk_watch",
+    "unknown",
+];
+
+const STATUS_ENUM: &[&str] = &["ok", "error", "cancelled"];
+
+// ── Top-level field allowlist ─────────────────────────────────────────────────
+
+const TOP_LEVEL_KEYS: &[&str] = &[
+    "idx",
+    "timestamp",
+    "kind",
+    "level",
+    "source",
+    "message",
+    "tool_name",
+    "duration_ms",
+    "span_id",
+    "parent_span_id",
+    "status",
+    "attrs",
+    "redacted",
+];
+
+// ── Attrs allowlist ───────────────────────────────────────────────────────────
+
+const ATTRS_ALLOWLIST: &[&str] = &[
+    "schema_version",
+    "session_uuid",
+    "model",
+    "route",
+    "status_code",
+    "exit_code",
+    "event_count",
+    "bytes_in",
+    "bytes_out",
+    "tokens_in",
+    "tokens_out",
+    "attempt",
+    "cache_hit",
+    "truncated",
+    "error_category",
+    "latency_ms",
+    "queue_depth",
+];
+
+// ── Compiled patterns ─────────────────────────────────────────────────────────
+
+fn bearer_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"(?i)\bbearer\s+\S+").unwrap())
+}
+
+fn win_path_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"(?i)([A-Za-z]:[/\\]Users[/\\])[^/\\\s]+").unwrap())
+}
+
+fn unix_path_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"(/home/)[^/\s]+").unwrap())
+}
+
+fn macos_path_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"(/Users/)[^/\s]+").unwrap())
+}
+
+fn url_query_token_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"(?i)([?&]\w*(?:token|key|secret|auth)\w*=)[^\s&]+").unwrap())
+}
+
+fn jwt_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b").unwrap())
+}
+
+fn tool_name_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"^[a-zA-Z0-9_.\-]{1,64}$").unwrap())
+}
+
+fn span_id_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"^[0-9a-f]{16}$").unwrap())
+}
+
+fn iso_utc_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$")
+            .unwrap()
+    })
+}
+
+fn session_uuid_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(r"(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$").unwrap()
+    })
+}
+
+fn route_query_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\?").unwrap())
+}
+
+// ── Text redaction ────────────────────────────────────────────────────────────
+
+/// Scrub bearer tokens, URL query tokens, JWTs, and path usernames from `text`.
+fn redact_text(text: &str) -> String {
+    let t = bearer_re().replace_all(text, "[REDACTED]");
+    let t = url_query_token_re().replace_all(&t, "${1}[REDACTED]");
+    let t = win_path_re().replace_all(&t, "${1}[REDACTED]");
+    let t = unix_path_re().replace_all(&t, "${1}[REDACTED]");
+    let t = macos_path_re().replace_all(&t, "${1}[REDACTED]");
+    jwt_re().replace_all(&t, "[REDACTED]").into_owned()
+}
+
+/// Scrub route-safe secret patterns from an HTTP route string.
+/// Does NOT apply filesystem path patterns (would corrupt valid routes like /Users/alice/…).
+fn redact_route_text(text: &str) -> String {
+    let t = bearer_re().replace_all(text, "[REDACTED]");
+    let t = url_query_token_re().replace_all(&t, "${1}[REDACTED]");
+    jwt_re().replace_all(&t, "[REDACTED]").into_owned()
+}
+
+// ── Attrs validation ──────────────────────────────────────────────────────────
+
+fn redact_attrs(raw_attrs: Option<&Value>) -> (HashMap<String, Value>, bool) {
+    let map = match raw_attrs {
+        Some(Value::Object(m)) => m,
+        Some(Value::Null) | None => return (HashMap::new(), false),
+        Some(_) => return (HashMap::new(), true), // non-null non-dict → redacted
+    };
+
+    let mut out = HashMap::new();
+    let mut redacted = false;
+
+    for (k, v) in map {
+        if !ATTRS_ALLOWLIST.contains(&k.as_str()) {
+            redacted = true;
+            continue;
+        }
+        match v {
+            Value::Object(_) | Value::Array(_) => {
+                redacted = true;
+                continue;
+            }
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+        }
+        // Special validators.
+        if k == "route" {
+            match v {
+                Value::String(s) if !route_query_re().is_match(s) => {
+                    let clean = redact_route_text(s);
+                    if clean != *s {
+                        redacted = true;
+                    }
+                    out.insert(k.clone(), Value::String(clean));
+                }
+                _ => {
+                    redacted = true;
+                    continue;
+                }
+            }
+        } else if k == "session_uuid" {
+            match v {
+                Value::String(s) if session_uuid_re().is_match(s) => {
+                    out.insert(k.clone(), v.clone());
+                }
+                _ => {
+                    redacted = true;
+                    continue;
+                }
+            }
+        } else if let Value::String(s) = v {
+            let clean = redact_text(s);
+            if clean != *s {
+                redacted = true;
+            }
+            out.insert(k.clone(), Value::String(clean));
+        } else {
+            out.insert(k.clone(), v.clone());
+        }
+    }
+
+    (out, redacted)
+}
+
+// ── Core field validators ─────────────────────────────────────────────────────
+
+fn validate_core_fields(
+    entry: &serde_json::Map<String, Value>,
+    out: &mut BrowseDebugEntry,
+) -> bool {
+    let mut redacted = false;
+
+    // idx
+    match entry.get("idx") {
+        Some(Value::Number(n)) if n.as_i64().map(|v| v >= 0).unwrap_or(false) => {
+            out.idx = n.as_u64().unwrap_or(0);
+        }
+        _ => {
+            out.idx = 0;
+            if entry.contains_key("idx") {
+                redacted = true;
+            }
+        }
+    }
+
+    // timestamp
+    match entry.get("timestamp") {
+        None | Some(Value::Null) => out.timestamp = None,
+        Some(Value::String(s)) if iso_utc_re().is_match(s) => {
+            out.timestamp = Some(s.clone());
+        }
+        Some(_) => {
+            out.timestamp = None;
+            redacted = true;
+        }
+    }
+
+    // kind
+    match entry.get("kind") {
+        Some(Value::String(s)) if KIND_ENUM.contains(&s.as_str()) => {
+            out.kind = s.clone();
+        }
+        Some(_) => {
+            out.kind = "generic".to_string();
+            redacted = true;
+        }
+        None => {
+            out.kind = "generic".to_string();
+        }
+    }
+
+    // level
+    match entry.get("level") {
+        None | Some(Value::Null) => out.level = None,
+        Some(Value::String(s)) if LEVEL_ENUM.contains(&s.as_str()) => {
+            out.level = Some(s.clone());
+        }
+        Some(_) => {
+            out.level = None;
+            redacted = true;
+        }
+    }
+
+    // source
+    match entry.get("source") {
+        Some(Value::String(s)) if SOURCE_ENUM.contains(&s.as_str()) => {
+            out.source = s.clone();
+        }
+        _ => {
+            out.source = "unknown".to_string();
+            if entry.contains_key("source") {
+                redacted = true;
+            }
+        }
+    }
+
+    redacted
+}
+
+fn validate_payload_fields(
+    entry: &serde_json::Map<String, Value>,
+    out: &mut BrowseDebugEntry,
+) -> bool {
+    let mut redacted = false;
+
+    // message
+    if let Some(raw_msg) = entry.get("message") {
+        let s_opt: Option<String> = match raw_msg {
+            Value::String(s) => Some(s.clone()),
+            Value::Null => None, // null message → leave as None; continue processing other fields
+            other => {
+                // Type coercion: stringify but mark redacted.
+                redacted = true;
+                Some(other.to_string())
+            }
+        };
+        if let Some(s) = s_opt {
+            let truncated: String = s.chars().take(MESSAGE_MAX).collect();
+            let clean = redact_text(&truncated);
+            if clean != truncated {
+                redacted = true;
+            }
+            out.message = Some(clean);
+        }
+    }
+
+    // tool_name
+    if let Some(raw_tn) = entry.get("tool_name") {
+        match raw_tn {
+            Value::String(s) if tool_name_re().is_match(s) => {
+                out.tool_name = Some(s.clone());
+            }
+            Value::Null => {}
+            _ => {
+                redacted = true;
+            }
+        }
+    }
+
+    // duration_ms
+    if let Some(raw_dur) = entry.get("duration_ms") {
+        match raw_dur {
+            Value::Number(n) => {
+                if let Some(f) = n.as_f64() {
+                    if f.is_finite() && f >= 0.0 {
+                        out.duration_ms = Some(f);
+                    } else {
+                        redacted = true;
+                    }
+                } else {
+                    redacted = true;
+                }
+            }
+            Value::Null => {}
+            _ => {
+                redacted = true;
+            }
+        }
+    }
+
+    // span_id, parent_span_id
+    for (key, field) in &[("span_id", false), ("parent_span_id", false)] {
+        let _ = field; // suppress unused warning
+        if let Some(raw_span) = entry.get(*key) {
+            match raw_span {
+                Value::String(s) if span_id_re().is_match(s) => {
+                    if *key == "span_id" {
+                        out.span_id = Some(s.clone());
+                    } else {
+                        out.parent_span_id = Some(s.clone());
+                    }
+                }
+                Value::Null => {}
+                _ => {
+                    redacted = true;
+                }
+            }
+        }
+    }
+
+    // status
+    if let Some(raw_status) = entry.get("status") {
+        match raw_status {
+            Value::String(s) if STATUS_ENUM.contains(&s.as_str()) => {
+                out.status = Some(s.clone());
+            }
+            Value::Null => {}
+            _ => {
+                redacted = true;
+            }
+        }
+    }
+
+    redacted
+}
+
+// ── Core redaction implementation ─────────────────────────────────────────────
+
+fn redact_entry_impl(entry: &Value) -> BrowseDebugEntry {
+    let map = match entry {
+        Value::Object(m) => m,
+        _ => {
+            return BrowseDebugEntry {
+                redacted: false,
+                ..BrowseDebugEntry::default()
+            };
+        }
+    };
+
+    let mut out = BrowseDebugEntry::default();
+    let mut redacted = validate_core_fields(map, &mut out);
+    redacted |= validate_payload_fields(map, &mut out);
+
+    let (attrs_out, attrs_redacted) = redact_attrs(map.get("attrs"));
+    out.attrs = attrs_out;
+
+    // Extra top-level keys not in allowlist → set redacted.
+    let extra_keys = map.keys().any(|k| !TOP_LEVEL_KEYS.contains(&k.as_str()));
+
+    out.redacted = redacted || attrs_redacted || extra_keys;
+    out
+}
+
+fn sentinel(entry: &Value) -> BrowseDebugEntry {
+    let idx = match entry {
+        Value::Object(m) => match m.get("idx") {
+            Some(Value::Number(n)) if n.as_i64().map(|v| v >= 0).unwrap_or(false) => {
+                n.as_u64().unwrap_or(0)
+            }
+            _ => 0,
+        },
+        _ => 0,
+    };
+    BrowseDebugEntry {
+        idx,
+        kind: "generic".to_string(),
+        level: Some("error".to_string()),
+        source: "unknown".to_string(),
+        attrs: HashMap::new(),
+        redacted: true,
+        ..Default::default()
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Redact a raw `BrowseDebugEntry` JSON value and return a safe `BrowseDebugEntry`.
+///
+/// Always returns a value.  On unexpected panic the fail-closed sentinel is
+/// returned (sets `redacted = true`).
+pub fn redact_entry(entry: &Value) -> BrowseDebugEntry {
+    // Panic guard: use std::panic::catch_unwind to mirror Python's fail-closed.
+    // We use a simple match instead since Rust panics should not happen in
+    // well-formed code; the sentinel path is exercised via tests.
+    redact_entry_impl(entry)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn entry(v: serde_json::Value) -> BrowseDebugEntry {
+        redact_entry(&v)
+    }
+
+    // ── Pass-through cases ────────────────────────────────────────────────────
+
+    #[test]
+    fn clean_entry_passes_through() {
+        let v = json!({
+            "idx": 1,
+            "kind": "tool_call",
+            "level": "info",
+            "source": "vscode",
+            "message": "hello world",
+            "attrs": {"tokens_in": 100, "tokens_out": 50}
+        });
+        let e = entry(v);
+        assert_eq!(e.idx, 1);
+        assert_eq!(e.kind, "tool_call");
+        assert_eq!(e.source, "vscode");
+        assert_eq!(e.message.as_deref(), Some("hello world"));
+        assert!(!e.redacted, "clean entry should not be redacted");
+    }
+
+    // ── Enum validation ───────────────────────────────────────────────────────
+
+    #[test]
+    fn unknown_kind_coerced_to_generic() {
+        let v = json!({"idx": 0, "kind": "invalid_kind", "source": "cli"});
+        let e = entry(v);
+        assert_eq!(e.kind, "generic");
+        assert!(e.redacted);
+    }
+
+    #[test]
+    fn unknown_source_coerced_to_unknown() {
+        let v = json!({"idx": 0, "kind": "generic", "source": "bad_source"});
+        let e = entry(v);
+        assert_eq!(e.source, "unknown");
+        assert!(e.redacted);
+    }
+
+    #[test]
+    fn unknown_status_dropped() {
+        let v = json!({"idx": 0, "kind": "generic", "source": "cli", "status": "pending"});
+        let e = entry(v);
+        assert!(e.status.is_none());
+        assert!(e.redacted);
+    }
+
+    #[test]
+    fn valid_status_passes() {
+        let v = json!({"idx": 0, "kind": "generic", "source": "cli", "status": "ok"});
+        let e = entry(v);
+        assert_eq!(e.status.as_deref(), Some("ok"));
+    }
+
+    // ── Bearer / JWT / token redaction ────────────────────────────────────────
+
+    #[test]
+    fn bearer_token_in_message_redacted() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "message": "Authorization: Bearer abc123xyz"
+        });
+        let e = entry(v);
+        assert!(
+            e.message.as_deref().unwrap_or("").contains("[REDACTED]"),
+            "bearer token should be redacted: {:?}",
+            e.message
+        );
+        assert!(e.redacted);
+    }
+
+    #[test]
+    fn jwt_in_message_redacted() {
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.XXXSIGNATUREXXX";
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "message": format!("token={jwt}")
+        });
+        let e = entry(v);
+        assert!(
+            e.message.as_deref().unwrap_or("").contains("[REDACTED]"),
+            "JWT should be redacted: {:?}",
+            e.message
+        );
+    }
+
+    #[test]
+    fn url_query_token_redacted() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "message": "https://example.com/api?token=secret123&other=ok"
+        });
+        let e = entry(v);
+        let msg = e.message.unwrap_or_default();
+        assert!(
+            msg.contains("[REDACTED]"),
+            "url token should be redacted: {msg}"
+        );
+        assert!(
+            !msg.contains("secret123"),
+            "secret should not appear: {msg}"
+        );
+    }
+
+    // ── Path redaction ────────────────────────────────────────────────────────
+
+    #[test]
+    fn unix_home_path_in_message_redacted() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "message": "reading /home/alice/.ssh/id_rsa"
+        });
+        let e = entry(v);
+        let msg = e.message.unwrap_or_default();
+        assert!(
+            msg.contains("[REDACTED]"),
+            "unix home path should be redacted: {msg}"
+        );
+        assert!(!msg.contains("alice"), "username should be redacted: {msg}");
+    }
+
+    #[test]
+    fn windows_home_path_in_message_redacted() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "message": r"reading C:\Users\alice\Documents\secret.txt"
+        });
+        let e = entry(v);
+        let msg = e.message.unwrap_or_default();
+        assert!(
+            msg.contains("[REDACTED]"),
+            "windows path should be redacted: {msg}"
+        );
+    }
+
+    // ── Attrs allowlist ───────────────────────────────────────────────────────
+
+    #[test]
+    fn attrs_args_key_dropped() {
+        // `args` is NOT in the attrs allowlist.
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "attrs": {"args": ["--verbose"], "tokens_in": 10}
+        });
+        let e = entry(v);
+        assert!(!e.attrs.contains_key("args"), "args should be dropped");
+        assert!(
+            e.attrs.contains_key("tokens_in"),
+            "tokens_in should be kept"
+        );
+        assert!(e.redacted, "dropping args should set redacted");
+    }
+
+    #[test]
+    fn attrs_tokens_in_out_kept() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "attrs": {"tokens_in": 100, "tokens_out": 200}
+        });
+        let e = entry(v);
+        assert_eq!(e.attrs.get("tokens_in"), Some(&json!(100)));
+        assert_eq!(e.attrs.get("tokens_out"), Some(&json!(200)));
+        assert!(!e.redacted);
+    }
+
+    #[test]
+    fn attrs_nested_object_dropped() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "attrs": {"tokens_in": 10, "schema_version": {"nested": "bad"}}
+        });
+        let e = entry(v);
+        assert!(!e.attrs.contains_key("schema_version"));
+        assert!(e.redacted);
+    }
+
+    // ── Tool name validation ──────────────────────────────────────────────────
+
+    #[test]
+    fn valid_tool_name_passes() {
+        let v = json!({
+            "idx": 0, "kind": "tool_call", "source": "cli",
+            "tool_name": "read_file"
+        });
+        let e = entry(v);
+        assert_eq!(e.tool_name.as_deref(), Some("read_file"));
+    }
+
+    #[test]
+    fn invalid_tool_name_dropped() {
+        let v = json!({
+            "idx": 0, "kind": "tool_call", "source": "cli",
+            "tool_name": "bad name with spaces!"
+        });
+        let e = entry(v);
+        assert!(e.tool_name.is_none(), "invalid tool_name should be dropped");
+        assert!(e.redacted);
+    }
+
+    // ── Span ID validation ────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_span_id_passes() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "span_id": "0123456789abcdef"
+        });
+        let e = entry(v);
+        assert_eq!(e.span_id.as_deref(), Some("0123456789abcdef"));
+        assert!(!e.redacted);
+    }
+
+    #[test]
+    fn invalid_span_id_dropped() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "span_id": "not-a-span-id"
+        });
+        let e = entry(v);
+        assert!(e.span_id.is_none());
+        assert!(e.redacted);
+    }
+
+    // ── Extra top-level keys ──────────────────────────────────────────────────
+
+    #[test]
+    fn extra_top_level_key_sets_redacted() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "unknown_field": "should_be_dropped"
+        });
+        let e = entry(v);
+        assert!(e.redacted, "extra keys should set redacted");
+    }
+
+    // ── Message max length ────────────────────────────────────────────────────
+
+    #[test]
+    fn message_truncated_to_2048() {
+        let long_msg = "a".repeat(3000);
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "message": long_msg
+        });
+        let e = entry(v);
+        assert!(
+            e.message.as_deref().map(|s| s.len()).unwrap_or(0) <= 2048,
+            "message should be truncated to 2048"
+        );
+    }
+
+    // ── route attr ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn route_with_query_string_dropped() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "attrs": {"route": "/api/v1?secret=abc"}
+        });
+        let e = entry(v);
+        assert!(
+            !e.attrs.contains_key("route"),
+            "route with query string should be dropped"
+        );
+        assert!(e.redacted);
+    }
+
+    #[test]
+    fn route_without_query_passes() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "attrs": {"route": "/api/v1/sessions"}
+        });
+        let e = entry(v);
+        assert_eq!(
+            e.attrs.get("route").and_then(Value::as_str),
+            Some("/api/v1/sessions")
+        );
+    }
+
+    // ── duration_ms ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn negative_duration_dropped() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "duration_ms": -1.0
+        });
+        let e = entry(v);
+        assert!(e.duration_ms.is_none());
+        assert!(e.redacted);
+    }
+
+    #[test]
+    fn valid_duration_passes() {
+        let v = json!({
+            "idx": 0, "kind": "generic", "source": "cli",
+            "duration_ms": 42.5
+        });
+        let e = entry(v);
+        assert_eq!(e.duration_ms, Some(42.5));
+        assert!(!e.redacted);
+    }
+
+    // ── null message parity (issue #455) ─────────────────────────────────────
+
+    #[test]
+    fn null_message_preserves_remaining_payload_fields() {
+        // Python: `if raw_msg is not None:` skips message block but continues.
+        // Rust must not early-return on Value::Null and must still validate
+        // tool_name, duration_ms, span_id, parent_span_id, and status.
+        let v = json!({
+            "idx": 1,
+            "kind": "tool_call",
+            "source": "cli",
+            "message": null,
+            "tool_name": "read_file",
+            "duration_ms": 12.5,
+            "span_id": "0123456789abcdef",
+            "parent_span_id": "fedcba9876543210",
+            "status": "ok"
+        });
+        let e = entry(v);
+        assert!(e.message.is_none(), "null message should remain None");
+        assert_eq!(
+            e.tool_name.as_deref(),
+            Some("read_file"),
+            "tool_name must be preserved when message is null"
+        );
+        assert_eq!(
+            e.duration_ms,
+            Some(12.5),
+            "duration_ms must be preserved when message is null"
+        );
+        assert_eq!(
+            e.span_id.as_deref(),
+            Some("0123456789abcdef"),
+            "span_id must be preserved when message is null"
+        );
+        assert_eq!(
+            e.parent_span_id.as_deref(),
+            Some("fedcba9876543210"),
+            "parent_span_id must be preserved when message is null"
+        );
+        assert_eq!(
+            e.status.as_deref(),
+            Some("ok"),
+            "status must be preserved when message is null"
+        );
+        assert!(
+            !e.redacted,
+            "entry with null message and valid fields should not be redacted"
+        );
+    }
+
+    // ── sentinel fallback ─────────────────────────────────────────────────────
+
+    #[test]
+    fn sentinel_preserves_idx() {
+        let v = json!({"idx": 7, "kind": "will_be_replaced"});
+        let s = sentinel(&v);
+        assert_eq!(s.idx, 7);
+        assert!(s.redacted);
+    }
+}

--- a/sk-rust/src/browse/importers/redaction.rs
+++ b/sk-rust/src/browse/importers/redaction.rs
@@ -457,10 +457,12 @@ fn sentinel(entry: &Value) -> BrowseDebugEntry {
 /// Always returns a value.  On unexpected panic the fail-closed sentinel is
 /// returned (sets `redacted = true`).
 pub fn redact_entry(entry: &Value) -> BrowseDebugEntry {
-    // Panic guard: use std::panic::catch_unwind to mirror Python's fail-closed.
-    // We use a simple match instead since Rust panics should not happen in
-    // well-formed code; the sentinel path is exercised via tests.
-    redact_entry_impl(entry)
+    // Panic guard: catch any unexpected panic and return the fail-closed sentinel
+    // so a single malformed entry never aborts the whole import.
+    match std::panic::catch_unwind(|| redact_entry_impl(entry)) {
+        Ok(result) => result,
+        Err(_) => sentinel(entry),
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -836,5 +838,21 @@ mod tests {
         let s = sentinel(&v);
         assert_eq!(s.idx, 7);
         assert!(s.redacted);
+    }
+
+    // ── public wrapper non-panic contract ─────────────────────────────────────
+
+    #[test]
+    fn redact_entry_handles_non_object_and_object_inputs() {
+        let v = json!("this is a string not an object");
+        let result = redact_entry(&v);
+        assert_eq!(result.kind, "generic");
+        assert!(!result.redacted);
+
+        // Verify the public API wraps the impl correctly for a normal object.
+        let v2 = json!({"idx": 3, "kind": "tool_call", "source": "vscode"});
+        let e = redact_entry(&v2);
+        assert_eq!(e.idx, 3);
+        assert!(!e.redacted);
     }
 }

--- a/sk-rust/src/browse/importers/vscode_debug.rs
+++ b/sk-rust/src/browse/importers/vscode_debug.rs
@@ -3,7 +3,7 @@
 //! Ports `browse/importers/vscode_agent_debug_log.py`.
 //! Source tag: `vscode-agent-debug-log`; BrowseDebugEntry source: `vscode`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::Path;
 use std::sync::OnceLock;
 
@@ -222,7 +222,7 @@ fn detect_format(path: &Path) -> Result<(), ImportError> {
 
 /// `(sid, name, parent_span_id)` — excludes `rIdx` per contract.
 type PairKey = (String, String, Option<String>);
-type PairQueues = HashMap<PairKey, Vec<String>>;
+type PairQueues = HashMap<PairKey, VecDeque<String>>;
 
 // ── Per-line parser ───────────────────────────────────────────────────────────
 
@@ -366,12 +366,15 @@ fn parse_line(obj: &Value, idx: u64, candidate_queues: &mut PairQueues) -> Resul
         let key: PairKey = (sid.clone(), name.clone(), parent_span_id.clone());
         if event_type == "tool_call" {
             let syn = synthetic_span_id(BROWSE_SOURCE, idx);
-            candidate_queues.entry(key).or_default().push(syn.clone());
+            candidate_queues
+                .entry(key)
+                .or_default()
+                .push_back(syn.clone());
             syn
         } else {
             // tool_result: pop FIFO or generate own synthetic
             match candidate_queues.get_mut(&key) {
-                Some(q) if !q.is_empty() => q.remove(0),
+                Some(q) if !q.is_empty() => q.pop_front().unwrap(),
                 _ => synthetic_span_id(BROWSE_SOURCE, idx),
             }
         }
@@ -492,14 +495,14 @@ impl Importer for super::VscodeDebugImporter {
 
         let file = std::fs::File::open(&resolved)?;
         for bl in iter_bounded_lines(file, cap) {
-            // Strip trailing CR/LF; skip blank lines silently
+            // Strip trailing CR/LF only (Python parity); skip blank lines silently.
             let stripped: Vec<u8> = bl
                 .bytes
                 .iter()
                 .copied()
                 .filter(|&b| b != b'\r' && b != b'\n')
                 .collect();
-            if stripped.iter().all(|b| b.is_ascii_whitespace()) {
+            if stripped.is_empty() {
                 continue;
             }
 
@@ -1399,5 +1402,37 @@ mod tests {
         ));
         assert!(fnmatch_simple("tools_v2.json", "tools_*.json"));
         assert!(!fnmatch_simple("main.jsonl", "tools_*.json"));
+    }
+
+    // ── Whitespace-only line parity (Python importer strips only CR/LF) ───────
+
+    #[test]
+    fn whitespace_only_line_counts_as_malformed() {
+        // Python only strips CR/LF before the blank check, so a line that is
+        // only spaces/tabs is non-blank → must be counted in total_lines and
+        // reported as malformed (invalid JSON), not silently skipped.
+        let td = TempDir::new();
+        let ws_line = "   \t  \n"; // spaces and tab, no JSON content
+        let p = write_temp(&td, &[BASE_LINE, ws_line, BASE_LINE]);
+        let (_, summary) = importer().import(&p, None, false).unwrap();
+        // BASE_LINE appears twice but has identical content → second is deduped.
+        assert_eq!(
+            summary.total_lines, 3,
+            "whitespace-only line + both BASE_LINEs must count toward total_lines (got {})",
+            summary.total_lines
+        );
+        assert_eq!(
+            summary.malformed_count, 1,
+            "whitespace-only line must be reported as malformed (got {})",
+            summary.malformed_count
+        );
+        assert!(
+            summary.malformed_reports[0]
+                .reason
+                .to_lowercase()
+                .contains("json"),
+            "malformed reason must mention JSON: {:?}",
+            summary.malformed_reports[0].reason
+        );
     }
 }

--- a/sk-rust/src/browse/importers/vscode_debug.rs
+++ b/sk-rust/src/browse/importers/vscode_debug.rs
@@ -1,0 +1,1403 @@
+//! VS Code agent debug-log importer.
+//!
+//! Ports `browse/importers/vscode_agent_debug_log.py`.
+//! Source tag: `vscode-agent-debug-log`; BrowseDebugEntry source: `vscode`.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::OnceLock;
+
+use chrono::TimeZone;
+use regex::Regex;
+use serde_json::Value;
+
+use super::common::{
+    check_path_safe, content_hash_16, file_hash_sha256, is_valid_span_id, iter_bounded_lines,
+    max_line_bytes, synthetic_span_id, DedupSet,
+};
+use super::redaction::redact_entry;
+use super::{BrowseDebugEntry, ImportError, ImportSummary, Importer, MalformedReport};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const SOURCE_TAG: &str = "vscode-agent-debug-log";
+const BROWSE_SOURCE: &str = "vscode";
+const SCHEMA_VERSION: u32 = 1;
+
+// ── Companion file patterns ───────────────────────────────────────────────────
+
+const COMPANION_PATTERNS: &[&str] = &[
+    "models.json",
+    "system_prompt_*.json",
+    "tools_*.json",
+    "title-*.jsonl",
+    "categorization-*.jsonl",
+    "summarize-*.jsonl",
+];
+
+/// Simple single-`*` glob match (sufficient for companion patterns).
+fn fnmatch_simple(name: &str, pattern: &str) -> bool {
+    match pattern.split_once('*') {
+        None => name == pattern,
+        Some((prefix, suffix)) => {
+            name.starts_with(prefix)
+                && name.ends_with(suffix)
+                && name.len() >= prefix.len() + suffix.len()
+        }
+    }
+}
+
+fn is_companion(filename: &str) -> bool {
+    COMPANION_PATTERNS
+        .iter()
+        .any(|p| fnmatch_simple(filename, p))
+}
+
+// ── Attr renames / unsafe drops ───────────────────────────────────────────────
+
+fn attr_renames() -> &'static HashMap<&'static str, &'static str> {
+    static MAP: OnceLock<HashMap<&'static str, &'static str>> = OnceLock::new();
+    MAP.get_or_init(|| {
+        let mut m = HashMap::new();
+        m.insert("inputTokens", "tokens_in");
+        m.insert("outputTokens", "tokens_out");
+        m.insert("latency", "latency_ms");
+        m
+    })
+}
+
+const UNSAFE_ATTR_DROP: &[&str] = &[
+    "args",
+    "result",
+    "content",
+    "response",
+    "reasoning",
+    "userRequest",
+    "inputMessages",
+    "systemPromptFile",
+    "toolsFile",
+    "messages",
+    "prompt",
+    "completion",
+    "tool_input",
+    "tool_output",
+    "text",
+    "body",
+    "data",
+    "payload",
+];
+
+// ── Tool name regex ───────────────────────────────────────────────────────────
+
+fn tool_name_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"^[a-zA-Z0-9_.\-]{1,64}$").unwrap())
+}
+
+// ── Type → kind mapping ───────────────────────────────────────────────────────
+
+fn type_to_kind(event_type: &str) -> &'static str {
+    match event_type {
+        "session_start" => "session_start",
+        "turn_start" => "turn_start",
+        "llm_request" => "llm_request",
+        "tool_call" => "tool_call",
+        "tool_result" => "tool_call", // paired completion
+        "agent_response" => "agent_response",
+        "subagent" => "subagent",
+        "hook" => "hook",
+        "error" => "error",
+        // Contract-safe generic fallback
+        _ => "generic",
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Epoch milliseconds → `"YYYY-MM-DDTHH:MM:SS.sssZ"`.
+fn epoch_ms_to_iso(ts_ms: f64) -> Option<String> {
+    if ts_ms <= 0.0 {
+        return None;
+    }
+    let secs = ts_ms.div_euclid(1000.0) as i64;
+    let nanos = (ts_ms.rem_euclid(1000.0) * 1_000_000.0) as u32;
+    match chrono::Utc.timestamp_opt(secs, nanos) {
+        chrono::LocalResult::Single(dt) => Some(dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()),
+        _ => None,
+    }
+}
+
+/// Pre-filter VS Code attrs: rename allowed fields, drop dangerous ones.
+fn map_attrs(raw_attrs: &Value) -> Value {
+    let map = match raw_attrs {
+        Value::Object(m) => m,
+        _ => return Value::Object(serde_json::Map::new()),
+    };
+    let renames = attr_renames();
+    let mut out = serde_json::Map::new();
+    for (k, v) in map {
+        if UNSAFE_ATTR_DROP.contains(&k.as_str()) {
+            continue;
+        }
+        let mapped_k = renames.get(k.as_str()).copied().unwrap_or(k.as_str());
+        out.insert(mapped_k.to_string(), v.clone());
+    }
+    Value::Object(out)
+}
+
+/// Return a Python-compatible type name string for use in malformed reasons.
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "NoneType",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "int",
+        Value::String(_) => "str",
+        Value::Array(_) => "list",
+        Value::Object(_) => "dict",
+    }
+}
+
+// ── Format detection ──────────────────────────────────────────────────────────
+
+/// Scan forward until the first parseable JSON value, then verify the VS Code
+/// fingerprint (`ts` numeric > 0, `sid` string).  EOF without fingerprint → error.
+fn detect_format(path: &Path) -> Result<(), ImportError> {
+    let cap = max_line_bytes();
+    let file = std::fs::File::open(path).map_err(ImportError::Io)?;
+    for bl in iter_bounded_lines(file, cap) {
+        let stripped: Vec<u8> = bl
+            .bytes
+            .iter()
+            .copied()
+            .filter(|&b| b != b'\r' && b != b'\n' && b != b' ' && b != b'\t')
+            .collect();
+        if stripped.is_empty() {
+            continue;
+        }
+        if bl.oversize_total.is_some() {
+            continue; // not format evidence — scan forward
+        }
+        if stripped.first() == Some(&b'[') {
+            return Err(ImportError::UnsupportedFormat(
+                "File starts with '[': expected JSONL objects, got JSON array. \
+                 Not a VS Code Agent debug log file."
+                    .to_string(),
+            ));
+        }
+        let line_str = String::from_utf8_lossy(&bl.bytes);
+        let obj: Value = match serde_json::from_str(line_str.trim()) {
+            Ok(v) => v,
+            Err(_) => continue, // not format evidence — scan forward
+        };
+        return match &obj {
+            Value::Object(map) => {
+                let ts_ok = match map.get("ts") {
+                    Some(Value::Number(n)) => n.as_f64().map(|f| f > 0.0).unwrap_or(false),
+                    _ => false,
+                };
+                let sid_ok = matches!(map.get("sid"), Some(Value::String(_)));
+                if ts_ok && sid_ok {
+                    Ok(())
+                } else {
+                    Err(ImportError::UnsupportedFormat(
+                        "First parseable JSON line lacks 'ts' (epoch-ms integer) or 'sid' \
+                         (string). Not a VS Code Agent debug log JSONL file."
+                            .to_string(),
+                    ))
+                }
+            }
+            _ => Err(ImportError::UnsupportedFormat(format!(
+                "First parseable JSON value is {}, expected dict. \
+                 Not a VS Code Agent debug log file.",
+                json_type_name(&obj)
+            ))),
+        };
+    }
+    Err(ImportError::UnsupportedFormat(
+        "No parseable VS Code Agent debug log fingerprint found before EOF.".to_string(),
+    ))
+}
+
+// ── FIFO pair-queue types ─────────────────────────────────────────────────────
+
+/// `(sid, name, parent_span_id)` — excludes `rIdx` per contract.
+type PairKey = (String, String, Option<String>);
+type PairQueues = HashMap<PairKey, Vec<String>>;
+
+// ── Per-line parser ───────────────────────────────────────────────────────────
+
+/// Parse one validated JSON object into an intermediate entry `Value`.
+///
+/// Mutates `candidate_queues` for FIFO synthetic span pairing (caller must
+/// commit or discard based on the dedup gate — PR #445 regression guard).
+///
+/// Returns `Ok(entry_value)` or `Err(malformed_reason)`.
+fn parse_line(obj: &Value, idx: u64, candidate_queues: &mut PairQueues) -> Result<Value, String> {
+    let map = match obj {
+        Value::Object(m) => m,
+        _ => {
+            return Err(format!(
+                "line is {}, expected JSON object",
+                json_type_name(obj)
+            ))
+        }
+    };
+
+    // Schema version check
+    if let Some(v) = map.get("v") {
+        let is_one = matches!(v, Value::Number(n) if n.as_i64() == Some(1));
+        if !is_one {
+            let v_repr = serde_json::to_string(v).unwrap_or_else(|_| format!("{v:?}"));
+            return Err(format!("unsupported schema version v={v_repr}"));
+        }
+    }
+
+    // Required: ts (positive numeric non-bool)
+    let ts_ms: f64 = match map.get("ts") {
+        Some(Value::Number(n)) => {
+            let f = n.as_f64().unwrap_or(0.0);
+            if f <= 0.0 {
+                return Err(
+                    "missing or invalid required field 'ts' (expected positive epoch-ms)"
+                        .to_string(),
+                );
+            }
+            f
+        }
+        _ => {
+            return Err(
+                "missing or invalid required field 'ts' (expected positive epoch-ms)".to_string(),
+            )
+        }
+    };
+
+    // Required: sid (string)
+    let sid: String = match map.get("sid") {
+        Some(Value::String(s)) => s.clone(),
+        _ => return Err("missing or invalid required field 'sid' (expected string)".to_string()),
+    };
+
+    // Required: type (string)
+    let event_type: String = match map.get("type") {
+        Some(Value::String(s)) => s.clone(),
+        _ => return Err("missing or invalid required field 'type' (expected string)".to_string()),
+    };
+
+    // Required: name (string)
+    let name: String = match map.get("name") {
+        Some(Value::String(s)) => s.clone(),
+        _ => return Err("missing or invalid required field 'name' (expected string)".to_string()),
+    };
+
+    // Required presence checks
+    if !map.contains_key("spanId") {
+        return Err("missing required field 'spanId'".to_string());
+    }
+    if !map.contains_key("status") {
+        return Err("missing required field 'status'".to_string());
+    }
+    if !map.contains_key("attrs") {
+        return Err("missing required field 'attrs'".to_string());
+    }
+
+    // spanId must be string (value may be non-16-hex — that's ok, handled below)
+    let span_id_raw: String = match &map["spanId"] {
+        Value::String(s) => s.clone(),
+        other => {
+            return Err(format!(
+                "invalid required field 'spanId': expected string, got {}",
+                json_type_name(other)
+            ))
+        }
+    };
+
+    // status must be string or null
+    let status_raw: Option<String> = match &map["status"] {
+        Value::Null => None,
+        Value::String(s) => Some(s.clone()),
+        other => {
+            return Err(format!(
+                "invalid required field 'status': expected string or null, got {}",
+                json_type_name(other)
+            ))
+        }
+    };
+
+    // attrs must be dict
+    let attrs_raw: &Value = match &map["attrs"] {
+        obj @ Value::Object(_) => obj,
+        other => {
+            return Err(format!(
+                "invalid required field 'attrs': expected dict, got {}",
+                json_type_name(other)
+            ))
+        }
+    };
+
+    // Type → kind
+    let kind = type_to_kind(&event_type);
+
+    // Timestamp
+    let timestamp = epoch_ms_to_iso(ts_ms);
+
+    // Duration: positive dur → duration_ms; zero/absent → omitted
+    let duration_ms: Option<f64> = match map.get("dur") {
+        Some(Value::Number(n)) => {
+            let f = n.as_f64().unwrap_or(0.0);
+            if f > 0.0 {
+                Some(f)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+
+    // Optional parentSpanId — only retained when valid 16 lower-hex
+    let parent_span_id: Option<String> = match map.get("parentSpanId") {
+        Some(Value::String(s)) if is_valid_span_id(s) => Some(s.clone()),
+        _ => None,
+    };
+
+    // Span ID — native path or FIFO synthetic pairing
+    let span_id: String = if is_valid_span_id(&span_id_raw) {
+        span_id_raw
+    } else if event_type == "tool_call" || event_type == "tool_result" {
+        let key: PairKey = (sid.clone(), name.clone(), parent_span_id.clone());
+        if event_type == "tool_call" {
+            let syn = synthetic_span_id(BROWSE_SOURCE, idx);
+            candidate_queues.entry(key).or_default().push(syn.clone());
+            syn
+        } else {
+            // tool_result: pop FIFO or generate own synthetic
+            match candidate_queues.get_mut(&key) {
+                Some(q) if !q.is_empty() => q.remove(0),
+                _ => synthetic_span_id(BROWSE_SOURCE, idx),
+            }
+        }
+    } else {
+        synthetic_span_id(BROWSE_SOURCE, idx)
+    };
+
+    // Status: only ok/error/cancelled retained
+    let status: Option<&str> = match status_raw.as_deref() {
+        Some("ok") => Some("ok"),
+        Some("error") => Some("error"),
+        Some("cancelled") => Some("cancelled"),
+        _ => None,
+    };
+
+    // Level: error iff kind == error
+    let level: Option<&str> = if kind == "error" { Some("error") } else { None };
+
+    // Attrs pre-filter (rename + drop dangerous keys)
+    let mapped_attrs = map_attrs(attrs_raw);
+
+    // Tool name: only for tool_call kind with valid name pattern
+    let tool_name: Option<String> = if kind == "tool_call" && tool_name_re().is_match(&name) {
+        Some(name.clone())
+    } else {
+        None
+    };
+
+    // Build intermediate entry value for redact_entry
+    let mut entry_map = serde_json::Map::new();
+    entry_map.insert("idx".to_string(), Value::Number(idx.into()));
+    entry_map.insert(
+        "timestamp".to_string(),
+        timestamp.map_or(Value::Null, Value::String),
+    );
+    entry_map.insert("kind".to_string(), Value::String(kind.to_string()));
+    entry_map.insert(
+        "level".to_string(),
+        level.map_or(Value::Null, |s| Value::String(s.to_string())),
+    );
+    entry_map.insert(
+        "source".to_string(),
+        Value::String(BROWSE_SOURCE.to_string()),
+    );
+    entry_map.insert("message".to_string(), Value::String(name));
+    entry_map.insert("attrs".to_string(), mapped_attrs);
+    if let Some(tn) = tool_name {
+        entry_map.insert("tool_name".to_string(), Value::String(tn));
+    }
+    if let Some(d) = duration_ms {
+        if let Some(n) = serde_json::Number::from_f64(d) {
+            entry_map.insert("duration_ms".to_string(), Value::Number(n));
+        }
+    }
+    entry_map.insert("span_id".to_string(), Value::String(span_id));
+    if let Some(p) = parent_span_id {
+        entry_map.insert("parent_span_id".to_string(), Value::String(p));
+    }
+    if let Some(st) = status {
+        entry_map.insert("status".to_string(), Value::String(st.to_string()));
+    }
+    Ok(Value::Object(entry_map))
+}
+
+// ── Importer implementation ───────────────────────────────────────────────────
+
+impl Importer for super::VscodeDebugImporter {
+    fn import(
+        &self,
+        path: &Path,
+        safe_base: Option<&Path>,
+        dry_run: bool,
+    ) -> Result<(Vec<BrowseDebugEntry>, ImportSummary), ImportError> {
+        // ── Path safety ──────────────────────────────────────────────────────
+        let resolved = check_path_safe(path, safe_base)?;
+
+        // ── Directory mode ───────────────────────────────────────────────────
+        let resolved = if resolved.is_dir() {
+            let target = resolved.join("main.jsonl");
+            if !target.exists() {
+                return Err(ImportError::FileNotFound(format!(
+                    "No main.jsonl found in directory: {}",
+                    resolved.display()
+                )));
+            }
+            check_path_safe(&target, safe_base)?
+        } else {
+            resolved
+        };
+
+        // ── Companion file guard ─────────────────────────────────────────────
+        let file_name = resolved
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if is_companion(&file_name) {
+            return Err(ImportError::UnsupportedFormat(format!(
+                "File '{file_name}' matches companion-skip pattern; \
+                 pass the containing directory or 'main.jsonl' explicitly."
+            )));
+        }
+
+        // ── Format detection ─────────────────────────────────────────────────
+        detect_format(&resolved)?;
+
+        // ── File hash ────────────────────────────────────────────────────────
+        let file_hash = file_hash_sha256(&resolved)?;
+
+        // ── Parse loop ───────────────────────────────────────────────────────
+        let cap = max_line_bytes();
+        let mut dedup = DedupSet::new();
+        let mut entries: Vec<BrowseDebugEntry> = Vec::new();
+        let mut malformed_reports: Vec<MalformedReport> = Vec::new();
+        let mut ok_count: u64 = 0;
+        let mut total_lines: u64 = 0;
+        let mut entry_idx: u64 = 0;
+        let mut pair_queues: PairQueues = HashMap::new();
+
+        let file = std::fs::File::open(&resolved)?;
+        for bl in iter_bounded_lines(file, cap) {
+            // Strip trailing CR/LF; skip blank lines silently
+            let stripped: Vec<u8> = bl
+                .bytes
+                .iter()
+                .copied()
+                .filter(|&b| b != b'\r' && b != b'\n')
+                .collect();
+            if stripped.iter().all(|b| b.is_ascii_whitespace()) {
+                continue;
+            }
+
+            total_lines += 1;
+
+            // Oversized line
+            if let Some(total) = bl.oversize_total {
+                malformed_reports.push(MalformedReport {
+                    line_number: bl.line_no,
+                    reason: format!("line exceeds max byte cap ({total} > {cap} bytes)"),
+                });
+                continue;
+            }
+
+            // JSON parse
+            let line_str = String::from_utf8_lossy(&stripped);
+            let obj: Value = match serde_json::from_str(line_str.trim()) {
+                Ok(v) => v,
+                Err(e) => {
+                    malformed_reports.push(MalformedReport {
+                        line_number: bl.line_no,
+                        reason: format!("JSON parse error: {e}"),
+                    });
+                    continue;
+                }
+            };
+
+            // Must be an object
+            if !obj.is_object() {
+                malformed_reports.push(MalformedReport {
+                    line_number: bl.line_no,
+                    reason: format!("line is {}, expected JSON object", json_type_name(&obj)),
+                });
+                continue;
+            }
+
+            // Clone pair_queues as candidate; mutations committed only after dedup passes
+            let mut candidate_queues = pair_queues.clone();
+
+            let entry_value = match parse_line(&obj, entry_idx, &mut candidate_queues) {
+                Ok(v) => v,
+                Err(reason) => {
+                    malformed_reports.push(MalformedReport {
+                        line_number: bl.line_no,
+                        reason,
+                    });
+                    continue;
+                }
+            };
+
+            // Redact
+            let redacted_entry = redact_entry(&entry_value);
+
+            // Dedup key uses raw source fields
+            let sid_str = obj.get("sid").and_then(|v| v.as_str()).unwrap_or("");
+            let type_str = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            let span_str = obj.get("spanId").and_then(|v| v.as_str()).unwrap_or("");
+            let ts_str = match obj.get("ts") {
+                Some(Value::Number(n)) => n.to_string(),
+                Some(v) => serde_json::to_string(v).unwrap_or_default(),
+                None => String::new(),
+            };
+            let ch16 = content_hash_16(&obj);
+            let dedup_key = format!("{SOURCE_TAG}:{sid_str}:{type_str}:{span_str}:{ts_str}:{ch16}");
+
+            if dedup.is_duplicate(&dedup_key) {
+                continue;
+            }
+
+            // Commit queue mutation — duplicate rows do not enqueue orphan spans
+            pair_queues = candidate_queues;
+            ok_count += 1;
+            entry_idx += 1;
+            if !dry_run {
+                entries.push(redacted_entry);
+            }
+        }
+
+        let malformed_count = malformed_reports.len() as u64;
+        let summary = ImportSummary {
+            source: SOURCE_TAG.to_string(),
+            schema_version: SCHEMA_VERSION,
+            total_lines,
+            ok_count,
+            malformed_count,
+            deduped_count: dedup.deduped as u64,
+            malformed_reports,
+            file_hash,
+            file_name,
+        };
+        Ok((entries, summary))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    // ── stdlib-only temp directory (tempfile crate not in dev-deps) ───────────
+
+    struct TempDir {
+        path: std::path::PathBuf,
+    }
+
+    impl TempDir {
+        fn new() -> Self {
+            static CTR: AtomicUsize = AtomicUsize::new(0);
+            let n = CTR.fetch_add(1, Ordering::Relaxed);
+            let pid = std::process::id();
+            let path = std::env::temp_dir().join(format!("vscode_debug_test_{pid}_{n}"));
+            std::fs::create_dir_all(&path).expect("create temp dir");
+            TempDir { path }
+        }
+
+        fn path(&self) -> &std::path::Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    // ── Env-var guard: removes the var on drop (cleanup on panic too) ─────────
+
+    struct EnvGuard {
+        name: &'static str,
+    }
+
+    impl EnvGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            std::env::set_var(name, value);
+            EnvGuard { name }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(self.name);
+        }
+    }
+
+    // Mutex to serialise tests that touch BROWSE_DEBUG_LOG_MAX_LINE_BYTES.
+    // All other tests must be safe at any cap value > max fixture line length (~250 bytes).
+    fn env_lock() -> &'static std::sync::Mutex<()> {
+        use std::sync::OnceLock;
+        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    // ── Fixture paths ─────────────────────────────────────────────────────────
+
+    fn fixture_root() -> std::path::PathBuf {
+        // sk-rust/Cargo.toml is at CARGO_MANIFEST_DIR; repo root is one level up.
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        manifest.parent().unwrap().join("tests/fixtures/debug-log")
+    }
+
+    fn aaaa_dir() -> std::path::PathBuf {
+        fixture_root().join("vscode-agent/debug-logs/0000fixture-session-aaaa")
+    }
+
+    fn aaaa_main() -> std::path::PathBuf {
+        aaaa_dir().join("main.jsonl")
+    }
+
+    fn bbbb_main() -> std::path::PathBuf {
+        fixture_root().join("vscode-agent/debug-logs/0000fixture-session-bbbb/main.jsonl")
+    }
+
+    fn cccc_main() -> std::path::PathBuf {
+        fixture_root().join("vscode-agent/debug-logs/0000fixture-session-cccc/main.jsonl")
+    }
+
+    fn otel_console() -> std::path::PathBuf {
+        fixture_root().join("otel/console-spans.jsonl")
+    }
+
+    fn importer() -> super::super::VscodeDebugImporter {
+        super::super::VscodeDebugImporter
+    }
+
+    // ── Helper: write temp main.jsonl ─────────────────────────────────────────
+
+    fn write_temp(dir: &TempDir, lines: &[&str]) -> std::path::PathBuf {
+        let p = dir.path().join("main.jsonl");
+        let mut f = std::fs::File::create(&p).unwrap();
+        for line in lines {
+            f.write_all(line.as_bytes()).unwrap();
+        }
+        p
+    }
+
+    const BASE_LINE: &str =
+        "{\"ts\": 1700000000000, \"dur\": 50, \"sid\": \"sx\", \"type\": \"session_start\",\
+         \"name\": \"s\", \"spanId\": \"a000000000000001\", \"status\": \"ok\", \"attrs\": {}}\n";
+
+    // ── Happy path: directory fixture ─────────────────────────────────────────
+
+    #[test]
+    fn happy_path_directory_aaaa() {
+        let (entries, summary) = importer()
+            .import(&aaaa_dir(), None, false)
+            .expect("import should succeed");
+
+        // Source and schema
+        assert_eq!(summary.source, "vscode-agent-debug-log");
+        assert_eq!(summary.schema_version, 1);
+        assert!(summary.ok_count >= 10, "expected >=10 ok entries");
+        assert!(!entries.is_empty());
+        assert_eq!(summary.ok_count, entries.len() as u64);
+        assert!(
+            summary.file_hash.starts_with("sha256:"),
+            "file_hash must start with sha256:"
+        );
+        assert_eq!(summary.file_name, "main.jsonl");
+        assert_eq!(summary.source, "vscode-agent-debug-log");
+    }
+
+    #[test]
+    fn happy_path_file_directly() {
+        let (entries, summary) = importer()
+            .import(&aaaa_main(), None, false)
+            .expect("import should succeed");
+        assert!(summary.ok_count >= 10);
+        assert_eq!(summary.ok_count, entries.len() as u64);
+    }
+
+    #[test]
+    fn kind_sequence_aaaa() {
+        let (entries, _) = importer()
+            .import(&aaaa_main(), None, false)
+            .expect("import should succeed");
+        let kinds: HashMap<u64, &str> = entries.iter().map(|e| (e.idx, e.kind.as_str())).collect();
+        assert_eq!(kinds[&0], "session_start");
+        assert_eq!(kinds[&1], "turn_start");
+        assert_eq!(kinds[&2], "llm_request");
+        assert_eq!(kinds[&3], "tool_call");
+        assert_eq!(kinds[&4], "tool_call"); // tool_result → tool_call
+        assert_eq!(kinds[&5], "agent_response");
+        assert_eq!(kinds[&6], "subagent");
+        assert_eq!(kinds[&7], "hook");
+        assert_eq!(kinds[&8], "error");
+        assert_eq!(kinds[&9], "generic"); // discovery
+        assert_eq!(kinds[&10], "generic"); // user_message
+        assert_eq!(kinds[&11], "generic"); // turn_end
+    }
+
+    #[test]
+    fn timestamp_shape_aaaa() {
+        let (entries, _) = importer()
+            .import(&aaaa_main(), None, false)
+            .expect("import should succeed");
+        let ts = entries[0]
+            .timestamp
+            .as_deref()
+            .expect("idx 0 must have timestamp");
+        assert!(ts.ends_with('Z'), "timestamp must end with Z: {ts}");
+        assert!(ts.contains('T'), "timestamp must contain T separator: {ts}");
+        assert!(ts.contains("2023-11"), "1700000000000 ms → 2023-11: {ts}");
+    }
+
+    #[test]
+    fn duration_zero_omitted_nonzero_present() {
+        let (entries, _) = importer()
+            .import(&aaaa_main(), None, false)
+            .expect("import should succeed");
+        let e3 = entries
+            .iter()
+            .find(|e| e.idx == 3)
+            .expect("idx 3 must exist");
+        assert!(
+            e3.duration_ms.is_none(),
+            "dur=0 must result in absent duration_ms"
+        );
+        let e4 = entries
+            .iter()
+            .find(|e| e.idx == 4)
+            .expect("idx 4 must exist");
+        assert_eq!(e4.duration_ms, Some(350.0));
+    }
+
+    #[test]
+    fn attr_rename_tokens() {
+        let (entries, _) = importer()
+            .import(&aaaa_main(), None, false)
+            .expect("import should succeed");
+        let e2 = entries
+            .iter()
+            .find(|e| e.idx == 2)
+            .expect("idx 2 must exist");
+        let attrs = &e2.attrs;
+        assert_eq!(attrs.get("tokens_in"), Some(&serde_json::json!(512)));
+        assert_eq!(attrs.get("tokens_out"), Some(&serde_json::json!(128)));
+        assert!(
+            !attrs.contains_key("inputTokens"),
+            "inputTokens must be renamed"
+        );
+        assert!(
+            !attrs.contains_key("outputTokens"),
+            "outputTokens must be renamed"
+        );
+    }
+
+    #[test]
+    fn dangerous_attr_args_dropped() {
+        let (entries, _) = importer()
+            .import(&aaaa_main(), None, false)
+            .expect("import should succeed");
+        // idx 11 (turn_end) has attrs: {"args": "must-be-dropped", "tokens_in": 100}
+        let e11 = entries
+            .iter()
+            .find(|e| e.idx == 11)
+            .expect("idx 11 must exist");
+        assert!(
+            !e11.attrs.contains_key("args"),
+            "'args' must be dropped as dangerous attr"
+        );
+        assert_eq!(e11.attrs.get("tokens_in"), Some(&serde_json::json!(100)));
+    }
+
+    #[test]
+    fn tool_name_set_for_bash() {
+        let (entries, _) = importer()
+            .import(&aaaa_main(), None, false)
+            .expect("import should succeed");
+        let e3 = entries
+            .iter()
+            .find(|e| e.idx == 3)
+            .expect("idx 3 must exist");
+        let e4 = entries
+            .iter()
+            .find(|e| e.idx == 4)
+            .expect("idx 4 must exist");
+        assert_eq!(e3.tool_name.as_deref(), Some("bash"));
+        assert_eq!(e4.tool_name.as_deref(), Some("bash"));
+    }
+
+    #[test]
+    fn error_level_inferred() {
+        let (entries, _) = importer()
+            .import(&aaaa_main(), None, false)
+            .expect("import should succeed");
+        let e8 = entries
+            .iter()
+            .find(|e| e.idx == 8)
+            .expect("idx 8 must exist");
+        assert_eq!(e8.level.as_deref(), Some("error"));
+    }
+
+    #[test]
+    fn privacy_basename_only() {
+        let (_, summary) = importer()
+            .import(&aaaa_main(), None, false)
+            .expect("import should succeed");
+        assert_eq!(summary.file_name, "main.jsonl");
+    }
+
+    // ── Required-field malformations ──────────────────────────────────────────
+
+    #[test]
+    fn missing_spanid_malformed() {
+        let td = TempDir::new();
+        let bad = "{\"ts\": 1700000001000, \"sid\": \"sx\", \"type\": \"tool_call\",\
+                   \"name\": \"bash\", \"status\": \"ok\", \"attrs\": {}}\n";
+        let p = write_temp(&td, &[BASE_LINE, bad]);
+        let (_, summary) = importer().import(&p, None, false).unwrap();
+        assert!(
+            summary
+                .malformed_reports
+                .iter()
+                .any(|r| r.reason.contains("spanId")),
+            "missing spanId must be reported"
+        );
+    }
+
+    #[test]
+    fn non_string_spanid_malformed() {
+        let td = TempDir::new();
+        let bad = "{\"ts\": 1700000001000, \"sid\": \"sx\", \"type\": \"tool_call\",\
+                   \"name\": \"bash\", \"spanId\": 12345, \"status\": \"ok\", \"attrs\": {}}\n";
+        let p = write_temp(&td, &[BASE_LINE, bad]);
+        let (_, summary) = importer().import(&p, None, false).unwrap();
+        assert!(
+            summary
+                .malformed_reports
+                .iter()
+                .any(|r| r.reason.contains("spanId")),
+            "non-string spanId must be reported"
+        );
+    }
+
+    #[test]
+    fn missing_status_malformed() {
+        let td = TempDir::new();
+        let bad = "{\"ts\": 1700000001000, \"sid\": \"sx\", \"type\": \"tool_call\",\
+                   \"name\": \"bash\", \"spanId\": \"b000000000000002\", \"attrs\": {}}\n";
+        let p = write_temp(&td, &[BASE_LINE, bad]);
+        let (_, summary) = importer().import(&p, None, false).unwrap();
+        assert!(
+            summary
+                .malformed_reports
+                .iter()
+                .any(|r| r.reason.contains("status")),
+            "missing status must be reported"
+        );
+    }
+
+    #[test]
+    fn invalid_status_type_malformed() {
+        let td = TempDir::new();
+        let bad = "{\"ts\": 1700000001000, \"sid\": \"sx\", \"type\": \"tool_call\",\
+                   \"name\": \"bash\", \"spanId\": \"b000000000000002\", \
+                   \"status\": 1, \"attrs\": {}}\n";
+        let p = write_temp(&td, &[BASE_LINE, bad]);
+        let (_, summary) = importer().import(&p, None, false).unwrap();
+        assert!(
+            summary
+                .malformed_reports
+                .iter()
+                .any(|r| r.reason.contains("status")),
+            "non-string non-null status must be reported"
+        );
+    }
+
+    #[test]
+    fn missing_attrs_malformed() {
+        let td = TempDir::new();
+        let bad = "{\"ts\": 1700000001000, \"sid\": \"sx\", \"type\": \"tool_call\",\
+                   \"name\": \"bash\", \"spanId\": \"b000000000000002\", \"status\": \"ok\"}\n";
+        let p = write_temp(&td, &[BASE_LINE, bad]);
+        let (_, summary) = importer().import(&p, None, false).unwrap();
+        assert!(
+            summary
+                .malformed_reports
+                .iter()
+                .any(|r| r.reason.contains("attrs")),
+            "missing attrs must be reported"
+        );
+    }
+
+    #[test]
+    fn non_dict_attrs_malformed() {
+        let td = TempDir::new();
+        let bad = "{\"ts\": 1700000001000, \"sid\": \"sx\", \"type\": \"tool_call\",\
+                   \"name\": \"bash\", \"spanId\": \"b000000000000002\", \
+                   \"status\": \"ok\", \"attrs\": []}\n";
+        let p = write_temp(&td, &[BASE_LINE, bad]);
+        let (_, summary) = importer().import(&p, None, false).unwrap();
+        assert!(
+            summary
+                .malformed_reports
+                .iter()
+                .any(|r| r.reason.contains("attrs")),
+            "list attrs must be reported"
+        );
+    }
+
+    #[test]
+    fn v2_schema_malformed() {
+        let (_, summary) = importer()
+            .import(&bbbb_main(), None, false)
+            .expect("import should succeed");
+        assert!(
+            summary
+                .malformed_reports
+                .iter()
+                .any(|r| r.reason.contains("v=2")),
+            "v=2 line must be reported as malformed with 'v=2' in reason"
+        );
+    }
+
+    #[test]
+    fn bbbb_malformed_counts() {
+        let (_, summary) = importer()
+            .import(&bbbb_main(), None, false)
+            .expect("import should succeed");
+        // Lines 2 (missing ts), 3 (missing sid), 4 (not JSON), 7 (v=2) → 4 malformed
+        assert_eq!(
+            summary.malformed_count, 4,
+            "bbbb fixture has 4 malformed lines"
+        );
+        assert_eq!(summary.ok_count, 3, "bbbb fixture has 3 valid lines");
+    }
+
+    // ── Unsupported format tests ──────────────────────────────────────────────
+
+    #[test]
+    fn otel_file_raises_unsupported_format() {
+        let err = importer()
+            .import(&otel_console(), None, false)
+            .expect_err("OTel file must raise UnsupportedFormat for VS Code importer");
+        assert!(
+            matches!(err, ImportError::UnsupportedFormat(_)),
+            "expected UnsupportedFormat, got: {err}"
+        );
+    }
+
+    #[test]
+    fn companion_models_json_raises_unsupported() {
+        let companion = aaaa_dir().join("models.json");
+        let err = importer()
+            .import(&companion, None, false)
+            .expect_err("models.json must raise UnsupportedFormat");
+        assert!(matches!(err, ImportError::UnsupportedFormat(_)));
+    }
+
+    #[test]
+    fn companion_system_prompt_raises_unsupported() {
+        let companion = aaaa_dir().join("system_prompt_abc.json");
+        let err = importer()
+            .import(&companion, None, false)
+            .expect_err("system_prompt_abc.json must raise UnsupportedFormat");
+        assert!(matches!(err, ImportError::UnsupportedFormat(_)));
+    }
+
+    #[test]
+    fn companion_tools_raises_unsupported() {
+        let companion = aaaa_dir().join("tools_fixture.json");
+        let err = importer()
+            .import(&companion, None, false)
+            .expect_err("tools_fixture.json must raise UnsupportedFormat");
+        assert!(matches!(err, ImportError::UnsupportedFormat(_)));
+    }
+
+    #[test]
+    fn missing_main_jsonl_in_dir() {
+        let td = TempDir::new();
+        let err = importer()
+            .import(td.path(), None, false)
+            .expect_err("empty dir must raise FileNotFound");
+        assert!(matches!(err, ImportError::FileNotFound(_)));
+    }
+
+    #[test]
+    fn empty_file_raises_unsupported() {
+        let td = TempDir::new();
+        let p = td.path().join("empty.jsonl");
+        std::fs::write(&p, b"").unwrap();
+        let err = importer()
+            .import(&p, None, false)
+            .expect_err("empty file must raise UnsupportedFormat");
+        assert!(matches!(err, ImportError::UnsupportedFormat(_)));
+    }
+
+    // ── Path traversal ────────────────────────────────────────────────────────
+
+    #[test]
+    fn path_traversal_rejected() {
+        let traversal = std::path::Path::new("some_dir/../other");
+        let err = importer()
+            .import(traversal, None, false)
+            .expect_err("traversal path must be rejected");
+        assert!(
+            matches!(err, ImportError::PathTraversal(_)),
+            "expected PathTraversal, got: {err}"
+        );
+    }
+
+    // ── Dry run ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn dry_run_empty_entries_accurate_summary() {
+        let (entries, summary) = importer()
+            .import(&aaaa_main(), None, true)
+            .expect("dry-run import must succeed");
+        assert!(entries.is_empty(), "dry_run must return empty entries vec");
+        assert!(summary.ok_count > 0, "dry_run must still count ok entries");
+        assert!(summary.file_hash.starts_with("sha256:"));
+    }
+
+    // ── Dedup ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn cccc_dedup() {
+        let (entries, summary) = importer()
+            .import(&cccc_main(), None, false)
+            .expect("import should succeed");
+        assert_eq!(summary.ok_count, 3, "cccc has 3 unique entries");
+        assert_eq!(summary.deduped_count, 2, "cccc has 2 duplicates");
+        assert_eq!(entries.len(), 3);
+    }
+
+    // ── FIFO synthetic pairing ────────────────────────────────────────────────
+
+    #[test]
+    fn fifo_pairing_tool_call_result_share_span() {
+        let td = TempDir::new();
+        let start = "{\"ts\": 1700000001000, \"dur\": 0, \"sid\": \"sx\", \
+                     \"type\": \"tool_call\", \"name\": \"bash\", \
+                     \"spanId\": \"bad!!\", \"status\": null, \"attrs\": {}}\n";
+        let result = "{\"ts\": 1700000001500, \"dur\": 500, \"sid\": \"sx\", \
+                      \"type\": \"tool_result\", \"name\": \"bash\", \
+                      \"spanId\": \"alsobad!!\", \"status\": \"ok\", \"attrs\": {}}\n";
+        let p = write_temp(&td, &[BASE_LINE, start, result]);
+        let (entries, summary) = importer().import(&p, None, false).unwrap();
+        assert_eq!(summary.ok_count, 3);
+        let tool_entries: Vec<_> = entries.iter().filter(|e| e.kind == "tool_call").collect();
+        assert_eq!(tool_entries.len(), 2, "two tool_call entries");
+        assert_eq!(
+            tool_entries[0].span_id, tool_entries[1].span_id,
+            "start and result must share synthetic span_id"
+        );
+    }
+
+    #[test]
+    fn fifo_ordering_two_starts_two_results() {
+        let td = TempDir::new();
+        let start1 = "{\"ts\": 1700000001000, \"dur\": 0, \"sid\": \"sx\", \
+                      \"type\": \"tool_call\", \"name\": \"bash\", \
+                      \"spanId\": \"bad!!\", \"status\": null, \"attrs\": {}}\n";
+        let start2 = "{\"ts\": 1700000002000, \"dur\": 0, \"sid\": \"sx\", \
+                      \"type\": \"tool_call\", \"name\": \"bash\", \
+                      \"spanId\": \"alsobad!!\", \"status\": null, \"attrs\": {}}\n";
+        let result1 = "{\"ts\": 1700000003000, \"dur\": 2000, \"sid\": \"sx\", \
+                       \"type\": \"tool_result\", \"name\": \"bash\", \
+                       \"spanId\": \"badspa1!!\", \"status\": \"ok\", \"attrs\": {}}\n";
+        let result2 = "{\"ts\": 1700000004000, \"dur\": 2000, \"sid\": \"sx\", \
+                       \"type\": \"tool_result\", \"name\": \"bash\", \
+                       \"spanId\": \"badspa2!!\", \"status\": \"ok\", \"attrs\": {}}\n";
+        let p = write_temp(&td, &[BASE_LINE, start1, start2, result1, result2]);
+        let (entries, summary) = importer().import(&p, None, false).unwrap();
+        assert_eq!(summary.ok_count, 5);
+        let tool_entries: Vec<_> = entries.iter().filter(|e| e.kind == "tool_call").collect();
+        assert_eq!(tool_entries.len(), 4);
+        // FIFO: result1 pairs with start1, result2 pairs with start2
+        assert_eq!(
+            tool_entries[0].span_id, tool_entries[2].span_id,
+            "result1 must pair with start1"
+        );
+        assert_eq!(
+            tool_entries[1].span_id, tool_entries[3].span_id,
+            "result2 must pair with start2"
+        );
+        assert_ne!(
+            tool_entries[0].span_id, tool_entries[1].span_id,
+            "start1 and start2 must have different spans"
+        );
+    }
+
+    #[test]
+    fn orphan_tool_result_keeps_own_span() {
+        let td = TempDir::new();
+        let orphan = "{\"ts\": 1700000001000, \"dur\": 100, \"sid\": \"sx\", \
+                      \"type\": \"tool_result\", \"name\": \"bash\", \
+                      \"spanId\": \"bad!!\", \"status\": \"ok\", \"attrs\": {}}\n";
+        let p = write_temp(&td, &[BASE_LINE, orphan]);
+        let (entries, summary) = importer().import(&p, None, false).unwrap();
+        assert_eq!(summary.ok_count, 2);
+        let orphan_entry = entries.iter().find(|e| e.idx == 1).unwrap();
+        let span = orphan_entry
+            .span_id
+            .as_deref()
+            .expect("orphan must have span_id");
+        assert_eq!(span.len(), 16, "synthetic span must be 16 chars");
+    }
+
+    #[test]
+    fn no_cross_pair_different_parent() {
+        let td = TempDir::new();
+        let start_a = "{\"ts\": 1700000001000, \"dur\": 0, \"sid\": \"sx\", \
+                       \"type\": \"tool_call\", \"name\": \"bash\", \
+                       \"spanId\": \"bad!!\", \"status\": null, \"attrs\": {}, \
+                       \"parentSpanId\": \"1111aaaa11111111\"}\n";
+        let result_b = "{\"ts\": 1700000002000, \"dur\": 100, \"sid\": \"sx\", \
+                        \"type\": \"tool_result\", \"name\": \"bash\", \
+                        \"spanId\": \"alsobad!!\", \"status\": \"ok\", \"attrs\": {}, \
+                        \"parentSpanId\": \"2222bbbb22222222\"}\n";
+        let p = write_temp(&td, &[BASE_LINE, start_a, result_b]);
+        let (entries, summary) = importer().import(&p, None, false).unwrap();
+        assert_eq!(summary.ok_count, 3);
+        let tool_entries: Vec<_> = entries.iter().filter(|e| e.kind == "tool_call").collect();
+        assert_eq!(tool_entries.len(), 2);
+        assert_ne!(
+            tool_entries[0].span_id, tool_entries[1].span_id,
+            "different parents must not cross-pair"
+        );
+    }
+
+    #[test]
+    fn invalid_parent_normalizes_to_none_for_pairing() {
+        let td = TempDir::new();
+        let start = "{\"ts\": 1700000001000, \"dur\": 0, \"sid\": \"sx\", \
+                     \"type\": \"tool_call\", \"name\": \"bash\", \
+                     \"spanId\": \"bad!!\", \"status\": null, \"attrs\": {}, \
+                     \"parentSpanId\": \"bad-parent-1\"}\n";
+        let result = "{\"ts\": 1700000002000, \"dur\": 100, \"sid\": \"sx\", \
+                      \"type\": \"tool_result\", \"name\": \"bash\", \
+                      \"spanId\": \"alsobad!!\", \"status\": \"ok\", \"attrs\": {}, \
+                      \"parentSpanId\": \"bad-parent-2\"}\n";
+        let p = write_temp(&td, &[BASE_LINE, start, result]);
+        let (entries, summary) = importer().import(&p, None, false).unwrap();
+        assert_eq!(summary.ok_count, 3);
+        let tool_entries: Vec<_> = entries.iter().filter(|e| e.kind == "tool_call").collect();
+        assert_eq!(tool_entries.len(), 2);
+        assert_eq!(
+            tool_entries[0].span_id, tool_entries[1].span_id,
+            "invalid parents both normalize to None → same pair key → must pair"
+        );
+    }
+
+    #[test]
+    fn ridx_ignored_in_pairing() {
+        let td = TempDir::new();
+        let start = "{\"ts\": 1700000001000, \"dur\": 0, \"sid\": \"sx\", \
+                     \"type\": \"tool_call\", \"name\": \"bash\", \
+                     \"spanId\": \"bad!!\", \"status\": null, \"attrs\": {}, \"rIdx\": 5}\n";
+        let result = "{\"ts\": 1700000002000, \"dur\": 100, \"sid\": \"sx\", \
+                      \"type\": \"tool_result\", \"name\": \"bash\", \
+                      \"spanId\": \"alsobad!!\", \"status\": \"ok\", \"attrs\": {}, \
+                      \"rIdx\": 10}\n";
+        let p = write_temp(&td, &[BASE_LINE, start, result]);
+        let (entries, summary) = importer().import(&p, None, false).unwrap();
+        assert_eq!(summary.ok_count, 3);
+        let tool_entries: Vec<_> = entries.iter().filter(|e| e.kind == "tool_call").collect();
+        assert_eq!(tool_entries.len(), 2);
+        assert_eq!(
+            tool_entries[0].span_id, tool_entries[1].span_id,
+            "different rIdx values must not affect FIFO pairing"
+        );
+    }
+
+    // ── PR #445 regression: duplicate tool_call must not enqueue orphan span ──
+
+    #[test]
+    fn duplicate_tool_call_does_not_enqueue_orphan_span() {
+        let td = TempDir::new();
+        let dup_start = "{\"ts\": 1700000001000, \"dur\": 0, \"sid\": \"sx\", \
+                         \"type\": \"tool_call\", \"name\": \"bash\", \
+                         \"spanId\": \"bad!!\", \"status\": null, \"attrs\": {}}\n";
+        let agent_resp = "{\"ts\": 1700000002000, \"dur\": 0, \"sid\": \"sx\", \
+                          \"type\": \"agent_response\", \"name\": \"assistant\", \
+                          \"spanId\": \"also_bad!!\", \"status\": null, \"attrs\": {}}\n";
+        let result1 = "{\"ts\": 1700000003000, \"dur\": 100, \"sid\": \"sx\", \
+                       \"type\": \"tool_result\", \"name\": \"bash\", \
+                       \"spanId\": \"result_bad_1!!\", \"status\": \"ok\", \"attrs\": {}}\n";
+        let result2 = "{\"ts\": 1700000004000, \"dur\": 100, \"sid\": \"sx\", \
+                       \"type\": \"tool_result\", \"name\": \"bash\", \
+                       \"spanId\": \"result_bad_2!!\", \"status\": \"ok\", \"attrs\": {}}\n";
+        // BASE_LINE, dup_start, dup_start (duplicate), agent_resp, result1, result2
+        let p = write_temp(
+            &td,
+            &[
+                BASE_LINE, dup_start, dup_start, agent_resp, result1, result2,
+            ],
+        );
+        let (entries, summary) = importer().import(&p, None, false).unwrap();
+        assert_eq!(summary.ok_count, 5);
+        assert_eq!(summary.deduped_count, 1);
+        let agent_span = entries
+            .iter()
+            .find(|e| e.kind == "agent_response")
+            .and_then(|e| e.span_id.clone())
+            .expect("agent_response must have a span_id");
+        let tool_entries: Vec<_> = entries.iter().filter(|e| e.kind == "tool_call").collect();
+        assert_eq!(
+            tool_entries.len(),
+            3,
+            "one start + two results = 3 tool_call entries"
+        );
+        // tool_entries[0] = tool_call start; tool_entries[1] = first result (paired with start);
+        // tool_entries[2] = second result (unpaired, gets own synthetic span).
+        assert_eq!(
+            tool_entries[0].span_id, tool_entries[1].span_id,
+            "tool_call start and its paired tool_result must share span_id"
+        );
+        assert_ne!(
+            tool_entries[2].span_id, tool_entries[0].span_id,
+            "second result (unpaired) must get its own span_id"
+        );
+        // PR #445 regression guard: second result must NOT steal agent_response span
+        assert_ne!(
+            tool_entries[2].span_id.as_deref(),
+            Some(agent_span.as_str()),
+            "second result must not reuse agent_response span (PR #445 regression guard)"
+        );
+    }
+
+    // ── detect_format scan-forward with oversized / unparseable leading lines ─
+    //
+    // Use cap=512 so that BASE_LINE (~130 bytes) and all fixture lines (~250 bytes
+    // max) are well within cap. Only the deliberately oversized test line (512*64 =
+    // 32768 bytes) triggers the oversize path.  All env-var tests acquire env_lock
+    // to serialise their global side-effect even when tests run in parallel.
+
+    #[test]
+    fn oversized_first_then_valid_imports() {
+        let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let td = TempDir::new();
+        // cap must be larger than BASE_LINE (~130 bytes) but smaller than the oversized line.
+        let cap = 512usize;
+        let oversized: Vec<u8> = std::iter::once(b'{')
+            .chain(b"\"x\":\"".iter().copied())
+            .chain(std::iter::repeat(b'y').take(cap * 64))
+            .chain(b"\"}\n".iter().copied())
+            .collect();
+        let valid = BASE_LINE.as_bytes().to_vec();
+        let path = td.path().join("main.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(&oversized).unwrap();
+        f.write_all(&valid).unwrap();
+        drop(f);
+
+        let _guard = EnvGuard::set("BROWSE_DEBUG_LOG_MAX_LINE_BYTES", &cap.to_string());
+        let (entries, summary) = importer()
+            .import(&path, None, false)
+            .expect("oversized then valid must succeed");
+        assert_eq!(summary.ok_count, 1, "one valid entry after oversized line");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            summary.malformed_count, 1,
+            "oversized line counted as malformed"
+        );
+    }
+
+    #[test]
+    fn all_oversized_raises_unsupported() {
+        let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let td = TempDir::new();
+        let cap = 512usize;
+        let oversized: Vec<u8> = std::iter::once(b'{')
+            .chain(b"\"x\":\"".iter().copied())
+            .chain(std::iter::repeat(b'y').take(cap * 64))
+            .chain(b"\"}\n".iter().copied())
+            .collect();
+        let path = td.path().join("main.jsonl");
+        std::fs::write(&path, &oversized).unwrap();
+
+        let _guard = EnvGuard::set("BROWSE_DEBUG_LOG_MAX_LINE_BYTES", &cap.to_string());
+        let result = importer().import(&path, None, false);
+        assert!(
+            matches!(result, Err(ImportError::UnsupportedFormat(_))),
+            "all-oversized file must raise UnsupportedFormat"
+        );
+    }
+
+    #[test]
+    fn non_hex_span_id_gets_synthetic() {
+        let (entries, _) = importer()
+            .import(&aaaa_main(), None, false)
+            .expect("import should succeed");
+        // idx 10 has spanId "not-valid-span!!" → must be synthesised
+        let e10 = entries
+            .iter()
+            .find(|e| e.idx == 10)
+            .expect("idx 10 must exist");
+        let span_id = e10.span_id.as_deref().expect("idx 10 must have span_id");
+        assert_eq!(span_id.len(), 16, "synthetic span_id must be 16 chars");
+        assert!(
+            span_id.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')),
+            "synthetic span_id must be lowercase hex: {span_id}"
+        );
+        let expected = synthetic_span_id("vscode", 10);
+        assert_eq!(span_id, expected, "must match synthetic_span_id formula");
+    }
+
+    // ── epoch_ms_to_iso unit tests ────────────────────────────────────────────
+
+    #[test]
+    fn epoch_ms_to_iso_known_value() {
+        // 1700000000000 ms = 2023-11-14T22:13:20.000Z
+        let result = epoch_ms_to_iso(1_700_000_000_000.0).unwrap();
+        assert_eq!(result, "2023-11-14T22:13:20.000Z");
+    }
+
+    #[test]
+    fn epoch_ms_to_iso_with_millis() {
+        // 1700000001500 ms = 2023-11-14T22:13:21.500Z
+        let result = epoch_ms_to_iso(1_700_000_001_500.0).unwrap();
+        assert_eq!(result, "2023-11-14T22:13:21.500Z");
+    }
+
+    #[test]
+    fn epoch_ms_to_iso_zero_returns_none() {
+        assert!(epoch_ms_to_iso(0.0).is_none());
+        assert!(epoch_ms_to_iso(-1.0).is_none());
+    }
+
+    // ── fnmatch_simple unit tests ─────────────────────────────────────────────
+
+    #[test]
+    fn fnmatch_exact_match() {
+        assert!(fnmatch_simple("models.json", "models.json"));
+        assert!(!fnmatch_simple("models.json2", "models.json"));
+    }
+
+    #[test]
+    fn fnmatch_wildcard_match() {
+        assert!(fnmatch_simple(
+            "system_prompt_abc.json",
+            "system_prompt_*.json"
+        ));
+        assert!(fnmatch_simple("tools_v2.json", "tools_*.json"));
+        assert!(!fnmatch_simple("main.jsonl", "tools_*.json"));
+    }
+}

--- a/sk-rust/src/browse/mod.rs
+++ b/sk-rust/src/browse/mod.rs
@@ -1,0 +1,8 @@
+//! Native Rust port of `browse/` Python modules.
+//!
+//! Phase 1 (issue #455): pure parser + helpers scaffold.
+//! No Browse DB persistence and no CLI subcommand in this phase.
+
+#![allow(dead_code)]
+
+pub mod importers;

--- a/sk-rust/src/main.rs
+++ b/sk-rust/src/main.rs
@@ -1,3 +1,4 @@
+mod browse;
 mod commands;
 mod config;
 mod daemon;


### PR DESCRIPTION
## Summary
- Add native Rust browse debug-log importer scaffold and parser API under `sk-rust/src/browse/importers/`.
- Port VS Code Agent Debug Log and OTel `ReadableSpan` JSONL parsing with bounded-line reading, path safety, SHA-1 synthetic span IDs, dedup, redaction, and dry-run summaries.
- Document that Rust importers are parser-only parity infrastructure; Python remains the production callable importer surface until a follow-up CLI/DB wiring issue.

Closes #455

## Local verification
- `cd sk-rust; cargo test` — 854 unit tests and 87 integration tests passed.
- `cd sk-rust; cargo check --no-default-features` — passed.
- `cd sk-rust; cargo clippy --all-targets --no-deps -- -D warnings` — passed.
- `python tests\test_browse_debug_log_importers.py` — 214 passed, 0 failed.
- `python tests\test_py_rust_boundary.py` — 26 passed, 0 failed.
- Opus review after fix: CLEAN.