### PR TITLE
feat(#450): port Rust browse core API endpoints

### DIFF
--- a/sk-rust/src/browse/api/compare.rs
+++ b/sk-rust/src/browse/api/compare.rs
@@ -1,0 +1,100 @@
+//! `GET /api/compare?a=<id>&b=<id>` handler (issue #450).
+//!
+//! Response contract matches the Python `/api/compare` endpoint exactly:
+//! `{ a: { session: SessionMeta|null, timeline: [...] },
+//!    b: { session: SessionMeta|null, timeline: [...] } }`
+//!
+//! - 400 `MISSING_PARAMS` when a or b are absent or blank.
+//! - 400 `BAD_SESSION_ID` when either id fails validation.
+//! - 200 always for valid ids — missing sessions yield `session: null`.
+
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json, Response};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::browse::db::BrowseDb;
+
+// ── Session-ID validation ─────────────────────────────────────────────────────
+
+/// Returns `true` when `id` matches `^[a-zA-Z0-9._-]{1,128}$`.
+fn is_valid_session_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 128
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
+}
+
+// ── Query params ──────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct CompareParams {
+    pub a: Option<String>,
+    pub b: Option<String>,
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+/// `GET /api/compare?a=<id>&b=<id>` — compare two sessions.
+///
+/// Returns `{ a: {session, timeline}, b: {session, timeline} }`.
+/// Missing sessions have `session: null, timeline: []` — never a 404.
+pub async fn handler(
+    State(db): State<Arc<BrowseDb>>,
+    Query(params): Query<CompareParams>,
+) -> Response {
+    let a = params.a.unwrap_or_default();
+    let b = params.b.unwrap_or_default();
+    let a = a.trim().to_string();
+    let b = b.trim().to_string();
+
+    if a.is_empty() || b.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "both 'a' and 'b' query params are required",
+                "code": "MISSING_PARAMS"
+            })),
+        )
+            .into_response();
+    }
+
+    if !is_valid_session_id(&a) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "invalid session ID for 'a'", "code": "BAD_SESSION_ID"})),
+        )
+            .into_response();
+    }
+    if !is_valid_session_id(&b) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "invalid session ID for 'b'", "code": "BAD_SESSION_ID"})),
+        )
+            .into_response();
+    }
+
+    match tokio::task::spawn_blocking(move || db.compare_sessions(&a, &b)).await {
+        Ok(Ok(result)) => (StatusCode::OK, Json(result)).into_response(),
+        Ok(Err(e)) => {
+            tracing::warn!("compare: db error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "db error"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::warn!("compare: spawn_blocking error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal error"})),
+            )
+                .into_response()
+        }
+    }
+}

--- a/sk-rust/src/browse/api/mod.rs
+++ b/sk-rust/src/browse/api/mod.rs
@@ -1,3 +1,5 @@
 //! API route handlers for the browse HTTP server.
 
+pub mod compare;
 pub mod live;
+pub mod sessions;

--- a/sk-rust/src/browse/api/sessions.rs
+++ b/sk-rust/src/browse/api/sessions.rs
@@ -1,0 +1,142 @@
+//! `GET /api/sessions` and `GET /api/sessions/{id}` handlers (issue #450).
+//!
+//! Response contracts match the Python `/api/sessions` endpoints exactly:
+//! - List: `{ items, total, page, page_size, has_more }`
+//! - Detail: `{ meta: SessionMeta, timeline: [TimelineEntry] }`
+//! - 400 `BAD_SESSION_ID` for invalid id regex; 404 `SESSION_NOT_FOUND` for miss.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json, Response};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::browse::db::BrowseDb;
+
+// ── Session-ID validation ─────────────────────────────────────────────────────
+
+/// Returns `true` when `id` matches `^[a-zA-Z0-9._-]{1,128}$`.
+fn is_valid_session_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 128
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
+}
+
+// ── Query params ──────────────────────────────────────────────────────────────
+
+/// Query parameters for `GET /api/sessions`.
+#[derive(Deserialize)]
+pub struct ListParams {
+    /// Optional full-text search query.
+    pub q: Option<String>,
+    /// 1-based page number (default 1).
+    pub page: Option<i64>,
+    /// Rows per page: 1–200, default 50.
+    pub page_size: Option<i64>,
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// `GET /api/sessions` — list sessions with pagination envelope.
+///
+/// Response: `{ items, total, page, page_size, has_more }`.
+/// - `page`: 1-based (default 1).
+/// - `page_size`: 1–200, default 50.
+/// - `q`: optional FTS search (falls back to full scan if FTS unavailable).
+pub async fn list_handler(
+    State(db): State<Arc<BrowseDb>>,
+    Query(params): Query<ListParams>,
+) -> Response {
+    let page = params.page.unwrap_or(1).max(1);
+    let page_size = params.page_size.unwrap_or(50).clamp(1, 200);
+    let q = params.q.map(|s| s.trim().to_string());
+    let q_ref: Option<String> = q;
+
+    match tokio::task::spawn_blocking(move || {
+        let q_str = q_ref.as_deref().unwrap_or("");
+        let q_opt = if q_str.is_empty() { None } else { Some(q_str) };
+        db.list_sessions(q_opt, page, page_size)
+    })
+    .await
+    {
+        Ok(Ok((items, total))) => {
+            let offset = (page - 1) * page_size;
+            let has_more = (offset + items.len() as i64) < total;
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "items": items,
+                    "total": total,
+                    "page": page,
+                    "page_size": page_size,
+                    "has_more": has_more,
+                })),
+            )
+                .into_response()
+        }
+        Ok(Err(e)) => {
+            tracing::warn!("sessions list: db error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "db error"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::warn!("sessions list: spawn_blocking error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// `GET /api/sessions/{id}` — full session detail.
+///
+/// - 400 `BAD_SESSION_ID` when id does not match `^[a-zA-Z0-9._-]{1,128}$`.
+/// - 404 `SESSION_NOT_FOUND` when session does not exist.
+/// - 200 `{ meta: SessionMeta, timeline: [TimelineEntry] }` on success.
+pub async fn detail_handler(State(db): State<Arc<BrowseDb>>, Path(id): Path<String>) -> Response {
+    if !is_valid_session_id(&id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "invalid session ID", "code": "BAD_SESSION_ID"})),
+        )
+            .into_response();
+    }
+
+    match tokio::task::spawn_blocking(move || db.get_session_detail(&id)).await {
+        Ok(Ok(Some((meta, timeline)))) => (
+            StatusCode::OK,
+            Json(json!({"meta": meta, "timeline": timeline})),
+        )
+            .into_response(),
+        Ok(Ok(None)) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "session not found", "code": "SESSION_NOT_FOUND"})),
+        )
+            .into_response(),
+        Ok(Err(e)) => {
+            tracing::warn!("session detail: db error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "db error"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::warn!("session detail: spawn_blocking error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal error"})),
+            )
+                .into_response()
+        }
+    }
+}

--- a/sk-rust/src/browse/api/sessions.rs
+++ b/sk-rust/src/browse/api/sessions.rs
@@ -34,9 +34,26 @@ pub struct ListParams {
     /// Optional full-text search query.
     pub q: Option<String>,
     /// 1-based page number (default 1).
-    pub page: Option<i64>,
+    pub page: Option<String>,
     /// Rows per page: 1–200, default 50.
-    pub page_size: Option<i64>,
+    pub page_size: Option<String>,
+}
+
+fn parse_int_param(value: Option<&str>, default: i64, min: i64, max: i64) -> i64 {
+    let parsed = value
+        .and_then(|raw| {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                trimmed
+                    .parse::<i128>()
+                    .ok()
+                    .map(|n| n.clamp(min as i128, max as i128) as i64)
+            }
+        })
+        .unwrap_or(default);
+    parsed.clamp(min, max)
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────────────
@@ -51,8 +68,8 @@ pub async fn list_handler(
     State(db): State<Arc<BrowseDb>>,
     Query(params): Query<ListParams>,
 ) -> Response {
-    let page = params.page.unwrap_or(1).max(1);
-    let page_size = params.page_size.unwrap_or(50).clamp(1, 200);
+    let page = parse_int_param(params.page.as_deref(), 1, 1, 10_000);
+    let page_size = parse_int_param(params.page_size.as_deref(), 50, 1, 200);
     let q = params.q.map(|s| s.trim().to_string());
     let q_ref: Option<String> = q;
 
@@ -64,8 +81,8 @@ pub async fn list_handler(
     .await
     {
         Ok(Ok((items, total))) => {
-            let offset = (page - 1) * page_size;
-            let has_more = (offset + items.len() as i64) < total;
+            let offset = page.saturating_sub(1).saturating_mul(page_size);
+            let has_more = offset.saturating_add(items.len() as i64) < total;
             (
                 StatusCode::OK,
                 Json(json!({

--- a/sk-rust/src/browse/db.rs
+++ b/sk-rust/src/browse/db.rs
@@ -8,7 +8,7 @@
 //! This module does NOT depend on `browse::server`.
 
 use anyhow::Context as _;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::OpenFlags;
@@ -98,9 +98,24 @@ pub struct HealthzStats {
 /// Values ≥ 1e11 in absolute value are treated as milliseconds.
 fn normalize_ts_real(ts: f64) -> String {
     let secs = if ts.abs() >= 1e11 { ts / 1000.0 } else { ts };
-    match DateTime::from_timestamp(secs as i64, 0) {
-        Some(dt) => dt.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+    let whole_secs = secs.floor();
+    let mut micros = ((secs - whole_secs) * 1_000_000.0).round() as u32;
+    let mut whole_secs = whole_secs as i64;
+    if micros >= 1_000_000 {
+        whole_secs = whole_secs.saturating_add(1);
+        micros = 0;
+    }
+    match DateTime::from_timestamp(whole_secs, micros * 1_000) {
+        Some(dt) => format_utc_timestamp(dt),
         None => secs.to_string(),
+    }
+}
+
+fn format_utc_timestamp(dt: DateTime<Utc>) -> String {
+    if dt.timestamp_subsec_micros() == 0 {
+        dt.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+    } else {
+        dt.to_rfc3339_opts(SecondsFormat::Micros, true)
     }
 }
 
@@ -113,15 +128,11 @@ fn normalize_ts_str(s: &str) -> Option<String> {
     // Replace trailing Z with +00:00 so parse_from_rfc3339 handles it.
     let s_utc = s.replace('Z', "+00:00");
     if let Ok(dt) = DateTime::parse_from_rfc3339(&s_utc) {
-        return Some(
-            dt.with_timezone(&Utc)
-                .format("%Y-%m-%dT%H:%M:%SZ")
-                .to_string(),
-        );
+        return Some(format_utc_timestamp(dt.with_timezone(&Utc)));
     }
     // Fallback: naive datetime (no timezone) → assume UTC.
-    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
-        return Some(ndt.and_utc().format("%Y-%m-%dT%H:%M:%SZ").to_string());
+    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f") {
+        return Some(format_utc_timestamp(ndt.and_utc()));
     }
     // Last resort: return as-is.
     Some(s.to_string())
@@ -646,8 +657,8 @@ impl BrowseDb {
 
     /// Collect all fields needed by `GET /healthz` in a single DB connection.
     ///
-    /// Returns `None` for fields whose backing table does not exist in the
-    /// current schema so older databases are handled gracefully.
+    /// Returns `0` for missing count tables and `None` for missing
+    /// `last_indexed_at` so older databases are handled gracefully.
     pub fn healthz_stats(&self) -> anyhow::Result<HealthzStats> {
         let conn = self.read_pool.get()?;
 
@@ -699,9 +710,9 @@ impl BrowseDb {
         page_size: i64,
     ) -> anyhow::Result<(Vec<serde_json::Value>, i64)> {
         let conn = self.read_pool.get()?;
-        let page = page.max(1);
+        let page = page.clamp(1, 10_000);
         let page_size = page_size.clamp(1, 200);
-        let offset = (page - 1) * page_size;
+        let offset = page.saturating_sub(1).saturating_mul(page_size);
 
         let select_cols = "SELECT s.id,
                     COALESCE(s.path,'') AS path,
@@ -1001,6 +1012,22 @@ mod tests {
     }
 
     // ── Helper method tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_ts_real_preserves_microseconds() {
+        assert_eq!(
+            normalize_ts_real(1_717_243_200.123456),
+            "2024-06-01T12:00:00.123456Z"
+        );
+    }
+
+    #[test]
+    fn normalize_ts_str_preserves_naive_fractional_seconds() {
+        assert_eq!(
+            normalize_ts_str("2024-01-01T10:00:00.123").as_deref(),
+            Some("2024-01-01T10:00:00.123000Z")
+        );
+    }
 
     #[test]
     fn count_entries_returns_three() {

--- a/sk-rust/src/browse/db.rs
+++ b/sk-rust/src/browse/db.rs
@@ -8,6 +8,7 @@
 //! This module does NOT depend on `browse::server`.
 
 use anyhow::Context as _;
+use chrono::{DateTime, Utc};
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::OpenFlags;
@@ -67,6 +68,225 @@ impl Drop for CheckpointHandle {
             let _ = jh.join();
         }
     }
+}
+
+// ── Public data types ──────────────────────────────────────────────────────────
+
+/// Stats collected for `GET /healthz`.
+pub struct HealthzStats {
+    /// Highest migration version in `migration_log`, or `0` when absent.
+    pub schema_version: i64,
+    /// Count of rows in `sessions`, or `0` when the table is absent.
+    pub sessions: i64,
+    /// Count of non-soft-deleted rows in `knowledge_entries`.
+    pub knowledge_entries: i64,
+    /// `MAX(indexed_at)` from `sessions`, or `None` when the table is absent
+    /// or empty.
+    pub last_indexed_at: Option<String>,
+}
+
+// SessionMeta is represented as serde_json::Value — see build_session_meta().
+// The JSON contract matches the Python normalize_session_meta() output:
+//   { id, path, summary, source, event_count_estimate, fts_indexed_at,
+//     indexed_at_r, file_mtime, total_checkpoints, total_research,
+//     total_files, has_plan, doc_count }
+// `indexed_at` (legacy TEXT column) is normalized and then excluded from output.
+
+// ── Timestamp normalization helpers ───────────────────────────────────────────
+
+/// Normalize a REAL Unix-timestamp column to RFC3339/Z string.
+/// Values ≥ 1e11 in absolute value are treated as milliseconds.
+fn normalize_ts_real(ts: f64) -> String {
+    let secs = if ts.abs() >= 1e11 { ts / 1000.0 } else { ts };
+    match DateTime::from_timestamp(secs as i64, 0) {
+        Some(dt) => dt.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        None => secs.to_string(),
+    }
+}
+
+/// Normalize a TEXT ISO-8601 timestamp to RFC3339/Z.  Returns `None` for blank input.
+fn normalize_ts_str(s: &str) -> Option<String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    // Replace trailing Z with +00:00 so parse_from_rfc3339 handles it.
+    let s_utc = s.replace('Z', "+00:00");
+    if let Ok(dt) = DateTime::parse_from_rfc3339(&s_utc) {
+        return Some(
+            dt.with_timezone(&Utc)
+                .format("%Y-%m-%dT%H:%M:%SZ")
+                .to_string(),
+        );
+    }
+    // Fallback: naive datetime (no timezone) → assume UTC.
+    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+        return Some(ndt.and_utc().format("%Y-%m-%dT%H:%M:%SZ").to_string());
+    }
+    // Last resort: return as-is.
+    Some(s.to_string())
+}
+
+/// Build a normalized SessionMeta JSON value from raw column values.
+///
+/// Mirrors `browse/api/_common.py::normalize_session_meta`.
+#[allow(clippy::too_many_arguments)]
+fn build_session_meta(
+    id: String,
+    path: String,
+    summary: String,
+    source: String,
+    event_count_estimate: Option<i64>,
+    fts_indexed_at_raw: Option<f64>,
+    indexed_at_r_raw: Option<f64>,
+    indexed_at_raw: Option<String>,
+    file_mtime_raw: Option<f64>,
+    total_checkpoints: i64,
+    total_research: i64,
+    total_files: i64,
+    has_plan: i64,
+    doc_count: i64,
+) -> serde_json::Value {
+    // Step 1: normalize timestamp columns.
+    let fts_ts = fts_indexed_at_raw.map(normalize_ts_real);
+    let idx_r_ts = indexed_at_r_raw.map(normalize_ts_real);
+    let fm_ts = file_mtime_raw.map(normalize_ts_real);
+    let indexed_at_ts = indexed_at_raw.as_deref().and_then(normalize_ts_str);
+
+    // Step 2: derive event_count_estimate.
+    let derived =
+        total_checkpoints + total_research + total_files + if has_plan != 0 { 1 } else { 0 };
+    let mut ece = event_count_estimate.unwrap_or(0);
+    if ece <= 0 {
+        let fallback = if derived > 0 { derived } else { doc_count };
+        if fallback > 0 {
+            ece = fallback;
+        }
+    }
+
+    // Step 3: fallback timestamps when session has content evidence.
+    let has_content = ece > 0 || derived > 0 || doc_count > 0;
+    let fallback_ts: Option<String> = fts_ts
+        .as_ref()
+        .or(idx_r_ts.as_ref())
+        .or(indexed_at_ts.as_ref())
+        .or(fm_ts.as_ref())
+        .cloned();
+
+    let final_fts = if has_content && fallback_ts.is_some() {
+        fts_ts.or_else(|| fallback_ts.clone())
+    } else {
+        fts_ts
+    };
+    let final_idx_r = if has_content && fallback_ts.is_some() {
+        idx_r_ts.or_else(|| fallback_ts.clone())
+    } else {
+        idx_r_ts
+    };
+    // file_mtime is not subject to fallback — normalize only.
+    // indexed_at is excluded from output per Python contract.
+
+    serde_json::json!({
+        "id": id,
+        "path": path,
+        "summary": summary,
+        "source": source,
+        "event_count_estimate": ece,
+        "fts_indexed_at": final_fts,
+        "indexed_at_r": final_idx_r,
+        "file_mtime": fm_ts,
+        "total_checkpoints": total_checkpoints,
+        "total_research": total_research,
+        "total_files": total_files,
+        "has_plan": has_plan,
+        "doc_count": doc_count,
+    })
+}
+
+/// Fetch one session's meta + timeline from an open connection.
+///
+/// Returns `(None, [])` when the session does not exist or `sessions` table
+/// is absent.  Timeline is empty when `documents` / `sections` are absent.
+fn fetch_one_session_conn(
+    conn: &rusqlite::Connection,
+    id: &str,
+) -> (Option<serde_json::Value>, Vec<serde_json::Value>) {
+    let meta = match conn.query_row(
+        "SELECT s.id,
+                COALESCE(s.path,'') AS path,
+                COALESCE(s.summary,'') AS summary,
+                COALESCE(s.source,'copilot') AS source,
+                s.event_count_estimate,
+                s.fts_indexed_at,
+                s.indexed_at_r,
+                s.indexed_at,
+                s.file_mtime,
+                COALESCE(s.total_checkpoints,0),
+                COALESCE(s.total_research,0),
+                COALESCE(s.total_files,0),
+                COALESCE(s.has_plan,0),
+                (SELECT COUNT(*) FROM documents d WHERE d.session_id = s.id) AS doc_count
+         FROM sessions s WHERE s.id = ?",
+        rusqlite::params![id],
+        |r| {
+            Ok(build_session_meta(
+                r.get(0)?,
+                r.get(1)?,
+                r.get(2)?,
+                r.get(3)?,
+                r.get(4)?,
+                r.get(5)?,
+                r.get(6)?,
+                r.get(7)?,
+                r.get(8)?,
+                r.get(9)?,
+                r.get(10)?,
+                r.get(11)?,
+                r.get(12)?,
+                r.get(13)?,
+            ))
+        },
+    ) {
+        Ok(m) => m,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return (None, vec![]),
+        Err(_) => return (None, vec![]), // sessions table absent or schema error
+    };
+
+    // Fetch timeline: documents LEFT JOIN sections, ordered by seq then section id.
+    let timeline: Vec<serde_json::Value> = match conn.prepare(
+        "SELECT d.seq, d.title, d.doc_type, s.section_name, s.content
+         FROM documents d
+         LEFT JOIN sections s ON s.document_id = d.id
+         WHERE d.session_id = ?
+         ORDER BY d.seq, s.id",
+    ) {
+        Ok(mut stmt) => stmt
+            .query_map(rusqlite::params![id], |r| {
+                let seq: i64 = r.get(0)?;
+                let title: String = r.get(1)?;
+                let doc_type: String = r.get(2)?;
+                let section_name: Option<String> = r.get(3)?;
+                let content: Option<String> = r.get(4)?;
+                Ok((seq, title, doc_type, section_name, content))
+            })
+            .map(|iter| {
+                iter.filter_map(|r| r.ok())
+                    .map(|(seq, title, doc_type, section_name, content)| {
+                        serde_json::json!({
+                            "seq": seq,
+                            "title": title,
+                            "doc_type": doc_type,
+                            "section_name": section_name,
+                            "content": content,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        Err(_) => vec![], // documents or sections absent
+    };
+
+    (Some(meta), timeline)
 }
 
 // ── BrowseDb ───────────────────────────────────────────────────────────────────
@@ -420,6 +640,237 @@ impl BrowseDb {
     ) -> anyhow::Result<Vec<KnowledgeEntry>> {
         let conn = self.read_pool.get()?;
         Ok(search_by_wing_room(&conn, wing, room, category, limit))
+    }
+
+    // ── Healthz stats ─────────────────────────────────────────────────────────
+
+    /// Collect all fields needed by `GET /healthz` in a single DB connection.
+    ///
+    /// Returns `None` for fields whose backing table does not exist in the
+    /// current schema so older databases are handled gracefully.
+    pub fn healthz_stats(&self) -> anyhow::Result<HealthzStats> {
+        let conn = self.read_pool.get()?;
+
+        let schema_version = conn
+            .query_row("SELECT MAX(version) FROM migration_log", [], |r| {
+                r.get::<_, Option<i64>>(0)
+            })
+            .unwrap_or(None)
+            .unwrap_or(0);
+
+        let has_sd = crate::db::fts::has_soft_delete(&conn);
+        let ke_sql = if has_sd {
+            "SELECT COUNT(*) FROM knowledge_entries WHERE deleted_at IS NULL"
+        } else {
+            "SELECT COUNT(*) FROM knowledge_entries"
+        };
+        let knowledge_entries = conn
+            .query_row(ke_sql, [], |r| r.get::<_, i64>(0))
+            .unwrap_or(0);
+
+        let sessions = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get::<_, i64>(0))
+            .unwrap_or(0);
+
+        let last_indexed_at = conn
+            .query_row("SELECT MAX(indexed_at) FROM sessions", [], |r| {
+                r.get::<_, Option<String>>(0)
+            })
+            .unwrap_or(None);
+
+        Ok(HealthzStats {
+            schema_version,
+            sessions,
+            knowledge_entries,
+            last_indexed_at,
+        })
+    }
+
+    // ── Session list / detail / compare ───────────────────────────────────────
+
+    /// List sessions with optional FTS search, returning `(items, total)`.
+    ///
+    /// Parameters mirror the Python `/api/sessions` endpoint:
+    /// - `q`: optional FTS search term (falls back to full list if FTS unavailable)
+    /// - `page`: 1-based page number (clamped to ≥ 1)
+    /// - `page_size`: rows per page (clamped 1–200, default 50)
+    ///
+    /// If the `sessions` table does not exist, returns `([], 0)`.
+    pub fn list_sessions(
+        &self,
+        q: Option<&str>,
+        page: i64,
+        page_size: i64,
+    ) -> anyhow::Result<(Vec<serde_json::Value>, i64)> {
+        let conn = self.read_pool.get()?;
+        let page = page.max(1);
+        let page_size = page_size.clamp(1, 200);
+        let offset = (page - 1) * page_size;
+
+        let select_cols = "SELECT s.id,
+                    COALESCE(s.path,'') AS path,
+                    COALESCE(s.summary,'') AS summary,
+                    COALESCE(s.source,'copilot') AS source,
+                    s.event_count_estimate,
+                    s.fts_indexed_at,
+                    s.indexed_at_r,
+                    s.indexed_at,
+                    s.file_mtime,
+                    COALESCE(s.total_checkpoints,0),
+                    COALESCE(s.total_research,0),
+                    COALESCE(s.total_files,0),
+                    COALESCE(s.has_plan,0),
+                    (SELECT COUNT(*) FROM documents d WHERE d.session_id = s.id) AS doc_count
+             FROM sessions s";
+
+        let order_clause = " ORDER BY CASE
+                 WHEN COALESCE(s.event_count_estimate,0) > 0
+                   OR COALESCE(s.total_checkpoints,0) + COALESCE(s.total_research,0)
+                      + COALESCE(s.total_files,0) + COALESCE(s.has_plan,0) > 0
+                   OR (SELECT COUNT(*) FROM documents d WHERE d.session_id = s.id) > 0
+                 THEN COALESCE(s.fts_indexed_at, s.indexed_at_r,
+                               CAST(strftime('%s', s.indexed_at) AS REAL),
+                               s.file_mtime, 0)
+                 ELSE COALESCE(s.fts_indexed_at, s.indexed_at_r, s.file_mtime, 0)
+               END DESC
+               LIMIT ?1 OFFSET ?2";
+
+        let map_row = |r: &rusqlite::Row<'_>| -> rusqlite::Result<serde_json::Value> {
+            Ok(build_session_meta(
+                r.get(0)?,
+                r.get(1)?,
+                r.get(2)?,
+                r.get(3)?,
+                r.get(4)?,
+                r.get(5)?,
+                r.get(6)?,
+                r.get(7)?,
+                r.get(8)?,
+                r.get(9)?,
+                r.get(10)?,
+                r.get(11)?,
+                r.get(12)?,
+                r.get(13)?,
+            ))
+        };
+
+        // Try FTS search when q is set and sessions_fts table exists.
+        let q_str = q.unwrap_or("").trim().to_string();
+        let mut use_fts = !q_str.is_empty();
+
+        if use_fts {
+            let has_fts: bool = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master \
+                     WHERE type='table' AND name='sessions_fts'",
+                    [],
+                    |r| r.get::<_, i64>(0),
+                )
+                .unwrap_or(0)
+                > 0;
+            use_fts = has_fts;
+        }
+
+        let (rows, total) = if use_fts {
+            let safe_q = sanitize_fts_query(&q_str);
+            let fts_sql = format!(
+                "{select_cols} WHERE s.id IN \
+                 (SELECT session_id FROM sessions_fts WHERE sessions_fts MATCH ?3)\
+                 {order_clause}"
+            );
+            let fts_rows: Option<Vec<serde_json::Value>> =
+                conn.prepare(&fts_sql).ok().and_then(|mut stmt| {
+                    stmt.query_map(rusqlite::params![page_size, offset, &safe_q], map_row)
+                        .ok()
+                        .map(|iter| iter.filter_map(|r| r.ok()).collect())
+                });
+
+            if let Some(rows) = fts_rows {
+                let total: i64 = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM sessions \
+                         WHERE id IN (SELECT session_id FROM sessions_fts \
+                                      WHERE sessions_fts MATCH ?)",
+                        rusqlite::params![&safe_q],
+                        |r| r.get(0),
+                    )
+                    .unwrap_or(0);
+                (rows, total)
+            } else {
+                // FTS failed — fall through to full scan.
+                self.list_sessions_full_scan(&conn, page_size, offset, select_cols, order_clause)?
+            }
+        } else {
+            self.list_sessions_full_scan(&conn, page_size, offset, select_cols, order_clause)?
+        };
+
+        Ok((rows, total))
+    }
+
+    fn list_sessions_full_scan(
+        &self,
+        conn: &rusqlite::Connection,
+        page_size: i64,
+        offset: i64,
+        select_cols: &str,
+        order_clause: &str,
+    ) -> anyhow::Result<(Vec<serde_json::Value>, i64)> {
+        let sql = format!("{select_cols}{order_clause}");
+        let rows: Vec<serde_json::Value> = match conn.prepare(&sql) {
+            Ok(mut stmt) => stmt
+                .query_map(rusqlite::params![page_size, offset], |r| {
+                    Ok(build_session_meta(
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                        r.get(6)?,
+                        r.get(7)?,
+                        r.get(8)?,
+                        r.get(9)?,
+                        r.get(10)?,
+                        r.get(11)?,
+                        r.get(12)?,
+                        r.get(13)?,
+                    ))
+                })
+                .map(|iter| iter.filter_map(|r| r.ok()).collect())
+                .unwrap_or_default(),
+            Err(_) => vec![], // sessions table absent
+        };
+        let total: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
+            .unwrap_or(0);
+        Ok((rows, total))
+    }
+
+    /// Full session detail: `(SessionMeta, timeline)`.
+    ///
+    /// Returns `Ok(None)` when the session does not exist or when the `sessions`
+    /// table is absent.
+    pub fn get_session_detail(
+        &self,
+        id: &str,
+    ) -> anyhow::Result<Option<(serde_json::Value, Vec<serde_json::Value>)>> {
+        let conn = self.read_pool.get()?;
+        let (meta, timeline) = fetch_one_session_conn(&conn, id);
+        Ok(meta.map(|m| (m, timeline)))
+    }
+
+    /// Compare two sessions: returns `{ a: {session, timeline}, b: {session, timeline} }`.
+    ///
+    /// Missing sessions produce `session: null, timeline: []` — never a 404.
+    /// Always returns `Ok(value)`.
+    pub fn compare_sessions(&self, id_a: &str, id_b: &str) -> anyhow::Result<serde_json::Value> {
+        let conn = self.read_pool.get()?;
+        let (meta_a, tl_a) = fetch_one_session_conn(&conn, id_a);
+        let (meta_b, tl_b) = fetch_one_session_conn(&conn, id_b);
+        Ok(serde_json::json!({
+            "a": { "session": meta_a, "timeline": tl_a },
+            "b": { "session": meta_b, "timeline": tl_b },
+        }))
     }
 
     // ── SSE live-stream helper ─────────────────────────────────────────────────

--- a/sk-rust/src/browse/db.rs
+++ b/sk-rust/src/browse/db.rs
@@ -74,11 +74,11 @@ impl Drop for CheckpointHandle {
 
 /// Stats collected for `GET /healthz`.
 pub struct HealthzStats {
-    /// Highest migration version in `migration_log`, or `0` when absent.
+    /// Highest migration version in `schema_version`, or `0` when absent.
     pub schema_version: i64,
     /// Count of rows in `sessions`, or `0` when the table is absent.
     pub sessions: i64,
-    /// Count of non-soft-deleted rows in `knowledge_entries`.
+    /// Count of rows in `knowledge_entries`.
     pub knowledge_entries: i64,
     /// `MAX(indexed_at)` from `sessions`, or `None` when the table is absent
     /// or empty.
@@ -577,11 +577,11 @@ impl BrowseDb {
         Ok(rows)
     }
 
-    /// Highest `version` from `migration_log`, or `0` when the table is absent.
+    /// Highest `version` from `schema_version`, or `0` when the table is absent.
     pub fn schema_version(&self) -> anyhow::Result<i64> {
         let conn = self.read_pool.get()?;
         let v = conn
-            .query_row("SELECT MAX(version) FROM migration_log", [], |r| {
+            .query_row("SELECT MAX(version) FROM schema_version", [], |r| {
                 r.get::<_, Option<i64>>(0)
             })
             .unwrap_or(None)
@@ -652,20 +652,16 @@ impl BrowseDb {
         let conn = self.read_pool.get()?;
 
         let schema_version = conn
-            .query_row("SELECT MAX(version) FROM migration_log", [], |r| {
+            .query_row("SELECT MAX(version) FROM schema_version", [], |r| {
                 r.get::<_, Option<i64>>(0)
             })
             .unwrap_or(None)
             .unwrap_or(0);
 
-        let has_sd = crate::db::fts::has_soft_delete(&conn);
-        let ke_sql = if has_sd {
-            "SELECT COUNT(*) FROM knowledge_entries WHERE deleted_at IS NULL"
-        } else {
-            "SELECT COUNT(*) FROM knowledge_entries"
-        };
         let knowledge_entries = conn
-            .query_row(ke_sql, [], |r| r.get::<_, i64>(0))
+            .query_row("SELECT COUNT(*) FROM knowledge_entries", [], |r| {
+                r.get::<_, i64>(0)
+            })
             .unwrap_or(0);
 
         let sessions = conn
@@ -956,7 +952,7 @@ mod tests {
         let conn = Connection::open(path).unwrap();
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
-             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);
+             CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');
              CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY);
              CREATE TABLE IF NOT EXISTS knowledge_entries (
                  id         INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -973,7 +969,7 @@ mod tests {
                  USING fts5(content, content=knowledge_entries, content_rowid=id);
              CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts
                  USING fts5(session_id UNINDEXED, title, user_messages, assistant_messages, tool_names);
-             INSERT INTO migration_log VALUES (1);
+             INSERT INTO schema_version (version, name) VALUES (1, 'test');
              INSERT INTO sessions VALUES ('sess-1');
              INSERT INTO sessions VALUES ('sess-2');
              INSERT INTO knowledge_entries
@@ -1095,8 +1091,8 @@ mod tests {
         let conn = Connection::open(&path).unwrap();
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
-             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);
-             INSERT INTO migration_log VALUES (1);",
+             CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');
+             INSERT INTO schema_version (version, name) VALUES (1, 'test');",
         )
         .unwrap();
         drop(conn);

--- a/sk-rust/src/browse/server.rs
+++ b/sk-rust/src/browse/server.rs
@@ -308,7 +308,7 @@ mod tests {
                    confidence REAL NOT NULL DEFAULT 0.5,\
                    deleted_at INTEGER\
                  );\
-                 CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);",
+                 CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');",
             )
             .unwrap();
         }

--- a/sk-rust/src/browse/server.rs
+++ b/sk-rust/src/browse/server.rs
@@ -4,7 +4,6 @@
 //! listener and runs the server with graceful Ctrl-C shutdown).
 //!
 //! Nothing is wired to `Commands::Browse` yet; the Python fallback remains.
-//! DB fields in `/healthz` are `null` pending issue #449.
 
 use std::sync::Arc;
 
@@ -132,6 +131,15 @@ pub fn app(state: AppState) -> Router {
         .route("/healthz", get(healthz_handler))
         .route("/.well-known/browse-host", get(discovery_handler))
         .route("/api/live", get(crate::browse::api::live::handler))
+        .route(
+            "/api/sessions",
+            get(crate::browse::api::sessions::list_handler),
+        )
+        .route(
+            "/api/sessions/:id",
+            get(crate::browse::api::sessions::detail_handler),
+        )
+        .route("/api/compare", get(crate::browse::api::compare::handler))
         .fallback(serve_static)
         .with_state(state.clone())
         // innermost middleware — auth
@@ -179,16 +187,29 @@ pub async fn start(state: AppState) -> anyhow::Result<()> {
 
 /// `GET /healthz` — open endpoint, no auth required.
 ///
-/// DB fields are `null` until issue #449 lands.
-async fn healthz_handler() -> Json<Value> {
-    Json(json!({
-        "status": "ok",
-        "schema_version": null,       // TODO(#449)
-        "sessions": null,             // TODO(#449)
-        "knowledge_entries": null,    // TODO(#449)
-        "last_indexed_at": null,      // TODO(#449)
-        "sync_status_endpoint": "/api/sync/status",
-    }))
+/// DB fields are populated from [`BrowseDb`].  If the DB query fails the
+/// response is still HTTP 200 but `status` is `"degraded"` and DB fields are
+/// `null` so callers can detect partial availability.
+async fn healthz_handler(State(db): State<Arc<BrowseDb>>) -> Json<Value> {
+    let result = tokio::task::spawn_blocking(move || db.healthz_stats()).await;
+    match result {
+        Ok(Ok(s)) => Json(json!({
+            "status": "ok",
+            "schema_version": s.schema_version,
+            "sessions": s.sessions,
+            "knowledge_entries": s.knowledge_entries,
+            "last_indexed_at": s.last_indexed_at,
+            "sync_status_endpoint": "/api/sync/status",
+        })),
+        _ => Json(json!({
+            "status": "degraded",
+            "schema_version": null,
+            "sessions": null,
+            "knowledge_entries": null,
+            "last_indexed_at": null,
+            "sync_status_endpoint": "/api/sync/status",
+        })),
+    }
 }
 
 /// `GET /.well-known/browse-host` — discovery endpoint, no auth required.
@@ -328,7 +349,10 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-        assert_eq!(v["status"], "ok", "status must be 'ok'");
+        assert!(
+            v["status"] == "ok" || v["status"] == "degraded",
+            "status must be ok or degraded"
+        );
         assert!(
             v.get("schema_version").is_some(),
             "schema_version key required"
@@ -346,16 +370,21 @@ mod tests {
             v["sync_status_endpoint"], "/api/sync/status",
             "sync_status_endpoint must be '/api/sync/status'"
         );
-        assert!(v["schema_version"].is_null(), "schema_version must be null");
-        assert!(v["sessions"].is_null(), "sessions must be null");
-        assert!(
-            v["knowledge_entries"].is_null(),
-            "knowledge_entries must be null"
-        );
-        assert!(
-            v["last_indexed_at"].is_null(),
-            "last_indexed_at must be null"
-        );
+        // When DB is reachable, numeric fields must not be null.
+        if v["status"] == "ok" {
+            assert!(
+                v["schema_version"].is_number(),
+                "schema_version must be a number when status=ok"
+            );
+            assert!(
+                v["sessions"].is_number(),
+                "sessions must be a number when status=ok"
+            );
+            assert!(
+                v["knowledge_entries"].is_number(),
+                "knowledge_entries must be a number when status=ok"
+            );
+        }
     }
 
     #[tokio::test]

--- a/sk-rust/tests/browse_server_test.rs
+++ b/sk-rust/tests/browse_server_test.rs
@@ -38,7 +38,7 @@ fn mk_db() -> Arc<BrowseDb> {
                confidence REAL NOT NULL DEFAULT 0.5,\
                deleted_at INTEGER\
              );\
-             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);",
+             CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');",
         )
         .unwrap();
     }

--- a/sk-rust/tests/browse_server_test.rs
+++ b/sk-rust/tests/browse_server_test.rs
@@ -118,12 +118,25 @@ async fn integration_healthz_json_exact_keys() {
     ] {
         assert!(v.get(key).is_some(), "healthz must contain key '{key}'");
     }
-    assert_eq!(v["status"], "ok");
+    // status is ok (DB reachable) or degraded (DB error — should not happen in tests).
+    assert!(
+        v["status"] == "ok" || v["status"] == "degraded",
+        "status must be 'ok' or 'degraded'"
+    );
     assert_eq!(v["sync_status_endpoint"], "/api/sync/status");
-    assert!(v["sessions"].is_null());
-    assert!(v["knowledge_entries"].is_null());
-    assert!(v["last_indexed_at"].is_null());
-    assert!(v["schema_version"].is_null());
+    // When DB is reachable, numeric counters must not be null.
+    if v["status"] == "ok" {
+        assert!(
+            v["schema_version"].is_number(),
+            "schema_version must be a number"
+        );
+        assert!(v["sessions"].is_number(), "sessions must be a number");
+        assert!(
+            v["knowledge_entries"].is_number(),
+            "knowledge_entries must be a number"
+        );
+        // last_indexed_at may be null (no sessions in the test fixture).
+    }
 }
 
 #[tokio::test]

--- a/sk-rust/tests/compare_api_test.rs
+++ b/sk-rust/tests/compare_api_test.rs
@@ -1,0 +1,293 @@
+//! Tests for `GET /api/compare?a=<id>&b=<id>` (issue #450).
+//!
+//! Contract: `{ a: {session: SessionMeta|null, timeline: [...]},
+//!   b: {session: SessionMeta|null, timeline: [...]} }`.
+//!
+//! - 400 MISSING_PARAMS when a or b absent/blank.
+//! - 400 BAD_SESSION_ID when either id is invalid.
+//! - 200 always for valid ids; missing session yields session:null.
+//!
+//! DDL uses production-faithful schema with `documents.file_path UNIQUE`.
+
+#![cfg(feature = "browse-server")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use rusqlite::Connection;
+use tower::ServiceExt;
+
+use sk::browse::db::{BrowseDb, BrowseDbConfig};
+use sk::browse::server::{app, AppState, ServerConfig};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn seeded_db(label: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "sk_compare_api_{label}_{n}_{}.db",
+        std::process::id()
+    ));
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);
+             -- Production-faithful sessions schema (base + all migration columns).
+             CREATE TABLE IF NOT EXISTS sessions (
+               id TEXT PRIMARY KEY,
+               path TEXT NOT NULL DEFAULT '',
+               summary TEXT DEFAULT '',
+               total_checkpoints INTEGER DEFAULT 0,
+               total_research INTEGER DEFAULT 0,
+               total_files INTEGER DEFAULT 0,
+               has_plan INTEGER DEFAULT 0,
+               source TEXT DEFAULT 'copilot',
+               indexed_at TEXT,
+               file_mtime REAL,
+               indexed_at_r REAL,
+               fts_indexed_at REAL,
+               event_count_estimate INTEGER DEFAULT 0
+             );
+             -- Production-faithful documents schema: file_path UNIQUE.
+             CREATE TABLE IF NOT EXISTS documents (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               session_id TEXT NOT NULL,
+               doc_type TEXT NOT NULL DEFAULT 'artifact',
+               seq INTEGER DEFAULT 0,
+               title TEXT NOT NULL DEFAULT '',
+               file_path TEXT NOT NULL UNIQUE
+             );
+             CREATE TABLE IF NOT EXISTS sections (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               document_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+               section_name TEXT NOT NULL,
+               content TEXT NOT NULL,
+               UNIQUE(document_id, section_name)
+             );
+             CREATE TABLE IF NOT EXISTS knowledge_entries (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               category TEXT NOT NULL DEFAULT '',
+               title TEXT NOT NULL DEFAULT '',
+               content TEXT NOT NULL DEFAULT '',
+               tags TEXT NOT NULL DEFAULT '',
+               wing TEXT, room TEXT,
+               confidence REAL NOT NULL DEFAULT 0.5,
+               deleted_at INTEGER
+             );
+             INSERT INTO migration_log VALUES (1);
+             INSERT INTO sessions (id, path, fts_indexed_at) VALUES
+               ('s-a', '/a', 1717243200.0),
+               ('s-b', '/b', 1704103200.0);
+             -- Distinct file paths per session (UNIQUE constraint).
+             INSERT INTO documents (session_id, doc_type, file_path, title)
+             VALUES
+               ('s-a', 'artifact', '/a/f1.md', 'F1'),
+               ('s-a', 'artifact', '/a/f2.md', 'F2'),
+               ('s-b', 'artifact', '/b/f3.md', 'F3'),
+               ('s-b', 'artifact', '/b/f4.md', 'F4');",
+        )
+        .unwrap();
+    }
+    let cfg = BrowseDbConfig {
+        path: path.clone(),
+        checkpoint_interval: None,
+        ..Default::default()
+    };
+    (
+        path,
+        Arc::new(BrowseDb::new_without_checkpoint(cfg).unwrap()),
+    )
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in &["", "-wal", "-shm"] {
+        let _ = std::fs::remove_file(format!("{}{suffix}", path.display()));
+    }
+}
+
+fn open_state(db: Arc<BrowseDb>) -> AppState {
+    AppState::new(Arc::new(ServerConfig::default()), db)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn compare_200_shape() {
+    let (path, db) = seeded_db("200");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/compare?a=s-a&b=s-b")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    // Must have a and b keys, each with session + timeline.
+    assert!(v.get("a").is_some(), "must have 'a' key");
+    assert!(v.get("b").is_some(), "must have 'b' key");
+    assert!(v["a"].get("session").is_some(), "a must have session");
+    assert!(v["a"].get("timeline").is_some(), "a must have timeline");
+    assert!(v["b"].get("session").is_some(), "b must have session");
+    assert!(v["b"].get("timeline").is_some(), "b must have timeline");
+    // Both sessions exist → session must be non-null.
+    assert!(!v["a"]["session"].is_null(), "session a must not be null");
+    assert!(!v["b"]["session"].is_null(), "session b must not be null");
+    assert_eq!(v["a"]["session"]["id"], "s-a");
+    assert_eq!(v["b"]["session"]["id"], "s-b");
+    // No shared_files or diff_summary.
+    assert!(
+        v.get("shared_files").is_none(),
+        "must NOT have shared_files"
+    );
+    assert!(
+        v.get("diff_summary").is_none(),
+        "must NOT have diff_summary"
+    );
+    // Timelines: 2 docs each.
+    assert_eq!(v["a"]["timeline"].as_array().unwrap().len(), 2);
+    assert_eq!(v["b"]["timeline"].as_array().unwrap().len(), 2);
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn compare_200_missing_session_a_is_null() {
+    let (path, db) = seeded_db("null_a");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/compare?a=no-such&b=s-b")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Must be 200, NOT 404.
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(
+        v["a"]["session"].is_null(),
+        "missing session a must be null"
+    );
+    assert_eq!(v["a"]["timeline"].as_array().unwrap().len(), 0);
+    assert!(!v["b"]["session"].is_null(), "session b must be non-null");
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn compare_200_missing_session_b_is_null() {
+    let (path, db) = seeded_db("null_b");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/compare?a=s-a&b=no-such")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(!v["a"]["session"].is_null(), "session a must be non-null");
+    assert!(
+        v["b"]["session"].is_null(),
+        "missing session b must be null"
+    );
+    assert_eq!(v["b"]["timeline"].as_array().unwrap().len(), 0);
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn compare_400_missing_params() {
+    let (path, db) = seeded_db("400mp");
+    let r = app(open_state(db.clone()))
+        .oneshot(
+            Request::builder()
+                .uri("/api/compare")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["code"], "MISSING_PARAMS");
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn compare_400_missing_b_param() {
+    let (path, db) = seeded_db("400b");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/compare?a=s-a")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["code"], "MISSING_PARAMS");
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn compare_400_invalid_id() {
+    let (path, db) = seeded_db("400id");
+    // ID with a space is invalid.
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/compare?a=bad%20id&b=s-b")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["code"], "BAD_SESSION_ID");
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn compare_session_meta_fields_no_branch() {
+    let (path, db) = seeded_db("meta");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/compare?a=s-a&b=s-b")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let sess = &v["a"]["session"];
+    assert!(sess.get("id").is_some());
+    assert!(sess.get("path").is_some());
+    assert!(sess.get("summary").is_some());
+    assert!(sess.get("source").is_some());
+    // Must NOT have branch / created_at / updated_at / indexed_at.
+    assert!(sess.get("branch").is_none());
+    assert!(sess.get("created_at").is_none());
+    assert!(sess.get("updated_at").is_none());
+    assert!(sess.get("indexed_at").is_none());
+    cleanup(&path);
+}

--- a/sk-rust/tests/compare_api_test.rs
+++ b/sk-rust/tests/compare_api_test.rs
@@ -36,7 +36,7 @@ fn seeded_db(label: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
         let conn = Connection::open(&path).unwrap();
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
-             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);
+             CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');
              -- Production-faithful sessions schema (base + all migration columns).
              CREATE TABLE IF NOT EXISTS sessions (
                id TEXT PRIMARY KEY,
@@ -79,7 +79,7 @@ fn seeded_db(label: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
                confidence REAL NOT NULL DEFAULT 0.5,
                deleted_at INTEGER
              );
-             INSERT INTO migration_log VALUES (1);
+             INSERT INTO schema_version (version, name) VALUES (1, 'test');
              INSERT INTO sessions (id, path, fts_indexed_at) VALUES
                ('s-a', '/a', 1717243200.0),
                ('s-b', '/b', 1704103200.0);

--- a/sk-rust/tests/healthz_db_test.rs
+++ b/sk-rust/tests/healthz_db_test.rs
@@ -1,0 +1,197 @@
+//! Tests that `GET /healthz` returns real DB-backed values (issue #450).
+
+#![cfg(feature = "browse-server")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use rusqlite::Connection;
+use tower::ServiceExt;
+
+use sk::browse::db::{BrowseDb, BrowseDbConfig};
+use sk::browse::server::{app, AppState, ServerConfig};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn seeded_db(label: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "sk_healthz_db_{label}_{n}_{}.db",
+        std::process::id()
+    ));
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);
+             CREATE TABLE IF NOT EXISTS sessions (
+               id TEXT PRIMARY KEY,
+               path TEXT NOT NULL DEFAULT '',
+               summary TEXT DEFAULT '',
+               indexed_at TEXT,
+               total_checkpoints INTEGER DEFAULT 0,
+               total_files INTEGER DEFAULT 0,
+               source TEXT DEFAULT 'copilot'
+             );
+             CREATE TABLE IF NOT EXISTS knowledge_entries (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               category TEXT NOT NULL DEFAULT '',
+               title TEXT NOT NULL DEFAULT '',
+               content TEXT NOT NULL DEFAULT '',
+               tags TEXT NOT NULL DEFAULT '',
+               wing TEXT, room TEXT,
+               confidence REAL NOT NULL DEFAULT 0.5,
+               deleted_at INTEGER
+             );
+             INSERT INTO migration_log VALUES (3);
+             INSERT INTO sessions (id, path, indexed_at) VALUES
+               ('sess-a', '/path/a', '2024-01-01T10:00:00'),
+               ('sess-b', '/path/b', '2024-06-01T12:00:00');
+             INSERT INTO knowledge_entries (category, title, content)
+             VALUES ('mistake', 'T1', 'c1'), ('pattern', 'T2', 'c2');",
+        )
+        .unwrap();
+    }
+    let cfg = BrowseDbConfig {
+        path: path.clone(),
+        checkpoint_interval: None,
+        ..Default::default()
+    };
+    (
+        path,
+        Arc::new(BrowseDb::new_without_checkpoint(cfg).unwrap()),
+    )
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in &["", "-wal", "-shm"] {
+        let _ = std::fs::remove_file(format!("{}{suffix}", path.display()));
+    }
+}
+
+fn state_with(db: Arc<BrowseDb>) -> AppState {
+    AppState::new(Arc::new(ServerConfig::default()), db)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn healthz_schema_version_is_real() {
+    let (path, db) = seeded_db("sv");
+    let r = app(state_with(db))
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["status"], "ok");
+    assert_eq!(
+        v["schema_version"], 3,
+        "schema_version must match migration_log MAX"
+    );
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn healthz_counts_match_seeded_fixture() {
+    let (path, db) = seeded_db("counts");
+    let r = app(state_with(db))
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["sessions"], 2, "must count seeded sessions");
+    assert_eq!(
+        v["knowledge_entries"], 2,
+        "must count seeded knowledge_entries"
+    );
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn healthz_last_indexed_at_is_max() {
+    let (path, db) = seeded_db("lia");
+    let r = app(state_with(db))
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    // MAX(indexed_at) of the two seeded sessions.
+    assert_eq!(
+        v["last_indexed_at"], "2024-06-01T12:00:00",
+        "last_indexed_at must be MAX(indexed_at)"
+    );
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn healthz_empty_db_returns_zeros() {
+    // DB with migration_log but no rows — schema_version=0, counts=0.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!("sk_healthz_empty_{n}_{}.db", std::process::id()));
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE IF NOT EXISTS knowledge_entries (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               category TEXT NOT NULL DEFAULT '',
+               title TEXT NOT NULL DEFAULT '',
+               content TEXT NOT NULL DEFAULT '',
+               tags TEXT NOT NULL DEFAULT '',
+               wing TEXT, room TEXT,
+               confidence REAL NOT NULL DEFAULT 0.5,
+               deleted_at INTEGER
+             );
+             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);",
+        )
+        .unwrap();
+    }
+    let cfg = BrowseDbConfig {
+        path: path.clone(),
+        checkpoint_interval: None,
+        ..Default::default()
+    };
+    let db = Arc::new(BrowseDb::new_without_checkpoint(cfg).unwrap());
+    let r = app(state_with(db))
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["status"], "ok");
+    assert_eq!(v["schema_version"], 0);
+    assert_eq!(v["sessions"], 0);
+    assert_eq!(v["knowledge_entries"], 0);
+    assert!(v["last_indexed_at"].is_null());
+    cleanup(&path);
+}

--- a/sk-rust/tests/healthz_db_test.rs
+++ b/sk-rust/tests/healthz_db_test.rs
@@ -27,7 +27,7 @@ fn seeded_db(label: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
         let conn = Connection::open(&path).unwrap();
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
-             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);
+             CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');
              CREATE TABLE IF NOT EXISTS sessions (
                id TEXT PRIMARY KEY,
                path TEXT NOT NULL DEFAULT '',
@@ -47,12 +47,15 @@ fn seeded_db(label: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
                confidence REAL NOT NULL DEFAULT 0.5,
                deleted_at INTEGER
              );
-             INSERT INTO migration_log VALUES (3);
+             INSERT INTO schema_version (version, name) VALUES (3, 'test');
              INSERT INTO sessions (id, path, indexed_at) VALUES
                ('sess-a', '/path/a', '2024-01-01T10:00:00'),
                ('sess-b', '/path/b', '2024-06-01T12:00:00');
-             INSERT INTO knowledge_entries (category, title, content)
-             VALUES ('mistake', 'T1', 'c1'), ('pattern', 'T2', 'c2');",
+             INSERT INTO knowledge_entries (category, title, content, deleted_at)
+             VALUES
+               ('mistake', 'T1', 'c1', NULL),
+               ('pattern', 'T2', 'c2', NULL),
+               ('discovery', 'T3', 'c3', 1);",
         )
         .unwrap();
     }
@@ -97,7 +100,7 @@ async fn healthz_schema_version_is_real() {
     assert_eq!(v["status"], "ok");
     assert_eq!(
         v["schema_version"], 3,
-        "schema_version must match migration_log MAX"
+        "schema_version must match schema_version MAX"
     );
     cleanup(&path);
 }
@@ -118,8 +121,8 @@ async fn healthz_counts_match_seeded_fixture() {
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(v["sessions"], 2, "must count seeded sessions");
     assert_eq!(
-        v["knowledge_entries"], 2,
-        "must count seeded knowledge_entries"
+        v["knowledge_entries"], 3,
+        "must count all seeded knowledge_entries"
     );
     cleanup(&path);
 }
@@ -148,7 +151,7 @@ async fn healthz_last_indexed_at_is_max() {
 
 #[tokio::test]
 async fn healthz_empty_db_returns_zeros() {
-    // DB with migration_log but no rows — schema_version=0, counts=0.
+    // DB with schema_version but no rows — schema_version=0, counts=0.
     use std::sync::atomic::{AtomicU64, Ordering};
     static CTR: AtomicU64 = AtomicU64::new(0);
     let n = CTR.fetch_add(1, Ordering::SeqCst);
@@ -167,7 +170,7 @@ async fn healthz_empty_db_returns_zeros() {
                confidence REAL NOT NULL DEFAULT 0.5,
                deleted_at INTEGER
              );
-             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);",
+             CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');",
         )
         .unwrap();
     }

--- a/sk-rust/tests/sessions_api_test.rs
+++ b/sk-rust/tests/sessions_api_test.rs
@@ -1,0 +1,407 @@
+//! Tests for `GET /api/sessions` and `GET /api/sessions/{id}` (issue #450).
+//!
+//! DDL uses production-faithful schema (all migration columns present).
+
+#![cfg(feature = "browse-server")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use rusqlite::Connection;
+use tower::ServiceExt;
+
+use sk::browse::db::{BrowseDb, BrowseDbConfig};
+use sk::browse::server::{app, AppState, ServerConfig};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn seeded_db(label: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "sk_sessions_api_{label}_{n}_{}.db",
+        std::process::id()
+    ));
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);
+             -- Production-faithful sessions schema (base + all migration columns).
+             CREATE TABLE IF NOT EXISTS sessions (
+               id TEXT PRIMARY KEY,
+               path TEXT NOT NULL DEFAULT '',
+               summary TEXT DEFAULT '',
+               total_checkpoints INTEGER DEFAULT 0,
+               total_research INTEGER DEFAULT 0,
+               total_files INTEGER DEFAULT 0,
+               has_plan INTEGER DEFAULT 0,
+               source TEXT DEFAULT 'copilot',
+               indexed_at TEXT,
+               file_mtime REAL,
+               indexed_at_r REAL,
+               fts_indexed_at REAL,
+               event_count_estimate INTEGER DEFAULT 0
+             );
+             CREATE TABLE IF NOT EXISTS documents (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               session_id TEXT NOT NULL,
+               doc_type TEXT NOT NULL,
+               seq INTEGER DEFAULT 0,
+               title TEXT NOT NULL,
+               file_path TEXT NOT NULL UNIQUE,
+               content_preview TEXT DEFAULT ''
+             );
+             CREATE TABLE IF NOT EXISTS sections (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               document_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+               section_name TEXT NOT NULL,
+               content TEXT NOT NULL,
+               UNIQUE(document_id, section_name)
+             );
+             CREATE TABLE IF NOT EXISTS knowledge_entries (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               category TEXT NOT NULL DEFAULT '',
+               title TEXT NOT NULL DEFAULT '',
+               content TEXT NOT NULL DEFAULT '',
+               tags TEXT NOT NULL DEFAULT '',
+               wing TEXT, room TEXT,
+               confidence REAL NOT NULL DEFAULT 0.5,
+               deleted_at INTEGER
+             );
+             INSERT INTO migration_log VALUES (1);
+             INSERT INTO sessions (id, path, summary, indexed_at, total_checkpoints, total_files,
+                                   fts_indexed_at)
+             VALUES
+               ('sess-1', '/p1', 'Summary one',   '2024-01-01T10:00:00', 2, 5, 1704103200.0),
+               ('sess-2', '/p2', 'Summary two',   '2024-06-01T12:00:00', 1, 3, 1717243200.0),
+               ('sess-3', '/p3', 'Summary three', '2023-12-01T08:00:00', 0, 1, 1701417600.0);
+             INSERT INTO documents (session_id, doc_type, seq, title, file_path)
+             VALUES
+               ('sess-1', 'checkpoint', 1, 'Chk A', '/p1/chk1.md'),
+               ('sess-1', 'checkpoint', 2, 'Chk B', '/p1/chk2.md'),
+               ('sess-2', 'checkpoint', 1, 'Chk C', '/p2/chk1.md');",
+        )
+        .unwrap();
+    }
+    let cfg = BrowseDbConfig {
+        path: path.clone(),
+        checkpoint_interval: None,
+        ..Default::default()
+    };
+    (
+        path,
+        Arc::new(BrowseDb::new_without_checkpoint(cfg).unwrap()),
+    )
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in &["", "-wal", "-shm"] {
+        let _ = std::fs::remove_file(format!("{}{suffix}", path.display()));
+    }
+}
+
+fn open_state(db: Arc<BrowseDb>) -> AppState {
+    AppState::new(Arc::new(ServerConfig::default()), db)
+}
+
+fn secured_state(db: Arc<BrowseDb>, token: &str) -> AppState {
+    AppState::new(
+        Arc::new(ServerConfig {
+            server_token: token.to_string(),
+            ..ServerConfig::default()
+        }),
+        db,
+    )
+}
+
+// ── /api/sessions list ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn sessions_list_returns_200() {
+    let (path, db) = seeded_db("list200");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn sessions_list_envelope_shape() {
+    let (path, db) = seeded_db("envelope");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    // Must be envelope, NOT bare array.
+    assert!(v.get("items").is_some(), "must have items key");
+    assert!(v.get("total").is_some(), "must have total key");
+    assert!(v.get("page").is_some(), "must have page key");
+    assert!(v.get("page_size").is_some(), "must have page_size key");
+    assert!(v.get("has_more").is_some(), "must have has_more key");
+    assert_eq!(v["total"], 3);
+    assert_eq!(v["page"], 1);
+    assert_eq!(v["page_size"], 50);
+    assert_eq!(v["has_more"], false);
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn sessions_list_default_limit_newest_first() {
+    let (path, db) = seeded_db("order");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let arr = v["items"].as_array().expect("items must be array");
+    assert_eq!(arr.len(), 3, "all 3 sessions returned");
+    // Newest-first by fts_indexed_at: sess-2 (Jun 2024) > sess-1 (Jan 2024) > sess-3 (Dec 2023).
+    assert_eq!(arr[0]["id"], "sess-2");
+    assert_eq!(arr[1]["id"], "sess-1");
+    assert_eq!(arr[2]["id"], "sess-3");
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn sessions_list_meta_fields_shape() {
+    let (path, db) = seeded_db("fields");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let first = &v["items"].as_array().unwrap()[0];
+    // SessionMeta fields present.
+    assert!(first.get("id").is_some(), "must have id");
+    assert!(first.get("path").is_some(), "must have path");
+    assert!(first.get("summary").is_some(), "must have summary");
+    assert!(first.get("source").is_some(), "must have source");
+    assert!(
+        first.get("event_count_estimate").is_some(),
+        "must have event_count_estimate"
+    );
+    assert!(
+        first.get("fts_indexed_at").is_some(),
+        "must have fts_indexed_at"
+    );
+    assert!(
+        first.get("total_checkpoints").is_some(),
+        "must have total_checkpoints"
+    );
+    assert!(first.get("doc_count").is_some(), "must have doc_count");
+    // branch / created_at / updated_at must NOT be present.
+    assert!(first.get("branch").is_none(), "must NOT have branch");
+    assert!(
+        first.get("created_at").is_none(),
+        "must NOT have created_at"
+    );
+    assert!(
+        first.get("updated_at").is_none(),
+        "must NOT have updated_at"
+    );
+    // indexed_at must NOT be present (removed by normalize).
+    assert!(
+        first.get("indexed_at").is_none(),
+        "must NOT have indexed_at"
+    );
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn sessions_list_pagination_page_page_size() {
+    let (path, db) = seeded_db("page");
+    // page=2, page_size=1 → second newest = sess-1.
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions?page=2&page_size=1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let arr = v["items"].as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["id"], "sess-1");
+    assert_eq!(v["page"], 2);
+    assert_eq!(v["page_size"], 1);
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn sessions_list_page_size_capped_at_200() {
+    let (path, db) = seeded_db("cap");
+    // Requesting page_size=999 must be clamped to 200 without error.
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions?page_size=999")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["page_size"], 200);
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn sessions_list_auth_required() {
+    let (path, db) = seeded_db("auth");
+    let r = app(secured_state(db, "mytoken"))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn sessions_list_auth_bearer_passes() {
+    let (path, db) = seeded_db("bearer");
+    let r = app(secured_state(db, "mytoken"))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions")
+                .header("authorization", "Bearer mytoken")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    cleanup(&path);
+}
+
+// ── /api/sessions/{id} detail ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn session_detail_200_found() {
+    let (path, db) = seeded_db("det200");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/sess-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    // Must be { meta, timeline }.
+    assert!(v.get("meta").is_some(), "must have meta");
+    assert!(v.get("timeline").is_some(), "must have timeline");
+    let meta = &v["meta"];
+    assert_eq!(meta["id"], "sess-1");
+    assert_eq!(meta["summary"], "Summary one");
+    assert_eq!(meta["total_checkpoints"], 2);
+    // branch / created_at / updated_at / indexed_at must NOT be in meta.
+    assert!(meta.get("branch").is_none());
+    assert!(meta.get("created_at").is_none());
+    assert!(meta.get("updated_at").is_none());
+    assert!(meta.get("indexed_at").is_none());
+    // Timeline: 2 documents for sess-1, no sections → 2 rows with null section_name.
+    let tl = v["timeline"].as_array().unwrap();
+    assert_eq!(tl.len(), 2, "2 docs for sess-1");
+    assert_eq!(tl[0]["title"], "Chk A");
+    assert_eq!(tl[1]["title"], "Chk B");
+    assert!(tl[0]["section_name"].is_null());
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn session_detail_400_invalid_id() {
+    let (path, db) = seeded_db("det400");
+    // ID with a space is invalid.
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/bad%20id")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["code"], "BAD_SESSION_ID");
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn session_detail_404_not_found() {
+    let (path, db) = seeded_db("det404");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/nonexistent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::NOT_FOUND);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["code"], "SESSION_NOT_FOUND");
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn session_detail_auth_required() {
+    let (path, db) = seeded_db("detauth");
+    let r = app(secured_state(db, "tok"))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/sess-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+    cleanup(&path);
+}

--- a/sk-rust/tests/sessions_api_test.rs
+++ b/sk-rust/tests/sessions_api_test.rs
@@ -77,7 +77,7 @@ fn seeded_db(label: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
                                    fts_indexed_at)
              VALUES
                ('sess-1', '/p1', 'Summary one',   '2024-01-01T10:00:00', 2, 5, 1704103200.0),
-               ('sess-2', '/p2', 'Summary two',   '2024-06-01T12:00:00', 1, 3, 1717243200.0),
+               ('sess-2', '/p2', 'Summary two',   '2024-06-01T12:00:00', 1, 3, 1717243200.123456),
                ('sess-3', '/p3', 'Summary three', '2023-12-01T08:00:00', 0, 1, 1701417600.0);
              INSERT INTO documents (session_id, doc_type, seq, title, file_path)
              VALUES
@@ -219,6 +219,10 @@ async fn sessions_list_meta_fields_shape() {
         "must have total_checkpoints"
     );
     assert!(first.get("doc_count").is_some(), "must have doc_count");
+    assert_eq!(
+        first["fts_indexed_at"], "2024-06-01T12:00:00.123456Z",
+        "fractional REAL timestamps must preserve microseconds"
+    );
     // branch / created_at / updated_at must NOT be present.
     assert!(first.get("branch").is_none(), "must NOT have branch");
     assert!(
@@ -277,6 +281,47 @@ async fn sessions_list_page_size_capped_at_200() {
     let body = r.into_body().collect().await.unwrap().to_bytes();
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(v["page_size"], 200);
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn sessions_list_bad_pagination_params_fall_back_to_defaults() {
+    let (path, db) = seeded_db("badparams");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions?page=abc&page_size=bad")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["page"], 1);
+    assert_eq!(v["page_size"], 50);
+    cleanup(&path);
+}
+
+#[tokio::test]
+async fn sessions_list_page_capped_at_10000() {
+    let (path, db) = seeded_db("pagecap");
+    let r = app(open_state(db))
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions?page=999999&page_size=1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["page"], 10000);
+    assert_eq!(v["page_size"], 1);
+    assert_eq!(v["items"].as_array().unwrap().len(), 0);
     cleanup(&path);
 }
 

--- a/sk-rust/tests/sessions_api_test.rs
+++ b/sk-rust/tests/sessions_api_test.rs
@@ -29,7 +29,7 @@ fn seeded_db(label: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
         let conn = Connection::open(&path).unwrap();
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
-             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);
+             CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');
              -- Production-faithful sessions schema (base + all migration columns).
              CREATE TABLE IF NOT EXISTS sessions (
                id TEXT PRIMARY KEY,
@@ -72,7 +72,7 @@ fn seeded_db(label: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
                confidence REAL NOT NULL DEFAULT 0.5,
                deleted_at INTEGER
              );
-             INSERT INTO migration_log VALUES (1);
+             INSERT INTO schema_version (version, name) VALUES (1, 'test');
              INSERT INTO sessions (id, path, summary, indexed_at, total_checkpoints, total_files,
                                    fts_indexed_at)
              VALUES


### PR DESCRIPTION
## Summary
- Ports #450 PR-A Rust browse core API surfaces for Python-contract parity.
- Adds DB-backed `/healthz`, `/api/sessions`, `/api/sessions/{id}`, and `/api/compare`.
- Keeps search/dashboard/operator/stream work out of scope for follow-up PRs.

## Verification
- `cargo fmt --check`
- `cargo check --features browse-server`
- `cargo check --no-default-features`
- `cargo clippy --features browse-server --all-targets --no-deps -- -D warnings`
- `cargo test --features browse-server` - 1,360 passed / 0 failed
- `python tests/test_browse_api_contract.py` - 48 passed / 0 failed

## Review evidence
- Opus rereview found contract blockers; fixed sessions/compare shape to match Python fixtures.
- Opus healthz tiebreaker confirmed `schema_version` table and raw `knowledge_entries COUNT(*)`; fixed and re-reviewed CLEAN with confidence 1.0.

Closes #450.