### PR TITLE
ci(#463): gate browse-server feature across OSes

### DIFF
--- a/.github/workflows/sk-ci.yml
+++ b/.github/workflows/sk-ci.yml
@@ -150,3 +150,35 @@ jobs:
             bin="sk-rust/target/debug/sk.exe"
           fi
           python3 tests/test_py_rust_boundary.py --rust-bin "$bin"
+
+  browse-server:
+    name: Browse server (feature-gated, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    defaults:
+      run:
+        working-directory: sk-rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            sk-rust/target/
+          key: ${{ matrix.os }}-cargo-browse-${{ hashFiles('sk-rust/Cargo.lock') }}
+          restore-keys: ${{ matrix.os }}-cargo-browse-
+      - name: Verify default build excludes browse-server
+        run: cargo check --no-default-features
+      - name: Build with browse-server feature
+        run: cargo build --features browse-server
+      - name: Clippy with browse-server feature
+        run: cargo clippy --features browse-server --all-targets --no-deps -- -D warnings
+      - name: Test with browse-server feature
+        run: cargo test --features browse-server

--- a/.github/workflows/sk-ci.yml
+++ b/.github/workflows/sk-ci.yml
@@ -172,9 +172,11 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             sk-rust/target/
-          key: ${{ matrix.os }}-cargo-browse-${{ hashFiles('sk-rust/Cargo.lock') }}
-          restore-keys: ${{ matrix.os }}-cargo-browse-
-      - name: Verify default build excludes browse-server
+          key: ${{ runner.os }}-cargo-browse-${{ hashFiles('sk-rust/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-browse-
+      - name: Check default feature build
+        run: cargo check
+      - name: Check no-default-features build
         run: cargo check --no-default-features
       - name: Build with browse-server feature
         run: cargo build --features browse-server

--- a/sk-rust/src/hooks/runner.rs
+++ b/sk-rust/src/hooks/runner.rs
@@ -228,7 +228,14 @@ pub(crate) fn dispatch_rules(event: &str, data: &Value) {
             if !msg.is_empty() {
                 println!("{msg}");
             }
-            let truncated = &msg[..msg.len().min(100)];
+            // Truncate to at most 100 bytes at a UTF-8 char boundary; info messages
+            // routinely contain multi-byte glyphs (e.g. box-drawing separators) that
+            // would otherwise panic on a raw byte slice.
+            let mut end = msg.len().min(100);
+            while end > 0 && !msg.is_char_boundary(end) {
+                end -= 1;
+            }
+            let truncated = &msg[..end];
             audit_log(event, tool_name, rule.name(), "info", truncated);
         }
     }


### PR DESCRIPTION
## Summary
- Add a feature-gated rowse-server Rust CI job across Ubuntu, Windows, and macOS.
- Run default-minimal check plus browse-server build, clippy, and tests.
- Fix UTF-8-safe audit-log truncation in the hook runner so the expanded test gate does not panic on Unicode briefing output.

## Validation
- cargo fmt --all -- --check
- cargo test --test integration_test auto_briefing_passes_session_start_flag -- --nocapture
- cargo test --features browse-server --test integration_test auto_briefing_passes_session_start_flag -- --nocapture
- cargo test
- cargo test --features browse-server
- cargo clippy --all-targets --no-deps -- -D warnings
- cargo clippy --features browse-server --all-targets --no-deps -- -D warnings

Closes #463. Provides the PR-time cross-platform browse-server CI evidence required by #465.
