### PR TITLE
feat: add Rust browse server foundation

### DIFF
--- a/sk-rust/Cargo.lock
+++ b/sk-rust/Cargo.lock
@@ -461,6 +461,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +481,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
@@ -1026,6 +1042,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1585,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,6 +1769,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "sk"
 version = "1.2.0"
 dependencies = [
@@ -1745,6 +1790,7 @@ dependencies = [
  "ctrlc",
  "dirs",
  "hmac",
+ "http-body-util",
  "notify",
  "predicates",
  "r2d2",
@@ -1756,7 +1802,9 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
+ "tempfile",
  "tokio",
+ "tower",
  "tower-http",
 ]
 
@@ -1829,6 +1877,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1912,6 +1973,7 @@ dependencies = [
  "libc",
  "mio 1.2.0",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/sk-rust/Cargo.lock
+++ b/sk-rust/Cargo.lock
@@ -1408,22 +1408,11 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -1440,31 +1429,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1825,7 +1795,7 @@ dependencies = [
  "predicates",
  "r2d2",
  "r2d2_sqlite",
- "rand 0.8.6",
+ "rand 0.9.4",
  "regex",
  "reqwest",
  "rusqlite",
@@ -1837,6 +1807,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]
@@ -2086,7 +2057,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sk-rust/Cargo.lock
+++ b/sk-rust/Cargo.lock
@@ -1408,11 +1408,22 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -1429,12 +1440,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1795,6 +1825,7 @@ dependencies = [
  "predicates",
  "r2d2",
  "r2d2_sqlite",
+ "rand 0.8.6",
  "regex",
  "reqwest",
  "rusqlite",

--- a/sk-rust/Cargo.toml
+++ b/sk-rust/Cargo.toml
@@ -26,6 +26,7 @@ native-extract = []
 browse-server  = [
     "dep:axum",
     "dep:tower-http",
+    "dep:tracing",
     "dep:r2d2",
     "dep:r2d2_sqlite",
     "dep:tokio",
@@ -65,9 +66,10 @@ tokio   = { version = "1",    features = ["rt-multi-thread", "macros"], optional
 # do not add a direct tower dep until needed to avoid duplicate-version splits.
 axum        = { version = "0.7", optional = true }
 tower-http  = { version = "0.6", features = ["cors", "trace"], optional = true }
+tracing     = { version = "0.1", optional = true }
 r2d2        = { version = "0.8", optional = true }
 r2d2_sqlite = { version = "0.24", optional = true }
-rand        = { version = "0.8", optional = true }
+rand        = { version = "0.9", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/sk-rust/Cargo.toml
+++ b/sk-rust/Cargo.toml
@@ -29,6 +29,7 @@ browse-server  = [
     "dep:r2d2",
     "dep:r2d2_sqlite",
     "dep:tokio",
+    "dep:rand",
     "tokio/rt-multi-thread",
     "tokio/macros",
     "tokio/signal",
@@ -66,6 +67,7 @@ axum        = { version = "0.7", optional = true }
 tower-http  = { version = "0.6", features = ["cors", "trace"], optional = true }
 r2d2        = { version = "0.8", optional = true }
 r2d2_sqlite = { version = "0.24", optional = true }
+rand        = { version = "0.8", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/sk-rust/Cargo.toml
+++ b/sk-rust/Cargo.toml
@@ -31,6 +31,9 @@ browse-server  = [
     "dep:tokio",
     "tokio/rt-multi-thread",
     "tokio/macros",
+    "tokio/signal",
+    "tokio/net",
+    "tokio/fs",
 ]
 
 [dependencies]
@@ -68,11 +71,18 @@ r2d2_sqlite = { version = "0.24", optional = true }
 assert_cmd = "2"
 predicates = "3"
 dirs = "5"
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite  = { version = "0.31", features = ["bundled"] }
+tower     = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"
+tempfile  = "3"
 
 [[bin]]
 name = "sk"
 path = "src/main.rs"
+
+[lib]
+name = "sk"
+path = "src/lib.rs"
 
 # Optimised release binary: smaller size, thin LTO, stripped symbols.
 [profile.release]

--- a/sk-rust/src/browse/auth.rs
+++ b/sk-rust/src/browse/auth.rs
@@ -1,0 +1,625 @@
+//! Authentication helpers and middleware for the browse HTTP server.
+//!
+//! Token extraction order: **Bearer > query-token > cookie**.
+//!
+//! Rules:
+//! - If the `Authorization: Bearer …` header is present, only Bearer auth is
+//!   attempted; failure returns `401` immediately (no fallthrough to query/cookie).
+//! - Query-token success sets `browse_token` cookie (`HttpOnly; SameSite=Strict`).
+//! - Debug routes (`/debug` prefix) reject query-token; Bearer/cookie only.
+//! - Empty `server_token` disables auth entirely (open mode).
+//! - `/healthz` and `/.well-known/…` are always open regardless of `server_token`.
+//! - `is_https_request` trusts proxy headers **only** if `ServerConfig.trusted_proxy`
+//!   is `true` (set when env `BROWSE_TRUSTED_PROXY` ∈ `1,true,yes`).
+
+use std::sync::Arc;
+
+use axum::extract::{Request, State};
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+use crate::browse::server::ServerConfig;
+
+// ── Constant-time comparison ──────────────────────────────────────────────────
+
+/// Compare two byte slices in constant time (hand-rolled XOR/OR).
+///
+/// Returns `false` immediately when lengths differ; this leaks the length
+/// comparison but is acceptable for fixed-format tokens.
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+// ── HTTPS detection ───────────────────────────────────────────────────────────
+
+/// Return `true` if the request appears to have arrived over HTTPS.
+///
+/// Only checks forwarded-proto headers when `trusted_proxy` is `true`.
+pub fn is_https_request(headers: &HeaderMap, trusted_proxy: bool) -> bool {
+    if !trusted_proxy {
+        return false;
+    }
+
+    if headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.eq_ignore_ascii_case("https"))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    if headers
+        .get("x-forwarded-ssl")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.eq_ignore_ascii_case("on"))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    if headers
+        .get("front-end-https")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.eq_ignore_ascii_case("on"))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    false
+}
+
+// ── Token extraction ──────────────────────────────────────────────────────────
+
+/// Which mechanism supplied the auth token.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum TokenSource {
+    Bearer,
+    QueryToken,
+    Cookie,
+}
+
+/// Extract the first available token from `headers` / `uri_query`.
+///
+/// Returns `None` if no token is present (caller should respond 401).
+/// On `is_debug_route == true`, query-token extraction is skipped.
+pub fn extract_token(
+    headers: &HeaderMap,
+    uri_query: Option<&str>,
+    is_debug_route: bool,
+) -> Option<(String, TokenSource)> {
+    // 1. Bearer — `Authorization: Bearer <token>`
+    if let Some(val) = headers.get(header::AUTHORIZATION) {
+        if let Ok(s) = val.to_str() {
+            if let Some(raw) = s.strip_prefix("Bearer ") {
+                let token = raw.trim().to_string();
+                if !token.is_empty() {
+                    return Some((token, TokenSource::Bearer));
+                }
+            }
+        }
+        // Authorization header present but not recognisable Bearer format;
+        // fall through to query/cookie (not "Bearer failure").
+    }
+
+    // 2. Query token — `?token=<value>` (skipped on debug routes)
+    if !is_debug_route {
+        if let Some(query) = uri_query {
+            if let Some(token) = extract_query_token(query) {
+                if !token.is_empty() {
+                    return Some((token, TokenSource::QueryToken));
+                }
+            }
+        }
+    }
+
+    // 3. Cookie — `browse_token=<value>`
+    if let Some(val) = headers.get(header::COOKIE) {
+        if let Ok(s) = val.to_str() {
+            for part in s.split(';') {
+                if let Some(raw) = part.trim().strip_prefix("browse_token=") {
+                    let token = raw.trim().to_string();
+                    if !token.is_empty() {
+                        return Some((token, TokenSource::Cookie));
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn extract_query_token(query: &str) -> Option<String> {
+    for pair in query.split('&') {
+        if let Some(raw) = pair.strip_prefix("token=") {
+            return Some(percent_decode_simple(raw));
+        }
+    }
+    None
+}
+
+/// Minimal percent-decoder for URL query values (handles `%XX` and `+`→space).
+fn percent_decode_simple(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(h), Some(l)) = (hex_nibble(bytes[i + 1]), hex_nibble(bytes[i + 2])) {
+                out.push(char::from(h << 4 | l));
+                i += 3;
+                continue;
+            }
+        } else if bytes[i] == b'+' {
+            out.push(' ');
+            i += 1;
+            continue;
+        }
+        out.push(char::from(bytes[i]));
+        i += 1;
+    }
+    out
+}
+
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+// ── Cookie builder ────────────────────────────────────────────────────────────
+
+/// Build a `Set-Cookie` header value for the browse token.
+///
+/// Appends `; Secure` when `secure` is `true` (HTTPS requests).
+pub fn build_set_cookie(token: &str, secure: bool) -> String {
+    let mut s = format!("browse_token={token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=86400");
+    if secure {
+        s.push_str("; Secure");
+    }
+    s
+}
+
+// ── Middleware ────────────────────────────────────────────────────────────────
+
+/// Auth middleware — validates tokens; passes open/no-token-configured paths.
+pub async fn auth_middleware(
+    State(config): State<Arc<ServerConfig>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let path = req.uri().path().to_string();
+
+    // Open paths bypass auth unconditionally.
+    if is_open_path(&path) {
+        return next.run(req).await;
+    }
+
+    // Empty server_token → open auth; every request passes.
+    if config.server_token.is_empty() {
+        return next.run(req).await;
+    }
+
+    let is_debug = path == "/debug" || path.starts_with("/debug/");
+    let is_https = is_https_request(req.headers(), config.trusted_proxy);
+    let uri_query = req.uri().query().map(str::to_string);
+    let headers = req.headers().clone();
+
+    let Some((token, source)) = extract_token(&headers, uri_query.as_deref(), is_debug) else {
+        return StatusCode::UNAUTHORIZED.into_response();
+    };
+
+    if !constant_time_eq(token.as_bytes(), config.server_token.as_bytes()) {
+        // Bearer failure does not fall through — same 401 for all sources.
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    if source == TokenSource::QueryToken {
+        // Query-token success: set the browser cookie so future requests use it.
+        let mut response = next.run(req).await;
+        let cookie_str = build_set_cookie(&token, is_https);
+        if let Ok(v) = HeaderValue::from_str(&cookie_str) {
+            response.headers_mut().insert(header::SET_COOKIE, v);
+        }
+        return response;
+    }
+
+    next.run(req).await
+}
+
+/// Paths that are always open (no auth even when `server_token` is set).
+fn is_open_path(path: &str) -> bool {
+    path == "/healthz" || path.starts_with("/.well-known/")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+
+    // ── constant_time_eq ─────────────────────────────────────────────────────
+
+    #[test]
+    fn ct_eq_identical() {
+        assert!(constant_time_eq(b"secret", b"secret"));
+    }
+
+    #[test]
+    fn ct_eq_different_value() {
+        assert!(!constant_time_eq(b"secret", b"Secret"));
+    }
+
+    #[test]
+    fn ct_eq_different_length() {
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+    }
+
+    #[test]
+    fn ct_eq_empty() {
+        assert!(constant_time_eq(b"", b""));
+        assert!(!constant_time_eq(b"", b"x"));
+    }
+
+    // ── is_https_request ─────────────────────────────────────────────────────
+
+    fn headers_with(name: &str, val: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(
+            HeaderName::from_bytes(name.as_bytes()).unwrap(),
+            HeaderValue::from_str(val).unwrap(),
+        );
+        h
+    }
+
+    use axum::http::HeaderName;
+
+    #[test]
+    fn https_no_trusted_proxy_always_false() {
+        let h = headers_with("x-forwarded-proto", "https");
+        assert!(!is_https_request(&h, false));
+    }
+
+    #[test]
+    fn https_x_forwarded_proto_https() {
+        let h = headers_with("x-forwarded-proto", "https");
+        assert!(is_https_request(&h, true));
+    }
+
+    #[test]
+    fn https_x_forwarded_proto_http_not_https() {
+        let h = headers_with("x-forwarded-proto", "http");
+        assert!(!is_https_request(&h, true));
+    }
+
+    #[test]
+    fn https_x_forwarded_ssl_on() {
+        let h = headers_with("x-forwarded-ssl", "on");
+        assert!(is_https_request(&h, true));
+    }
+
+    #[test]
+    fn https_front_end_https_on() {
+        let h = headers_with("front-end-https", "on");
+        assert!(is_https_request(&h, true));
+    }
+
+    #[test]
+    fn https_no_proxy_headers_false() {
+        assert!(!is_https_request(&HeaderMap::new(), true));
+    }
+
+    // ── extract_token ────────────────────────────────────────────────────────
+
+    fn bearer_headers(token: &str) -> HeaderMap {
+        headers_with("authorization", &format!("Bearer {token}"))
+    }
+
+    fn cookie_headers(token: &str) -> HeaderMap {
+        headers_with("cookie", &format!("browse_token={token}"))
+    }
+
+    #[test]
+    fn extract_bearer() {
+        let h = bearer_headers("abc123");
+        let result = extract_token(&h, None, false);
+        assert_eq!(result, Some(("abc123".to_string(), TokenSource::Bearer)));
+    }
+
+    #[test]
+    fn extract_query_token() {
+        let result = extract_token(&HeaderMap::new(), Some("token=mytoken"), false);
+        assert_eq!(
+            result,
+            Some(("mytoken".to_string(), TokenSource::QueryToken))
+        );
+    }
+
+    #[test]
+    fn extract_cookie() {
+        let h = cookie_headers("cookietoken");
+        let result = extract_token(&h, None, false);
+        assert_eq!(
+            result,
+            Some(("cookietoken".to_string(), TokenSource::Cookie))
+        );
+    }
+
+    #[test]
+    fn bearer_takes_precedence_over_query() {
+        let mut h = bearer_headers("bearertoken");
+        h.insert(
+            header::COOKIE,
+            HeaderValue::from_static("browse_token=cookietoken"),
+        );
+        let result = extract_token(&h, Some("token=querytoken"), false);
+        assert_eq!(
+            result,
+            Some(("bearertoken".to_string(), TokenSource::Bearer))
+        );
+    }
+
+    #[test]
+    fn query_takes_precedence_over_cookie() {
+        let h = cookie_headers("cookietoken");
+        let result = extract_token(&h, Some("token=querytoken"), false);
+        assert_eq!(
+            result,
+            Some(("querytoken".to_string(), TokenSource::QueryToken))
+        );
+    }
+
+    #[test]
+    fn debug_route_rejects_query_token() {
+        // Query token is ignored on debug routes; only bearer/cookie accepted.
+        let result = extract_token(&HeaderMap::new(), Some("token=mytoken"), true);
+        assert_eq!(result, None, "query token must be ignored on debug routes");
+    }
+
+    #[test]
+    fn debug_route_accepts_bearer() {
+        let h = bearer_headers("bearertoken");
+        let result = extract_token(&h, Some("token=querytoken"), true);
+        assert_eq!(
+            result,
+            Some(("bearertoken".to_string(), TokenSource::Bearer))
+        );
+    }
+
+    #[test]
+    fn debug_route_accepts_cookie() {
+        let h = cookie_headers("cookietoken");
+        let result = extract_token(&h, Some("token=querytoken"), true);
+        assert_eq!(
+            result,
+            Some(("cookietoken".to_string(), TokenSource::Cookie))
+        );
+    }
+
+    #[test]
+    fn no_token_returns_none() {
+        assert_eq!(extract_token(&HeaderMap::new(), None, false), None);
+    }
+
+    // ── build_set_cookie ─────────────────────────────────────────────────────
+
+    #[test]
+    fn set_cookie_not_secure() {
+        let c = build_set_cookie("tok", false);
+        assert_eq!(
+            c,
+            "browse_token=tok; HttpOnly; SameSite=Strict; Path=/; Max-Age=86400"
+        );
+        assert!(
+            !c.contains("Secure"),
+            "must not contain Secure for non-HTTPS"
+        );
+    }
+
+    #[test]
+    fn set_cookie_secure() {
+        let c = build_set_cookie("tok", true);
+        assert!(
+            c.ends_with("; Secure"),
+            "Set-Cookie must end with '; Secure' for HTTPS"
+        );
+        assert!(c.contains("browse_token=tok"));
+        assert!(c.contains("HttpOnly"));
+        assert!(c.contains("SameSite=Strict"));
+        assert!(c.contains("Max-Age=86400"));
+    }
+
+    // ── percent_decode_simple ────────────────────────────────────────────────
+
+    #[test]
+    fn percent_decode_encoded() {
+        assert_eq!(percent_decode_simple("abc%2Bdef"), "abc+def");
+        assert_eq!(percent_decode_simple("hello+world"), "hello world");
+        assert_eq!(percent_decode_simple("plain"), "plain");
+    }
+
+    // ── auth middleware integration ───────────────────────────────────────────
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use axum::Router;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    fn protected_app(token: &str) -> Router {
+        use axum::middleware;
+        let config = Arc::new(ServerConfig {
+            server_token: token.to_string(),
+            ..ServerConfig::default()
+        });
+        Router::new()
+            .route("/secret", get(|| async { "ok" }))
+            .route("/healthz", get(|| async { "open" }))
+            .with_state(Arc::clone(&config))
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&config),
+                auth_middleware,
+            ))
+    }
+
+    #[tokio::test]
+    async fn open_auth_passes_all() {
+        let app = protected_app("");
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .uri("/secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn healthz_open_even_with_token_set() {
+        let app = protected_app("mysecret");
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn bearer_valid_passes() {
+        let app = protected_app("mysecret");
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .uri("/secret")
+                    .header("authorization", "Bearer mysecret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn bearer_invalid_returns_401() {
+        let app = protected_app("mysecret");
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .uri("/secret")
+                    .header("authorization", "Bearer wrongtoken")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn query_token_valid_sets_cookie() {
+        let app = protected_app("mysecret");
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .uri("/secret?token=mysecret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let cookie = r.headers().get("set-cookie").unwrap().to_str().unwrap();
+        assert!(
+            cookie.contains("browse_token=mysecret"),
+            "must set browse_token cookie"
+        );
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("SameSite=Strict"));
+    }
+
+    #[tokio::test]
+    async fn query_token_secure_flag_via_trusted_proxy() {
+        use axum::middleware;
+        let config = Arc::new(ServerConfig {
+            server_token: "s3cr3t".to_string(),
+            trusted_proxy: true,
+            ..ServerConfig::default()
+        });
+        let app = Router::new()
+            .route("/secret", get(|| async { "ok" }))
+            .with_state(Arc::clone(&config))
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&config),
+                auth_middleware,
+            ));
+
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .uri("/secret?token=s3cr3t")
+                    .header("x-forwarded-proto", "https")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let cookie = r.headers().get("set-cookie").unwrap().to_str().unwrap();
+        assert!(
+            cookie.contains("; Secure"),
+            "cookie must have Secure flag on HTTPS"
+        );
+    }
+
+    #[tokio::test]
+    async fn debug_route_rejects_query_token_middleware() {
+        use axum::middleware;
+        let config = Arc::new(ServerConfig {
+            server_token: "tok".to_string(),
+            ..ServerConfig::default()
+        });
+        let app = Router::new()
+            .route("/debug/info", get(|| async { "debug" }))
+            .with_state(Arc::clone(&config))
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&config),
+                auth_middleware,
+            ));
+
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .uri("/debug/info?token=tok")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Query token on debug route must be ignored → no valid token → 401
+        assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/sk-rust/src/browse/auth.rs
+++ b/sk-rust/src/browse/auth.rs
@@ -101,14 +101,16 @@ pub fn extract_token(
     if let Some(val) = headers.get(header::AUTHORIZATION) {
         if let Ok(s) = val.to_str() {
             if let Some(raw) = s.strip_prefix("Bearer ") {
+                // Always return a Bearer result — even for an empty/whitespace
+                // token.  The middleware validates the token with constant_time_eq
+                // and returns 401 on mismatch.  An empty bearer must NOT fall
+                // through to query/cookie auth (matches Python behaviour).
                 let token = raw.trim().to_string();
-                if !token.is_empty() {
-                    return Some((token, TokenSource::Bearer));
-                }
+                return Some((token, TokenSource::Bearer));
             }
         }
-        // Authorization header present but not recognisable Bearer format;
-        // fall through to query/cookie (not "Bearer failure").
+        // Authorization header present but not Bearer format (e.g. "Basic …");
+        // fall through to query/cookie.
     }
 
     // 2. Query token — `?token=<value>` (skipped on debug routes)
@@ -415,6 +417,31 @@ mod tests {
         assert_eq!(extract_token(&HeaderMap::new(), None, false), None);
     }
 
+    #[test]
+    fn bearer_empty_token_is_bearer_not_fallthrough() {
+        // "Authorization: Bearer " (empty after prefix) must return a Bearer
+        // result with an empty token, never fall through to query/cookie.
+        let h = bearer_headers(""); // "Authorization: Bearer "
+        let result = extract_token(&h, Some("token=querytoken"), false);
+        assert_eq!(
+            result,
+            Some(("".to_string(), TokenSource::Bearer)),
+            "empty bearer must yield Bearer source, not fall through to query"
+        );
+    }
+
+    #[test]
+    fn bearer_whitespace_only_is_bearer_not_fallthrough() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer    "),
+        );
+        let result = extract_token(&h, Some("token=querytoken"), false);
+        // trim() gives empty string → still a Bearer result
+        assert_eq!(result, Some(("".to_string(), TokenSource::Bearer)));
+    }
+
     // ── build_set_cookie ─────────────────────────────────────────────────────
 
     #[test]
@@ -621,5 +648,27 @@ mod tests {
             .unwrap();
         // Query token on debug route must be ignored → no valid token → 401
         assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn bearer_empty_with_valid_query_token_returns_401() {
+        // Python returns failure immediately for any Bearer header with empty
+        // token; the query token must NOT be consulted as a fallback.
+        let app = protected_app("mysecret");
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .uri("/secret?token=mysecret")
+                    .header("authorization", "Bearer ")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            r.status(),
+            StatusCode::UNAUTHORIZED,
+            "empty Bearer must not fall through to valid query token"
+        );
     }
 }

--- a/sk-rust/src/browse/cors.rs
+++ b/sk-rust/src/browse/cors.rs
@@ -19,10 +19,10 @@
 //!
 //! ## Allowed methods per path
 //!
-//! | Path pattern            | Allowed methods                   |
-//! |-------------------------|-----------------------------------|
-//! | `/api/**`               | `GET, POST, DELETE, PATCH, OPTIONS` |
-//! | `/healthz`, `/.well-known/**` | `GET, OPTIONS`             |
+//! | Path pattern                  | Allowed methods                   |
+//! |-------------------------------|-----------------------------------|
+//! | `/api/operator/**`            | `GET, POST, DELETE, PATCH, OPTIONS` |
+//! | `/api/**` (other), `/healthz`, `/.well-known/**` | `GET, OPTIONS` |
 
 use std::sync::Arc;
 
@@ -66,9 +66,11 @@ pub fn is_cors_eligible_path(path: &str) -> bool {
 
 /// Return `true` for paths that support the full operator method set.
 ///
-/// All `/api/…` paths are treated as operator paths.
+/// Only `/api/operator/…` paths receive the full method set
+/// (`GET, POST, DELETE, PATCH, OPTIONS`).  All other `/api/…` paths receive
+/// `GET, OPTIONS` only, matching Python server behaviour.
 pub fn is_operator_path(path: &str) -> bool {
-    path == "/api" || path.starts_with("/api/")
+    path.starts_with("/api/operator/")
 }
 
 fn allowed_methods_for(path: &str) -> &'static str {
@@ -345,13 +347,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn preflight_api_allows_full_methods() {
+    async fn preflight_api_operator_allows_full_methods() {
         let app = cors_app(&["https://example.com"]);
         let r = app
             .oneshot(
                 Request::builder()
                     .method("OPTIONS")
-                    .uri("/api/items")
+                    .uri("/api/operator/pairing")
                     .header("origin", "https://example.com")
                     .header("access-control-request-method", "DELETE")
                     .body(Body::empty())
@@ -372,6 +374,49 @@ mod tests {
             "operator paths must allow DELETE"
         );
         assert!(methods.contains("PATCH"), "operator paths must allow PATCH");
+    }
+
+    #[tokio::test]
+    async fn preflight_api_sessions_get_only() {
+        // Non-operator /api paths must advertise only GET, OPTIONS — matching
+        // Python server behaviour.
+        let app = cors_app(&["https://example.com"]);
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .method("OPTIONS")
+                    .uri("/api/sessions")
+                    .header("origin", "https://example.com")
+                    .header("access-control-request-method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::NO_CONTENT);
+        let methods = r
+            .headers()
+            .get("access-control-allow-methods")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            !methods.contains("POST"),
+            "/api/sessions must not advertise POST"
+        );
+        assert!(
+            !methods.contains("DELETE"),
+            "/api/sessions must not advertise DELETE"
+        );
+        assert!(
+            !methods.contains("PATCH"),
+            "/api/sessions must not advertise PATCH"
+        );
+        assert!(methods.contains("GET"), "/api/sessions must advertise GET");
+        assert!(
+            methods.contains("OPTIONS"),
+            "/api/sessions must advertise OPTIONS"
+        );
     }
 
     #[tokio::test]

--- a/sk-rust/src/browse/cors.rs
+++ b/sk-rust/src/browse/cors.rs
@@ -1,0 +1,497 @@
+//! CORS and Private Network Access (PNA) middleware for the browse HTTP server.
+//!
+//! Origins are parsed from `BROWSE_CORS_ORIGINS` (comma-separated) at startup
+//! and stored in [`ServerConfig::cors_origins`].  Each origin is normalised by
+//! stripping a trailing `/`.  No wildcards are accepted.
+//!
+//! ## Request handling
+//!
+//! - **Simple/actual requests** (non-OPTIONS): if the `Origin` header matches
+//!   an allowlisted origin and the path is CORS-eligible, the response gets
+//!   `Access-Control-Allow-Origin` and `Vary: Origin`.
+//! - **Preflight (OPTIONS)**:
+//!   - Recognised path + allowlisted origin → `204 No Content` with CORS headers.
+//!   - Recognised path + non-allowlisted origin → `403 Forbidden`.
+//!   - Unrecognised path (not a CORS-eligible route) → `405 Method Not Allowed`.
+//! - **PNA**: `Access-Control-Allow-Private-Network: true` is echoed only when
+//!   the request included `Access-Control-Request-Private-Network: true` and the
+//!   origin is allowlisted.
+//!
+//! ## Allowed methods per path
+//!
+//! | Path pattern            | Allowed methods                   |
+//! |-------------------------|-----------------------------------|
+//! | `/api/**`               | `GET, POST, DELETE, PATCH, OPTIONS` |
+//! | `/healthz`, `/.well-known/**` | `GET, OPTIONS`             |
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{header, HeaderName, HeaderValue, Method, Response as HttpResponse, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+use crate::browse::server::ServerConfig;
+
+// ── Origin parsing ────────────────────────────────────────────────────────────
+
+/// Parse a comma-separated list of CORS origins, stripping trailing slashes.
+pub fn parse_cors_origins(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim().trim_end_matches('/').to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+// ── Origin allowlist ──────────────────────────────────────────────────────────
+
+/// Return `true` if `origin` (with trailing `/` stripped) is in `allowed`.
+pub fn is_origin_allowed(origin: &str, allowed: &[String]) -> bool {
+    let normalised = origin.trim_end_matches('/');
+    allowed.iter().any(|o| o == normalised)
+}
+
+// ── Path classification ───────────────────────────────────────────────────────
+
+/// Return `true` when CORS headers should be added to this path.
+///
+/// CORS-eligible: `/healthz`, `/.well-known/…`, `/api` and `/api/…`.
+pub fn is_cors_eligible_path(path: &str) -> bool {
+    path == "/healthz"
+        || path.starts_with("/.well-known/")
+        || path == "/api"
+        || path.starts_with("/api/")
+}
+
+/// Return `true` for paths that support the full operator method set.
+///
+/// All `/api/…` paths are treated as operator paths.
+pub fn is_operator_path(path: &str) -> bool {
+    path == "/api" || path.starts_with("/api/")
+}
+
+fn allowed_methods_for(path: &str) -> &'static str {
+    if is_operator_path(path) {
+        "GET, POST, DELETE, PATCH, OPTIONS"
+    } else {
+        "GET, OPTIONS"
+    }
+}
+
+// ── Middleware ────────────────────────────────────────────────────────────────
+
+/// CORS / PNA middleware.
+///
+/// Handles OPTIONS preflights and annotates actual responses for allowlisted
+/// origins.  OPTIONS requests short-circuit and never reach auth or handlers.
+pub async fn cors_middleware(
+    State(config): State<Arc<ServerConfig>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+    let origin = req.headers().get(header::ORIGIN).cloned();
+    let pna_requested = req
+        .headers()
+        .get("access-control-request-private-network")
+        .map(|v| v.as_bytes() == b"true")
+        .unwrap_or(false);
+
+    if method == Method::OPTIONS {
+        return handle_preflight(origin, &path, pna_requested, &config.cors_origins);
+    }
+
+    let mut response = next.run(req).await;
+
+    // Annotate actual responses for allowlisted origins.
+    if let Some(origin_hv) = &origin {
+        if let Ok(origin_str) = origin_hv.to_str() {
+            if is_origin_allowed(origin_str, &config.cors_origins) && is_cors_eligible_path(&path) {
+                let hdrs = response.headers_mut();
+                if let Ok(v) = HeaderValue::from_str(origin_str.trim_end_matches('/')) {
+                    hdrs.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, v);
+                }
+                hdrs.append(
+                    HeaderName::from_static("vary"),
+                    HeaderValue::from_static("Origin"),
+                );
+                if pna_requested {
+                    hdrs.insert(
+                        HeaderName::from_static("access-control-allow-private-network"),
+                        HeaderValue::from_static("true"),
+                    );
+                }
+            }
+        }
+    }
+
+    response
+}
+
+fn handle_preflight(
+    origin: Option<HeaderValue>,
+    path: &str,
+    pna_requested: bool,
+    allowed_origins: &[String],
+) -> Response {
+    let cors_eligible = is_cors_eligible_path(path);
+
+    let origin_str = origin
+        .as_ref()
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .trim_end_matches('/');
+
+    let allowlisted = !origin_str.is_empty() && is_origin_allowed(origin_str, allowed_origins);
+
+    if cors_eligible && allowlisted {
+        let methods = allowed_methods_for(path);
+
+        let mut builder = HttpResponse::builder()
+            .status(StatusCode::NO_CONTENT)
+            .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin_str)
+            .header(HeaderName::from_static("vary"), "Origin")
+            .header(
+                header::ACCESS_CONTROL_ALLOW_HEADERS,
+                "Authorization, Content-Type",
+            )
+            .header(header::ACCESS_CONTROL_ALLOW_METHODS, methods)
+            .header(header::ACCESS_CONTROL_MAX_AGE, "86400");
+
+        if pna_requested {
+            builder = builder.header(
+                HeaderName::from_static("access-control-allow-private-network"),
+                "true",
+            );
+        }
+
+        builder
+            .body(Body::empty())
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+    } else if cors_eligible {
+        // Recognised path, non-allowlisted origin.
+        StatusCode::FORBIDDEN.into_response()
+    } else {
+        // Unrecognised path — OPTIONS not supported.
+        StatusCode::METHOD_NOT_ALLOWED.into_response()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::middleware;
+    use axum::routing::get;
+    use axum::Router;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    fn cors_app(origins: &[&str]) -> Router {
+        let config = Arc::new(ServerConfig {
+            cors_origins: origins.iter().map(|s| s.to_string()).collect(),
+            ..ServerConfig::default()
+        });
+        Router::new()
+            .route("/healthz", get(|| async { "ok" }))
+            .route("/api/data", get(|| async { "data" }))
+            .route("/api/items", get(|| async { "items" }))
+            .with_state(Arc::clone(&config))
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&config),
+                cors_middleware,
+            ))
+    }
+
+    // ── parse_cors_origins ───────────────────────────────────────────────────
+
+    #[test]
+    fn parse_strips_trailing_slash() {
+        let origins = parse_cors_origins("https://example.com/,https://other.com");
+        assert_eq!(origins, vec!["https://example.com", "https://other.com"]);
+    }
+
+    #[test]
+    fn parse_ignores_empty_segments() {
+        let origins = parse_cors_origins("https://a.com,,https://b.com,");
+        assert_eq!(origins, vec!["https://a.com", "https://b.com"]);
+    }
+
+    // ── is_origin_allowed ────────────────────────────────────────────────────
+
+    #[test]
+    fn origin_allowed_exact_match() {
+        let allowed = vec!["https://example.com".to_string()];
+        assert!(is_origin_allowed("https://example.com", &allowed));
+    }
+
+    #[test]
+    fn origin_allowed_strips_trailing_slash_on_check() {
+        let allowed = vec!["https://example.com".to_string()];
+        assert!(is_origin_allowed("https://example.com/", &allowed));
+    }
+
+    #[test]
+    fn origin_not_allowed_different_host() {
+        let allowed = vec!["https://example.com".to_string()];
+        assert!(!is_origin_allowed("https://evil.com", &allowed));
+    }
+
+    #[test]
+    fn origin_no_wildcard() {
+        let allowed = vec!["https://*.example.com".to_string()];
+        assert!(!is_origin_allowed("https://sub.example.com", &allowed));
+    }
+
+    // ── is_cors_eligible_path ────────────────────────────────────────────────
+
+    #[test]
+    fn cors_eligible_healthz() {
+        assert!(is_cors_eligible_path("/healthz"));
+    }
+
+    #[test]
+    fn cors_eligible_well_known() {
+        assert!(is_cors_eligible_path("/.well-known/browse-host"));
+    }
+
+    #[test]
+    fn cors_eligible_api() {
+        assert!(is_cors_eligible_path("/api/sync/status"));
+        assert!(is_cors_eligible_path("/api"));
+    }
+
+    #[test]
+    fn cors_not_eligible_static() {
+        assert!(!is_cors_eligible_path("/app.js"));
+        assert!(!is_cors_eligible_path("/index.html"));
+        assert!(!is_cors_eligible_path("/debug/info"));
+    }
+
+    // ── preflight responses ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn preflight_allowed_origin_returns_204() {
+        let app = cors_app(&["https://example.com"]);
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .method("OPTIONS")
+                    .uri("/healthz")
+                    .header("origin", "https://example.com")
+                    .header("access-control-request-method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::NO_CONTENT);
+        assert_eq!(
+            r.headers()
+                .get("access-control-allow-origin")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "https://example.com"
+        );
+        assert_eq!(
+            r.headers()
+                .get("access-control-max-age")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "86400"
+        );
+    }
+
+    #[tokio::test]
+    async fn preflight_non_allowlisted_returns_403() {
+        let app = cors_app(&["https://example.com"]);
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .method("OPTIONS")
+                    .uri("/healthz")
+                    .header("origin", "https://evil.com")
+                    .header("access-control-request-method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn preflight_unrecognised_path_returns_405() {
+        let app = cors_app(&["https://example.com"]);
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .method("OPTIONS")
+                    .uri("/app.js")
+                    .header("origin", "https://example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn preflight_api_allows_full_methods() {
+        let app = cors_app(&["https://example.com"]);
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .method("OPTIONS")
+                    .uri("/api/items")
+                    .header("origin", "https://example.com")
+                    .header("access-control-request-method", "DELETE")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::NO_CONTENT);
+        let methods = r
+            .headers()
+            .get("access-control-allow-methods")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(methods.contains("POST"), "operator paths must allow POST");
+        assert!(
+            methods.contains("DELETE"),
+            "operator paths must allow DELETE"
+        );
+        assert!(methods.contains("PATCH"), "operator paths must allow PATCH");
+    }
+
+    #[tokio::test]
+    async fn preflight_health_only_get_options() {
+        let app = cors_app(&["https://example.com"]);
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .method("OPTIONS")
+                    .uri("/healthz")
+                    .header("origin", "https://example.com")
+                    .header("access-control-request-method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::NO_CONTENT);
+        let methods = r
+            .headers()
+            .get("access-control-allow-methods")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(!methods.contains("POST"), "health must not allow POST");
+        assert!(methods.contains("GET"));
+        assert!(methods.contains("OPTIONS"));
+    }
+
+    // ── PNA echo ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn preflight_pna_echo_when_requested() {
+        let app = cors_app(&["https://example.com"]);
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .method("OPTIONS")
+                    .uri("/api/data")
+                    .header("origin", "https://example.com")
+                    .header("access-control-request-method", "GET")
+                    .header("access-control-request-private-network", "true")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::NO_CONTENT);
+        assert_eq!(
+            r.headers()
+                .get("access-control-allow-private-network")
+                .map(|v| v.as_bytes()),
+            Some(b"true".as_ref())
+        );
+    }
+
+    #[tokio::test]
+    async fn pna_not_echoed_without_request() {
+        let app = cors_app(&["https://example.com"]);
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .method("OPTIONS")
+                    .uri("/api/data")
+                    .header("origin", "https://example.com")
+                    .header("access-control-request-method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            r.headers()
+                .get("access-control-allow-private-network")
+                .is_none(),
+            "PNA header must not appear unless requested"
+        );
+    }
+
+    // ── CORS headers on actual GET ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn actual_request_gets_acao_header() {
+        let app = cors_app(&["https://example.com"]);
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .header("origin", "https://example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        assert_eq!(
+            r.headers()
+                .get("access-control-allow-origin")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "https://example.com"
+        );
+    }
+
+    #[tokio::test]
+    async fn actual_request_no_acao_for_non_allowlisted() {
+        let app = cors_app(&["https://example.com"]);
+        let r = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .header("origin", "https://evil.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Non-allowlisted: no CORS header, but the request still succeeds.
+        assert_eq!(r.status(), StatusCode::OK);
+        assert!(r.headers().get("access-control-allow-origin").is_none());
+    }
+}

--- a/sk-rust/src/browse/cors.rs
+++ b/sk-rust/src/browse/cors.rs
@@ -157,7 +157,7 @@ fn handle_preflight(
             .header(HeaderName::from_static("vary"), "Origin")
             .header(
                 header::ACCESS_CONTROL_ALLOW_HEADERS,
-                "Authorization, Content-Type",
+                "Authorization, Content-Type, Last-Event-ID, X-Resume-Token",
             )
             .header(header::ACCESS_CONTROL_ALLOW_METHODS, methods)
             .header(header::ACCESS_CONTROL_MAX_AGE, "86400");

--- a/sk-rust/src/browse/mod.rs
+++ b/sk-rust/src/browse/mod.rs
@@ -7,9 +7,15 @@
 #![allow(dead_code)]
 
 #[cfg(feature = "browse-server")]
+pub mod auth;
+#[cfg(feature = "browse-server")]
+pub mod cors;
+#[cfg(feature = "browse-server")]
 pub mod db;
 #[cfg(feature = "browse-server")]
 pub mod db_debug_log;
 pub mod importers;
 #[cfg(feature = "browse-server")]
 pub mod server;
+#[cfg(feature = "browse-server")]
+pub mod static_files;

--- a/sk-rust/src/browse/server.rs
+++ b/sk-rust/src/browse/server.rs
@@ -111,13 +111,20 @@ pub fn app(config: Arc<ServerConfig>) -> Router {
         // security headers on all responses
         .layer(middleware::from_fn(security_headers_middleware))
         // outermost — tracing (uses tower-http/trace feature)
-        .layer(TraceLayer::new_for_http())
+        .layer(
+            TraceLayer::new_for_http().make_span_with(|request: &Request<_>| {
+                tracing::debug_span!(
+                    "http_request",
+                    method = %request.method(),
+                    path = %request.uri().path(),
+                )
+            }),
+        )
 }
 
 /// Bind and run the server, shutting down gracefully on Ctrl-C.
 pub async fn start(config: Arc<ServerConfig>) -> anyhow::Result<()> {
-    let addr = format!("{}:{}", config.host, config.port);
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    let listener = tokio::net::TcpListener::bind((config.host.as_str(), config.port)).await?;
     let router = app(config);
 
     axum::serve(listener, router)
@@ -201,7 +208,7 @@ pub async fn security_headers_middleware(req: Request, next: Next) -> Response {
 fn generate_nonce() -> String {
     use rand::RngCore;
     let mut bytes = [0u8; 16];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 

--- a/sk-rust/src/browse/server.rs
+++ b/sk-rust/src/browse/server.rs
@@ -1,4 +1,366 @@
-//! Browse HTTP server — scaffold for issue #447 (`browse-server` feature).
+//! Browse HTTP server — issue #447 (`browse-server` feature).
 //!
-//! Axum router, middleware, and handlers will be implemented here once the
-//! `browse-server` feature is stabilised.  Nothing is wired to the CLI yet.
+//! Provides [`app`] (builds the Axum [`Router`]) and [`start`] (binds the
+//! listener and runs the server with graceful Ctrl-C shutdown).
+//!
+//! Nothing is wired to `Commands::Browse` yet; the Python fallback remains.
+//! DB fields in `/healthz` are `null` pending issue #449.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Request, State};
+use axum::http::{HeaderName, HeaderValue};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Json, Response};
+use axum::routing::get;
+use axum::Router;
+use serde_json::{json, Value};
+use tower_http::trace::TraceLayer;
+
+use crate::browse::auth::auth_middleware;
+use crate::browse::cors::cors_middleware;
+use crate::browse::static_files::serve_static;
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+/// Runtime configuration for the browse HTTP server.
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    /// TCP port to listen on (default: 8765).
+    pub port: u16,
+    /// Bind address (default: "127.0.0.1").
+    pub host: String,
+    /// Shared secret token; empty string disables auth (open mode).
+    pub server_token: String,
+    /// Root directory for static file serving.
+    pub static_root: std::path::PathBuf,
+    /// Allowlisted CORS origins (trailing `/` already stripped).
+    pub cors_origins: Vec<String>,
+    /// Whether to trust `X-Forwarded-*` / `X-Forwarded-Ssl` proxy headers.
+    pub trusted_proxy: bool,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            port: 8765,
+            host: "127.0.0.1".to_string(),
+            server_token: String::new(),
+            static_root: std::path::PathBuf::new(),
+            cors_origins: Vec::new(),
+            trusted_proxy: false,
+        }
+    }
+}
+
+impl ServerConfig {
+    /// Build from environment variables with sensible defaults.
+    pub fn from_env() -> Self {
+        let trusted_proxy = std::env::var("BROWSE_TRUSTED_PROXY")
+            .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+
+        let cors_origins = crate::browse::cors::parse_cors_origins(
+            &std::env::var("BROWSE_CORS_ORIGINS").unwrap_or_default(),
+        );
+
+        Self {
+            port: std::env::var("BROWSE_PORT")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(8765),
+            host: std::env::var("BROWSE_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
+            server_token: std::env::var("BROWSE_SERVER_TOKEN").unwrap_or_default(),
+            static_root: std::env::var("BROWSE_STATIC_ROOT")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_default(),
+            cors_origins,
+            trusted_proxy,
+        }
+    }
+}
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+/// Build the Axum router for the given server configuration.
+///
+/// Layer ordering (outermost → innermost):
+/// 1. `TraceLayer` — request/response tracing
+/// 2. `security_headers_middleware` — CSP, X-Content-Type-Options, X-Frame-Options
+/// 3. `cors_middleware` — CORS headers + OPTIONS preflight short-circuit
+/// 4. `auth_middleware` — Bearer / query-token / cookie authentication
+/// 5. route handlers
+pub fn app(config: Arc<ServerConfig>) -> Router {
+    use axum::middleware;
+
+    Router::new()
+        .route("/healthz", get(healthz_handler))
+        .route("/.well-known/browse-host", get(discovery_handler))
+        .fallback(serve_static)
+        .with_state(Arc::clone(&config))
+        // innermost middleware — auth
+        .layer(middleware::from_fn_with_state(
+            Arc::clone(&config),
+            auth_middleware,
+        ))
+        // CORS (short-circuits OPTIONS before auth runs)
+        .layer(middleware::from_fn_with_state(
+            Arc::clone(&config),
+            cors_middleware,
+        ))
+        // security headers on all responses
+        .layer(middleware::from_fn(security_headers_middleware))
+        // outermost — tracing (uses tower-http/trace feature)
+        .layer(TraceLayer::new_for_http())
+}
+
+/// Bind and run the server, shutting down gracefully on Ctrl-C.
+pub async fn start(config: Arc<ServerConfig>) -> anyhow::Result<()> {
+    let addr = format!("{}:{}", config.host, config.port);
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    let router = app(config);
+
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async {
+            tokio::signal::ctrl_c()
+                .await
+                .expect("failed to install Ctrl-C handler");
+        })
+        .await?;
+
+    Ok(())
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// `GET /healthz` — open endpoint, no auth required.
+///
+/// DB fields are `null` until issue #449 lands.
+async fn healthz_handler() -> Json<Value> {
+    Json(json!({
+        "status": "ok",
+        "schema_version": null,       // TODO(#449)
+        "sessions": null,             // TODO(#449)
+        "knowledge_entries": null,    // TODO(#449)
+        "last_indexed_at": null,      // TODO(#449)
+        "sync_status_endpoint": "/api/sync/status",
+    }))
+}
+
+/// `GET /.well-known/browse-host` — discovery endpoint, no auth required.
+async fn discovery_handler(State(_config): State<Arc<ServerConfig>>) -> impl IntoResponse {
+    Json(json!({
+        "type": "browse-host",
+        "version": "1",
+    }))
+}
+
+// ── Security-headers middleware ────────────────────────────────────────────────
+
+/// Add `Content-Security-Policy` (with per-request nonce),
+/// `X-Content-Type-Options: nosniff`, and `X-Frame-Options: DENY` to every
+/// response, including CORS preflight 204s.
+pub async fn security_headers_middleware(req: Request, next: Next) -> Response {
+    let nonce = generate_nonce();
+    let mut response = next.run(req).await;
+
+    let csp = format!(
+        "default-src 'self'; \
+         script-src 'self' 'nonce-{nonce}'; \
+         style-src 'self' 'unsafe-inline'; \
+         img-src 'self' data:; \
+         font-src 'self'; \
+         connect-src 'self'; \
+         frame-ancestors 'none'"
+    );
+
+    let headers = response.headers_mut();
+
+    if let Ok(v) = HeaderValue::from_str(&csp) {
+        headers.insert(HeaderName::from_static("content-security-policy"), v);
+    }
+    headers.insert(
+        HeaderName::from_static("x-content-type-options"),
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-frame-options"),
+        HeaderValue::from_static("DENY"),
+    );
+
+    response
+}
+
+// ── Nonce generation ──────────────────────────────────────────────────────────
+
+static NONCE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a 32-character hex nonce for CSP.
+///
+/// Uses a monotonic counter mixed with sub-second timestamp entropy.
+/// Not cryptographically secure, but unique per request in normal operation.
+fn generate_nonce() -> String {
+    let count = NONCE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64)
+        .unwrap_or(0);
+
+    // Mix counter and timestamp with distinct multipliers.
+    let a = ts
+        .wrapping_mul(0x9e3779b97f4a7c15_u64)
+        .wrapping_add(count.wrapping_mul(0x6c62272e07bb0142_u64));
+    let b = count
+        .wrapping_mul(0xbf58476d1ce4e5b9_u64)
+        .wrapping_add(ts.wrapping_add(0xb63c1c3b1d47c9a5_u64));
+
+    format!("{a:016x}{b:016x}")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    fn test_config() -> Arc<ServerConfig> {
+        Arc::new(ServerConfig {
+            port: 0,
+            host: "127.0.0.1".to_string(),
+            server_token: String::new(),
+            static_root: std::path::PathBuf::new(),
+            cors_origins: Vec::new(),
+            trusted_proxy: false,
+        })
+    }
+
+    #[tokio::test]
+    async fn test_healthz_status_ok() {
+        let response = app(test_config())
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_healthz_json_shape() {
+        let response = app(test_config())
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(v["status"], "ok", "status must be 'ok'");
+        assert!(
+            v.get("schema_version").is_some(),
+            "schema_version key required"
+        );
+        assert!(v.get("sessions").is_some(), "sessions key required");
+        assert!(
+            v.get("knowledge_entries").is_some(),
+            "knowledge_entries key required"
+        );
+        assert!(
+            v.get("last_indexed_at").is_some(),
+            "last_indexed_at key required"
+        );
+        assert_eq!(
+            v["sync_status_endpoint"], "/api/sync/status",
+            "sync_status_endpoint must be '/api/sync/status'"
+        );
+        assert!(v["schema_version"].is_null(), "schema_version must be null");
+        assert!(v["sessions"].is_null(), "sessions must be null");
+        assert!(
+            v["knowledge_entries"].is_null(),
+            "knowledge_entries must be null"
+        );
+        assert!(
+            v["last_indexed_at"].is_null(),
+            "last_indexed_at must be null"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_security_headers_present() {
+        let response = app(test_config())
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let h = response.headers();
+        assert!(
+            h.get("content-security-policy").is_some(),
+            "Content-Security-Policy required"
+        );
+        assert_eq!(
+            h.get("x-content-type-options").map(|v| v.as_bytes()),
+            Some(b"nosniff".as_ref()),
+        );
+        assert_eq!(
+            h.get("x-frame-options").map(|v| v.as_bytes()),
+            Some(b"DENY".as_ref()),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_csp_contains_nonce() {
+        let response = app(test_config())
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let csp = response
+            .headers()
+            .get("content-security-policy")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(csp.contains("nonce-"), "CSP must contain a nonce");
+    }
+
+    #[test]
+    fn test_generate_nonce_length() {
+        let n = generate_nonce();
+        assert_eq!(n.len(), 32, "nonce must be 32 hex chars");
+        assert!(
+            n.chars().all(|c| c.is_ascii_hexdigit()),
+            "nonce must be hex"
+        );
+    }
+
+    #[test]
+    fn test_generate_nonce_unique() {
+        let a = generate_nonce();
+        let b = generate_nonce();
+        assert_ne!(a, b, "consecutive nonces must differ");
+    }
+}

--- a/sk-rust/src/browse/server.rs
+++ b/sk-rust/src/browse/server.rs
@@ -6,9 +6,7 @@
 //! Nothing is wired to `Commands::Browse` yet; the Python fallback remains.
 //! DB fields in `/healthz` are `null` pending issue #449.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::extract::{Request, State};
 use axum::http::{HeaderName, HeaderValue};
@@ -195,28 +193,16 @@ pub async fn security_headers_middleware(req: Request, next: Next) -> Response {
 
 // ── Nonce generation ──────────────────────────────────────────────────────────
 
-static NONCE_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Generate a 32-character hex nonce for CSP.
+/// Generate a 32-character hex nonce for CSP using a CSPRNG.
 ///
-/// Uses a monotonic counter mixed with sub-second timestamp entropy.
-/// Not cryptographically secure, but unique per request in normal operation.
+/// Generates 16 cryptographically random bytes via [`rand::thread_rng`] and
+/// hex-encodes them, yielding a 32-character lowercase hex string.  Each call
+/// produces an unpredictable, independent nonce.
 fn generate_nonce() -> String {
-    let count = NONCE_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.subsec_nanos() as u64)
-        .unwrap_or(0);
-
-    // Mix counter and timestamp with distinct multipliers.
-    let a = ts
-        .wrapping_mul(0x9e3779b97f4a7c15_u64)
-        .wrapping_add(count.wrapping_mul(0x6c62272e07bb0142_u64));
-    let b = count
-        .wrapping_mul(0xbf58476d1ce4e5b9_u64)
-        .wrapping_add(ts.wrapping_add(0xb63c1c3b1d47c9a5_u64));
-
-    format!("{a:016x}{b:016x}")
+    use rand::RngCore;
+    let mut bytes = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -350,7 +336,7 @@ mod tests {
     #[test]
     fn test_generate_nonce_length() {
         let n = generate_nonce();
-        assert_eq!(n.len(), 32, "nonce must be 32 hex chars");
+        assert_eq!(n.len(), 32, "nonce must be 32 hex chars (16 random bytes)");
         assert!(
             n.chars().all(|c| c.is_ascii_hexdigit()),
             "nonce must be hex"
@@ -359,6 +345,9 @@ mod tests {
 
     #[test]
     fn test_generate_nonce_unique() {
+        // CSPRNG nonces must be statistically distinct across calls.
+        // Testing two consecutive calls is a basic sanity check; the guarantee
+        // comes from OS-level entropy via rand::thread_rng, not a counter.
         let a = generate_nonce();
         let b = generate_nonce();
         assert_ne!(a, b, "consecutive nonces must differ");

--- a/sk-rust/src/browse/static_files.rs
+++ b/sk-rust/src/browse/static_files.rs
@@ -1,0 +1,392 @@
+//! Static-file handler for the browse HTTP server.
+//!
+//! Serves files from a configured canonical root directory with strict security
+//! checks to prevent path-traversal, symlink-escape, and out-of-root access.
+//!
+//! ## Security checks (in order)
+//!
+//! 1. Reject raw URI-path components containing `..`, NUL bytes, absolute
+//!    path indicators (`/`-prefixed, `\`-prefixed, or Windows drive letters).
+//! 2. Reject symlinks via `symlink_metadata` before canonicalisation.
+//! 3. Canonicalise both root and candidate; verify the candidate starts with the
+//!    root (`std::fs::canonicalize` + `Path::starts_with`).
+//!
+//! ## MIME allowlist
+//!
+//! Only files with a recognised extension are served.  Unknown extensions
+//! return `403 Forbidden`; missing files return `404 Not Found`.  No cache
+//! headers are emitted.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::extract::{Request, State};
+use axum::http::{HeaderName, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+
+use crate::browse::server::ServerConfig;
+
+// ── MIME allowlist ────────────────────────────────────────────────────────────
+
+const MIME_ALLOWLIST: &[(&str, &str)] = &[
+    (".js", "text/javascript; charset=utf-8"),
+    (".mjs", "text/javascript; charset=utf-8"),
+    (".css", "text/css; charset=utf-8"),
+    (".woff2", "font/woff2"),
+    (".woff", "font/woff"),
+    (".ttf", "font/ttf"),
+    (".png", "image/png"),
+    (".jpg", "image/jpeg"),
+    (".jpeg", "image/jpeg"),
+    (".gif", "image/gif"),
+    (".svg", "image/svg+xml"),
+    (".ico", "image/x-icon"),
+    (".webmanifest", "application/manifest+json"),
+    (".html", "text/html; charset=utf-8"),
+    (".txt", "text/plain; charset=utf-8"),
+    (".map", "application/json"),
+];
+
+/// Return the MIME type for `path` based on its extension, or `None` if the
+/// extension is not in the allowlist.
+pub fn get_mime_type(path: &Path) -> Option<&'static str> {
+    let ext = path.extension()?.to_str()?;
+    let dot_ext = format!(".{ext}");
+    MIME_ALLOWLIST
+        .iter()
+        .find(|(e, _)| e.eq_ignore_ascii_case(&dot_ext))
+        .map(|(_, mime)| *mime)
+}
+
+// ── Path-safety checks ────────────────────────────────────────────────────────
+
+/// Error categories returned by [`check_path_component`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum PathSafetyError {
+    /// Path contains `..` (traversal attempt).
+    DotDot,
+    /// Path contains a NUL byte.
+    NulByte,
+    /// Path is absolute (starts with `/`, `\`, or a Windows drive letter).
+    Absolute,
+    /// Path component is empty after stripping the leading `/`.
+    Empty,
+}
+
+/// Validate a URI path before constructing a filesystem path.
+///
+/// `uri_path` must be the raw URI path component (e.g., `/app.js`).
+/// Returns the relative path string (leading `/` stripped) on success.
+pub fn check_path_component(uri_path: &str) -> Result<&str, PathSafetyError> {
+    // Strip exactly one leading `/` (all valid URI paths start with `/`).
+    let rel = uri_path.strip_prefix('/').unwrap_or(uri_path);
+
+    if rel.is_empty() {
+        return Err(PathSafetyError::Empty);
+    }
+
+    // NUL bytes anywhere.
+    if rel.contains('\0') {
+        return Err(PathSafetyError::NulByte);
+    }
+
+    // Absolute path indicators after stripping the leading `/`.
+    if rel.starts_with('/') || rel.starts_with('\\') {
+        return Err(PathSafetyError::Absolute);
+    }
+
+    // Windows drive letters (e.g. `C:`).
+    if rel.len() >= 2 {
+        let mut chars = rel.chars();
+        if let (Some(c), Some(':')) = (chars.next(), chars.next()) {
+            if c.is_ascii_alphabetic() {
+                return Err(PathSafetyError::Absolute);
+            }
+        }
+    }
+
+    // `..` as a full path component (URL-decoded form is what we check here).
+    for component in rel.split(['/', '\\']) {
+        if component == ".." {
+            return Err(PathSafetyError::DotDot);
+        }
+    }
+
+    Ok(rel)
+}
+
+// ── File resolver ─────────────────────────────────────────────────────────────
+
+/// Resolve and return the bytes of the file at `uri_path` under `root`.
+///
+/// All security checks are performed before reading.
+async fn resolve_file(root: &Path, uri_path: &str) -> Result<(Vec<u8>, &'static str), StatusCode> {
+    // 1. Static path safety.
+    let rel = check_path_component(uri_path).map_err(|_| StatusCode::FORBIDDEN)?;
+
+    let candidate = root.join(rel);
+
+    // 2. MIME check (before I/O — fail fast on unknown extensions).
+    let mime = get_mime_type(&candidate).ok_or(StatusCode::FORBIDDEN)?;
+
+    // 3. Reject symlinks before canonicalisation.
+    match std::fs::symlink_metadata(&candidate) {
+        Ok(meta) if meta.file_type().is_symlink() => return Err(StatusCode::FORBIDDEN),
+        Err(_) => return Err(StatusCode::NOT_FOUND),
+        Ok(_) => {}
+    }
+
+    // 4. Canonicalise root and candidate; verify containment.
+    let root_canonical = std::fs::canonicalize(root).map_err(|_| StatusCode::NOT_FOUND)?;
+    let candidate_canonical =
+        std::fs::canonicalize(&candidate).map_err(|_| StatusCode::NOT_FOUND)?;
+
+    if !candidate_canonical.starts_with(&root_canonical) {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    // 5. Read file asynchronously.
+    let bytes = tokio::fs::read(&candidate_canonical)
+        .await
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+
+    Ok((bytes, mime))
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+/// Fallback handler that serves static files from `ServerConfig::static_root`.
+pub async fn serve_static(State(config): State<Arc<ServerConfig>>, request: Request) -> Response {
+    let uri_path = request.uri().path().to_string();
+
+    if config.static_root.as_os_str().is_empty() {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    match resolve_file(&config.static_root, &uri_path).await {
+        Ok((bytes, mime)) => {
+            let mut response = Response::new(axum::body::Body::from(bytes));
+            *response.status_mut() = StatusCode::OK;
+            response.headers_mut().insert(
+                HeaderName::from_static("content-type"),
+                HeaderValue::from_static(mime),
+            );
+            response
+        }
+        Err(status) => status.into_response(),
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    // ── check_path_component ─────────────────────────────────────────────────
+
+    #[test]
+    fn safe_path_returns_relative() {
+        assert_eq!(check_path_component("/app.js"), Ok("app.js"));
+        assert_eq!(
+            check_path_component("/assets/style.css"),
+            Ok("assets/style.css")
+        );
+    }
+
+    #[test]
+    fn dotdot_rejected() {
+        assert_eq!(
+            check_path_component("/../etc/passwd"),
+            Err(PathSafetyError::DotDot)
+        );
+        assert_eq!(
+            check_path_component("/foo/../bar"),
+            Err(PathSafetyError::DotDot)
+        );
+        assert_eq!(check_path_component("/.."), Err(PathSafetyError::DotDot));
+    }
+
+    #[test]
+    fn nul_byte_rejected() {
+        assert_eq!(
+            check_path_component("/foo\0bar"),
+            Err(PathSafetyError::NulByte)
+        );
+    }
+
+    #[test]
+    fn absolute_path_after_strip_rejected() {
+        // After stripping the first `/`, another `/` means absolute.
+        assert_eq!(
+            check_path_component("//etc/passwd"),
+            Err(PathSafetyError::Absolute)
+        );
+        assert_eq!(
+            check_path_component("/\\windows"),
+            Err(PathSafetyError::Absolute)
+        );
+    }
+
+    #[test]
+    fn windows_drive_letter_rejected() {
+        assert_eq!(
+            check_path_component("/C:/Windows"),
+            Err(PathSafetyError::Absolute)
+        );
+        assert_eq!(
+            check_path_component("/c:/users"),
+            Err(PathSafetyError::Absolute)
+        );
+    }
+
+    #[test]
+    fn empty_path_rejected() {
+        assert_eq!(check_path_component("/"), Err(PathSafetyError::Empty));
+    }
+
+    // ── get_mime_type ────────────────────────────────────────────────────────
+
+    #[test]
+    fn mime_js() {
+        assert_eq!(
+            get_mime_type(Path::new("bundle.js")),
+            Some("text/javascript; charset=utf-8")
+        );
+    }
+
+    #[test]
+    fn mime_mjs() {
+        assert!(get_mime_type(Path::new("mod.mjs")).is_some());
+    }
+
+    #[test]
+    fn mime_css() {
+        assert_eq!(
+            get_mime_type(Path::new("style.css")),
+            Some("text/css; charset=utf-8")
+        );
+    }
+
+    #[test]
+    fn mime_html() {
+        assert_eq!(
+            get_mime_type(Path::new("index.html")),
+            Some("text/html; charset=utf-8")
+        );
+    }
+
+    #[test]
+    fn mime_woff2() {
+        assert!(get_mime_type(Path::new("font.woff2")).is_some());
+    }
+
+    #[test]
+    fn mime_svg() {
+        assert!(get_mime_type(Path::new("icon.svg")).is_some());
+    }
+
+    #[test]
+    fn mime_webmanifest() {
+        assert!(get_mime_type(Path::new("site.webmanifest")).is_some());
+    }
+
+    #[test]
+    fn mime_map_sourcemap() {
+        assert!(get_mime_type(Path::new("bundle.js.map")).is_some());
+    }
+
+    #[test]
+    fn mime_unknown_extension_none() {
+        assert!(get_mime_type(Path::new("file.exe")).is_none());
+        assert!(get_mime_type(Path::new("archive.zip")).is_none());
+        assert!(get_mime_type(Path::new("script.sh")).is_none());
+    }
+
+    #[test]
+    fn mime_no_extension_none() {
+        assert!(get_mime_type(Path::new("Makefile")).is_none());
+        assert!(get_mime_type(Path::new("noext")).is_none());
+    }
+
+    #[test]
+    fn mime_case_insensitive() {
+        assert!(get_mime_type(Path::new("image.PNG")).is_some());
+        assert!(get_mime_type(Path::new("style.CSS")).is_some());
+    }
+
+    // ── resolve_file (filesystem tests) ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn serve_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        std::fs::write(root.join("index.html"), b"<html></html>").unwrap();
+
+        let (bytes, mime) = resolve_file(&root, "/index.html").await.unwrap();
+        assert_eq!(bytes, b"<html></html>");
+        assert!(mime.contains("text/html"));
+    }
+
+    #[tokio::test]
+    async fn missing_file_returns_404() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = resolve_file(dir.path(), "/missing.html").await.unwrap_err();
+        assert_eq!(err, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn unknown_extension_returns_403() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        std::fs::write(root.join("data.bin"), b"binary").unwrap();
+
+        let err = resolve_file(&root, "/data.bin").await.unwrap_err();
+        assert_eq!(err, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn dotdot_path_returns_403() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = resolve_file(dir.path(), "/../etc/passwd")
+            .await
+            .unwrap_err();
+        assert_eq!(err, StatusCode::FORBIDDEN);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn symlink_returns_403() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let target = root.join("real.html");
+        std::fs::write(&target, b"real").unwrap();
+        let link = root.join("link.html");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let err = resolve_file(&root, "/link.html").await.unwrap_err();
+        assert_eq!(err, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn path_outside_root_returns_403_or_not_found() {
+        // A canonicalize-based outside-root attempt; the check returns 403 or
+        // 404 depending on whether the path exists outside the root.
+        let dir = tempfile::tempdir().unwrap();
+        // Create a subdirectory inside the root so relative path resolves.
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+
+        // Attempt to serve with a crafted relative path.
+        // `check_path_component` already rejects `..`, so this tests the
+        // integration path.  The error must be 403 or 404.
+        let result = resolve_file(dir.path(), "/../etc/passwd").await;
+        assert!(result.is_err(), "outside-root access must fail");
+        let status = result.unwrap_err();
+        assert!(
+            status == StatusCode::FORBIDDEN || status == StatusCode::NOT_FOUND,
+            "expected 403 or 404, got {status}"
+        );
+    }
+}

--- a/sk-rust/src/browse/static_files.rs
+++ b/sk-rust/src/browse/static_files.rs
@@ -122,28 +122,37 @@ pub fn check_path_component(uri_path: &str) -> Result<&str, PathSafetyError> {
 /// All security checks are performed before reading.
 async fn resolve_file(root: &Path, uri_path: &str) -> Result<(Vec<u8>, &'static str), StatusCode> {
     // 1. Static path safety.
-    let rel = check_path_component(uri_path).map_err(|_| StatusCode::FORBIDDEN)?;
+    let rel = check_path_component(uri_path).map_err(|e| match e {
+        PathSafetyError::Empty => StatusCode::NOT_FOUND,
+        _ => StatusCode::FORBIDDEN,
+    })?;
 
     let candidate = root.join(rel);
 
     // 2. MIME check (before I/O — fail fast on unknown extensions).
     let mime = get_mime_type(&candidate).ok_or(StatusCode::FORBIDDEN)?;
 
-    // 3. Reject symlinks before canonicalisation.
-    match std::fs::symlink_metadata(&candidate) {
-        Ok(meta) if meta.file_type().is_symlink() => return Err(StatusCode::FORBIDDEN),
-        Err(_) => return Err(StatusCode::NOT_FOUND),
-        Ok(_) => {}
-    }
-
-    // 4. Canonicalise root and candidate; verify containment.
-    let root_canonical = std::fs::canonicalize(root).map_err(|_| StatusCode::NOT_FOUND)?;
+    // 3+4. Move blocking FS checks into spawn_blocking to avoid runtime starvation.
+    let candidate_for_block = candidate.clone();
+    let root_for_block = root.to_path_buf();
     let candidate_canonical =
-        std::fs::canonicalize(&candidate).map_err(|_| StatusCode::NOT_FOUND)?;
-
-    if !candidate_canonical.starts_with(&root_canonical) {
-        return Err(StatusCode::FORBIDDEN);
-    }
+        tokio::task::spawn_blocking(move || -> Result<std::path::PathBuf, StatusCode> {
+            match std::fs::symlink_metadata(&candidate_for_block) {
+                Ok(meta) if meta.file_type().is_symlink() => return Err(StatusCode::FORBIDDEN),
+                Err(_) => return Err(StatusCode::NOT_FOUND),
+                Ok(_) => {}
+            }
+            let root_canonical =
+                std::fs::canonicalize(&root_for_block).map_err(|_| StatusCode::NOT_FOUND)?;
+            let candidate_canonical =
+                std::fs::canonicalize(&candidate_for_block).map_err(|_| StatusCode::NOT_FOUND)?;
+            if !candidate_canonical.starts_with(&root_canonical) {
+                return Err(StatusCode::FORBIDDEN);
+            }
+            Ok(candidate_canonical)
+        })
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)??;
 
     // 5. Read file asynchronously.
     let bytes = tokio::fs::read(&candidate_canonical)
@@ -157,6 +166,12 @@ async fn resolve_file(root: &Path, uri_path: &str) -> Result<(Vec<u8>, &'static 
 
 /// Fallback handler that serves static files from `ServerConfig::static_root`.
 pub async fn serve_static(State(config): State<Arc<ServerConfig>>, request: Request) -> Response {
+    use axum::http::Method;
+
+    if request.method() != Method::GET && request.method() != Method::HEAD {
+        return StatusCode::METHOD_NOT_ALLOWED.into_response();
+    }
+
     let uri_path = request.uri().path().to_string();
 
     if config.static_root.as_os_str().is_empty() {

--- a/sk-rust/src/embeddings/tfidf.rs
+++ b/sk-rust/src/embeddings/tfidf.rs
@@ -637,6 +637,12 @@ pub fn search_tfidf_native(query: &str, model_blob: &[u8], limit: usize) -> Vec<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Serialise all cache-mutating tests to prevent the global TFIDF_CACHE
+    // from being invalidated by a concurrent test between two lookups in the
+    // same test body.  This is a test-only lock; production code is unchanged.
+    static CACHE_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn tokenize_produces_unigrams_and_bigrams() {
@@ -839,6 +845,7 @@ mod tests {
 
     #[test]
     fn cache_hit_returns_same_arc() {
+        let _guard = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         invalidate_tfidf_cache();
         let texts = vec!["cache test document one", "cache test document two"];
         let doc_ids = vec![100i64, 200];
@@ -852,6 +859,7 @@ mod tests {
 
     #[test]
     fn cache_invalidated_on_new_generation() {
+        let _guard = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         invalidate_tfidf_cache();
         let texts = vec!["invalidation test alpha"];
         let doc_ids = vec![1i64];
@@ -869,6 +877,7 @@ mod tests {
 
     #[test]
     fn cache_search_results_consistent() {
+        let _guard = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         invalidate_tfidf_cache();
         let texts = vec!["knowledge database search", "embedding vector cosine"];
         let doc_ids = vec![1i64, 2];
@@ -892,6 +901,7 @@ mod tests {
 
     #[test]
     fn invalidate_then_reload_works() {
+        let _guard = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let texts = vec!["reload after invalidation test"];
         let doc_ids = vec![42i64];
         let blob = build_tfidf_model(&texts, &doc_ids);
@@ -905,6 +915,7 @@ mod tests {
 
     #[test]
     fn cache_binary_path_works() {
+        let _guard = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         invalidate_tfidf_cache();
         let texts = vec!["binary cache path test"];
         let doc_ids = vec![1i64];

--- a/sk-rust/src/lib.rs
+++ b/sk-rust/src/lib.rs
@@ -3,3 +3,11 @@
 
 #[cfg(feature = "browse-server")]
 pub mod browse;
+
+#[cfg(feature = "browse-server")]
+#[allow(dead_code)]
+mod config;
+
+#[cfg(feature = "browse-server")]
+#[allow(dead_code)]
+mod db;

--- a/sk-rust/src/lib.rs
+++ b/sk-rust/src/lib.rs
@@ -1,0 +1,5 @@
+//! Library surface for `sk` — currently only exposes browse modules for
+//! integration testing and future crate-level reuse.
+
+#[cfg(feature = "browse-server")]
+pub mod browse;

--- a/sk-rust/tests/browse_server_test.rs
+++ b/sk-rust/tests/browse_server_test.rs
@@ -125,19 +125,20 @@ async fn integration_security_headers_on_healthz() {
 
 #[tokio::test]
 async fn integration_auth_bearer_valid_passes() {
+    // /api/noroute is protected; valid Bearer must pass auth and reach the router (404 = no handler).
     let config = secured_config("supersecret");
     let r = app(config)
         .oneshot(
             Request::builder()
-                .uri("/healthz") // healthz is open — use a real protected path
+                .uri("/api/noroute")
                 .header("authorization", "Bearer supersecret")
                 .body(Body::empty())
                 .unwrap(),
         )
         .await
         .unwrap();
-    // healthz is open regardless
-    assert_eq!(r.status(), StatusCode::OK);
+    // Auth passed → reaches router → unregistered route = 404 (not 401).
+    assert_eq!(r.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]

--- a/sk-rust/tests/browse_server_test.rs
+++ b/sk-rust/tests/browse_server_test.rs
@@ -1,0 +1,304 @@
+//! Feature-gated integration tests for the browse HTTP server (`browse-server` feature).
+//!
+//! These tests drive the full Axum router stack (CORS + auth + security headers
+//! + static files) via `tower::ServiceExt::oneshot`.
+
+#![cfg(feature = "browse-server")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use sk::browse::server::{app, ServerConfig};
+
+fn open_config() -> Arc<ServerConfig> {
+    Arc::new(ServerConfig {
+        port: 0,
+        host: "127.0.0.1".to_string(),
+        server_token: String::new(),
+        static_root: std::path::PathBuf::new(),
+        cors_origins: vec!["https://allowed.example".to_string()],
+        trusted_proxy: false,
+    })
+}
+
+fn secured_config(token: &str) -> Arc<ServerConfig> {
+    Arc::new(ServerConfig {
+        server_token: token.to_string(),
+        cors_origins: vec!["https://allowed.example".to_string()],
+        ..ServerConfig::default()
+    })
+}
+
+// ── /healthz ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn integration_healthz_200_open() {
+    let r = app(open_config())
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn integration_healthz_json_exact_keys() {
+    let r = app(open_config())
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    for key in &[
+        "status",
+        "schema_version",
+        "sessions",
+        "knowledge_entries",
+        "last_indexed_at",
+        "sync_status_endpoint",
+    ] {
+        assert!(v.get(key).is_some(), "healthz must contain key '{key}'");
+    }
+    assert_eq!(v["status"], "ok");
+    assert_eq!(v["sync_status_endpoint"], "/api/sync/status");
+    assert!(v["sessions"].is_null());
+    assert!(v["knowledge_entries"].is_null());
+    assert!(v["last_indexed_at"].is_null());
+    assert!(v["schema_version"].is_null());
+}
+
+#[tokio::test]
+async fn integration_healthz_open_even_with_auth() {
+    let r = app(secured_config("mysecret"))
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+}
+
+// ── Security headers ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn integration_security_headers_on_healthz() {
+    let r = app(open_config())
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let h = r.headers();
+    let csp = h.get("content-security-policy").unwrap().to_str().unwrap();
+    assert!(csp.contains("nonce-"), "CSP must contain a nonce");
+    assert!(csp.contains("default-src"), "CSP must contain default-src");
+    assert_eq!(
+        h.get("x-content-type-options").unwrap().to_str().unwrap(),
+        "nosniff"
+    );
+    assert_eq!(h.get("x-frame-options").unwrap().to_str().unwrap(), "DENY");
+}
+
+// ── Auth — full stack ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn integration_auth_bearer_valid_passes() {
+    let config = secured_config("supersecret");
+    let r = app(config)
+        .oneshot(
+            Request::builder()
+                .uri("/healthz") // healthz is open — use a real protected path
+                .header("authorization", "Bearer supersecret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // healthz is open regardless
+    assert_eq!(r.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn integration_auth_missing_token_401() {
+    // /api/data is not a registered route but goes through auth middleware.
+    // With server_token set and no credentials: 401.
+    let config = secured_config("tok");
+    let r = app(config)
+        .oneshot(
+            Request::builder()
+                .uri("/api/noroute")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Should be 401 Unauthorized from auth middleware.
+    assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ── CORS — full stack ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn integration_cors_preflight_allowed_origin() {
+    let r = app(open_config())
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/healthz")
+                .header("origin", "https://allowed.example")
+                .header("access-control-request-method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::NO_CONTENT);
+    assert_eq!(
+        r.headers()
+            .get("access-control-allow-origin")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "https://allowed.example"
+    );
+}
+
+#[tokio::test]
+async fn integration_cors_preflight_blocked_origin() {
+    let r = app(open_config())
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/healthz")
+                .header("origin", "https://evil.example")
+                .header("access-control-request-method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn integration_cors_static_path_options_405() {
+    let r = app(open_config())
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/index.html")
+                .header("origin", "https://allowed.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+// ── Static files — empty root ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn integration_static_empty_root_404() {
+    let r = app(open_config())
+        .oneshot(
+            Request::builder()
+                .uri("/index.html")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // No static root configured → 404.
+    assert_eq!(r.status(), StatusCode::NOT_FOUND);
+}
+
+// ── Static files — with root ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn integration_static_serves_known_extension() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("app.js"), b"console.log('ok');").unwrap();
+
+    let config = Arc::new(ServerConfig {
+        static_root: dir.path().to_path_buf(),
+        ..ServerConfig::default()
+    });
+    let r = app(config)
+        .oneshot(
+            Request::builder()
+                .uri("/app.js")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    let ct = r.headers().get("content-type").unwrap().to_str().unwrap();
+    assert!(ct.contains("javascript"), "content-type must indicate JS");
+}
+
+#[tokio::test]
+async fn integration_static_unknown_extension_403() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("data.bin"), b"bin").unwrap();
+
+    let config = Arc::new(ServerConfig {
+        static_root: dir.path().to_path_buf(),
+        ..ServerConfig::default()
+    });
+    let r = app(config)
+        .oneshot(
+            Request::builder()
+                .uri("/data.bin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn integration_static_dotdot_403() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = Arc::new(ServerConfig {
+        static_root: dir.path().to_path_buf(),
+        ..ServerConfig::default()
+    });
+    let r = app(config)
+        .oneshot(
+            Request::builder()
+                .uri("/../etc/passwd")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        r.status() == StatusCode::FORBIDDEN || r.status() == StatusCode::NOT_FOUND,
+        "dotdot must be rejected"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds the Rust browse server foundation for issue #447 under the existing `browse-server` feature.
- Implements Axum app/start helpers, healthz, auth/cookie behavior, CORS/PNA handling, CSP/security headers, and safe static file serving.
- Keeps the Python browse CLI fallback intact and avoids wiring production routes beyond the foundation endpoints/tests.

## Validation
- `cargo fmt --all --check`
- `cargo check --no-default-features`
- `cargo check --features browse-server`
- `cargo clippy --features browse-server --all-targets --no-deps -- -D warnings`
- `cargo test --features browse-server`
- `cargo test`
- Independent Opus review: CLEAN after security fixes and post-rebase library-target review.

Closes #447
