### PR TITLE
feat: add Rust browse DB layer

### DIFF
--- a/sk-rust/src/browse/db.rs
+++ b/sk-rust/src/browse/db.rs
@@ -17,9 +17,7 @@ use std::thread;
 use std::time::Duration;
 
 // Re-export FTS helpers so callers import from one place.
-pub use crate::db::fts::{
-    search_by_wing_room, search_fts, search_fts_filtered, KnowledgeEntry,
-};
+pub use crate::db::fts::{search_by_wing_room, search_fts, search_fts_filtered, KnowledgeEntry};
 
 // ── Config ─────────────────────────────────────────────────────────────────────
 

--- a/sk-rust/src/browse/db.rs
+++ b/sk-rust/src/browse/db.rs
@@ -17,6 +17,7 @@ use std::thread;
 use std::time::Duration;
 
 // Re-export FTS helpers so callers import from one place.
+use crate::db::fts::sanitize_fts_query;
 pub use crate::db::fts::{search_by_wing_room, search_fts, search_fts_filtered, KnowledgeEntry};
 
 // ── Config ─────────────────────────────────────────────────────────────────────
@@ -28,7 +29,8 @@ pub struct BrowseDbConfig {
     pub path: PathBuf,
     /// Read pool max connections (default 8).
     pub read_pool_size: u32,
-    /// Write pool max connections — clamped to ≥ 1 (default 1).
+    /// Write pool max connections — always clamped to exactly 1 to prevent
+    /// concurrent WAL writers; this field is reserved for future use.
     pub write_pool_size: u32,
     /// r2d2 connection-acquisition timeout (default 5 s).
     pub connection_timeout: Duration,
@@ -120,14 +122,14 @@ impl BrowseDb {
                 ))
             });
         let write_pool = Pool::builder()
-            .max_size(config.write_pool_size.max(1))
+            .max_size(1) // write pool is always max 1 to prevent concurrent WAL writers
             .connection_timeout(config.connection_timeout)
             .build(write_mgr)
             .context("browse write pool")?;
 
         // Optional background WAL checkpoint thread.
         let checkpoint = if with_checkpoint {
-            config.checkpoint_interval.map(|interval| {
+            if let Some(interval) = config.checkpoint_interval {
                 let wpool = write_pool.clone();
                 let (stop_tx, stop_rx) = mpsc::sync_channel::<()>(0);
                 let jh = thread::Builder::new()
@@ -141,12 +143,14 @@ impl BrowseDb {
                             let _ = conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE);");
                         }
                     })
-                    .expect("browse checkpoint thread spawn");
-                CheckpointHandle {
+                    .context("browse checkpoint thread spawn")?;
+                Some(CheckpointHandle {
                     stop_tx,
                     join: Some(jh),
-                }
-            })
+                })
+            } else {
+                None
+            }
         } else {
             None
         };
@@ -365,11 +369,11 @@ impl BrowseDb {
         Ok(v)
     }
 
-    /// `true` when the `ke_fts` FTS5 virtual table is present in the schema.
+    /// `true` when the `sessions_fts` FTS5 virtual table is present in the schema.
     pub fn has_sessions_fts(&self) -> anyhow::Result<bool> {
         let conn = self.read_pool.get()?;
         let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ke_fts'",
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='sessions_fts'",
             [],
             |r| r.get(0),
         )?;
@@ -378,7 +382,7 @@ impl BrowseDb {
 
     // ── FTS wrapper methods ────────────────────────────────────────────────────
 
-    /// FTS5 search from the read pool.
+    /// FTS5 search from the read pool. Sanitizes `fts_query` before use.
     pub fn fts_search(
         &self,
         fts_query: &str,
@@ -386,10 +390,11 @@ impl BrowseDb {
         limit: usize,
     ) -> anyhow::Result<Vec<KnowledgeEntry>> {
         let conn = self.read_pool.get()?;
-        Ok(search_fts(&conn, fts_query, category, limit))
+        let sanitized = sanitize_fts_query(fts_query);
+        Ok(search_fts(&conn, &sanitized, category, limit))
     }
 
-    /// FTS5 search with wing/room filters from the read pool.
+    /// FTS5 search with wing/room filters from the read pool. Sanitizes `fts_query` before use.
     pub fn fts_search_filtered(
         &self,
         fts_query: &str,
@@ -399,8 +404,9 @@ impl BrowseDb {
         limit: usize,
     ) -> anyhow::Result<Vec<KnowledgeEntry>> {
         let conn = self.read_pool.get()?;
+        let sanitized = sanitize_fts_query(fts_query);
         Ok(search_fts_filtered(
-            &conn, fts_query, category, wing, room, limit,
+            &conn, &sanitized, category, wing, room, limit,
         ))
     }
 
@@ -454,6 +460,8 @@ mod tests {
              );
              CREATE VIRTUAL TABLE IF NOT EXISTS ke_fts
                  USING fts5(content, content=knowledge_entries, content_rowid=id);
+             CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts
+                 USING fts5(session_id UNINDEXED, title, user_messages, assistant_messages, tool_names);
              INSERT INTO migration_log VALUES (1);
              INSERT INTO sessions VALUES ('sess-1');
              INSERT INTO sessions VALUES ('sess-2');
@@ -563,8 +571,31 @@ mod tests {
 
     #[test]
     fn has_sessions_fts_true_with_table() {
+        // bootstrap creates sessions_fts — has_sessions_fts must return true.
         let (path, db) = test_db();
         assert!(db.has_sessions_fts().unwrap());
+        cleanup(&path);
+    }
+
+    #[test]
+    fn has_sessions_fts_false_without_table() {
+        // Open a DB with no sessions_fts table — has_sessions_fts must return false.
+        let path = temp_db_path();
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);
+             INSERT INTO migration_log VALUES (1);",
+        )
+        .unwrap();
+        drop(conn);
+        let cfg = BrowseDbConfig {
+            path: path.clone(),
+            checkpoint_interval: None,
+            ..Default::default()
+        };
+        let db = BrowseDb::new_without_checkpoint(cfg).unwrap();
+        assert!(!db.has_sessions_fts().unwrap());
         cleanup(&path);
     }
 
@@ -650,6 +681,31 @@ mod tests {
         let (path, db) = test_db();
         let (busy, _log, _ckpt) = db.checkpoint_truncate().unwrap();
         assert!(busy >= 0);
+        cleanup(&path);
+    }
+
+    // ── FTS sanitization ──────────────────────────────────────────────────────
+
+    /// fts_search must sanitize raw operators so they don't reach the FTS engine.
+    #[test]
+    fn fts_search_sanitizes_operators() {
+        let (path, db) = test_db();
+        // "content AND OR NOT" has FTS operators that would cause a parse error
+        // if forwarded raw; sanitization turns them into safe tokens.
+        let results = db.fts_search("content AND OR NOT", "", 10).unwrap();
+        // We just need the call to succeed without error.
+        let _ = results;
+        cleanup(&path);
+    }
+
+    /// fts_search_filtered must also sanitize its query.
+    #[test]
+    fn fts_search_filtered_sanitizes_operators() {
+        let (path, db) = test_db();
+        let results = db
+            .fts_search_filtered("content AND OR NOT", "", None, None, 10)
+            .unwrap();
+        let _ = results;
         cleanup(&path);
     }
 }

--- a/sk-rust/src/browse/db.rs
+++ b/sk-rust/src/browse/db.rs
@@ -1,4 +1,657 @@
-//! Browse connection pool — scaffold for issue #449 (`browse-server` feature).
+//! Browse DB connection pool — issue #449 (`browse-server` feature).
 //!
-//! r2d2 / r2d2_sqlite pool initialisation and helper types will live here once
-//! the `browse-server` feature is stabilised.  Nothing is wired to the CLI yet.
+//! Two r2d2_sqlite pools: a read pool (read-only, up to 8 connections) and a
+//! write pool (read-write, max 1 connection).  A background WAL checkpoint
+//! thread is spawned by default; `new_without_checkpoint` / setting
+//! `checkpoint_interval = None` in the config disables it for tests.
+//!
+//! This module does NOT depend on `browse::server`.
+
+use anyhow::Context as _;
+use r2d2::Pool;
+use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::OpenFlags;
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+// Re-export FTS helpers so callers import from one place.
+pub use crate::db::fts::{
+    search_by_wing_room, search_fts, search_fts_filtered, KnowledgeEntry,
+};
+
+// ── Config ─────────────────────────────────────────────────────────────────────
+
+/// Configuration for `BrowseDb` pools and WAL checkpoint.
+#[derive(Debug, Clone)]
+pub struct BrowseDbConfig {
+    /// Path to `knowledge.db`; defaults to `crate::db::connection::knowledge_db_path()`.
+    pub path: PathBuf,
+    /// Read pool max connections (default 8).
+    pub read_pool_size: u32,
+    /// Write pool max connections — clamped to ≥ 1 (default 1).
+    pub write_pool_size: u32,
+    /// r2d2 connection-acquisition timeout (default 5 s).
+    pub connection_timeout: Duration,
+    /// SQLite `PRAGMA busy_timeout` applied to write connections (default 5 000 ms).
+    pub busy_timeout: Duration,
+    /// Interval between automatic WAL checkpoints. `None` disables the thread.
+    pub checkpoint_interval: Option<Duration>,
+}
+
+impl Default for BrowseDbConfig {
+    fn default() -> Self {
+        Self {
+            path: crate::db::connection::knowledge_db_path(),
+            read_pool_size: 8,
+            write_pool_size: 1,
+            connection_timeout: Duration::from_secs(5),
+            busy_timeout: Duration::from_secs(5),
+            checkpoint_interval: Some(Duration::from_secs(60)),
+        }
+    }
+}
+
+// ── Checkpoint handle ──────────────────────────────────────────────────────────
+
+struct CheckpointHandle {
+    stop_tx: mpsc::SyncSender<()>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for CheckpointHandle {
+    fn drop(&mut self) {
+        let _ = self.stop_tx.send(());
+        if let Some(jh) = self.join.take() {
+            let _ = jh.join();
+        }
+    }
+}
+
+// ── BrowseDb ───────────────────────────────────────────────────────────────────
+
+/// Two-pool connection manager for `knowledge.db`.
+///
+/// Holds a read pool (read-only, up to `read_pool_size` connections) and a
+/// write pool (read-write, max 1 connection).
+pub struct BrowseDb {
+    read_pool: Pool<SqliteConnectionManager>,
+    write_pool: Pool<SqliteConnectionManager>,
+    _checkpoint: Option<CheckpointHandle>,
+}
+
+impl BrowseDb {
+    /// Open with the given config and background WAL checkpoint enabled.
+    pub fn new(config: BrowseDbConfig) -> anyhow::Result<Self> {
+        Self::open_impl(config, true)
+    }
+
+    /// Open without the background checkpoint thread (useful in tests).
+    pub fn new_without_checkpoint(config: BrowseDbConfig) -> anyhow::Result<Self> {
+        Self::open_impl(config, false)
+    }
+
+    fn open_impl(config: BrowseDbConfig, with_checkpoint: bool) -> anyhow::Result<Self> {
+        let busy_ms = config.busy_timeout.as_millis() as u64;
+
+        // Read pool — READ_ONLY | NO_MUTEX; query_only + mmap pragmas.
+        // Do NOT set WAL from a read-only connection.
+        let read_mgr = SqliteConnectionManager::file(&config.path)
+            .with_flags(OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX)
+            .with_init(|conn| {
+                conn.execute_batch(
+                    "PRAGMA query_only=ON;\
+                     PRAGMA mmap_size=268435456;",
+                )
+            });
+        let read_pool = Pool::builder()
+            .max_size(config.read_pool_size)
+            .connection_timeout(config.connection_timeout)
+            .build(read_mgr)
+            .context("browse read pool")?;
+
+        // Write pool — READ_WRITE | NO_MUTEX; WAL + NORMAL sync + busy_timeout.
+        let write_mgr = SqliteConnectionManager::file(&config.path)
+            .with_flags(OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX)
+            .with_init(move |conn| {
+                conn.execute_batch(&format!(
+                    "PRAGMA journal_mode=WAL;\
+                     PRAGMA synchronous=NORMAL;\
+                     PRAGMA busy_timeout={busy_ms};"
+                ))
+            });
+        let write_pool = Pool::builder()
+            .max_size(config.write_pool_size.max(1))
+            .connection_timeout(config.connection_timeout)
+            .build(write_mgr)
+            .context("browse write pool")?;
+
+        // Optional background WAL checkpoint thread.
+        let checkpoint = if with_checkpoint {
+            config.checkpoint_interval.map(|interval| {
+                let wpool = write_pool.clone();
+                let (stop_tx, stop_rx) = mpsc::sync_channel::<()>(0);
+                let jh = thread::Builder::new()
+                    .name("browse-wal-checkpoint".into())
+                    .spawn(move || loop {
+                        match stop_rx.recv_timeout(interval) {
+                            Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                            Err(mpsc::RecvTimeoutError::Timeout) => {}
+                        }
+                        if let Ok(conn) = wpool.get() {
+                            let _ = conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE);");
+                        }
+                    })
+                    .expect("browse checkpoint thread spawn");
+                CheckpointHandle {
+                    stop_tx,
+                    join: Some(jh),
+                }
+            })
+        } else {
+            None
+        };
+
+        Ok(Self {
+            read_pool,
+            write_pool,
+            _checkpoint: checkpoint,
+        })
+    }
+
+    // ── WAL checkpoint helpers ─────────────────────────────────────────────────
+
+    /// Run a PASSIVE WAL checkpoint. Returns `(busy, log, checkpointed)`.
+    pub fn checkpoint_passive(&self) -> anyhow::Result<(i64, i64, i64)> {
+        let conn = self.write_pool.get()?;
+        let row = conn.query_row("PRAGMA wal_checkpoint(PASSIVE)", [], |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, i64>(1)?,
+                r.get::<_, i64>(2)?,
+            ))
+        })?;
+        Ok(row)
+    }
+
+    /// Run a TRUNCATE WAL checkpoint. Returns `(busy, log, checkpointed)`.
+    pub fn checkpoint_truncate(&self) -> anyhow::Result<(i64, i64, i64)> {
+        let conn = self.write_pool.get()?;
+        let row = conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, i64>(1)?,
+                r.get::<_, i64>(2)?,
+            ))
+        })?;
+        Ok(row)
+    }
+
+    // ── Read helpers ───────────────────────────────────────────────────────────
+
+    /// Total count of (non-soft-deleted) knowledge entries.
+    pub fn count_entries(&self) -> anyhow::Result<i64> {
+        let conn = self.read_pool.get()?;
+        let has_sd = crate::db::fts::has_soft_delete(&conn);
+        let sql = if has_sd {
+            "SELECT COUNT(*) FROM knowledge_entries WHERE deleted_at IS NULL"
+        } else {
+            "SELECT COUNT(*) FROM knowledge_entries"
+        };
+        Ok(conn.query_row(sql, [], |r| r.get::<_, i64>(0))?)
+    }
+
+    /// Maximum `id` in `knowledge_entries` (suitable for SSE `Last-Event-ID`).
+    pub fn latest_entry_id(&self) -> anyhow::Result<Option<i64>> {
+        let conn = self.read_pool.get()?;
+        Ok(
+            conn.query_row("SELECT MAX(id) FROM knowledge_entries", [], |r| {
+                r.get::<_, Option<i64>>(0)
+            })?,
+        )
+    }
+
+    /// Up to `limit` entries with `id > after_id`, ordered by id ASC.
+    pub fn entries_after(
+        &self,
+        after_id: i64,
+        limit: usize,
+    ) -> anyhow::Result<Vec<KnowledgeEntry>> {
+        let conn = self.read_pool.get()?;
+        let has_sd = crate::db::fts::has_soft_delete(&conn);
+        let sd = if has_sd {
+            " AND deleted_at IS NULL"
+        } else {
+            ""
+        };
+        let sql = format!(
+            "SELECT id, title, content, tags, confidence,\
+                    COALESCE(wing,'') AS wing, COALESCE(room,'') AS room \
+             FROM knowledge_entries WHERE id > ?{sd} \
+             ORDER BY id ASC LIMIT ?"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(rusqlite::params![after_id, limit as i64], |r| {
+                Ok(KnowledgeEntry {
+                    id: r.get(0)?,
+                    title: r.get(1)?,
+                    content: r.get(2)?,
+                    tags: r.get(3)?,
+                    confidence: r.get(4)?,
+                    wing: r.get(5)?,
+                    room: r.get(6)?,
+                })
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
+
+    /// Entry counts grouped by `category`.
+    pub fn category_counts(&self) -> anyhow::Result<Vec<(String, i64)>> {
+        let conn = self.read_pool.get()?;
+        let has_sd = crate::db::fts::has_soft_delete(&conn);
+        let sd = if has_sd {
+            " WHERE deleted_at IS NULL"
+        } else {
+            ""
+        };
+        let sql = format!(
+            "SELECT category, COUNT(*) FROM knowledge_entries{sd} \
+             GROUP BY category ORDER BY category ASC"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
+
+    /// Entry counts grouped by `wing` (NULL wing excluded).
+    pub fn wing_counts(&self) -> anyhow::Result<Vec<(String, i64)>> {
+        let conn = self.read_pool.get()?;
+        let has_sd = crate::db::fts::has_soft_delete(&conn);
+        let sd = if has_sd {
+            " AND deleted_at IS NULL"
+        } else {
+            ""
+        };
+        let sql = format!(
+            "SELECT COALESCE(wing,'') AS wing, COUNT(*) \
+             FROM knowledge_entries \
+             WHERE wing IS NOT NULL{sd} \
+             GROUP BY wing ORDER BY wing ASC"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
+
+    /// Distinct session IDs from the `sessions` table (empty when absent).
+    pub fn distinct_sessions(&self) -> anyhow::Result<Vec<String>> {
+        let conn = self.read_pool.get()?;
+        let rows = match conn.prepare("SELECT id FROM sessions ORDER BY id ASC") {
+            Ok(mut stmt) => {
+                let r: Vec<String> = stmt
+                    .query_map([], |r| r.get::<_, String>(0))?
+                    .filter_map(|r| r.ok())
+                    .collect();
+                r
+            }
+            Err(_) => vec![],
+        };
+        Ok(rows)
+    }
+
+    /// Distinct non-NULL `wing` values, sorted.
+    pub fn list_wings(&self) -> anyhow::Result<Vec<String>> {
+        let conn = self.read_pool.get()?;
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT wing FROM knowledge_entries \
+             WHERE wing IS NOT NULL ORDER BY wing ASC",
+        )?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
+
+    /// Distinct non-NULL `category` values, sorted.
+    pub fn list_categories(&self) -> anyhow::Result<Vec<String>> {
+        let conn = self.read_pool.get()?;
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT category FROM knowledge_entries \
+             WHERE category IS NOT NULL ORDER BY category ASC",
+        )?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
+
+    /// `content` of the `limit` most-recently-added entries (by `id` DESC).
+    pub fn recent_entries_content(&self, limit: usize) -> anyhow::Result<Vec<String>> {
+        let conn = self.read_pool.get()?;
+        let has_sd = crate::db::fts::has_soft_delete(&conn);
+        let sd = if has_sd {
+            " WHERE deleted_at IS NULL"
+        } else {
+            ""
+        };
+        let sql = format!("SELECT content FROM knowledge_entries{sd} ORDER BY id DESC LIMIT ?");
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(rusqlite::params![limit as i64], |r| r.get::<_, String>(0))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
+
+    /// Highest `version` from `migration_log`, or `0` when the table is absent.
+    pub fn schema_version(&self) -> anyhow::Result<i64> {
+        let conn = self.read_pool.get()?;
+        let v = conn
+            .query_row("SELECT MAX(version) FROM migration_log", [], |r| {
+                r.get::<_, Option<i64>>(0)
+            })
+            .unwrap_or(None)
+            .unwrap_or(0);
+        Ok(v)
+    }
+
+    /// `true` when the `ke_fts` FTS5 virtual table is present in the schema.
+    pub fn has_sessions_fts(&self) -> anyhow::Result<bool> {
+        let conn = self.read_pool.get()?;
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ke_fts'",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    // ── FTS wrapper methods ────────────────────────────────────────────────────
+
+    /// FTS5 search from the read pool.
+    pub fn fts_search(
+        &self,
+        fts_query: &str,
+        category: &str,
+        limit: usize,
+    ) -> anyhow::Result<Vec<KnowledgeEntry>> {
+        let conn = self.read_pool.get()?;
+        Ok(search_fts(&conn, fts_query, category, limit))
+    }
+
+    /// FTS5 search with wing/room filters from the read pool.
+    pub fn fts_search_filtered(
+        &self,
+        fts_query: &str,
+        category: &str,
+        wing: Option<&str>,
+        room: Option<&str>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<KnowledgeEntry>> {
+        let conn = self.read_pool.get()?;
+        Ok(search_fts_filtered(
+            &conn, fts_query, category, wing, room, limit,
+        ))
+    }
+
+    /// Wing/room search without FTS from the read pool.
+    pub fn wing_room_search(
+        &self,
+        wing: Option<&str>,
+        room: Option<&str>,
+        category: &str,
+        limit: usize,
+    ) -> anyhow::Result<Vec<KnowledgeEntry>> {
+        let conn = self.read_pool.get()?;
+        Ok(search_by_wing_room(&conn, wing, room, category, limit))
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Barrier};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    /// Unique temp-file path for a test DB (no external crates needed).
+    fn temp_db_path() -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        std::env::temp_dir().join(format!("browse_db_test_{}_{}.db", std::process::id(), n))
+    }
+
+    /// Bootstrap a minimal knowledge.db fixture at `path`.
+    fn bootstrap(path: &PathBuf) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);
+             CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY);
+             CREATE TABLE IF NOT EXISTS knowledge_entries (
+                 id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                 category   TEXT NOT NULL,
+                 title      TEXT NOT NULL,
+                 content    TEXT NOT NULL,
+                 tags       TEXT NOT NULL DEFAULT '',
+                 wing       TEXT,
+                 room       TEXT,
+                 confidence REAL NOT NULL DEFAULT 0.5,
+                 deleted_at INTEGER
+             );
+             CREATE VIRTUAL TABLE IF NOT EXISTS ke_fts
+                 USING fts5(content, content=knowledge_entries, content_rowid=id);
+             INSERT INTO migration_log VALUES (1);
+             INSERT INTO sessions VALUES ('sess-1');
+             INSERT INTO sessions VALUES ('sess-2');
+             INSERT INTO knowledge_entries
+                 (category, title, content, tags, wing, room, confidence)
+             VALUES
+                 ('mistake', 'Entry A', 'content a', 'tag1', 'backend',  'auth', 0.9),
+                 ('pattern', 'Entry B', 'content b', '',     'frontend', 'ui',   0.7),
+                 ('mistake', 'Entry C', 'content c', 'tag2', 'backend',  'auth', 0.8);",
+        )
+        .unwrap();
+    }
+
+    fn test_db() -> (PathBuf, BrowseDb) {
+        let path = temp_db_path();
+        bootstrap(&path);
+        let cfg = BrowseDbConfig {
+            path: path.clone(),
+            checkpoint_interval: None,
+            ..Default::default()
+        };
+        let db = BrowseDb::new_without_checkpoint(cfg).unwrap();
+        (path, db)
+    }
+
+    fn cleanup(path: &std::path::Path) {
+        for suffix in &["", "-wal", "-shm"] {
+            let _ = std::fs::remove_file(format!("{}{suffix}", path.display()));
+        }
+    }
+
+    // ── Helper method tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn count_entries_returns_three() {
+        let (path, db) = test_db();
+        assert_eq!(db.count_entries().unwrap(), 3);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn latest_entry_id_is_max() {
+        let (path, db) = test_db();
+        assert_eq!(db.latest_entry_id().unwrap(), Some(3));
+        cleanup(&path);
+    }
+
+    #[test]
+    fn entries_after_returns_subset() {
+        let (path, db) = test_db();
+        let entries = db.entries_after(1, 10).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].id, 2);
+        assert_eq!(entries[1].id, 3);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn category_counts_groups_correctly() {
+        let (path, db) = test_db();
+        let map: std::collections::HashMap<_, _> =
+            db.category_counts().unwrap().into_iter().collect();
+        assert_eq!(map["mistake"], 2);
+        assert_eq!(map["pattern"], 1);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn wing_counts_groups_correctly() {
+        let (path, db) = test_db();
+        let map: std::collections::HashMap<_, _> = db.wing_counts().unwrap().into_iter().collect();
+        assert_eq!(map["backend"], 2);
+        assert_eq!(map["frontend"], 1);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn list_wings_sorted() {
+        let (path, db) = test_db();
+        assert_eq!(db.list_wings().unwrap(), vec!["backend", "frontend"]);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn list_categories_sorted() {
+        let (path, db) = test_db();
+        assert_eq!(db.list_categories().unwrap(), vec!["mistake", "pattern"]);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn recent_entries_content_by_id_desc() {
+        let (path, db) = test_db();
+        let contents = db.recent_entries_content(2).unwrap();
+        assert_eq!(contents.len(), 2);
+        assert_eq!(contents[0], "content c");
+        assert_eq!(contents[1], "content b");
+        cleanup(&path);
+    }
+
+    #[test]
+    fn schema_version_is_one() {
+        let (path, db) = test_db();
+        assert_eq!(db.schema_version().unwrap(), 1);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn has_sessions_fts_true_with_table() {
+        let (path, db) = test_db();
+        assert!(db.has_sessions_fts().unwrap());
+        cleanup(&path);
+    }
+
+    #[test]
+    fn distinct_sessions_returns_two() {
+        let (path, db) = test_db();
+        let sessions = db.distinct_sessions().unwrap();
+        assert_eq!(sessions.len(), 2);
+        cleanup(&path);
+    }
+
+    // ── Parity tests against raw SQL ───────────────────────────────────────────
+
+    #[test]
+    fn parity_count_with_raw_sql() {
+        let (path, db) = test_db();
+        let pool_count = db.count_entries().unwrap();
+        let raw = Connection::open(&path).unwrap();
+        let raw_count: i64 = raw
+            .query_row("SELECT COUNT(*) FROM knowledge_entries", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(pool_count, raw_count);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn parity_entries_after_ids_match_raw() {
+        let (path, db) = test_db();
+        let pool_entries = db.entries_after(0, 100).unwrap();
+        let raw = Connection::open(&path).unwrap();
+        let mut stmt = raw
+            .prepare("SELECT id FROM knowledge_entries ORDER BY id ASC")
+            .unwrap();
+        let raw_ids: Vec<i64> = stmt
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        let pool_ids: Vec<i64> = pool_entries.iter().map(|e| e.id).collect();
+        assert_eq!(pool_ids, raw_ids);
+        cleanup(&path);
+    }
+
+    // ── Concurrent reads ───────────────────────────────────────────────────────
+
+    /// Prove 8 simultaneous read connections can all execute concurrently.
+    #[test]
+    fn concurrent_reads_eight_connections() {
+        let (path, db) = test_db();
+        let db = Arc::new(db);
+        let barrier = Arc::new(Barrier::new(8));
+        let path_clone = path.clone();
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let db = db.clone();
+                let b = barrier.clone();
+                thread::spawn(move || {
+                    b.wait(); // all 8 start simultaneously
+                    db.count_entries().unwrap()
+                })
+            })
+            .collect();
+
+        for h in handles {
+            assert_eq!(h.join().unwrap(), 3);
+        }
+        cleanup(&path_clone);
+    }
+
+    // ── Checkpoint methods ─────────────────────────────────────────────────────
+
+    #[test]
+    fn checkpoint_passive_returns_ok() {
+        let (path, db) = test_db();
+        let (busy, _log, _ckpt) = db.checkpoint_passive().unwrap();
+        assert!(busy >= 0);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn checkpoint_truncate_returns_ok() {
+        let (path, db) = test_db();
+        let (busy, _log, _ckpt) = db.checkpoint_truncate().unwrap();
+        assert!(busy >= 0);
+        cleanup(&path);
+    }
+}

--- a/sk-rust/src/browse/db_debug_log.rs
+++ b/sk-rust/src/browse/db_debug_log.rs
@@ -1,0 +1,648 @@
+//! Local-only bounded debug-log storage — port of `browse/core/debug_log_storage.py`.
+//!
+//! Feature-disabled by default; enable with `BROWSE_DEBUG_LOG_ENABLED=1|true|yes`.
+//!
+//! Storage location: `~/.copilot/operator-console/debug-log/debug-log.db`.
+//! Override directory with `BROWSE_DEBUG_LOG_DIR`.
+//!
+//! This module is intentionally isolated from `knowledge.db` and session-state.
+//! It does NOT depend on `browse::server`.
+
+use rusqlite::{Connection, OpenFlags};
+use serde_json::Value;
+use std::path::PathBuf;
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+pub const DEFAULT_MAX_AGE_S: u64 = 86_400; // 24 hours
+pub const DEFAULT_MAX_BYTES: u64 = 50 * 1024 * 1024; // 50 MiB
+pub const DEFAULT_RETENTION_INTERVAL_S: u64 = 300; // 5 minutes
+
+const DB_FILENAME: &str = "debug-log.db";
+const PRUNE_CHUNK: i64 = 100;
+
+// ── Schema ─────────────────────────────────────────────────────────────────────
+
+const SCHEMA_SQL: &str = "\
+CREATE TABLE IF NOT EXISTS debug_log_events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_ns      INTEGER NOT NULL,
+    session_id TEXT NOT NULL,
+    idx        INTEGER NOT NULL,
+    kind       TEXT NOT NULL,
+    payload    TEXT NOT NULL,
+    byte_len   INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_debug_session ON debug_log_events (session_id, idx);
+CREATE INDEX IF NOT EXISTS idx_debug_ts      ON debug_log_events (ts_ns);
+CREATE TABLE IF NOT EXISTS debug_log_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+INSERT OR IGNORE INTO debug_log_meta (key, value) VALUES ('schema_version', '1');
+";
+
+// ── Env helpers ────────────────────────────────────────────────────────────────
+
+/// Read `name` (or any alias) as `u64`; return `default` if unset or unparseable.
+fn env_u64(name: &str, aliases: &[&str], default: u64) -> u64 {
+    for key in std::iter::once(name).chain(aliases.iter().copied()) {
+        if let Ok(raw) = std::env::var(key) {
+            let trimmed = raw.trim().to_string();
+            if !trimmed.is_empty() {
+                if let Ok(n) = trimmed.parse::<u64>() {
+                    return n;
+                }
+            }
+        }
+    }
+    default
+}
+
+/// Return `true` when `BROWSE_DEBUG_LOG_ENABLED` is `1`, `true`, or `yes`.
+pub fn is_enabled() -> bool {
+    std::env::var("BROWSE_DEBUG_LOG_ENABLED")
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+// ── Path helper ────────────────────────────────────────────────────────────────
+
+/// Return the default debug-log DB path.
+///
+/// Honors `BROWSE_DEBUG_LOG_DIR`; otherwise
+/// `~/.copilot/operator-console/debug-log/debug-log.db`.
+pub fn default_debug_log_path() -> PathBuf {
+    if let Ok(dir) = std::env::var("BROWSE_DEBUG_LOG_DIR") {
+        let dir = dir.trim().to_string();
+        if !dir.is_empty() {
+            return PathBuf::from(dir).join(DB_FILENAME);
+        }
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".copilot")
+        .join("operator-console")
+        .join("debug-log")
+        .join(DB_FILENAME)
+}
+
+// ── Config ─────────────────────────────────────────────────────────────────────
+
+/// Configuration for `DebugLogStorage`.
+#[derive(Debug, Clone)]
+pub struct DebugLogConfig {
+    /// Path to `debug-log.db`; defaults to `default_debug_log_path()`.
+    pub path: PathBuf,
+    /// Maximum age of retained events in seconds (default 86 400 s / 24 h).
+    pub max_age_s: u64,
+    /// Maximum total `byte_len` of stored events (default 50 MiB).
+    pub max_bytes: u64,
+    /// Retention-thread run interval in seconds (default 300 s / 5 min).
+    pub retention_interval_s: u64,
+    /// When `true`, the DB file and WAL/SHM siblings are removed on `drop`.
+    pub ephemeral: bool,
+}
+
+impl Default for DebugLogConfig {
+    fn default() -> Self {
+        let max_age_s = env_u64(
+            "BROWSE_DEBUG_LOG_MAX_AGE_S",
+            &["BROWSE_DEBUG_LOG_MAX_AGE_SECONDS"],
+            DEFAULT_MAX_AGE_S,
+        );
+        let max_bytes = env_u64("BROWSE_DEBUG_LOG_MAX_BYTES", &[], DEFAULT_MAX_BYTES);
+        let retention_interval_s = env_u64(
+            "BROWSE_DEBUG_LOG_RETENTION_INTERVAL_S",
+            &["BROWSE_DEBUG_LOG_RETENTION_INTERVAL_SECONDS"],
+            DEFAULT_RETENTION_INTERVAL_S,
+        );
+        let ephemeral = std::env::var("BROWSE_DEBUG_LOG_EPHEMERAL")
+            .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+        Self {
+            path: default_debug_log_path(),
+            max_age_s,
+            max_bytes,
+            retention_interval_s,
+            ephemeral,
+        }
+    }
+}
+
+// ── PruneStats ─────────────────────────────────────────────────────────────────
+
+/// Statistics returned by `prune_now`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PruneStats {
+    pub deleted_age: usize,
+    pub deleted_size: usize,
+    pub remaining: usize,
+}
+
+// ── Inner state ────────────────────────────────────────────────────────────────
+
+struct Inner {
+    /// `None` after `shutdown` / `drop` has closed the connection.
+    conn: Option<Connection>,
+    config: DebugLogConfig,
+}
+
+// ── Retention handle ───────────────────────────────────────────────────────────
+
+struct RetentionHandle {
+    stop_tx: mpsc::SyncSender<()>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for RetentionHandle {
+    fn drop(&mut self) {
+        let _ = self.stop_tx.send(());
+        if let Some(jh) = self.join.take() {
+            let _ = jh.join();
+        }
+    }
+}
+
+// ── DebugLogStorage ────────────────────────────────────────────────────────────
+
+/// Bounded local-only debug-log storage backed by a single SQLite connection.
+///
+/// Thread-safe via `Arc<Mutex<Inner>>`.  Spawns an optional background
+/// retention thread that calls `prune_now` on a configurable interval.
+pub struct DebugLogStorage {
+    inner: Arc<Mutex<Inner>>,
+    retention: Option<RetentionHandle>,
+}
+
+impl DebugLogStorage {
+    /// Open storage with the given config and start the retention thread.
+    pub fn open(config: DebugLogConfig) -> anyhow::Result<Self> {
+        Self::open_impl(config, true)
+    }
+
+    /// Open without the retention thread (useful in tests).
+    pub fn open_without_retention(config: DebugLogConfig) -> anyhow::Result<Self> {
+        Self::open_impl(config, false)
+    }
+
+    fn open_impl(config: DebugLogConfig, with_retention: bool) -> anyhow::Result<Self> {
+        // Create parent directory if needed.
+        if let Some(parent) = config.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open_with_flags(
+            &config.path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_CREATE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;\
+             PRAGMA synchronous=NORMAL;",
+        )?;
+        conn.execute_batch(SCHEMA_SQL)?;
+
+        let inner = Arc::new(Mutex::new(Inner {
+            conn: Some(conn),
+            config: config.clone(),
+        }));
+
+        let retention = if with_retention {
+            let interval = Duration::from_secs(config.retention_interval_s.max(1));
+            let inner_clone = inner.clone();
+            let (stop_tx, stop_rx) = mpsc::sync_channel::<()>(0);
+            let jh = thread::Builder::new()
+                .name("debug-log-retention".into())
+                .spawn(move || loop {
+                    match stop_rx.recv_timeout(interval) {
+                        Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                        Err(mpsc::RecvTimeoutError::Timeout) => {}
+                    }
+                    if let Ok(mut guard) = inner_clone.lock() {
+                        let _ = prune_inner(&mut guard);
+                    }
+                })?;
+            Some(RetentionHandle {
+                stop_tx,
+                join: Some(jh),
+            })
+        } else {
+            None
+        };
+
+        Ok(Self { inner, retention })
+    }
+
+    /// Append a debug-log event after redacting `payload`.
+    ///
+    /// `payload` is passed through
+    /// `crate::browse::importers::redaction::redact_entry`; the resulting
+    /// `BrowseDebugEntry` is JSON-serialised and stored.
+    pub fn append_event(
+        &self,
+        session_id: &str,
+        idx: i64,
+        kind: &str,
+        payload: &Value,
+    ) -> anyhow::Result<()> {
+        let redacted = crate::browse::importers::redaction::redact_entry(payload);
+        let payload_json = serde_json::to_string(&redacted)?;
+        let byte_len = payload_json.len() as i64;
+        let ts_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as i64;
+
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        let conn = guard
+            .conn
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("storage already closed"))?;
+        conn.execute(
+            "INSERT INTO debug_log_events \
+             (ts_ns, session_id, idx, kind, payload, byte_len) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+            rusqlite::params![ts_ns, session_id, idx, kind, payload_json, byte_len],
+        )?;
+        Ok(())
+    }
+
+    /// Prune age-expired rows, then enforce the size cap.
+    pub fn prune_now(&self) -> anyhow::Result<PruneStats> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        prune_inner(&mut guard)
+    }
+
+    /// Stop the retention thread and, if `ephemeral`, remove DB files.
+    ///
+    /// Consuming `self` ensures the connection is dropped before file removal
+    /// on platforms that require it.
+    pub fn shutdown(mut self) {
+        // Stop retention thread synchronously (join in RetentionHandle::drop).
+        drop(self.retention.take());
+
+        // Close the SQLite connection explicitly before attempting file removal.
+        let (ephemeral, path) = {
+            match self.inner.lock() {
+                Ok(mut guard) => {
+                    let eph = guard.config.ephemeral;
+                    let p = guard.config.path.clone();
+                    drop(guard.conn.take()); // close connection
+                    (eph, p)
+                }
+                Err(_) => return,
+            }
+        };
+
+        if ephemeral {
+            for suffix in &["", "-wal", "-shm"] {
+                let p = format!("{}{suffix}", path.display());
+                let _ = std::fs::remove_file(&p);
+            }
+        }
+    }
+}
+
+impl Drop for DebugLogStorage {
+    fn drop(&mut self) {
+        // Stop the retention thread first so it no longer accesses `inner`.
+        drop(self.retention.take());
+
+        // Close connection and perform ephemeral cleanup if configured.
+        if let Ok(mut guard) = self.inner.lock() {
+            let ephemeral = guard.config.ephemeral;
+            let path = guard.config.path.clone();
+            drop(guard.conn.take()); // close connection before file removal
+            if ephemeral {
+                for suffix in &["", "-wal", "-shm"] {
+                    let p = format!("{}{suffix}", path.display());
+                    let _ = std::fs::remove_file(&p);
+                }
+            }
+        }
+    }
+}
+
+// ── Internal prune logic ───────────────────────────────────────────────────────
+
+fn prune_inner(guard: &mut Inner) -> anyhow::Result<PruneStats> {
+    let conn = match guard.conn.as_ref() {
+        Some(c) => c,
+        None => return Ok(PruneStats::default()),
+    };
+
+    let now_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as i64;
+
+    let max_age_ns = (guard.config.max_age_s as i64).saturating_mul(1_000_000_000i64);
+    let age_cutoff_ns = now_ns.saturating_sub(max_age_ns);
+
+    // Age-based deletion.
+    let deleted_age = conn.execute(
+        "DELETE FROM debug_log_events WHERE ts_ns < ?",
+        rusqlite::params![age_cutoff_ns],
+    )?;
+
+    // Size cap: delete oldest rows in chunks until total ≤ max_bytes.
+    let mut deleted_size = 0usize;
+    let max_bytes = guard.config.max_bytes as i64;
+    loop {
+        let total: i64 = conn.query_row(
+            "SELECT COALESCE(SUM(byte_len), 0) FROM debug_log_events",
+            [],
+            |r| r.get(0),
+        )?;
+        if total <= max_bytes {
+            break;
+        }
+        let ids: Vec<i64> = {
+            let mut stmt = conn.prepare(
+                "SELECT id FROM debug_log_events \
+                 ORDER BY ts_ns ASC, id ASC LIMIT ?",
+            )?;
+            let mapped = stmt.query_map(rusqlite::params![PRUNE_CHUNK], |r| r.get::<_, i64>(0))?;
+            mapped.filter_map(|r| r.ok()).collect()
+        };
+        if ids.is_empty() {
+            break;
+        }
+        let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!("DELETE FROM debug_log_events WHERE id IN ({placeholders})");
+        let n = conn.execute(&sql, rusqlite::params_from_iter(ids.iter()))?;
+        deleted_size += n;
+    }
+
+    let remaining: usize =
+        conn.query_row("SELECT COUNT(*) FROM debug_log_events", [], |r| r.get(0))?;
+
+    Ok(PruneStats {
+        deleted_age,
+        deleted_size,
+        remaining,
+    })
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_db_path() -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        std::env::temp_dir().join(format!("debug_log_test_{}_{}.db", std::process::id(), n))
+    }
+
+    fn test_cfg(path: &std::path::Path) -> DebugLogConfig {
+        DebugLogConfig {
+            path: path.to_path_buf(),
+            max_age_s: DEFAULT_MAX_AGE_S,
+            max_bytes: DEFAULT_MAX_BYTES,
+            retention_interval_s: DEFAULT_RETENTION_INTERVAL_S,
+            ephemeral: false,
+        }
+    }
+
+    fn cleanup(path: &std::path::Path) {
+        for suffix in &["", "-wal", "-shm"] {
+            let _ = std::fs::remove_file(format!("{}{suffix}", path.display()));
+        }
+    }
+
+    fn sample_payload() -> Value {
+        json!({
+            "idx": 1,
+            "kind": "tool_call",
+            "level": "info",
+            "source": "cli",
+            "message": "hello world"
+        })
+    }
+
+    // ── Schema and basic append ────────────────────────────────────────────────
+
+    #[test]
+    fn schema_created_on_open() {
+        let path = temp_db_path();
+        let storage = DebugLogStorage::open_without_retention(test_cfg(&path)).unwrap();
+        drop(storage);
+        // Reopen and verify schema_version row exists.
+        let conn = Connection::open(&path).unwrap();
+        let v: String = conn
+            .query_row(
+                "SELECT value FROM debug_log_meta WHERE key='schema_version'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(v, "1");
+        cleanup(&path);
+    }
+
+    #[test]
+    fn append_event_stores_row() {
+        let path = temp_db_path();
+        let storage = DebugLogStorage::open_without_retention(test_cfg(&path)).unwrap();
+        storage
+            .append_event("sess-1", 0, "tool_call", &sample_payload())
+            .unwrap();
+        let conn = Connection::open(&path).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM debug_log_events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        cleanup(&path);
+    }
+
+    // ── Redaction ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn append_event_redacts_bearer_token() {
+        let path = temp_db_path();
+        let storage = DebugLogStorage::open_without_retention(test_cfg(&path)).unwrap();
+        let payload = json!({
+            "idx": 1,
+            "kind": "generic",
+            "level": "info",
+            "source": "cli",
+            "message": "auth Bearer supersecrettoken123"
+        });
+        storage
+            .append_event("sess-1", 0, "generic", &payload)
+            .unwrap();
+        let conn = Connection::open(&path).unwrap();
+        let stored: String = conn
+            .query_row("SELECT payload FROM debug_log_events LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        // The bearer token must be redacted.
+        assert!(
+            !stored.contains("supersecrettoken123"),
+            "raw token must not appear in stored payload"
+        );
+        assert!(
+            stored.contains("[REDACTED]"),
+            "redaction marker must appear"
+        );
+        cleanup(&path);
+    }
+
+    // ── Prune: age expiry ──────────────────────────────────────────────────────
+
+    #[test]
+    fn prune_deletes_age_expired_rows() {
+        let path = temp_db_path();
+        let mut cfg = test_cfg(&path);
+        cfg.max_age_s = 1; // 1-second max age
+        let storage = DebugLogStorage::open_without_retention(cfg).unwrap();
+        storage
+            .append_event("sess-1", 0, "generic", &sample_payload())
+            .unwrap();
+
+        // Back-date the event to be clearly expired.
+        {
+            let guard = storage.inner.lock().unwrap();
+            let conn = guard.conn.as_ref().unwrap();
+            let old_ns: i64 = 0; // epoch 0 — far in the past
+            conn.execute(
+                "UPDATE debug_log_events SET ts_ns = ?",
+                rusqlite::params![old_ns],
+            )
+            .unwrap();
+        }
+
+        let stats = storage.prune_now().unwrap();
+        assert_eq!(stats.deleted_age, 1);
+        assert_eq!(stats.remaining, 0);
+        cleanup(&path);
+    }
+
+    // ── Prune: size cap ────────────────────────────────────────────────────────
+
+    #[test]
+    fn prune_enforces_size_cap() {
+        let path = temp_db_path();
+        let mut cfg = test_cfg(&path);
+        cfg.max_bytes = 10; // very small cap
+        let storage = DebugLogStorage::open_without_retention(cfg).unwrap();
+
+        // Insert a few events whose combined byte_len exceeds the cap.
+        for i in 0..5i64 {
+            storage
+                .append_event("sess-1", i, "generic", &sample_payload())
+                .unwrap();
+        }
+
+        let stats = storage.prune_now().unwrap();
+        assert!(stats.deleted_size > 0, "some rows must be pruned for size");
+
+        // Verify remaining total byte_len ≤ cap.
+        let guard = storage.inner.lock().unwrap();
+        let conn = guard.conn.as_ref().unwrap();
+        let total: i64 = conn
+            .query_row(
+                "SELECT COALESCE(SUM(byte_len), 0) FROM debug_log_events",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(total <= 10, "remaining byte_len {total} must be ≤ 10");
+        cleanup(&path);
+    }
+
+    // ── Retention thread start / stop ──────────────────────────────────────────
+
+    #[test]
+    fn retention_thread_starts_and_stops() {
+        let path = temp_db_path();
+        let mut cfg = test_cfg(&path);
+        cfg.retention_interval_s = 3600; // long interval — won't fire during test
+        let storage = DebugLogStorage::open(cfg).unwrap();
+        // Thread is running while storage is alive.
+        assert!(storage.retention.is_some());
+        // Drop triggers RetentionHandle::drop which joins the thread.
+        drop(storage);
+        cleanup(&path);
+    }
+
+    // ── Ephemeral cleanup ──────────────────────────────────────────────────────
+
+    #[test]
+    fn ephemeral_shutdown_removes_db_file() {
+        let path = temp_db_path();
+        let cfg = DebugLogConfig {
+            path: path.clone(),
+            ephemeral: true,
+            retention_interval_s: 3600,
+            ..Default::default()
+        };
+        let storage = DebugLogStorage::open_without_retention(cfg).unwrap();
+        assert!(path.exists(), "DB file must exist before shutdown");
+        storage.shutdown();
+        assert!(
+            !path.exists(),
+            "DB file must be removed after ephemeral shutdown"
+        );
+    }
+
+    // ── Env-var aliases ────────────────────────────────────────────────────────
+
+    #[test]
+    fn env_u64_primary_name_takes_precedence() {
+        // Test the env_u64 helper directly via DebugLogConfig::default() by
+        // verifying built-in defaults are returned when no env vars are set.
+        let cfg = DebugLogConfig {
+            path: temp_db_path(),
+            max_age_s: DEFAULT_MAX_AGE_S,
+            max_bytes: DEFAULT_MAX_BYTES,
+            retention_interval_s: DEFAULT_RETENTION_INTERVAL_S,
+            ephemeral: false,
+        };
+        assert_eq!(cfg.max_age_s, 86_400);
+        assert_eq!(cfg.max_bytes, 50 * 1024 * 1024);
+        assert_eq!(cfg.retention_interval_s, 300);
+    }
+
+    #[test]
+    fn is_enabled_false_when_env_not_set() {
+        // Guard: remove the env var if somehow set in a previous test.
+        std::env::remove_var("BROWSE_DEBUG_LOG_ENABLED");
+        assert!(!is_enabled());
+    }
+
+    // ── Multiple appends and prune stats ───────────────────────────────────────
+
+    #[test]
+    fn prune_stats_remaining_count_is_accurate() {
+        let path = temp_db_path();
+        let storage = DebugLogStorage::open_without_retention(test_cfg(&path)).unwrap();
+        for i in 0..10i64 {
+            storage
+                .append_event("sess-1", i, "generic", &sample_payload())
+                .unwrap();
+        }
+        // No rows should be pruned with default (large) limits.
+        let stats = storage.prune_now().unwrap();
+        assert_eq!(stats.deleted_age, 0);
+        assert_eq!(stats.deleted_size, 0);
+        assert_eq!(stats.remaining, 10);
+        cleanup(&path);
+    }
+}

--- a/sk-rust/src/browse/db_debug_log.rs
+++ b/sk-rust/src/browse/db_debug_log.rs
@@ -355,33 +355,36 @@ fn prune_inner(guard: &mut Inner) -> anyhow::Result<PruneStats> {
         rusqlite::params![age_cutoff_ns],
     )?;
 
-    // Size cap: delete oldest rows in chunks until total ≤ max_bytes.
+    // Size cap: compute total once, then delete oldest rows in chunks,
+    // decrementing the running total to avoid re-querying SUM every iteration.
+    let mut total: i64 = conn.query_row(
+        "SELECT COALESCE(SUM(byte_len), 0) FROM debug_log_events",
+        [],
+        |r| r.get(0),
+    )?;
     let mut deleted_size = 0usize;
     let max_bytes = guard.config.max_bytes as i64;
-    loop {
-        let total: i64 = conn.query_row(
-            "SELECT COALESCE(SUM(byte_len), 0) FROM debug_log_events",
-            [],
-            |r| r.get(0),
-        )?;
-        if total <= max_bytes {
-            break;
-        }
-        let ids: Vec<i64> = {
+    while total > max_bytes {
+        let rows: Vec<(i64, i64)> = {
             let mut stmt = conn.prepare(
-                "SELECT id FROM debug_log_events \
+                "SELECT id, byte_len FROM debug_log_events \
                  ORDER BY ts_ns ASC, id ASC LIMIT ?",
             )?;
-            let mapped = stmt.query_map(rusqlite::params![PRUNE_CHUNK], |r| r.get::<_, i64>(0))?;
+            let mapped = stmt.query_map(rusqlite::params![PRUNE_CHUNK], |r| {
+                Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?))
+            })?;
             mapped.filter_map(|r| r.ok()).collect()
         };
-        if ids.is_empty() {
+        if rows.is_empty() {
             break;
         }
+        let chunk_bytes: i64 = rows.iter().map(|(_, b)| b).sum();
+        let ids: Vec<i64> = rows.into_iter().map(|(id, _)| id).collect();
         let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
         let sql = format!("DELETE FROM debug_log_events WHERE id IN ({placeholders})");
         let n = conn.execute(&sql, rusqlite::params_from_iter(ids.iter()))?;
         deleted_size += n;
+        total -= chunk_bytes;
     }
 
     let remaining: usize =
@@ -606,18 +609,30 @@ mod tests {
 
     #[test]
     fn env_u64_primary_name_takes_precedence() {
-        // Test the env_u64 helper directly via DebugLogConfig::default() by
-        // verifying built-in defaults are returned when no env vars are set.
-        let cfg = DebugLogConfig {
-            path: temp_db_path(),
-            max_age_s: DEFAULT_MAX_AGE_S,
-            max_bytes: DEFAULT_MAX_BYTES,
-            retention_interval_s: DEFAULT_RETENTION_INTERVAL_S,
-            ephemeral: false,
-        };
-        assert_eq!(cfg.max_age_s, 86_400);
-        assert_eq!(cfg.max_bytes, 50 * 1024 * 1024);
-        assert_eq!(cfg.retention_interval_s, 300);
+        // Set primary and alias to different values; primary must win.
+        std::env::set_var("BROWSE_DEBUG_LOG_MAX_AGE_S", "9999");
+        std::env::set_var("BROWSE_DEBUG_LOG_MAX_AGE_SECONDS", "1111");
+        let cfg = DebugLogConfig::default();
+        // Clean up immediately so other tests are not affected.
+        std::env::remove_var("BROWSE_DEBUG_LOG_MAX_AGE_S");
+        std::env::remove_var("BROWSE_DEBUG_LOG_MAX_AGE_SECONDS");
+        assert_eq!(
+            cfg.max_age_s, 9999,
+            "primary env var must take precedence over alias"
+        );
+    }
+
+    #[test]
+    fn env_u64_alias_used_when_primary_absent() {
+        // Only the alias is set; it should be picked up.
+        std::env::remove_var("BROWSE_DEBUG_LOG_MAX_AGE_S");
+        std::env::set_var("BROWSE_DEBUG_LOG_MAX_AGE_SECONDS", "7777");
+        let cfg = DebugLogConfig::default();
+        std::env::remove_var("BROWSE_DEBUG_LOG_MAX_AGE_SECONDS");
+        assert_eq!(
+            cfg.max_age_s, 7777,
+            "alias env var must be used when primary is absent"
+        );
     }
 
     #[test]

--- a/sk-rust/src/browse/mod.rs
+++ b/sk-rust/src/browse/mod.rs
@@ -8,6 +8,8 @@
 
 #[cfg(feature = "browse-server")]
 pub mod db;
+#[cfg(feature = "browse-server")]
+pub mod db_debug_log;
 pub mod importers;
 #[cfg(feature = "browse-server")]
 pub mod server;


### PR DESCRIPTION
## Summary
- Adds the Rust browse DB layer for issue #449 under the existing `browse-server` feature.
- Implements read/write r2d2_sqlite pools, browse knowledge query helpers, periodic WAL checkpoint support, and debug-log storage/retention.
- Keeps the layer decoupled from `browse::server` and does not wire routes or CLI behavior.

## Validation
- `cargo fmt --all --check`
- `cargo check --no-default-features`
- `cargo check --features browse-server`
- `cargo clippy --features browse-server --all-targets --no-deps -- -D warnings`
- `cargo test --features browse-server browse::db`
- `cargo test --features browse-server browse::db_debug_log`
- `cargo test --features browse-server`
- `rg -n 'browse::server' sk-rust/src/browse/db.rs sk-rust/src/browse/db_debug_log.rs` only finds explanatory doc comments; no code dependency.
- Independent Opus review: CLEAN.

Closes #449