### PR TITLE
feat(#448): add Rust SSE live stream foundation

### DIFF
--- a/sk-rust/Cargo.lock
+++ b/sk-rust/Cargo.lock
@@ -1805,6 +1805,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tower",
  "tower-http",
  "tracing",
@@ -1999,6 +2000,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/sk-rust/Cargo.toml
+++ b/sk-rust/Cargo.toml
@@ -30,6 +30,7 @@ browse-server  = [
     "dep:r2d2",
     "dep:r2d2_sqlite",
     "dep:tokio",
+    "dep:tokio-stream",
     "dep:rand",
     "tokio/rt-multi-thread",
     "tokio/macros",
@@ -69,6 +70,7 @@ tower-http  = { version = "0.6", features = ["cors", "trace"], optional = true }
 tracing     = { version = "0.1", optional = true }
 r2d2        = { version = "0.8", optional = true }
 r2d2_sqlite = { version = "0.24", optional = true }
+tokio-stream = { version = "0.1", features = ["sync"], optional = true }
 rand        = { version = "0.9", optional = true }
 
 [dev-dependencies]

--- a/sk-rust/src/browse/api/live.rs
+++ b/sk-rust/src/browse/api/live.rs
@@ -6,6 +6,12 @@
 //! `id > cursor`.  Each row is sent as a JSON-framed SSE event with an `id:`
 //! field so clients can resume with `Last-Event-ID` on reconnect.
 //!
+//! On reconnect, a client may supply a `Last-Event-ID` header with the last
+//! event id it received.  When the value is a valid positive integer the
+//! handler uses it as the starting cursor so no events are missed during the
+//! reconnect window.  An invalid or absent header falls back to the latest
+//! snapshot without panicking.
+//!
 //! The poll task exits when:
 //! - the client disconnects (the [`tokio::sync::mpsc::Sender`] reports closed),
 //! - the connection reaches [`MAX_CONNECTION_SECS`], or
@@ -15,6 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::extract::State;
+use axum::http::HeaderMap;
 use axum::response::IntoResponse;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -26,14 +33,38 @@ use crate::browse::sse::{json_event_with_id, sse_response, MAX_CONNECTION_SECS};
 /// Extracts [`Arc<BrowseDb>`] from the router state via
 /// [`axum::extract::FromRef`] and opens an SSE stream of new
 /// `knowledge_entries` rows.
-pub async fn handler(State(db): State<Arc<BrowseDb>>) -> impl IntoResponse {
-    // Snapshot current max id as the cursor so we only stream NEW entries.
-    let cursor: i64 = match db.latest_entry_id() {
-        Ok(Some(id)) => id,
-        Ok(None) => 0,
-        Err(e) => {
-            tracing::warn!("live handler: failed to snapshot latest_entry_id: {e}");
-            0
+///
+/// Honors the `Last-Event-ID` request header for reconnecting clients: a valid
+/// positive integer value is used directly as the starting cursor so that
+/// events emitted between the disconnect and the reconnect are not lost.
+/// Invalid or missing values fall back to a fresh `MAX(id)` snapshot.
+pub async fn handler(headers: HeaderMap, State(db): State<Arc<BrowseDb>>) -> impl IntoResponse {
+    // Honor Last-Event-ID for reconnecting clients (SSE spec §9.2).
+    // A valid positive integer resumes from that id; anything else falls back
+    // to the latest snapshot so new connections only receive future events.
+    let resume_id: Option<i64> = headers
+        .get("last-event-id")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|&id| id > 0);
+
+    let cursor: i64 = if let Some(id) = resume_id {
+        id
+    } else {
+        // Snapshot current max id on a blocking thread to avoid stalling the
+        // Tokio executor with a synchronous SQLite/r2d2 call.
+        let db2 = Arc::clone(&db);
+        match tokio::task::spawn_blocking(move || db2.latest_entry_id()).await {
+            Ok(Ok(Some(id))) => id,
+            Ok(Ok(None)) => 0,
+            Ok(Err(e)) => {
+                tracing::warn!("live handler: failed to snapshot latest_entry_id: {e}");
+                0
+            }
+            Err(e) => {
+                tracing::warn!("live handler: spawn_blocking join error: {e}");
+                0
+            }
         }
     };
 

--- a/sk-rust/src/browse/api/live.rs
+++ b/sk-rust/src/browse/api/live.rs
@@ -1,0 +1,94 @@
+//! `GET /api/live` — SSE live-stream of new knowledge entries (issue #448).
+//!
+//! Streams [`serde_json`] events as new rows are inserted into `knowledge_entries`.
+//! The handler snapshots the current `MAX(id)` as the starting cursor, then
+//! polls every 2 seconds via a background [`tokio::task`] for rows with
+//! `id > cursor`.  Each row is sent as a JSON-framed SSE event with an `id:`
+//! field so clients can resume with `Last-Event-ID` on reconnect.
+//!
+//! The poll task exits when:
+//! - the client disconnects (the [`tokio::sync::mpsc::Sender`] reports closed),
+//! - the connection reaches [`MAX_CONNECTION_SECS`], or
+//! - a database query returns an error (logged via [`tracing`]).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::response::IntoResponse;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::browse::db::BrowseDb;
+use crate::browse::sse::{json_event_with_id, sse_response, MAX_CONNECTION_SECS};
+
+/// `GET /api/live` handler.
+///
+/// Extracts [`Arc<BrowseDb>`] from the router state via
+/// [`axum::extract::FromRef`] and opens an SSE stream of new
+/// `knowledge_entries` rows.
+pub async fn handler(State(db): State<Arc<BrowseDb>>) -> impl IntoResponse {
+    // Snapshot current max id as the cursor so we only stream NEW entries.
+    let cursor: i64 = match db.latest_entry_id() {
+        Ok(Some(id)) => id,
+        Ok(None) => 0,
+        Err(e) => {
+            tracing::warn!("live handler: failed to snapshot latest_entry_id: {e}");
+            0
+        }
+    };
+
+    let (tx, rx) =
+        tokio::sync::mpsc::channel::<Result<axum::response::sse::Event, axum::Error>>(64);
+
+    tokio::spawn(poll_task(db, cursor, tx));
+
+    sse_response(ReceiverStream::new(rx))
+}
+
+/// Background polling task: queries new entries every 2 seconds and forwards
+/// them as SSE events.  Exits on client disconnect, deadline, or DB error.
+async fn poll_task(
+    db: Arc<BrowseDb>,
+    initial_cursor: i64,
+    tx: tokio::sync::mpsc::Sender<Result<axum::response::sse::Event, axum::Error>>,
+) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(MAX_CONNECTION_SECS);
+    let mut poll = tokio::time::interval(Duration::from_secs(2));
+    let mut cursor = initial_cursor;
+
+    loop {
+        // Wait for the next poll tick, a disconnect, or deadline.
+        tokio::select! {
+            _ = poll.tick() => {}
+            _ = tx.closed() => { return; }
+            _ = tokio::time::sleep_until(deadline) => { return; }
+        }
+
+        // Run the DB query on a blocking thread to avoid stalling the async executor.
+        let db2 = Arc::clone(&db);
+        let cur = cursor;
+        let result = tokio::task::spawn_blocking(move || db2.entries_after_live(cur, 50)).await;
+
+        let entries = match result {
+            Ok(Ok(rows)) => rows,
+            Ok(Err(e)) => {
+                tracing::warn!("live handler: db query error: {e}");
+                return;
+            }
+            Err(e) => {
+                tracing::warn!("live handler: spawn_blocking join error: {e}");
+                return;
+            }
+        };
+
+        for entry in &entries {
+            let id = entry["id"].as_i64().unwrap_or(0);
+            let event = json_event_with_id(entry, &id.to_string());
+            if tx.send(event).await.is_err() {
+                // Receiver dropped — client disconnected.
+                return;
+            }
+            cursor = id;
+        }
+    }
+}

--- a/sk-rust/src/browse/api/mod.rs
+++ b/sk-rust/src/browse/api/mod.rs
@@ -1,0 +1,3 @@
+//! API route handlers for the browse HTTP server.
+
+pub mod live;

--- a/sk-rust/src/browse/db.rs
+++ b/sk-rust/src/browse/db.rs
@@ -455,16 +455,19 @@ impl BrowseDb {
         );
         let mut stmt = conn.prepare(&sql)?;
         let rows = stmt
-            .query_map(rusqlite::params![after_id, limit as i64], |r| {
+            .query_map(rusqlite::params![after_id, limit as i64], move |r| {
                 let id: i64 = r.get(0)?;
                 let category: String = r.get(1)?;
                 let title: String = r.get(2)?;
                 let wing: String = r.get(3)?;
                 let room: String = r.get(4)?;
-                let created_at: Option<String> = r.get(5).ok().flatten();
+                // When the column exists, propagate real conversion errors via `?`.
+                // When it was projected as NULL (older schema), skip the call entirely.
+                let created_at: Option<String> = if has_ca { r.get(5)? } else { None };
                 Ok((id, category, title, wing, room, created_at))
             })?
-            .filter_map(|r| r.ok())
+            .collect::<Result<Vec<_>, rusqlite::Error>>()?
+            .into_iter()
             .map(|(id, category, title, wing, room, created_at)| {
                 serde_json::json!({
                     "id": id,

--- a/sk-rust/src/browse/db.rs
+++ b/sk-rust/src/browse/db.rs
@@ -421,6 +421,63 @@ impl BrowseDb {
         let conn = self.read_pool.get()?;
         Ok(search_by_wing_room(&conn, wing, room, category, limit))
     }
+
+    // ── SSE live-stream helper ─────────────────────────────────────────────────
+
+    /// Up to `limit` entries with `id > after_id`, returning the JSON shape
+    /// required by `/api/live`: `{id, category, title, wing, room, created_at}`.
+    ///
+    /// `created_at` is `null` when the column is absent from the schema
+    /// (older databases without the migration that adds it).
+    pub fn entries_after_live(
+        &self,
+        after_id: i64,
+        limit: usize,
+    ) -> anyhow::Result<Vec<serde_json::Value>> {
+        let conn = self.read_pool.get()?;
+        let has_sd = crate::db::fts::has_soft_delete(&conn);
+        let sd = if has_sd {
+            " AND deleted_at IS NULL"
+        } else {
+            ""
+        };
+        // Probe whether the created_at column exists on knowledge_entries.
+        let has_ca = conn
+            .prepare("SELECT created_at FROM knowledge_entries LIMIT 0")
+            .is_ok();
+        let ca_col = if has_ca { "created_at" } else { "NULL" };
+        let sql = format!(
+            "SELECT id, category, title, \
+                    COALESCE(wing,'') AS wing, COALESCE(room,'') AS room, \
+                    {ca_col} AS created_at \
+             FROM knowledge_entries WHERE id > ?{sd} \
+             ORDER BY id ASC LIMIT ?"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(rusqlite::params![after_id, limit as i64], |r| {
+                let id: i64 = r.get(0)?;
+                let category: String = r.get(1)?;
+                let title: String = r.get(2)?;
+                let wing: String = r.get(3)?;
+                let room: String = r.get(4)?;
+                let created_at: Option<String> = r.get(5).ok().flatten();
+                Ok((id, category, title, wing, room, created_at))
+            })?
+            .filter_map(|r| r.ok())
+            .map(|(id, category, title, wing, room, created_at)| {
+                serde_json::json!({
+                    "id": id,
+                    "category": category,
+                    "title": title,
+                    "wing": wing,
+                    "room": room,
+                    "created_at": created_at,
+                })
+            })
+            .collect();
+        Ok(rows)
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────

--- a/sk-rust/src/browse/mod.rs
+++ b/sk-rust/src/browse/mod.rs
@@ -7,6 +7,8 @@
 #![allow(dead_code)]
 
 #[cfg(feature = "browse-server")]
+pub mod api;
+#[cfg(feature = "browse-server")]
 pub mod auth;
 #[cfg(feature = "browse-server")]
 pub mod cors;
@@ -17,5 +19,7 @@ pub mod db_debug_log;
 pub mod importers;
 #[cfg(feature = "browse-server")]
 pub mod server;
+#[cfg(feature = "browse-server")]
+pub mod sse;
 #[cfg(feature = "browse-server")]
 pub mod static_files;

--- a/sk-rust/src/browse/server.rs
+++ b/sk-rust/src/browse/server.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use axum::extract::{Request, State};
+use axum::extract::{FromRef, Request, State};
 use axum::http::{HeaderName, HeaderValue};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Json, Response};
@@ -19,6 +19,7 @@ use tower_http::trace::TraceLayer;
 
 use crate::browse::auth::auth_middleware;
 use crate::browse::cors::cors_middleware;
+use crate::browse::db::BrowseDb;
 use crate::browse::static_files::serve_static;
 
 // ── Configuration ─────────────────────────────────────────────────────────────
@@ -80,9 +81,43 @@ impl ServerConfig {
     }
 }
 
+// ── AppState ──────────────────────────────────────────────────────────────────
+
+/// Combined router state holding both server configuration and the DB pool.
+///
+/// [`axum::extract::FromRef`] is implemented for both [`Arc<ServerConfig>`] and
+/// [`Arc<BrowseDb>`] so existing handlers that extract `State<Arc<ServerConfig>>`
+/// continue to compile without modification.
+#[derive(Clone)]
+pub struct AppState {
+    /// Server configuration (CORS origins, token, static root, …).
+    pub config: Arc<ServerConfig>,
+    /// Shared DB connection pools.
+    pub db: Arc<BrowseDb>,
+}
+
+impl AppState {
+    /// Construct a new [`AppState`].
+    pub fn new(config: Arc<ServerConfig>, db: Arc<BrowseDb>) -> Self {
+        Self { config, db }
+    }
+}
+
+impl FromRef<AppState> for Arc<ServerConfig> {
+    fn from_ref(state: &AppState) -> Self {
+        Arc::clone(&state.config)
+    }
+}
+
+impl FromRef<AppState> for Arc<BrowseDb> {
+    fn from_ref(state: &AppState) -> Self {
+        Arc::clone(&state.db)
+    }
+}
+
 // ── Router ────────────────────────────────────────────────────────────────────
 
-/// Build the Axum router for the given server configuration.
+/// Build the Axum router for the given application state.
 ///
 /// Layer ordering (outermost → innermost):
 /// 1. `TraceLayer` — request/response tracing
@@ -90,22 +125,23 @@ impl ServerConfig {
 /// 3. `cors_middleware` — CORS headers + OPTIONS preflight short-circuit
 /// 4. `auth_middleware` — Bearer / query-token / cookie authentication
 /// 5. route handlers
-pub fn app(config: Arc<ServerConfig>) -> Router {
+pub fn app(state: AppState) -> Router {
     use axum::middleware;
 
     Router::new()
         .route("/healthz", get(healthz_handler))
         .route("/.well-known/browse-host", get(discovery_handler))
+        .route("/api/live", get(crate::browse::api::live::handler))
         .fallback(serve_static)
-        .with_state(Arc::clone(&config))
+        .with_state(state.clone())
         // innermost middleware — auth
         .layer(middleware::from_fn_with_state(
-            Arc::clone(&config),
+            state.clone(),
             auth_middleware,
         ))
         // CORS (short-circuits OPTIONS before auth runs)
         .layer(middleware::from_fn_with_state(
-            Arc::clone(&config),
+            state.clone(),
             cors_middleware,
         ))
         // security headers on all responses
@@ -123,9 +159,10 @@ pub fn app(config: Arc<ServerConfig>) -> Router {
 }
 
 /// Bind and run the server, shutting down gracefully on Ctrl-C.
-pub async fn start(config: Arc<ServerConfig>) -> anyhow::Result<()> {
-    let listener = tokio::net::TcpListener::bind((config.host.as_str(), config.port)).await?;
-    let router = app(config);
+pub async fn start(state: AppState) -> anyhow::Result<()> {
+    let listener =
+        tokio::net::TcpListener::bind((state.config.host.as_str(), state.config.port)).await?;
+    let router = app(state);
 
     axum::serve(listener, router)
         .with_graceful_shutdown(async {
@@ -222,20 +259,49 @@ mod tests {
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
-    fn test_config() -> Arc<ServerConfig> {
-        Arc::new(ServerConfig {
-            port: 0,
-            host: "127.0.0.1".to_string(),
-            server_token: String::new(),
-            static_root: std::path::PathBuf::new(),
-            cors_origins: Vec::new(),
-            trusted_proxy: false,
-        })
+    use crate::browse::db::{BrowseDb, BrowseDbConfig};
+
+    /// Create a minimal [`AppState`] for unit tests — no seeded data needed.
+    fn test_state() -> AppState {
+        AppState::new(Arc::new(ServerConfig::default()), Arc::new(empty_db()))
+    }
+
+    /// Open a temporary, empty DB (no WAL checkpoint) for tests.
+    fn empty_db() -> BrowseDb {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static CTR: AtomicU64 = AtomicU64::new(0);
+        let n = CTR.fetch_add(1, Ordering::SeqCst);
+        let path =
+            std::env::temp_dir().join(format!("sk_srv_unit_{}_{}.db", std::process::id(), n));
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "PRAGMA journal_mode=WAL;\
+                 CREATE TABLE IF NOT EXISTS knowledge_entries (\
+                   id INTEGER PRIMARY KEY AUTOINCREMENT,\
+                   category TEXT NOT NULL DEFAULT '',\
+                   title TEXT NOT NULL DEFAULT '',\
+                   content TEXT NOT NULL DEFAULT '',\
+                   tags TEXT NOT NULL DEFAULT '',\
+                   wing TEXT, room TEXT,\
+                   confidence REAL NOT NULL DEFAULT 0.5,\
+                   deleted_at INTEGER\
+                 );\
+                 CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);",
+            )
+            .unwrap();
+        }
+        let cfg = BrowseDbConfig {
+            path,
+            checkpoint_interval: None,
+            ..Default::default()
+        };
+        BrowseDb::new_without_checkpoint(cfg).unwrap()
     }
 
     #[tokio::test]
     async fn test_healthz_status_ok() {
-        let response = app(test_config())
+        let response = app(test_state())
             .oneshot(
                 Request::builder()
                     .uri("/healthz")
@@ -249,7 +315,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_healthz_json_shape() {
-        let response = app(test_config())
+        let response = app(test_state())
             .oneshot(
                 Request::builder()
                     .uri("/healthz")
@@ -294,7 +360,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_security_headers_present() {
-        let response = app(test_config())
+        let response = app(test_state())
             .oneshot(
                 Request::builder()
                     .uri("/healthz")
@@ -321,7 +387,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_csp_contains_nonce() {
-        let response = app(test_config())
+        let response = app(test_state())
             .oneshot(
                 Request::builder()
                     .uri("/healthz")

--- a/sk-rust/src/browse/sse.rs
+++ b/sk-rust/src/browse/sse.rs
@@ -1,0 +1,138 @@
+//! SSE response helpers for the browse HTTP server (issue #448).
+//!
+//! # Client-disconnect cleanup
+//!
+//! When an SSE client disconnects, axum drops the streaming body future.
+//! This causes the [`tokio_stream::wrappers::ReceiverStream`] wrapping the
+//! [`tokio::sync::mpsc::Receiver`] to be dropped, which closes the channel
+//! and causes [`tokio::sync::mpsc::Sender::closed`] to resolve in the polling
+//! task. Polling tasks must select on `tx.closed()` (or check
+//! `tx.send(…).await.is_err()`) so they exit promptly without leaking.
+//!
+//! # Heartbeat comment semantics
+//!
+//! [`sse_response`] configures [`axum::response::sse::KeepAlive`] with
+//! `.text("ping")`.  This emits SSE *comment* lines (`: ping\n\n`) on the
+//! wire every [`HEARTBEAT_SECS`] seconds.  SSE comments (lines starting with
+//! `:`) are valid per the specification and pass through HTTP/2 proxies and
+//! load balancers, but the browser `EventSource` API silently ignores them.
+//! They keep the TCP connection alive through idle-connection timeouts without
+//! triggering `onmessage` on the client.
+
+use axum::response::sse::{Event, KeepAlive, Sse};
+use std::time::Duration;
+use tokio::sync::mpsc::Receiver;
+use tokio_stream::wrappers::ReceiverStream;
+
+/// Interval between SSE keep-alive comment frames (seconds).
+pub const HEARTBEAT_SECS: u64 = 15;
+
+/// Maximum SSE connection lifetime in seconds.
+///
+/// After this duration the server closes the stream.  The client is expected
+/// to reconnect using its stored `Last-Event-ID` value so the server can
+/// resume from the correct cursor.
+pub const MAX_CONNECTION_SECS: u64 = 600;
+
+/// Wrap a [`ReceiverStream`] in an [`axum::response::sse::Sse`] response with
+/// a periodic keep-alive comment (`: ping`) every [`HEARTBEAT_SECS`] seconds.
+///
+/// `E` must satisfy `Into<Box<dyn Error + Send + Sync>>` so axum can convert
+/// stream errors into HTTP error responses.
+pub fn sse_response<E>(
+    stream: ReceiverStream<Result<Event, E>>,
+) -> Sse<ReceiverStream<Result<Event, E>>>
+where
+    E: Into<axum::BoxError> + Send + 'static,
+{
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(HEARTBEAT_SECS))
+            .text("ping"),
+    )
+}
+
+/// Serialize `data` as a JSON-encoded SSE `data:` field.
+///
+/// Returns `Err(axum::Error)` if `data` cannot be serialized to JSON.
+pub fn json_event<T: serde::Serialize>(data: &T) -> Result<Event, axum::Error> {
+    Event::default().json_data(data)
+}
+
+/// Serialize `data` as a JSON-encoded SSE event with an `id:` field.
+///
+/// The `id` is emitted before the `data` line.  Clients store the last
+/// received `id` as the `Last-Event-ID` for reconnection, allowing the server
+/// to resume polling from the correct cursor position.
+///
+/// Returns `Err(axum::Error)` if `data` cannot be serialized to JSON.
+pub fn json_event_with_id<T: serde::Serialize>(data: &T, id: &str) -> Result<Event, axum::Error> {
+    Ok(Event::default().json_data(data)?.id(id))
+}
+
+/// Convert a [`tokio::sync::mpsc::Receiver`] into a
+/// [`tokio_stream::wrappers::ReceiverStream`] suitable for use with
+/// [`sse_response`].
+pub fn channel_stream<T>(rx: Receiver<T>) -> ReceiverStream<T> {
+    ReceiverStream::new(rx)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn json_event_ok_for_valid_data() {
+        let v = json!({"hello": "world"});
+        assert!(json_event(&v).is_ok());
+    }
+
+    #[test]
+    fn json_event_with_id_ok_for_valid_data() {
+        let v = json!({"n": 42});
+        assert!(json_event_with_id(&v, "42").is_ok());
+    }
+
+    #[test]
+    fn json_event_null_is_valid() {
+        assert!(json_event(&json!(null)).is_ok());
+    }
+
+    const _: () = {
+        assert!(HEARTBEAT_SECS > 0);
+        assert!(MAX_CONNECTION_SECS > HEARTBEAT_SECS);
+    };
+
+    #[test]
+    fn heartbeat_interval_compiles() {
+        // Verify KeepAlive uses HEARTBEAT_SECS constant correctly.
+        let _ka = KeepAlive::new()
+            .interval(Duration::from_secs(HEARTBEAT_SECS))
+            .text("ping");
+    }
+
+    #[tokio::test]
+    async fn channel_stream_yields_sent_values() {
+        use tokio_stream::StreamExt as _;
+        let (tx, rx) = tokio::sync::mpsc::channel::<i32>(4);
+        tx.send(10).await.unwrap();
+        tx.send(20).await.unwrap();
+        drop(tx);
+        let mut s = channel_stream(rx);
+        assert_eq!(s.next().await, Some(10));
+        assert_eq!(s.next().await, Some(20));
+        assert_eq!(s.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn channel_stream_ends_when_sender_dropped() {
+        use tokio_stream::StreamExt as _;
+        let (tx, rx) = tokio::sync::mpsc::channel::<u8>(1);
+        drop(tx);
+        let mut s = channel_stream(rx);
+        assert_eq!(s.next().await, None);
+    }
+}

--- a/sk-rust/tests/browse_server_test.rs
+++ b/sk-rust/tests/browse_server_test.rs
@@ -12,7 +12,43 @@ use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use tower::ServiceExt;
 
-use sk::browse::server::{app, ServerConfig};
+use sk::browse::db::{BrowseDb, BrowseDbConfig};
+use sk::browse::server::{app, AppState, ServerConfig};
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+/// Create a temporary empty [`BrowseDb`] for tests that only need the DB pool
+/// initialised (no data required).
+fn mk_db() -> Arc<BrowseDb> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!("sk_srv_int_{}_{}.db", std::process::id(), n));
+    {
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;\
+             CREATE TABLE IF NOT EXISTS knowledge_entries (\
+               id INTEGER PRIMARY KEY AUTOINCREMENT,\
+               category TEXT NOT NULL DEFAULT '',\
+               title TEXT NOT NULL DEFAULT '',\
+               content TEXT NOT NULL DEFAULT '',\
+               tags TEXT NOT NULL DEFAULT '',\
+               wing TEXT, room TEXT,\
+               confidence REAL NOT NULL DEFAULT 0.5,\
+               deleted_at INTEGER\
+             );\
+             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);",
+        )
+        .unwrap();
+    }
+    let cfg = BrowseDbConfig {
+        path,
+        checkpoint_interval: None,
+        ..Default::default()
+    };
+    Arc::new(BrowseDb::new_without_checkpoint(cfg).unwrap())
+}
 
 fn open_config() -> Arc<ServerConfig> {
     Arc::new(ServerConfig {
@@ -33,11 +69,19 @@ fn secured_config(token: &str) -> Arc<ServerConfig> {
     })
 }
 
+fn open_state() -> AppState {
+    AppState::new(open_config(), mk_db())
+}
+
+fn secured_state(token: &str) -> AppState {
+    AppState::new(secured_config(token), mk_db())
+}
+
 // ── /healthz ─────────────────────────────────────────────────────────────────
 
 #[tokio::test]
 async fn integration_healthz_200_open() {
-    let r = app(open_config())
+    let r = app(open_state())
         .oneshot(
             Request::builder()
                 .uri("/healthz")
@@ -51,7 +95,7 @@ async fn integration_healthz_200_open() {
 
 #[tokio::test]
 async fn integration_healthz_json_exact_keys() {
-    let r = app(open_config())
+    let r = app(open_state())
         .oneshot(
             Request::builder()
                 .uri("/healthz")
@@ -84,7 +128,7 @@ async fn integration_healthz_json_exact_keys() {
 
 #[tokio::test]
 async fn integration_healthz_open_even_with_auth() {
-    let r = app(secured_config("mysecret"))
+    let r = app(secured_state("mysecret"))
         .oneshot(
             Request::builder()
                 .uri("/healthz")
@@ -100,7 +144,7 @@ async fn integration_healthz_open_even_with_auth() {
 
 #[tokio::test]
 async fn integration_security_headers_on_healthz() {
-    let r = app(open_config())
+    let r = app(open_state())
         .oneshot(
             Request::builder()
                 .uri("/healthz")
@@ -126,8 +170,7 @@ async fn integration_security_headers_on_healthz() {
 #[tokio::test]
 async fn integration_auth_bearer_valid_passes() {
     // /api/noroute is protected; valid Bearer must pass auth and reach the router (404 = no handler).
-    let config = secured_config("supersecret");
-    let r = app(config)
+    let r = app(secured_state("supersecret"))
         .oneshot(
             Request::builder()
                 .uri("/api/noroute")
@@ -145,8 +188,7 @@ async fn integration_auth_bearer_valid_passes() {
 async fn integration_auth_missing_token_401() {
     // /api/data is not a registered route but goes through auth middleware.
     // With server_token set and no credentials: 401.
-    let config = secured_config("tok");
-    let r = app(config)
+    let r = app(secured_state("tok"))
         .oneshot(
             Request::builder()
                 .uri("/api/noroute")
@@ -163,7 +205,7 @@ async fn integration_auth_missing_token_401() {
 
 #[tokio::test]
 async fn integration_cors_preflight_allowed_origin() {
-    let r = app(open_config())
+    let r = app(open_state())
         .oneshot(
             Request::builder()
                 .method("OPTIONS")
@@ -188,7 +230,7 @@ async fn integration_cors_preflight_allowed_origin() {
 
 #[tokio::test]
 async fn integration_cors_preflight_blocked_origin() {
-    let r = app(open_config())
+    let r = app(open_state())
         .oneshot(
             Request::builder()
                 .method("OPTIONS")
@@ -205,7 +247,7 @@ async fn integration_cors_preflight_blocked_origin() {
 
 #[tokio::test]
 async fn integration_cors_static_path_options_405() {
-    let r = app(open_config())
+    let r = app(open_state())
         .oneshot(
             Request::builder()
                 .method("OPTIONS")
@@ -223,7 +265,7 @@ async fn integration_cors_static_path_options_405() {
 
 #[tokio::test]
 async fn integration_static_empty_root_404() {
-    let r = app(open_config())
+    let r = app(open_state())
         .oneshot(
             Request::builder()
                 .uri("/index.html")
@@ -247,7 +289,7 @@ async fn integration_static_serves_known_extension() {
         static_root: dir.path().to_path_buf(),
         ..ServerConfig::default()
     });
-    let r = app(config)
+    let r = app(AppState::new(config, mk_db()))
         .oneshot(
             Request::builder()
                 .uri("/app.js")
@@ -270,7 +312,7 @@ async fn integration_static_unknown_extension_403() {
         static_root: dir.path().to_path_buf(),
         ..ServerConfig::default()
     });
-    let r = app(config)
+    let r = app(AppState::new(config, mk_db()))
         .oneshot(
             Request::builder()
                 .uri("/data.bin")
@@ -289,7 +331,7 @@ async fn integration_static_dotdot_403() {
         static_root: dir.path().to_path_buf(),
         ..ServerConfig::default()
     });
-    let r = app(config)
+    let r = app(AppState::new(config, mk_db()))
         .oneshot(
             Request::builder()
                 .uri("/../etc/passwd")

--- a/sk-rust/tests/live_sse_test.rs
+++ b/sk-rust/tests/live_sse_test.rs
@@ -82,6 +82,70 @@ fn seed_two_entries(path: &std::path::Path) {
     .unwrap();
 }
 
+/// Read from `conn` accumulating bytes until the HTTP header separator
+/// `\r\n\r\n` is found, the 5-second deadline expires, or the connection
+/// closes.  Prevents packet-splitting flakes caused by a single fixed-size
+/// read.
+async fn read_http_headers(conn: &mut tokio::net::TcpStream) -> String {
+    use tokio::io::AsyncReadExt;
+    let mut buf: Vec<u8> = Vec::with_capacity(2048);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let mut chunk = vec![0u8; 512];
+        match tokio::time::timeout(remaining, conn.read(&mut chunk)).await {
+            Ok(Ok(0)) | Err(_) => break,
+            Ok(Ok(n)) => {
+                buf.extend_from_slice(&chunk[..n]);
+                if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            Ok(Err(_)) => break,
+        }
+    }
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// Read SSE body chunks from `conn`, accumulating until *all* strings in
+/// `expect` are present in the buffer or a 6-second wall-clock deadline
+/// passes.  Avoids chunk/timing flakes caused by a single read after a fixed
+/// sleep.
+async fn read_until_sse_contains(conn: &mut tokio::net::TcpStream, expect: &[&str]) -> String {
+    use tokio::io::AsyncReadExt;
+    let mut accumulated = String::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(6);
+    loop {
+        if expect.iter().all(|e| accumulated.contains(e)) {
+            break;
+        }
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let mut chunk = vec![0u8; 4096];
+        match tokio::time::timeout(
+            remaining.min(Duration::from_millis(500)),
+            conn.read(&mut chunk),
+        )
+        .await
+        {
+            Ok(Ok(0)) | Err(_) => {
+                // Either connection closed or this poll window expired; loop
+                // back to check the deadline and expected-string conditions.
+            }
+            Ok(Ok(n)) => {
+                accumulated.push_str(&String::from_utf8_lossy(&chunk[..n]));
+            }
+            Ok(Err(_)) => break,
+        }
+    }
+    accumulated
+}
+
 // ── Header tests (oneshot) ────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -172,7 +236,7 @@ async fn live_returns_401_without_token_when_auth_required() {
 /// with `id:` fields and JSON with the required shape keys.
 #[tokio::test]
 async fn live_seeded_two_events_appear_in_stream() {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::io::AsyncWriteExt;
 
     let db_path = unique_db_path("seed");
     let db = mk_db_at(&db_path);
@@ -207,14 +271,9 @@ async fn live_seeded_two_events_appear_in_stream() {
     .await
     .unwrap();
 
-    // Read until we get a 200 response header (the SSE body starts after the
-    // blank line).  Collect the initial bytes to verify the header.
-    let mut header_buf = vec![0u8; 1024];
-    let n = tokio::time::timeout(Duration::from_secs(3), conn.read(&mut header_buf))
-        .await
-        .expect("timed out reading HTTP response headers")
-        .unwrap();
-    let header_str = std::str::from_utf8(&header_buf[..n]).unwrap_or("");
+    // Read until the HTTP header separator to verify the 200 / content-type.
+    // Using a loop-until-\r\n\r\n helper prevents packet-splitting flakes.
+    let header_str = read_http_headers(&mut conn).await;
     assert!(
         header_str.contains("200"),
         "expected 200 response, got: {header_str}"
@@ -227,17 +286,13 @@ async fn live_seeded_two_events_appear_in_stream() {
     // Seed two entries AFTER the connection is established (cursor = 0 on empty DB).
     seed_two_entries(&db_path);
 
-    // The poll task fires every 2 seconds; wait 3 s for it to pick up the entries.
-    tokio::time::sleep(Duration::from_secs(3)).await;
-
-    // Read whatever the server has sent (may span multiple TCP segments).
-    let mut event_buf = vec![0u8; 4096];
-    let n = tokio::time::timeout(Duration::from_secs(2), conn.read(&mut event_buf))
-        .await
-        .unwrap_or(Ok(0))
-        .unwrap_or(0);
-
-    let event_str = std::str::from_utf8(&event_buf[..n]).unwrap_or("");
+    // Read SSE body chunks until both expected fields appear or the 6-second
+    // deadline passes.  Avoids a fixed sleep + single-read timing fragility.
+    let event_str = read_until_sse_contains(
+        &mut conn,
+        &["\"category\"", "\"title\"", "\"wing\"", "\"room\""],
+    )
+    .await;
 
     // In HTTP/1.1 chunked encoding the SSE text is embedded inside chunk
     // boundaries.  We search the raw bytes for the SSE fields we expect.

--- a/sk-rust/tests/live_sse_test.rs
+++ b/sk-rust/tests/live_sse_test.rs
@@ -1,0 +1,269 @@
+//! Integration tests for `GET /api/live` SSE endpoint (issue #448).
+//!
+//! Tests cover:
+//! - Content-type and cache-control response headers.
+//! - Auth: 401 when a server token is set and no credentials are provided.
+//! - Seeded events: two entries added after connection appear in the stream
+//!   with correct `id:` fields and JSON shape.
+//!
+//! The seeded-events test uses a real TCP listener so the streaming body can be
+//! read incrementally.  All other tests use `tower::ServiceExt::oneshot`.
+
+#![cfg(feature = "browse-server")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use sk::browse::db::{BrowseDb, BrowseDbConfig};
+use sk::browse::server::{app, AppState, ServerConfig};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn mk_db_at(path: &std::path::Path) -> Arc<BrowseDb> {
+    let conn = rusqlite::Connection::open(path).unwrap();
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;\
+         CREATE TABLE IF NOT EXISTS knowledge_entries (\
+           id INTEGER PRIMARY KEY AUTOINCREMENT,\
+           category TEXT NOT NULL DEFAULT '',\
+           title TEXT NOT NULL DEFAULT '',\
+           content TEXT NOT NULL DEFAULT '',\
+           tags TEXT NOT NULL DEFAULT '',\
+           wing TEXT, room TEXT,\
+           confidence REAL NOT NULL DEFAULT 0.5,\
+           deleted_at INTEGER\
+         );\
+         CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);",
+    )
+    .unwrap();
+    drop(conn);
+    let cfg = BrowseDbConfig {
+        path: path.to_path_buf(),
+        checkpoint_interval: None,
+        ..Default::default()
+    };
+    Arc::new(BrowseDb::new_without_checkpoint(cfg).unwrap())
+}
+
+fn unique_db_path(tag: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::SeqCst);
+    std::env::temp_dir().join(format!(
+        "sk_live_test_{tag}_{pid}_{n}.db",
+        pid = std::process::id()
+    ))
+}
+
+fn open_state_with_db(db: Arc<BrowseDb>) -> AppState {
+    AppState::new(
+        Arc::new(ServerConfig {
+            cors_origins: vec!["https://allowed.example".to_string()],
+            ..ServerConfig::default()
+        }),
+        db,
+    )
+}
+
+/// Insert two knowledge entries directly into the DB at `path` (bypasses the
+/// r2d2 pool so it can run from a test thread while the pool is open elsewhere).
+fn seed_two_entries(path: &std::path::Path) {
+    let conn = rusqlite::Connection::open(path).unwrap();
+    conn.execute_batch(
+        "INSERT INTO knowledge_entries (category, title, content, wing, room) \
+         VALUES \
+           ('pattern', 'Entry One',   'content 1', 'backend',  'auth'), \
+           ('mistake', 'Entry Two',   'content 2', 'frontend', 'ui');",
+    )
+    .unwrap();
+}
+
+// ── Header tests (oneshot) ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn live_returns_text_event_stream_content_type() {
+    let path = unique_db_path("ct");
+    let db = mk_db_at(&path);
+    let r = app(open_state_with_db(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/live")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::OK);
+    let ct = r
+        .headers()
+        .get("content-type")
+        .expect("content-type header required")
+        .to_str()
+        .unwrap();
+    assert!(
+        ct.contains("text/event-stream"),
+        "content-type must be text/event-stream, got {ct}"
+    );
+}
+
+#[tokio::test]
+async fn live_has_cache_control_no_cache() {
+    let path = unique_db_path("cc");
+    let db = mk_db_at(&path);
+    let r = app(open_state_with_db(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/live")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::OK);
+    let cc = r
+        .headers()
+        .get("cache-control")
+        .expect("cache-control header required")
+        .to_str()
+        .unwrap();
+    assert!(
+        cc.contains("no-cache"),
+        "cache-control must contain no-cache for SSE, got {cc}"
+    );
+}
+
+// ── Auth test (oneshot) ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn live_returns_401_without_token_when_auth_required() {
+    let path = unique_db_path("auth");
+    let db = mk_db_at(&path);
+    let state = AppState::new(
+        Arc::new(ServerConfig {
+            server_token: "secret".to_string(),
+            ..ServerConfig::default()
+        }),
+        db,
+    );
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/live")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ── Seeded-events test (real TCP server) ─────────────────────────────────────
+
+/// Start the router on a random port, connect via raw TCP, seed two entries,
+/// wait for the 2-second poll, then verify the SSE stream contains both events
+/// with `id:` fields and JSON with the required shape keys.
+#[tokio::test]
+async fn live_seeded_two_events_appear_in_stream() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let db_path = unique_db_path("seed");
+    let db = mk_db_at(&db_path);
+    let state = open_state_with_db(db);
+
+    // Bind a random OS-assigned port.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Spawn the server; it will shut itself down after 8 seconds via a sleep.
+    tokio::spawn(async move {
+        axum::serve(listener, app(state))
+            .with_graceful_shutdown(async {
+                tokio::time::sleep(Duration::from_secs(8)).await;
+            })
+            .await
+            .ok();
+    });
+
+    // Give the server a moment to bind.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Open a raw HTTP/1.1 connection for the SSE request.
+    let mut conn = tokio::net::TcpStream::connect(addr).await.unwrap();
+    conn.write_all(
+        b"GET /api/live HTTP/1.1\r\n\
+          Host: 127.0.0.1\r\n\
+          Accept: text/event-stream\r\n\
+          Connection: keep-alive\r\n\
+          \r\n",
+    )
+    .await
+    .unwrap();
+
+    // Read until we get a 200 response header (the SSE body starts after the
+    // blank line).  Collect the initial bytes to verify the header.
+    let mut header_buf = vec![0u8; 1024];
+    let n = tokio::time::timeout(Duration::from_secs(3), conn.read(&mut header_buf))
+        .await
+        .expect("timed out reading HTTP response headers")
+        .unwrap();
+    let header_str = std::str::from_utf8(&header_buf[..n]).unwrap_or("");
+    assert!(
+        header_str.contains("200"),
+        "expected 200 response, got: {header_str}"
+    );
+    assert!(
+        header_str.contains("text/event-stream"),
+        "expected text/event-stream in response headers"
+    );
+
+    // Seed two entries AFTER the connection is established (cursor = 0 on empty DB).
+    seed_two_entries(&db_path);
+
+    // The poll task fires every 2 seconds; wait 3 s for it to pick up the entries.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Read whatever the server has sent (may span multiple TCP segments).
+    let mut event_buf = vec![0u8; 4096];
+    let n = tokio::time::timeout(Duration::from_secs(2), conn.read(&mut event_buf))
+        .await
+        .unwrap_or(Ok(0))
+        .unwrap_or(0);
+
+    let event_str = std::str::from_utf8(&event_buf[..n]).unwrap_or("");
+
+    // In HTTP/1.1 chunked encoding the SSE text is embedded inside chunk
+    // boundaries.  We search the raw bytes for the SSE fields we expect.
+    assert!(
+        event_str.contains("id:") || event_str.contains("id: "),
+        "expected id: field in SSE stream, got: {event_str:?}"
+    );
+    assert!(
+        event_str.contains("data:") || event_str.contains("data: "),
+        "expected data: field in SSE stream, got: {event_str:?}"
+    );
+    // Verify JSON keys in the data payload.
+    assert!(
+        event_str.contains("\"category\""),
+        "SSE data must include 'category' key"
+    );
+    assert!(
+        event_str.contains("\"title\""),
+        "SSE data must include 'title' key"
+    );
+    assert!(
+        event_str.contains("\"wing\""),
+        "SSE data must include 'wing' key"
+    );
+    assert!(
+        event_str.contains("\"room\""),
+        "SSE data must include 'room' key"
+    );
+}


### PR DESCRIPTION
## Summary
- Add reusable Rust/Axum SSE helpers under sk-rust/src/browse/sse.rs.
- Add the feature-gated /api/live SSE endpoint backed by BrowseDb with bounded channel streaming, disconnect cleanup, 600s cap, and 15s keepalive comments.
- Refactor browse server state to AppState with FromRef so existing ServerConfig extractors keep working while /api/live can extract BrowseDb.

## Acceptance mapping
- /api/live streams new knowledge entries as id: + JSON data: frames.
- Heartbeat uses Axum KeepAlive every 15s with ping comment semantics.
- Client disconnect closes the bounded channel and exits the poll task.
- EventSource/fetch SSE compatibility is covered by standard 	ext/event-stream response behavior and tests.
- /api/operator/sessions/{id}/stream?run= remains the #451 follow-up that will reuse sse.rs.

## Validation
- cargo fmt --all -- --check
- cargo check --no-default-features
- cargo build --features browse-server
- cargo clippy --features browse-server --all-targets --no-deps -- -D warnings
- cargo test --features browse-server
- cargo test

Refs #448. Follow-up for operator stream: #451.
