### PR TITLE
perf: push browse search ranking into SQL

### DIFF
--- a/browse/routes/search_api.py
+++ b/browse/routes/search_api.py
@@ -133,11 +133,7 @@ def _build_knowledge_arm(safe_q: str, in_cols: list, kind_list: list, ktable: st
     ktable must be one of the two safe values returned by _knowledge_table().
     kind_list items are inserted via ? placeholders (never interpolated).
     """
-    ke_query = (
-        _build_column_scoped_query(safe_q, ["title"])
-        if ("title" in in_cols and len(in_cols) == 1)
-        else safe_q
-    )
+    ke_query = _build_column_scoped_query(safe_q, ["title"]) if ("title" in in_cols and len(in_cols) == 1) else safe_q
 
     kind_args: list = []
     kind_clause = ""

--- a/browse/routes/search_api.py
+++ b/browse/routes/search_api.py
@@ -185,7 +185,7 @@ def _execute_combined(db, arms: list[str], arm_params: list[list], limit: int) -
 
     # Fallback: run arms independently (pre-optimisation behaviour)
     results: list = []
-    for arm, ap in zip(arms, arm_params):
+    for arm, ap in zip(arms, arm_params, strict=False):
         try:
             for r in db.execute(arm, [*ap, limit]):
                 results.append(_row_to_result(r))

--- a/browse/routes/search_api.py
+++ b/browse/routes/search_api.py
@@ -1,4 +1,11 @@
-"""browse/routes/search_api.py — /api/search JSON endpoint (F7)."""
+"""browse/routes/search_api.py — /api/search JSON endpoint (F7).
+
+Ranking is pushed entirely into SQL via UNION ALL + ORDER BY score LIMIT,
+eliminating the Python-side sort and over-fetching of up to 2×limit rows.
+Each source arm contributes at most `limit` candidates; the outer ORDER BY
+LIMIT selects the global top-`limit` in a single DB round-trip when both
+sources are active.
+"""
 
 import html
 import json
@@ -33,6 +40,10 @@ _VALID_KINDS = frozenset(
         "refactor",
     }
 )
+
+# Uniform column aliases shared by both UNION ALL arms.
+# type  id  title  snip  score  wing  kind
+_ARM_COLS = ("type", "id", "title", "snip", "score", "wing", "kind")
 
 
 def _knowledge_table(db) -> str:
@@ -69,6 +80,121 @@ def _parse_csv(value: str, valid: frozenset) -> list:
     return [v.strip() for v in value.split(",") if v.strip() in valid]
 
 
+def _row_to_result(r) -> dict:
+    """Convert a unified search row (type/id/title/snip/score/wing/kind) to result dict."""
+    if r["type"] == "session":
+        return {
+            "type": "session",
+            "id": r["id"],
+            "title": r["title"] or r["id"],
+            "snippet": _safe_snippet(r["snip"] or ""),
+            "score": r["score"],
+        }
+    return {
+        "type": "knowledge",
+        "id": r["id"],
+        "title": r["title"] or "",
+        "wing": r["wing"] or "",
+        "kind": r["kind"] or "",
+        "snippet": _safe_snippet(r["snip"] or ""),
+        "score": r["score"],
+    }
+
+
+def _build_sessions_arm(safe_q: str, in_cols: list) -> tuple[str, list]:
+    """Return (arm_sql, params) for the sessions FTS arm.
+
+    The arm uses uniform column aliases matching _ARM_COLS so it can be
+    combined in a UNION ALL with the knowledge arm.
+    """
+    col_names = [_SESSION_COL_MAP[c][0] for c in in_cols if c in _SESSION_COL_MAP]
+    all_cols = list(_SESSION_COL_MAP.keys())
+    if col_names and sorted(col_names) != sorted(_SESSION_COL_MAP[c][0] for c in all_cols):
+        fts_query = _build_column_scoped_query(safe_q, col_names)
+    else:
+        fts_query = safe_q
+
+    # snippet col -1 = auto-pick best matching column
+    sql = (
+        "SELECT 'session' AS type, s.id AS id, s.summary AS title,"
+        " snippet(sessions_fts,-1,'<mark>','</mark>','...',15) AS snip,"
+        " bm25(sessions_fts) AS score, '' AS wing, '' AS kind"
+        " FROM sessions_fts"
+        " JOIN sessions AS s ON s.id = sessions_fts.session_id"
+        " WHERE sessions_fts MATCH ?"
+        " ORDER BY bm25(sessions_fts) LIMIT ?"
+    )
+    return sql, [fts_query]  # limit appended by caller
+
+
+def _build_knowledge_arm(safe_q: str, in_cols: list, kind_list: list, ktable: str) -> tuple[str, list]:
+    """Return (arm_sql, params) for the knowledge FTS arm.
+
+    ktable must be one of the two safe values returned by _knowledge_table().
+    kind_list items are inserted via ? placeholders (never interpolated).
+    """
+    ke_query = (
+        _build_column_scoped_query(safe_q, ["title"])
+        if ("title" in in_cols and len(in_cols) == 1)
+        else safe_q
+    )
+
+    kind_args: list = []
+    kind_clause = ""
+    if kind_list:
+        placeholders = ",".join("?" * len(kind_list))
+        kind_clause = f" AND k.category IN ({placeholders})"
+        kind_args = list(kind_list)
+
+    sql = (
+        f"SELECT 'knowledge' AS type, CAST(k.id AS TEXT) AS id, k.title AS title,"
+        f" snippet(ke_fts,1,'<mark>','</mark>','...',15) AS snip,"
+        f" bm25(ke_fts) AS score, k.wing AS wing, k.category AS kind"
+        f" FROM ke_fts"
+        f" JOIN {ktable} AS k ON k.id = ke_fts.rowid"
+        f" WHERE ke_fts MATCH ?{kind_clause}"
+        f" ORDER BY bm25(ke_fts) LIMIT ?"
+    )
+    return sql, [ke_query, *kind_args]  # limit appended by caller
+
+
+def _execute_combined(db, arms: list[str], arm_params: list[list], limit: int) -> list:
+    """Execute arms via UNION ALL + ORDER BY score LIMIT in a single round-trip.
+
+    Each arm is wrapped in a derived-table subquery so its per-arm ORDER BY LIMIT
+    is materialised before the outer merge.  Falls back to independent arm queries
+    (restoring previous Python-sort behaviour) on OperationalError.
+    """
+    assert len(arms) == len(arm_params)
+
+    # Build flat param list: [arm0_params…, limit, arm1_params…, limit, …, outer_limit]
+    flat_params: list = []
+    for ap in arm_params:
+        flat_params.extend(ap)
+        flat_params.append(limit)
+    flat_params.append(limit)  # outer LIMIT
+
+    # Wrap each arm in SELECT * FROM (arm) so that ORDER BY + LIMIT inside is honoured
+    wrapped = " UNION ALL ".join(f"SELECT * FROM ({a})" for a in arms)
+    sql = f"SELECT * FROM ({wrapped}) ORDER BY score LIMIT ?"
+
+    try:
+        return [_row_to_result(r) for r in db.execute(sql, flat_params)]
+    except sqlite3.OperationalError:
+        pass
+
+    # Fallback: run arms independently (pre-optimisation behaviour)
+    results: list = []
+    for arm, ap in zip(arms, arm_params):
+        try:
+            for r in db.execute(arm, [*ap, limit]):
+                results.append(_row_to_result(r))
+        except sqlite3.OperationalError:
+            pass
+    results.sort(key=lambda x: x["score"])
+    return results[:limit]
+
+
 @route("/api/search", methods=["GET"])
 def handle_search_api(db, params, token, nonce) -> tuple:
     """
@@ -80,6 +206,10 @@ def handle_search_api(db, params, token, nonce) -> tuple:
       src   (csv) Sources: sessions,knowledge (default both)
       kind  (csv) Knowledge categories to filter (default all)
       limit (int) Max results, default 20, max 100
+
+    Ranking is pushed into SQL: when both sources are active a single
+    UNION ALL query replaces two separate fetches, eliminating the
+    Python-side sort and the 2×limit over-fetch.
     """
     t0 = time.perf_counter()
 
@@ -108,91 +238,33 @@ def handle_search_api(db, params, token, nonce) -> tuple:
     if not src_list:
         src_list = ["sessions", "knowledge"]
 
-    results: list = []
+    # ── Build active SQL arms ─────────────────────────────────────────────────
+    arms: list[str] = []
+    arm_params: list[list] = []
 
-    # ── 1. Sessions FTS ───────────────────────────────────────────────────────
     if "sessions" in src_list and _probe_sessions_fts(db):
-        col_names = [_SESSION_COL_MAP[c][0] for c in in_cols if c in _SESSION_COL_MAP]
-        all_cols = list(_SESSION_COL_MAP.keys())
-        if col_names and sorted(col_names) != sorted(_SESSION_COL_MAP[c][0] for c in all_cols):
-            fts_query = _build_column_scoped_query(safe_q, col_names)
-        else:
-            fts_query = safe_q
+        s_sql, s_params = _build_sessions_arm(safe_q, in_cols)
+        arms.append(s_sql)
+        arm_params.append(s_params)
 
-        try:
-            rows = list(
-                db.execute(
-                    # snippet col -1 = auto-pick best matching column
-                    """SELECT s.id, s.summary, s.source,
-                          snippet(sessions_fts, -1, '<mark>', '</mark>', '...', 15) AS snip,
-                          bm25(sessions_fts) AS score
-                   FROM sessions_fts
-                   JOIN sessions AS s ON s.id = sessions_fts.session_id
-                   WHERE sessions_fts MATCH ?
-                   ORDER BY bm25(sessions_fts)
-                   LIMIT ?""",
-                    (fts_query, limit),
-                )
-            )
-            for r in rows:
-                results.append(
-                    {
-                        "type": "session",
-                        "id": r["id"],
-                        "title": r["summary"] or r["id"],
-                        "snippet": _safe_snippet(r["snip"] or ""),
-                        "score": r["score"],
-                    }
-                )
-        except sqlite3.OperationalError:
-            pass
-
-    # ── 2. Knowledge FTS ──────────────────────────────────────────────────────
     if "knowledge" in src_list:
-        # Scope ke_fts query to title column only when title is the sole selection
-        if "title" in in_cols and len(in_cols) == 1:
-            ke_query = _build_column_scoped_query(safe_q, ["title"])
-        else:
-            ke_query = safe_q
-
-        kind_args: list = []
-        kind_clause = ""
-        if kind_list:
-            placeholders = ",".join("?" * len(kind_list))
-            kind_clause = f" AND k.category IN ({placeholders})"
-            kind_args = kind_list
-
         ktable = _knowledge_table(db)
-        try:
-            sql = (
-                f"SELECT k.id, k.title, k.category, k.wing, k.room,"
-                f"       snippet(ke_fts, 1, '<mark>', '</mark>', '...', 15) AS snip,"
-                f"       bm25(ke_fts) AS score"
-                f" FROM ke_fts"
-                f" JOIN {ktable} AS k ON k.id = ke_fts.rowid"
-                f" WHERE ke_fts MATCH ?{kind_clause}"
-                f" ORDER BY bm25(ke_fts)"
-                f" LIMIT ?"
-            )
-            rows = list(db.execute(sql, (ke_query, *kind_args, limit)))
-            for r in rows:
-                results.append(
-                    {
-                        "type": "knowledge",
-                        "id": r["id"],
-                        "title": r["title"] or "",
-                        "wing": r["wing"] or "",
-                        "kind": r["category"] or "",
-                        "snippet": _safe_snippet(r["snip"] or ""),
-                        "score": r["score"],
-                    }
-                )
-        except sqlite3.OperationalError:
-            pass
+        k_sql, k_params = _build_knowledge_arm(safe_q, in_cols, kind_list, ktable)
+        arms.append(k_sql)
+        arm_params.append(k_params)
 
-    # bm25 returns negative values; sort ascending → best matches first
-    results.sort(key=lambda x: x["score"])
-    results = results[:limit]
+    # ── Execute: single round-trip when multiple arms, direct otherwise ───────
+    if not arms:
+        results: list = []
+    elif len(arms) == 1:
+        # Single source — run the arm directly (ORDER BY LIMIT already in arm)
+        try:
+            results = [_row_to_result(r) for r in db.execute(arms[0], [*arm_params[0], limit])]
+        except sqlite3.OperationalError:
+            results = []
+    else:
+        # Both sources active — UNION ALL with SQL-level ranking (single round-trip)
+        results = _execute_combined(db, arms, arm_params, limit)
 
     took_ms = round((time.perf_counter() - t0) * 1000)
     payload = json.dumps(

--- a/browse/routes/search_api.py
+++ b/browse/routes/search_api.py
@@ -115,6 +115,8 @@ def _build_sessions_arm(safe_q: str, in_cols: list) -> tuple[str, list]:
         fts_query = safe_q
 
     # snippet col -1 = auto-pick best matching column
+    # ORDER BY uses the `score` alias; SQLite allows alias references in ORDER BY
+    # within the same SELECT, avoiding bm25() recomputation in the subquery.
     sql = (
         "SELECT 'session' AS type, s.id AS id, s.summary AS title,"
         " snippet(sessions_fts,-1,'<mark>','</mark>','...',15) AS snip,"
@@ -122,7 +124,7 @@ def _build_sessions_arm(safe_q: str, in_cols: list) -> tuple[str, list]:
         " FROM sessions_fts"
         " JOIN sessions AS s ON s.id = sessions_fts.session_id"
         " WHERE sessions_fts MATCH ?"
-        " ORDER BY bm25(sessions_fts) LIMIT ?"
+        " ORDER BY score LIMIT ?"
     )
     return sql, [fts_query]  # limit appended by caller
 
@@ -149,7 +151,9 @@ def _build_knowledge_arm(safe_q: str, in_cols: list, kind_list: list, ktable: st
         f" FROM ke_fts"
         f" JOIN {ktable} AS k ON k.id = ke_fts.rowid"
         f" WHERE ke_fts MATCH ?{kind_clause}"
-        f" ORDER BY bm25(ke_fts) LIMIT ?"
+        # ORDER BY uses the `score` alias; SQLite allows alias references in ORDER BY
+        # within the same SELECT, avoiding bm25() recomputation in the subquery.
+        f" ORDER BY score LIMIT ?"
     )
     return sql, [ke_query, *kind_args]  # limit appended by caller
 
@@ -170,16 +174,21 @@ def _execute_combined(db, arms: list[str], arm_params: list[list], limit: int) -
         flat_params.append(limit)
     flat_params.append(limit)  # outer LIMIT
 
-    # Wrap each arm in SELECT * FROM (arm) so that ORDER BY + LIMIT inside is honoured
+    # Wrap each arm in SELECT * FROM (arm) so that ORDER BY + LIMIT inside is honoured.
+    # Outer ORDER BY: score first, then sessions before knowledge for equal scores
+    # (preserving the old Python stable-merge semantics where sessions were appended
+    # before knowledge and stable sort kept their relative order), then id for a
+    # fully deterministic row ordering.
     wrapped = " UNION ALL ".join(f"SELECT * FROM ({a})" for a in arms)
-    sql = f"SELECT * FROM ({wrapped}) ORDER BY score LIMIT ?"
+    sql = f"SELECT * FROM ({wrapped}) ORDER BY score, CASE type WHEN 'session' THEN 0 ELSE 1 END, id LIMIT ?"
 
     try:
         return [_row_to_result(r) for r in db.execute(sql, flat_params)]
     except sqlite3.OperationalError:
         pass
 
-    # Fallback: run arms independently (pre-optimisation behaviour)
+    # Fallback: run arms independently (pre-optimisation behaviour).
+    # Sort uses the same tie-break key: score, then sessions before knowledge, then id.
     results: list = []
     for arm, ap in zip(arms, arm_params, strict=False):
         try:
@@ -187,7 +196,7 @@ def _execute_combined(db, arms: list[str], arm_params: list[list], limit: int) -
                 results.append(_row_to_result(r))
         except sqlite3.OperationalError:
             pass
-    results.sort(key=lambda x: x["score"])
+    results.sort(key=lambda x: (x["score"], 0 if x["type"] == "session" else 1, x["id"]))
     return results[:limit]
 
 

--- a/tests/test_browse_search_v2.py
+++ b/tests/test_browse_search_v2.py
@@ -339,8 +339,8 @@ def run_all_tests() -> int:
     # Insert three sessions with varying relevance to "alpha"
     for sid, summary, msg in [
         ("s-high", "alpha alpha alpha session", "alpha alpha alpha alpha alpha"),
-        ("s-mid",  "alpha session mid",          "alpha alpha mentioned once"),
-        ("s-low",  "unrelated session",           "only one alpha here"),
+        ("s-mid", "alpha session mid", "alpha alpha mentioned once"),
+        ("s-low", "unrelated session", "only one alpha here"),
     ]:
         db8.execute(
             "INSERT INTO sessions VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
@@ -353,7 +353,7 @@ def run_all_tests() -> int:
     # Insert two knowledge entries with varying relevance to "alpha"
     for kid, title, content, cat in [
         (1, "alpha alpha knowledge", "alpha alpha alpha alpha best knowledge", "pattern"),
-        (2, "alpha knowledge low",   "alpha once in content", "pattern"),
+        (2, "alpha knowledge low", "alpha once in content", "pattern"),
     ]:
         db8.execute("INSERT INTO knowledge VALUES (?,?,?,?,?,?)", (kid, title, content, cat, "w", "r"))
         db8.execute("INSERT INTO ke_fts VALUES (?,?)", (title, content))
@@ -378,9 +378,7 @@ def run_all_tests() -> int:
         ids8 = [r["id"] for r in results8]
         test(
             "S8: high-relevance session precedes low-relevance session",
-            "s-high" in ids8
-            and "s-low" in ids8
-            and ids8.index("s-high") < ids8.index("s-low"),
+            "s-high" in ids8 and "s-low" in ids8 and ids8.index("s-high") < ids8.index("s-low"),
         )
 
         # Both types must appear (UNION ALL combines sources)
@@ -392,19 +390,15 @@ def run_all_tests() -> int:
 
         # ── EXPLAIN QUERY PLAN evidence ──────────────────────────────────────
         # Capture the query plan for the combined UNION ALL path as documentation.
-        from browse.core.fts import _sanitize_fts_query, _probe_sessions_fts
-        from browse.routes.search_api import _build_sessions_arm, _build_knowledge_arm
+        from browse.core.fts import _probe_sessions_fts, _sanitize_fts_query
+        from browse.routes.search_api import _build_knowledge_arm, _build_sessions_arm
 
         safe_q8 = _sanitize_fts_query("alpha")
         in_cols8 = ["user", "assistant", "tools", "title"]
         s_sql, s_params = _build_sessions_arm(safe_q8, in_cols8)
         k_sql, k_params = _build_knowledge_arm(safe_q8, in_cols8, [], "knowledge")
 
-        wrapped = (
-            f"SELECT * FROM ({s_sql})"
-            f" UNION ALL"
-            f" SELECT * FROM ({k_sql})"
-        )
+        wrapped = f"SELECT * FROM ({s_sql}) UNION ALL SELECT * FROM ({k_sql})"
         combined = f"SELECT * FROM ({wrapped}) ORDER BY score LIMIT ?"
         flat_params = [*s_params, 5, *k_params, 5, 5]
         plan_rows = list(db8.execute(f"EXPLAIN QUERY PLAN {combined}", flat_params))

--- a/tests/test_browse_search_v2.py
+++ b/tests/test_browse_search_v2.py
@@ -304,6 +304,117 @@ def run_all_tests() -> int:
     finally:
         server.shutdown()
 
+    # ── S8: SQL-ranking parity — ordering matches expected top-K ─────────────
+    # Verifies that the UNION ALL / ORDER BY score LIMIT path produces the same
+    # ranking as the previous Python-sort approach on deterministic data.
+    print("\n-- S8: SQL-ranking parity (issue-458 regression)")
+    db8 = sqlite3.connect(":memory:", check_same_thread=False)
+    db8.row_factory = sqlite3.Row
+    db8.executescript("""
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY, path TEXT, summary TEXT, source TEXT,
+            file_mtime REAL, indexed_at_r REAL, fts_indexed_at REAL,
+            event_count_estimate INTEGER, file_size_bytes INTEGER,
+            total_checkpoints INTEGER, total_research INTEGER,
+            total_files INTEGER, has_plan INTEGER, indexed_at TEXT
+        );
+        CREATE TABLE knowledge (
+            id INTEGER PRIMARY KEY, title TEXT, content TEXT,
+            category TEXT, wing TEXT, room TEXT
+        );
+        CREATE TABLE schema_version (version INTEGER PRIMARY KEY, name TEXT, applied_at TEXT);
+        INSERT INTO schema_version VALUES (8, 'add_sessions_fts', '2026-01-01');
+    """)
+    db8.execute(
+        """CREATE VIRTUAL TABLE sessions_fts USING fts5(
+            session_id UNINDEXED, title, user_messages,
+            assistant_messages, tool_names, tokenize='unicode61'
+        )"""
+    )
+    db8.execute(
+        """CREATE VIRTUAL TABLE ke_fts USING fts5(
+            title, content, tokenize='unicode61'
+        )"""
+    )
+    # Insert three sessions with varying relevance to "alpha"
+    for sid, summary, msg in [
+        ("s-high", "alpha alpha alpha session", "alpha alpha alpha alpha alpha"),
+        ("s-mid",  "alpha session mid",          "alpha alpha mentioned once"),
+        ("s-low",  "unrelated session",           "only one alpha here"),
+    ]:
+        db8.execute(
+            "INSERT INTO sessions VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (sid, "/p", summary, "copilot", 1.0, 2.0, 3.0, 1, 100, 0, 0, 0, 0, "2026-01-01"),
+        )
+        db8.execute(
+            "INSERT INTO sessions_fts VALUES (?,?,?,?,?)",
+            (sid, summary, msg, "", ""),
+        )
+    # Insert two knowledge entries with varying relevance to "alpha"
+    for kid, title, content, cat in [
+        (1, "alpha alpha knowledge", "alpha alpha alpha alpha best knowledge", "pattern"),
+        (2, "alpha knowledge low",   "alpha once in content", "pattern"),
+    ]:
+        db8.execute("INSERT INTO knowledge VALUES (?,?,?,?,?,?)", (kid, title, content, cat, "w", "r"))
+        db8.execute("INSERT INTO ke_fts VALUES (?,?)", (title, content))
+    db8.commit()
+
+    server8, host8, port8 = _start_server(db8, token="tok8")
+    try:
+        status8, _, body8 = _get(host8, port8, "/api/search?q=alpha&limit=5&token=tok8")
+        test("S8: status 200", status8 == 200)
+        data8 = json.loads(body8)
+        results8 = data8.get("results", [])
+        test("S8: returns results", len(results8) >= 2)
+
+        # Scores must be strictly non-decreasing (bm25 is negative; best = most negative first)
+        scores8 = [r["score"] for r in results8]
+        test(
+            "S8: results ordered by score ascending (best first)",
+            all(scores8[i] <= scores8[i + 1] for i in range(len(scores8) - 1)),
+        )
+
+        # The highest-relevance session ("s-high") must outrank the lowest ("s-low")
+        ids8 = [r["id"] for r in results8]
+        test(
+            "S8: high-relevance session precedes low-relevance session",
+            "s-high" in ids8
+            and "s-low" in ids8
+            and ids8.index("s-high") < ids8.index("s-low"),
+        )
+
+        # Both types must appear (UNION ALL combines sources)
+        types8 = {r["type"] for r in results8}
+        test("S8: both session and knowledge results present", types8 == {"session", "knowledge"})
+
+        # Verify total <= limit
+        test("S8: total <= requested limit", data8.get("total", 999) <= 5)
+
+        # ── EXPLAIN QUERY PLAN evidence ──────────────────────────────────────
+        # Capture the query plan for the combined UNION ALL path as documentation.
+        from browse.core.fts import _sanitize_fts_query, _probe_sessions_fts
+        from browse.routes.search_api import _build_sessions_arm, _build_knowledge_arm
+
+        safe_q8 = _sanitize_fts_query("alpha")
+        in_cols8 = ["user", "assistant", "tools", "title"]
+        s_sql, s_params = _build_sessions_arm(safe_q8, in_cols8)
+        k_sql, k_params = _build_knowledge_arm(safe_q8, in_cols8, [], "knowledge")
+
+        wrapped = (
+            f"SELECT * FROM ({s_sql})"
+            f" UNION ALL"
+            f" SELECT * FROM ({k_sql})"
+        )
+        combined = f"SELECT * FROM ({wrapped}) ORDER BY score LIMIT ?"
+        flat_params = [*s_params, 5, *k_params, 5, 5]
+        plan_rows = list(db8.execute(f"EXPLAIN QUERY PLAN {combined}", flat_params))
+        plan_text = "\n".join(f"  {r[0]} {r[1]} {r[2]} {r[3]}" for r in plan_rows)
+        print(f"  [EXPLAIN] UNION ALL query plan:\n{plan_text}")
+        test("S8: EXPLAIN QUERY PLAN produced output", len(plan_rows) > 0)
+
+    finally:
+        server8.shutdown()
+
     # ── Summary ───────────────────────────────────────────────────────────────
     print(f"\n{'=' * 40}")
     total = _PASS + _FAIL


### PR DESCRIPTION
## Summary
- Push combined session/knowledge search ranking into SQL with a UNION ALL top-K merge.
- Preserve parameterized FTS queries, source filters, response shape, and fallback behavior for missing FTS surfaces.
- Add deterministic SQL-ranking parity coverage with EXPLAIN QUERY PLAN evidence.

Closes #458

## Local verification
- `python -m py_compile browse\routes\search_api.py tests\test_browse_search_v2.py` — passed.
- `python tests\test_browse_search_v2.py` — new S8 SQL-ranking checks passed; existing S1 `/search` HTML checks still fail on clean `origin/main` baseline too.
- `python test_fixes.py` — 226 passed, 0 failed.
- `python test_security.py` — 12 passed, 0 failed.
- Opus review: CLEAN.