### PR TITLE
feat(#452): add Rust browse algorithm helpers

### DIFF
--- a/sk-rust/src/browse/algo/communities.rs
+++ b/sk-rust/src/browse/algo/communities.rs
@@ -1,0 +1,340 @@
+//! Pure-Rust port of `browse/core/communities.py` — deterministic connected-component
+//! communities over knowledge-relation edges.
+//!
+//! No I/O, no DB.  Determinism matches Python: components seeded by sorted
+//! adjacency keys, members sorted, representative entries by (-local_degree, id).
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+// ── structs ───────────────────────────────────────────────────────────────────
+
+pub struct Entry {
+    pub id: i64,
+    pub title: String,
+    pub category: String,
+    pub wing: String,
+}
+
+pub struct RelationEdge {
+    pub source_id: i64,
+    pub target_id: i64,
+    pub relation_type: String,
+}
+
+pub struct Community {
+    pub id: String,
+    pub entry_count: usize,
+    /// (category_name, count), sorted by (-count, name asc), up to 3.
+    pub top_categories: Vec<(String, usize)>,
+    /// Wing names (top 3 by count, ties by name asc).
+    pub wings: Vec<String>,
+    /// (relation_type, count), sorted by (-count, name asc), up to 3.
+    pub top_relation_types: Vec<(String, usize)>,
+    /// (id, title, category) for up to 3 representative entries,
+    /// chosen by (-local_degree, entry_id).
+    pub representative_entries: Vec<(i64, String, String)>,
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Sort `counts` by (-count, name_asc) and return the first `limit` pairs.
+fn top_counts(counts: &HashMap<String, usize>, limit: usize) -> Vec<(String, usize)> {
+    let mut v: Vec<(&String, usize)> = counts.iter().map(|(k, &c)| (k, c)).collect();
+    v.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
+    v.into_iter()
+        .take(limit)
+        .map(|(k, c)| (k.clone(), c))
+        .collect()
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+/// Build deterministic community summaries from entries and relation edges.
+///
+/// Mirrors `get_communities` from Python (minus the DB layer):
+/// - ignores self-loops
+/// - ignores edges whose endpoints are not in `entries`
+/// - returns `[]` when there are no valid edges
+/// - components seeded by sorted adjacency keys (BTreeMap iteration order)
+/// - communities sorted by (-entry_count, community_id asc)
+pub fn find_communities(
+    entries: &[Entry],
+    relations: &[RelationEdge],
+    min_entry_count: usize,
+) -> Vec<Community> {
+    // Build entry map.
+    let entry_map: HashMap<i64, &Entry> = entries.iter().map(|e| (e.id, e)).collect();
+    if entry_map.is_empty() {
+        return vec![];
+    }
+
+    // Build adjacency (sorted Vec per key) and collect valid relation edges.
+    let mut adjacency: BTreeMap<i64, Vec<i64>> = BTreeMap::new();
+    let mut valid_edges: Vec<(i64, i64, String)> = Vec::new();
+
+    for rel in relations {
+        if rel.source_id == rel.target_id {
+            continue;
+        }
+        if !entry_map.contains_key(&rel.source_id) || !entry_map.contains_key(&rel.target_id) {
+            continue;
+        }
+        adjacency
+            .entry(rel.source_id)
+            .or_default()
+            .push(rel.target_id);
+        adjacency
+            .entry(rel.target_id)
+            .or_default()
+            .push(rel.source_id);
+        valid_edges.push((rel.source_id, rel.target_id, rel.relation_type.clone()));
+    }
+
+    if adjacency.is_empty() {
+        return vec![];
+    }
+
+    // Sort adjacency lists and deduplicate (multiple edges between same pair).
+    for neighbors in adjacency.values_mut() {
+        neighbors.sort_unstable();
+        neighbors.dedup();
+    }
+
+    // Find connected components with iterative DFS seeded by sorted adjacency keys.
+    let mut visited: HashSet<i64> = HashSet::new();
+    let mut components: Vec<Vec<i64>> = Vec::new();
+
+    for &seed in adjacency.keys() {
+        if visited.contains(&seed) {
+            continue;
+        }
+        let mut stack = vec![seed];
+        let mut component: Vec<i64> = Vec::new();
+        while let Some(node_id) = stack.pop() {
+            if visited.contains(&node_id) {
+                continue;
+            }
+            visited.insert(node_id);
+            component.push(node_id);
+            if let Some(neighbors) = adjacency.get(&node_id) {
+                for &nb in neighbors {
+                    if !visited.contains(&nb) {
+                        stack.push(nb);
+                    }
+                }
+            }
+        }
+        component.sort_unstable();
+        if component.len() >= min_entry_count {
+            components.push(component);
+        }
+    }
+
+    // Build community summaries.
+    let mut communities: Vec<Community> = Vec::new();
+
+    for members in &components {
+        let member_set: HashSet<i64> = members.iter().copied().collect();
+
+        let mut category_counts: HashMap<String, usize> = HashMap::new();
+        let mut wing_counts: HashMap<String, usize> = HashMap::new();
+
+        for &eid in members {
+            if let Some(e) = entry_map.get(&eid) {
+                *category_counts.entry(e.category.clone()).or_insert(0) += 1;
+                *wing_counts.entry(e.wing.clone()).or_insert(0) += 1;
+            }
+        }
+
+        let mut rel_type_counts: HashMap<String, usize> = HashMap::new();
+        for (src, tgt, rtype) in &valid_edges {
+            if member_set.contains(src) && member_set.contains(tgt) {
+                *rel_type_counts.entry(rtype.clone()).or_insert(0) += 1;
+            }
+        }
+
+        // Local degree (edges within this component only).
+        let local_degree: HashMap<i64, usize> = members
+            .iter()
+            .map(|&eid| {
+                let deg = adjacency
+                    .get(&eid)
+                    .map(|nbs| nbs.iter().filter(|&&n| member_set.contains(&n)).count())
+                    .unwrap_or(0);
+                (eid, deg)
+            })
+            .collect();
+
+        // Representatives: top 3 by (-local_degree, entry_id asc).
+        let mut rep_ids = members.clone();
+        rep_ids.sort_by_key(|&id| {
+            let deg = local_degree.get(&id).copied().unwrap_or(0);
+            (usize::MAX - deg, id) // sort by descending degree then ascending id
+        });
+        let rep_entries: Vec<(i64, String, String)> = rep_ids
+            .into_iter()
+            .take(3)
+            .filter_map(|id| {
+                entry_map
+                    .get(&id)
+                    .map(|e| (id, e.title.clone(), e.category.clone()))
+            })
+            .collect();
+
+        let top_cats = top_counts(&category_counts, 3);
+        let top_wings = top_counts(&wing_counts, 3);
+        let top_rels = top_counts(&rel_type_counts, 3);
+
+        communities.push(Community {
+            id: format!("c-{}", members[0]),
+            entry_count: members.len(),
+            top_categories: top_cats,
+            wings: top_wings.into_iter().map(|(k, _)| k).collect(),
+            top_relation_types: top_rels,
+            representative_entries: rep_entries,
+        });
+    }
+
+    // Sort by (-entry_count, community_id asc).
+    communities.sort_by(|a, b| b.entry_count.cmp(&a.entry_count).then(a.id.cmp(&b.id)));
+
+    communities
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn e(id: i64, title: &str, category: &str, wing: &str) -> Entry {
+        Entry {
+            id,
+            title: title.to_string(),
+            category: category.to_string(),
+            wing: wing.to_string(),
+        }
+    }
+    fn r(src: i64, tgt: i64, rtype: &str) -> RelationEdge {
+        RelationEdge {
+            source_id: src,
+            target_id: tgt,
+            relation_type: rtype.to_string(),
+        }
+    }
+
+    // ── empty / no-edge cases ─────────────────────────────────────────────────
+
+    #[test]
+    fn empty_entries_returns_empty() {
+        let c = find_communities(&[], &[r(1, 2, "x")], 2);
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn empty_relations_returns_empty() {
+        let entries = vec![
+            e(1, "A", "pattern", "backend"),
+            e(2, "B", "mistake", "frontend"),
+        ];
+        let c = find_communities(&entries, &[], 2);
+        assert!(c.is_empty());
+    }
+
+    // ── self-loop ignored ─────────────────────────────────────────────────────
+
+    #[test]
+    fn self_loop_ignored() {
+        let entries = vec![e(1, "A", "p", "b"), e(2, "B", "m", "f")];
+        // Only a self-loop on 1 — no valid edge → no adjacency → empty.
+        let c = find_communities(&entries, &[r(1, 1, "self")], 2);
+        assert!(c.is_empty());
+    }
+
+    // ── missing relation endpoint ignored ─────────────────────────────────────
+
+    #[test]
+    fn missing_relation_endpoint_ignored() {
+        let entries = vec![e(1, "A", "p", "b")];
+        // 2 is not in entries; edge (1,2) must be ignored → no adjacency.
+        let c = find_communities(&entries, &[r(1, 2, "x")], 2);
+        assert!(c.is_empty());
+    }
+
+    // ── two connected components ──────────────────────────────────────────────
+
+    #[test]
+    fn two_components() {
+        let entries = vec![
+            e(1, "A", "pattern", "backend"),
+            e(2, "B", "mistake", "frontend"),
+            e(3, "C", "decision", "backend"),
+            e(4, "D", "pattern", "backend"),
+        ];
+        let relations = vec![r(1, 2, "related"), r(3, 4, "similar")];
+        let comms = find_communities(&entries, &relations, 2);
+        assert_eq!(comms.len(), 2, "expected 2 components");
+
+        // Both components have entry_count=2; sorted by (entry_count desc, id asc):
+        // c-1 < c-3 → first community is c-1.
+        assert_eq!(comms[0].id, "c-1");
+        assert_eq!(comms[1].id, "c-3");
+        assert_eq!(comms[0].entry_count, 2);
+        assert_eq!(comms[1].entry_count, 2);
+    }
+
+    // ── single component: categories, wings, rep entries ─────────────────────
+
+    #[test]
+    fn single_component_correct_metadata() {
+        // entries 1,2,3 all connected; entry 2 has degree 2 (hub), 1 and 3 have degree 1.
+        let entries = vec![
+            e(1, "A", "pattern", "backend"),
+            e(2, "B", "mistake", "frontend"),
+            e(3, "C", "decision", "backend"),
+        ];
+        let relations = vec![r(1, 2, "related"), r(2, 3, "similar")];
+        let comms = find_communities(&entries, &relations, 2);
+        assert_eq!(comms.len(), 1);
+
+        let c = &comms[0];
+        assert_eq!(c.id, "c-1");
+        assert_eq!(c.entry_count, 3);
+
+        // Wings: backend(2), frontend(1) → ["backend","frontend"]
+        assert_eq!(c.wings[0], "backend");
+        assert_eq!(c.wings[1], "frontend");
+
+        // Representative entries: entry 2 has degree 2 (hub) → first.
+        // entries 1 and 3 both have degree 1; 1 < 3 → 1 second.
+        assert_eq!(c.representative_entries[0].0, 2);
+        assert_eq!(c.representative_entries[1].0, 1);
+        assert_eq!(c.representative_entries[2].0, 3);
+    }
+
+    // ── tie ordering: same entry_count, sort by community id ─────────────────
+
+    #[test]
+    fn tie_ordering_by_community_id() {
+        // Three pairs forming three isolated 2-node components.
+        let entries: Vec<Entry> = (1..=6).map(|i| e(i, "X", "p", "b")).collect();
+        let relations = vec![r(1, 2, "x"), r(3, 4, "x"), r(5, 6, "x")];
+        let comms = find_communities(&entries, &relations, 2);
+        assert_eq!(comms.len(), 3);
+        // All have entry_count=2; sorted by id asc: c-1 < c-3 < c-5
+        assert_eq!(comms[0].id, "c-1");
+        assert_eq!(comms[1].id, "c-3");
+        assert_eq!(comms[2].id, "c-5");
+    }
+
+    // ── min_entry_count filter ────────────────────────────────────────────────
+
+    #[test]
+    fn min_entry_count_filters_small_components() {
+        let entries: Vec<Entry> = (1..=4).map(|i| e(i, "X", "p", "b")).collect();
+        // Two 2-node pairs, but min_entry_count=3 should filter both out.
+        let relations = vec![r(1, 2, "x"), r(3, 4, "x")];
+        let comms = find_communities(&entries, &relations, 3);
+        assert!(comms.is_empty());
+    }
+}

--- a/sk-rust/src/browse/algo/mod.rs
+++ b/sk-rust/src/browse/algo/mod.rs
@@ -1,0 +1,6 @@
+//! Pure algorithm port of browse Python modules: projection, similarity, communities.
+//! No I/O, no HTTP, no DB, no cache. Suitable for use without any Cargo features.
+
+pub mod communities;
+pub mod projection;
+pub mod similarity;

--- a/sk-rust/src/browse/algo/projection.rs
+++ b/sk-rust/src/browse/algo/projection.rs
@@ -1,0 +1,351 @@
+//! Pure-Rust port of `browse/core/projection.py` — PCA-to-2D projection.
+//!
+//! No I/O, no cache, no DB, no RNG dependency.  The only difference from
+//! Python is that `pca_2d` uses a *deterministic* fixed init for power
+//! iteration rather than `random.gauss`; eigenvectors may differ by sign.
+
+/// Number of rows sampled from the full data to compute eigenvectors.
+pub const PCA_SAMPLE: usize = 500;
+/// Power-iteration count used when finding each eigenvector.
+pub const POWER_ITERS: usize = 50;
+
+// ── low-level vector helpers ─────────────────────────────────────────────────
+
+/// Decode a little-endian f32 BLOB into a `Vec<f32>`.
+///
+/// Returns `None` when `blob` is shorter than `n_dims * 4` bytes.
+pub fn decode_vector_le_f32(blob: &[u8], n_dims: usize) -> Option<Vec<f32>> {
+    if blob.len() < n_dims * 4 {
+        return None;
+    }
+    let mut out = Vec::with_capacity(n_dims);
+    for i in 0..n_dims {
+        let b = [
+            blob[i * 4],
+            blob[i * 4 + 1],
+            blob[i * 4 + 2],
+            blob[i * 4 + 3],
+        ];
+        out.push(f32::from_le_bytes(b));
+    }
+    Some(out)
+}
+
+/// Dot product of two equal-length slices.
+pub fn dot(a: &[f64], b: &[f64]) -> f64 {
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+}
+
+/// Euclidean norm of a vector.
+pub fn norm(v: &[f64]) -> f64 {
+    v.iter().map(|x| x * x).sum::<f64>().sqrt()
+}
+
+/// Normalise `v`; returns the original vec unchanged when norm < 1e-12.
+pub fn normalize(v: &[f64]) -> Vec<f64> {
+    let n = norm(v);
+    if n < 1e-12 {
+        return v.to_vec();
+    }
+    let inv = 1.0 / n;
+    v.iter().map(|x| x * inv).collect()
+}
+
+/// Matrix–vector product: `X @ v`  (X is a row-major slice).
+pub fn mat_vec(x: &[Vec<f64>], v: &[f64]) -> Vec<f64> {
+    x.iter().map(|row| dot(row, v)).collect()
+}
+
+/// Transposed matrix–vector product: `X^T @ w`.
+pub fn mat_t_vec(x: &[Vec<f64>], w: &[f64]) -> Vec<f64> {
+    if x.is_empty() {
+        return vec![];
+    }
+    let n_dims = x[0].len();
+    let mut result = vec![0.0_f64; n_dims];
+    for (i, row) in x.iter().enumerate() {
+        let wi = w[i];
+        if wi == 0.0 {
+            continue;
+        }
+        for (j, &xij) in row.iter().enumerate() {
+            result[j] += wi * xij;
+        }
+    }
+    result
+}
+
+/// Remove the component along unit vector `e` from every row of `X`.
+pub fn deflate(x: &[Vec<f64>], e: &[f64]) -> Vec<Vec<f64>> {
+    x.iter()
+        .map(|row| {
+            let d = dot(row, e);
+            row.iter()
+                .zip(e.iter())
+                .map(|(xi, ei)| xi - d * ei)
+                .collect()
+        })
+        .collect()
+}
+
+/// Dominant eigenvector of `X^T X` via power iteration.
+///
+/// `init` is the starting vector (caller supplies a deterministic value).
+/// Returns an empty vec when `X` is empty or all-zero.
+pub fn power_iter(x: &[Vec<f64>], n_iters: usize, init: &[f64]) -> Vec<f64> {
+    if x.is_empty() || x[0].is_empty() {
+        return vec![];
+    }
+    let n_dims = x[0].len();
+    // Normalise the supplied init; fall back to the first standard basis vector
+    // if init normalises to zero (e.g. after deflation killed the component).
+    let mut v = normalize(init);
+    if norm(&v) < 1e-12 {
+        let mut basis = vec![0.0_f64; n_dims];
+        if n_dims > 0 {
+            basis[0] = 1.0;
+        }
+        v = basis;
+    }
+    for _ in 0..n_iters {
+        let w = mat_vec(x, &v);
+        let u = mat_t_vec(x, &w);
+        let vn = normalize(&u);
+        if norm(&vn) < 1e-12 {
+            break;
+        }
+        v = vn;
+    }
+    v
+}
+
+// ── PCA 2D ───────────────────────────────────────────────────────────────────
+
+/// Project *vectors* (equal-length rows) to 2D via two-component PCA.
+///
+/// Mirrors `projection.pca_2d` from Python.  Uses a fixed deterministic init
+/// instead of `random.gauss`; eigenvectors may differ by sign from Python.
+///
+/// Returns `(xs, ys)`.
+pub fn pca_2d(vectors: &[Vec<f64>]) -> (Vec<f64>, Vec<f64>) {
+    let n = vectors.len();
+    if n == 0 {
+        return (vec![], vec![]);
+    }
+    let n_dims = vectors[0].len();
+    if n_dims < 2 {
+        let xs: Vec<f64> = vectors
+            .iter()
+            .map(|v| if v.is_empty() { 0.0 } else { v[0] })
+            .collect();
+        let ys = vec![0.0_f64; n];
+        return (xs, ys);
+    }
+
+    // Centre the data.
+    let mut mean = vec![0.0_f64; n_dims];
+    for v in vectors {
+        for (j, &x) in v.iter().enumerate() {
+            mean[j] += x;
+        }
+    }
+    for m in &mut mean {
+        *m /= n as f64;
+    }
+    let centered: Vec<Vec<f64>> = vectors
+        .iter()
+        .map(|v| v.iter().zip(&mean).map(|(x, m)| x - m).collect())
+        .collect();
+
+    // Sample for eigenvector computation (deterministic: first PCA_SAMPLE rows).
+    let sample: &[Vec<f64>] = if n > PCA_SAMPLE {
+        &centered[..PCA_SAMPLE]
+    } else {
+        &centered
+    };
+
+    // First eigenvector: all-ones init (normalised inside power_iter).
+    let init_e1 = vec![1.0_f64; n_dims];
+    let e1 = power_iter(sample, POWER_ITERS, &init_e1);
+    if norm(&e1) < 1e-12 {
+        return (vec![0.0_f64; n], vec![0.0_f64; n]);
+    }
+
+    // Second eigenvector: deflate then use the second standard basis vector.
+    let sample_d = deflate(sample, &e1);
+    let mut init_e2 = vec![0.0_f64; n_dims];
+    init_e2[1] = 1.0; // second standard basis
+    let e2 = power_iter(&sample_d, POWER_ITERS, &init_e2);
+
+    let xs: Vec<f64> = centered.iter().map(|row| dot(row, &e1)).collect();
+    let ys: Vec<f64> = if norm(&e2) < 1e-12 {
+        vec![0.0_f64; n]
+    } else {
+        centered.iter().map(|row| dot(row, &e2)).collect()
+    };
+
+    (xs, ys)
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper: assert two f64 values are within `tol` of each other.
+    fn approx(a: f64, b: f64, tol: f64) -> bool {
+        (a - b).abs() <= tol
+    }
+
+    #[test]
+    fn decode_le_f32_roundtrip() {
+        // 1.0f32 LE = 0x3F800000, 2.0f32 LE = 0x40000000
+        let blob: Vec<u8> = vec![0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x40];
+        let v = decode_vector_le_f32(&blob, 2).expect("should decode");
+        assert_eq!(v.len(), 2);
+        assert!((v[0] - 1.0_f32).abs() < 1e-7, "v[0]={}", v[0]);
+        assert!((v[1] - 2.0_f32).abs() < 1e-7, "v[1]={}", v[1]);
+    }
+
+    #[test]
+    fn decode_le_f32_too_short_returns_none() {
+        let blob: Vec<u8> = vec![0x00, 0x00, 0x80]; // only 3 bytes, need 4 for 1 f32
+        assert!(decode_vector_le_f32(&blob, 1).is_none());
+    }
+
+    #[test]
+    fn dot_basic() {
+        assert!(approx(dot(&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0]), 32.0, 1e-12));
+    }
+
+    #[test]
+    fn norm_basic() {
+        assert!(approx(norm(&[3.0, 4.0]), 5.0, 1e-12));
+    }
+
+    #[test]
+    fn normalize_unit_vector() {
+        let v = normalize(&[3.0, 4.0]);
+        assert!(approx(v[0], 0.6, 1e-12));
+        assert!(approx(v[1], 0.8, 1e-12));
+        assert!(approx(norm(&v), 1.0, 1e-12));
+    }
+
+    #[test]
+    fn normalize_near_zero_unchanged() {
+        let v = normalize(&[0.0, 1e-15]);
+        // norm < 1e-12, so original returned unchanged
+        assert_eq!(v, vec![0.0, 1e-15]);
+    }
+
+    #[test]
+    fn mat_vec_basic() {
+        let x = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+        let v = vec![1.0, 1.0];
+        let r = mat_vec(&x, &v);
+        assert_eq!(r, vec![3.0, 7.0]);
+    }
+
+    #[test]
+    fn mat_t_vec_basic() {
+        // X = [[1,2],[3,4]], w = [1,1]  →  X^T w = [1+3, 2+4] = [4, 6]
+        let x = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+        let w = vec![1.0, 1.0];
+        let r = mat_t_vec(&x, &w);
+        assert_eq!(r, vec![4.0, 6.0]);
+    }
+
+    #[test]
+    fn mat_t_vec_empty_x() {
+        let x: Vec<Vec<f64>> = vec![];
+        let r = mat_t_vec(&x, &[]);
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn deflate_removes_component() {
+        // e = [1, 0]; removing x-component leaves only y
+        let x = vec![vec![3.0, 4.0], vec![5.0, 6.0]];
+        let e = vec![1.0, 0.0];
+        let d = deflate(&x, &e);
+        assert_eq!(d[0], vec![0.0, 4.0]);
+        assert_eq!(d[1], vec![0.0, 6.0]);
+    }
+
+    #[test]
+    fn power_iter_converges_to_dominant_axis() {
+        // X has all variance in the first dimension.
+        // X = [[2,0],[-2,0],[1,0],[-1,0]]  →  dominant eigenvector of X^T X is [1,0] or [-1,0].
+        let x = vec![
+            vec![2.0, 0.0],
+            vec![-2.0, 0.0],
+            vec![1.0, 0.0],
+            vec![-1.0, 0.0],
+        ];
+        let init = vec![1.0, 1.0];
+        let e = power_iter(&x, POWER_ITERS, &init);
+        assert_eq!(e.len(), 2);
+        // |e[0]| ≈ 1, |e[1]| ≈ 0 (sign flexible)
+        assert!(approx(e[0].abs(), 1.0, 1e-10), "e[0]={}", e[0]);
+        assert!(approx(e[1].abs(), 0.0, 1e-10), "e[1]={}", e[1]);
+    }
+
+    #[test]
+    fn power_iter_empty_x_returns_empty() {
+        let x: Vec<Vec<f64>> = vec![];
+        assert!(power_iter(&x, 10, &[1.0]).is_empty());
+    }
+
+    #[test]
+    fn pca_2d_empty() {
+        let (xs, ys) = pca_2d(&[]);
+        assert!(xs.is_empty() && ys.is_empty());
+    }
+
+    #[test]
+    fn pca_2d_n_dims_lt_2() {
+        let vectors = vec![vec![1.0], vec![2.0], vec![3.0]];
+        let (xs, ys) = pca_2d(&vectors);
+        assert_eq!(xs.len(), 3);
+        assert_eq!(ys.len(), 3);
+        // xs should equal the raw values, ys should be 0
+        assert!(approx(xs[0], 1.0, 1e-12));
+        assert!(approx(xs[1], 2.0, 1e-12));
+        assert_eq!(ys, vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn pca_2d_axis_aligned_variance() {
+        // All variance in x-axis; mean is 0.
+        // Vectors: (2,0),(-2,0),(0,1),(0,-1)
+        // X^T X = [[8,0],[0,2]]  →  e1 = [1,0] or [-1,0], e2 = [0,1] or [0,-1]
+        let vectors = vec![
+            vec![2.0_f64, 0.0],
+            vec![-2.0, 0.0],
+            vec![0.0, 1.0],
+            vec![0.0, -1.0],
+        ];
+        let (xs, ys) = pca_2d(&vectors);
+        assert_eq!(xs.len(), 4);
+        assert_eq!(ys.len(), 4);
+
+        // xs projections: |dots with e1| should be [2, 2, 0, 0] in some sign/order
+        let s = xs[0].signum(); // consistent sign
+        assert!(approx(xs[0], s * 2.0, 1e-6), "xs[0]={}", xs[0]);
+        assert!(approx(xs[1], s * -2.0, 1e-6), "xs[1]={}", xs[1]);
+        assert!(approx(xs[2].abs(), 0.0, 1e-6), "xs[2]={}", xs[2]);
+        assert!(approx(xs[3].abs(), 0.0, 1e-6), "xs[3]={}", xs[3]);
+
+        // ys projections: |dots with e2| should be [0, 0, 1, -1] in some sign
+        let s2 = if ys[2].abs() > 1e-9 {
+            ys[2].signum()
+        } else {
+            1.0
+        };
+        assert!(approx(ys[0].abs(), 0.0, 1e-6), "ys[0]={}", ys[0]);
+        assert!(approx(ys[1].abs(), 0.0, 1e-6), "ys[1]={}", ys[1]);
+        assert!(approx(ys[2], s2 * 1.0, 1e-6), "ys[2]={}", ys[2]);
+        assert!(approx(ys[3], -s2, 1e-6), "ys[3]={}", ys[3]);
+    }
+}

--- a/sk-rust/src/browse/algo/projection.rs
+++ b/sk-rust/src/browse/algo/projection.rs
@@ -1,8 +1,18 @@
 //! Pure-Rust port of `browse/core/projection.py` — PCA-to-2D projection.
 //!
-//! No I/O, no cache, no DB, no RNG dependency.  The only difference from
-//! Python is that `pca_2d` uses a *deterministic* fixed init for power
-//! iteration rather than `random.gauss`; eigenvectors may differ by sign.
+//! No I/O, no cache, no DB, no RNG dependency.
+//!
+//! ## Known parity differences from Python
+//!
+//! 1. **Power-iteration init**: Rust uses a deterministic fixed init vector
+//!    (all-ones normalised, then second standard basis for the deflated pass)
+//!    instead of Python's `random.gauss`-seeded vector.  Eigenvectors may
+//!    therefore differ by sign.
+//!
+//! 2. **PCA sample selection**: when `n > PCA_SAMPLE`, Rust takes the *first*
+//!    `PCA_SAMPLE` centered rows; Python uses
+//!    `random.Random(99).sample(range(n), PCA_SAMPLE)`.  Projection
+//!    coordinates may differ numerically for large datasets.
 
 /// Number of rows sampled from the full data to compute eigenvectors.
 pub const PCA_SAMPLE: usize = 500;

--- a/sk-rust/src/browse/algo/similarity.rs
+++ b/sk-rust/src/browse/algo/similarity.rs
@@ -1,0 +1,362 @@
+//! Pure-Rust port of `browse/core/similarity.py` — cosine kNN over embeddings.
+//!
+//! No I/O, no cache, no DB.
+
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+// ── constants ─────────────────────────────────────────────────────────────────
+
+pub const MAX_K: usize = 50;
+pub const MAX_REQUESTED_ENTRY_IDS: usize = 200;
+pub const MAX_COMPUTE_PAIRS: usize = 250_000;
+pub const CACHE_NEIGHBORS: usize = 50;
+/// Denominator epsilon: treat cosine denominators ≤ EPS as zero.
+pub const EPS: f64 = 1e-12;
+
+// ── structs ───────────────────────────────────────────────────────────────────
+
+/// One deduplicated embedding row.
+///
+/// `source_id` is `e.source_id` from the DB (= knowledge-entry id); used as the
+/// dedup key.  `entry_id` mirrors the Python `entry_id` field (same value).
+pub struct Row {
+    pub source_id: i64,
+    pub entry_id: i64,
+    pub title: String,
+    pub category: String,
+    pub vec: Vec<f64>,
+    pub norm: f64,
+    pub dims: usize,
+    /// Raw little-endian float32 BLOB (for fingerprinting).
+    pub blob: Vec<u8>,
+}
+
+/// One similar entry returned by the kNN search.
+pub struct Neighbor {
+    pub id: i64,
+    pub title: String,
+    pub category: String,
+    pub score: f64,
+}
+
+// ── public functions ──────────────────────────────────────────────────────────
+
+/// Deduplicate rows by `source_id`, keeping the **first** occurrence (i.e. the
+/// row that appeared earliest in the slice, which Python produces from
+/// `ORDER BY source_id ASC, id DESC`).
+pub fn dedup_rows(rows: Vec<Row>) -> Vec<Row> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for row in rows {
+        if seen.insert(row.source_id) {
+            out.push(row);
+        }
+    }
+    out
+}
+
+/// SHA-256 fingerprint of the row set.
+///
+/// Mirrors `_fingerprint_rows` exactly:
+/// for each row feed `entry_id|dims|<blob bytes>|title|category\n` to the hash.
+pub fn fingerprint_rows(rows: &[Row]) -> String {
+    let mut h = Sha256::new();
+    for row in rows {
+        h.update(row.entry_id.to_string().as_bytes());
+        h.update(b"|");
+        h.update(row.dims.to_string().as_bytes());
+        h.update(b"|");
+        h.update(&row.blob);
+        h.update(b"|");
+        h.update(row.title.as_bytes());
+        h.update(b"|");
+        h.update(row.category.as_bytes());
+        h.update(b"\n");
+    }
+    format!("{:x}", h.finalize())
+}
+
+/// Build the top-`max_neighbors` neighbors for `src` from `rows`.
+///
+/// Ordering: higher cosine score first; ties (within EPS) broken by smaller
+/// `entry_id`.  Scores are rounded to 6 decimal places.
+/// Returns `(neighbors, pair_count)`.
+pub fn build_top_neighbors(
+    src: &Row,
+    rows: &[Row],
+    max_neighbors: usize,
+) -> (Vec<Neighbor>, usize) {
+    let mut candidates: Vec<(f64, i64, String, String)> = Vec::new();
+    let mut pairs = 0usize;
+
+    for dst in rows {
+        if dst.entry_id == src.entry_id {
+            continue;
+        }
+        pairs += 1;
+        let denom = src.norm * dst.norm;
+        if denom <= EPS {
+            continue;
+        }
+        let dot_val: f64 = src.vec.iter().zip(dst.vec.iter()).map(|(a, b)| a * b).sum();
+        let score = dot_val / denom;
+        candidates.push((score, dst.entry_id, dst.title.clone(), dst.category.clone()));
+    }
+
+    // Sort: highest score first; ties by smaller entry_id.
+    candidates.sort_by(|a, b| match b.0.partial_cmp(&a.0) {
+        Some(std::cmp::Ordering::Equal) | None => a.1.cmp(&b.1),
+        Some(o) => o,
+    });
+
+    let neighbors = candidates
+        .into_iter()
+        .take(max_neighbors)
+        .map(|(score, id, title, category)| Neighbor {
+            id,
+            title,
+            category,
+            score: (score * 1_000_000.0).round() / 1_000_000.0,
+        })
+        .collect();
+
+    (neighbors, pairs)
+}
+
+/// Remove duplicates from `ids`, preserving order; positive values only.
+pub fn unique_entry_ids(ids: &[i64]) -> Vec<i64> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for &id in ids {
+        if id > 0 && seen.insert(id) {
+            out.push(id);
+        }
+    }
+    out
+}
+
+/// Compute neighbors for `source_entry_ids` subject to `max_pairs` budget.
+///
+/// Mirrors `_compute_missing_neighbors`:
+/// - skips IDs not in `rows`
+/// - caps `allowed_sources = min(valid, max(1, max_pairs / pairs_per_source))`
+/// - returns `(neighbors_map, skipped_ids, computed_pairs)`
+pub fn compute_neighbors(
+    rows: &[Row],
+    source_entry_ids: &[i64],
+    max_neighbors: usize,
+    max_pairs: usize,
+) -> (BTreeMap<i64, Vec<Neighbor>>, Vec<i64>, usize) {
+    let rows_by_id: std::collections::HashMap<i64, &Row> =
+        rows.iter().map(|r| (r.entry_id, r)).collect();
+
+    // Preserve order from source_entry_ids.
+    let valid_sources: Vec<i64> = source_entry_ids
+        .iter()
+        .filter(|&&eid| rows_by_id.contains_key(&eid))
+        .copied()
+        .collect();
+
+    if valid_sources.is_empty() {
+        return (BTreeMap::new(), vec![], 0);
+    }
+
+    let pairs_per_source = (rows.len() as i64 - 1).max(1) as usize;
+    let allowed_sources = valid_sources
+        .len()
+        .min((max_pairs / pairs_per_source).max(1));
+
+    let computed_ids = &valid_sources[..allowed_sources];
+    let skipped_ids = valid_sources[allowed_sources..].to_vec();
+
+    let mut neighbors_map: BTreeMap<i64, Vec<Neighbor>> = BTreeMap::new();
+    let mut computed_pairs = 0usize;
+
+    for &source_id in computed_ids {
+        let src = rows_by_id[&source_id];
+        let (top, pair_count) = build_top_neighbors(src, rows, max_neighbors);
+        computed_pairs += pair_count;
+        neighbors_map.insert(source_id, top);
+    }
+
+    (neighbors_map, skipped_ids, computed_pairs)
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_row(entry_id: i64, vec: Vec<f64>, title: &str, category: &str) -> Row {
+        let blob: Vec<u8> = vec.iter().flat_map(|&v| (v as f32).to_le_bytes()).collect();
+        let n = vec.iter().map(|x| x * x).sum::<f64>().sqrt();
+        Row {
+            source_id: entry_id,
+            entry_id,
+            title: title.to_string(),
+            category: category.to_string(),
+            dims: vec.len(),
+            blob,
+            norm: n,
+            vec,
+        }
+    }
+
+    // ── fingerprint_rows ───────────────────────────────────────────────────────
+
+    #[test]
+    fn fingerprint_rows_hard_coded_golden() {
+        // Input: one row with entry_id=1, dims=2, blob=pack('<ff',1.0,2.0), title="test", category="pattern"
+        // Blob bytes: 1.0f32 LE = [0x00,0x00,0x80,0x3f], 2.0f32 LE = [0x00,0x00,0x00,0x40]
+        // Python sha256 feed: "1|2|<8 bytes>|test|pattern\n"
+        // Verified with: python3 -c "import hashlib,struct; h=hashlib.sha256();
+        //   h.update(b'1|2|'); h.update(struct.pack('<ff',1.0,2.0));
+        //   h.update(b'|test|pattern\n'); print(h.hexdigest())"
+        // → 42552434afcb6e905bb05876d26893efe8f4a534d01d1114e38a9b94dfd6882a
+        let row = Row {
+            source_id: 1,
+            entry_id: 1,
+            title: "test".to_string(),
+            category: "pattern".to_string(),
+            vec: vec![1.0, 2.0],
+            norm: (1.0_f64 * 1.0 + 2.0 * 2.0_f64).sqrt(),
+            dims: 2,
+            blob: vec![0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x40],
+        };
+        let fp = fingerprint_rows(&[row]);
+        assert_eq!(
+            fp,
+            "42552434afcb6e905bb05876d26893efe8f4a534d01d1114e38a9b94dfd6882a"
+        );
+    }
+
+    // ── dedup_rows ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn dedup_rows_keeps_first_per_source_id() {
+        let rows = vec![
+            make_row(10, vec![1.0, 0.0], "first", "pattern"),
+            make_row(20, vec![0.0, 1.0], "other", "mistake"),
+            // duplicate source_id=10 — should be dropped
+            make_row(10, vec![0.5, 0.5], "dup", "decision"),
+        ];
+        let deduped = dedup_rows(rows);
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(deduped[0].entry_id, 10);
+        assert_eq!(deduped[0].title, "first");
+        assert_eq!(deduped[1].entry_id, 20);
+    }
+
+    #[test]
+    fn dedup_rows_no_duplicates_unchanged() {
+        let rows = vec![
+            make_row(1, vec![1.0, 0.0], "a", "pattern"),
+            make_row(2, vec![0.0, 1.0], "b", "mistake"),
+        ];
+        let deduped = dedup_rows(rows);
+        assert_eq!(deduped.len(), 2);
+    }
+
+    // ── build_top_neighbors ────────────────────────────────────────────────────
+
+    #[test]
+    fn build_top_neighbors_order_by_score() {
+        // row1 = [1,0], row2 = [0.9, 0.435] (cosine ~0.9), row3 = [0,1] (cosine 0)
+        let row1 = make_row(1, vec![1.0, 0.0], "src", "pattern");
+        let row2 = make_row(
+            2,
+            vec![0.9_f64, (1.0_f64 - 0.81_f64).sqrt()],
+            "close",
+            "pattern",
+        );
+        let row3 = make_row(3, vec![0.0, 1.0], "far", "mistake");
+        let rows = [
+            make_row(1, vec![1.0, 0.0], "src", "pattern"),
+            make_row(
+                2,
+                vec![0.9_f64, (1.0_f64 - 0.81_f64).sqrt()],
+                "close",
+                "pattern",
+            ),
+            make_row(3, vec![0.0, 1.0], "far", "mistake"),
+        ];
+        let src = &rows[0];
+        let (neighbors, pairs) = build_top_neighbors(src, &rows, 2);
+        assert_eq!(pairs, 2, "should count 2 pairs (excluding self)");
+        assert_eq!(neighbors.len(), 2);
+        // highest cosine score first
+        assert!(neighbors[0].score >= neighbors[1].score);
+        assert_eq!(neighbors[0].id, row2.entry_id);
+        assert_eq!(neighbors[1].id, row3.entry_id);
+        let _ = row1; // suppress unused warning
+    }
+
+    #[test]
+    fn build_top_neighbors_tiebreak_smaller_id() {
+        // Two entries with identical vectors → cosine = 1.0 for both.
+        // Tiebreak: smaller id wins (comes first in output).
+        let src = make_row(10, vec![1.0, 0.0], "src", "p");
+        let rows = [
+            make_row(10, vec![1.0, 0.0], "src", "p"),
+            make_row(30, vec![1.0, 0.0], "tied-high-id", "p"),
+            make_row(20, vec![1.0, 0.0], "tied-low-id", "p"),
+        ];
+        let (neighbors, _) = build_top_neighbors(&src, &rows, 10);
+        // Both have score=1.0; id=20 < id=30, so 20 first.
+        assert_eq!(neighbors[0].id, 20);
+        assert_eq!(neighbors[1].id, 30);
+    }
+
+    #[test]
+    fn build_top_neighbors_excludes_self() {
+        let rows = [
+            make_row(1, vec![1.0, 0.0], "a", "p"),
+            make_row(2, vec![0.9, 0.1], "b", "p"),
+        ];
+        let (neighbors, pairs) = build_top_neighbors(&rows[0], &rows, 10);
+        assert_eq!(pairs, 1);
+        assert_eq!(neighbors.len(), 1);
+        assert_eq!(neighbors[0].id, 2);
+    }
+
+    // ── unique_entry_ids ───────────────────────────────────────────────────────
+
+    #[test]
+    fn unique_entry_ids_deduplicates_and_filters_nonpositive() {
+        let ids = vec![3, 1, 3, 0, -1, 2, 1];
+        let u = unique_entry_ids(&ids);
+        assert_eq!(u, vec![3, 1, 2]);
+    }
+
+    // ── compute_neighbors ──────────────────────────────────────────────────────
+
+    #[test]
+    fn compute_neighbors_max_pairs_skip_behavior() {
+        // 4 rows → pairs_per_source = max(1, 4-1) = 3
+        // max_pairs=9 → allowed = min(4, max(1, 9/3)) = min(4,3) = 3
+        // source_entry_ids = [1,2,3,4] → computed=[1,2,3], skipped=[4]
+        let rows: Vec<Row> = (1..=4)
+            .map(|i| make_row(i, vec![i as f64, 0.0], "t", "p"))
+            .collect();
+        let source_ids: Vec<i64> = vec![1, 2, 3, 4];
+        let (map, skipped, _pairs) = compute_neighbors(&rows, &source_ids, 3, 9);
+        assert!(map.contains_key(&1));
+        assert!(map.contains_key(&2));
+        assert!(map.contains_key(&3));
+        assert!(!map.contains_key(&4));
+        assert_eq!(skipped, vec![4i64]);
+    }
+
+    #[test]
+    fn compute_neighbors_missing_source_skipped() {
+        let rows: Vec<Row> = (1..=2)
+            .map(|i| make_row(i, vec![i as f64], "t", "p"))
+            .collect();
+        let source_ids = vec![99i64]; // not in rows
+        let (map, skipped, _) = compute_neighbors(&rows, &source_ids, 5, 100_000);
+        assert!(map.is_empty());
+        assert!(skipped.is_empty());
+    }
+}

--- a/sk-rust/src/browse/algo/similarity.rs
+++ b/sk-rust/src/browse/algo/similarity.rs
@@ -79,8 +79,9 @@ pub fn fingerprint_rows(rows: &[Row]) -> String {
 
 /// Build the top-`max_neighbors` neighbors for `src` from `rows`.
 ///
-/// Ordering: higher cosine score first; ties (within EPS) broken by smaller
-/// `entry_id`.  Scores are rounded to 6 decimal places.
+/// Ordering: higher cosine score first; ties broken by smaller `entry_id`
+/// (using exact f64 equality, not an epsilon band).
+/// Scores are rounded to 6 decimal places.
 /// Returns `(neighbors, pair_count)`.
 pub fn build_top_neighbors(
     src: &Row,

--- a/sk-rust/src/browse/mod.rs
+++ b/sk-rust/src/browse/mod.rs
@@ -6,6 +6,7 @@
 
 #![allow(dead_code)]
 
+pub mod algo;
 #[cfg(feature = "browse-server")]
 pub mod api;
 #[cfg(feature = "browse-server")]

--- a/sk-rust/src/lib.rs
+++ b/sk-rust/src/lib.rs
@@ -1,7 +1,8 @@
 //! Library surface for `sk` — currently only exposes browse modules for
 //! integration testing and future crate-level reuse.
 
-#[cfg(feature = "browse-server")]
+// `browse::algo` (pure algorithms) is always compiled in; feature-gated
+// submodules inside `browse/mod.rs` guard the server-specific code.
 pub mod browse;
 
 #[cfg(feature = "browse-server")]

--- a/sk-rust/tests/browse_algo_test.rs
+++ b/sk-rust/tests/browse_algo_test.rs
@@ -1,0 +1,217 @@
+//! Integration-level tests for `browse::algo` — imported as a Rust integration test
+//! so they exercise the public API as an external consumer would.
+
+use sk::browse::algo::{communities, projection, similarity};
+
+// ─── projection ──────────────────────────────────────────────────────────────
+
+#[test]
+fn projection_decode_le_f32_two_elements() {
+    // 1.0f32 LE = 0x3F800000, 2.0f32 LE = 0x40000000
+    let blob = vec![0x00u8, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x40];
+    let v = projection::decode_vector_le_f32(&blob, 2).unwrap();
+    assert!((v[0] - 1.0_f32).abs() < 1e-7);
+    assert!((v[1] - 2.0_f32).abs() < 1e-7);
+}
+
+#[test]
+fn projection_pca_2d_empty_input() {
+    let (xs, ys) = projection::pca_2d(&[]);
+    assert!(xs.is_empty() && ys.is_empty());
+}
+
+#[test]
+fn projection_pca_2d_single_dim_vectors() {
+    let vectors = vec![vec![1.0_f64], vec![2.0], vec![3.0]];
+    let (xs, ys) = projection::pca_2d(&vectors);
+    assert_eq!(xs.len(), 3);
+    assert_eq!(ys, vec![0.0, 0.0, 0.0]);
+}
+
+#[test]
+fn projection_pca_2d_axis_aligned_variance_sign_flexible() {
+    // 2D data with all variance in x; mean = 0.
+    let vectors = vec![
+        vec![2.0_f64, 0.0],
+        vec![-2.0, 0.0],
+        vec![0.0, 1.0],
+        vec![0.0, -1.0],
+    ];
+    let (xs, ys) = projection::pca_2d(&vectors);
+    let s = xs[0].signum();
+    assert!((xs[0] - s * 2.0).abs() < 1e-6, "xs[0]={}", xs[0]);
+    assert!((xs[1] - s * -2.0).abs() < 1e-6, "xs[1]={}", xs[1]);
+    assert!(xs[2].abs() < 1e-6, "xs[2]={}", xs[2]);
+    assert!(xs[3].abs() < 1e-6, "xs[3]={}", xs[3]);
+
+    let s2 = if ys[2].abs() > 1e-9 {
+        ys[2].signum()
+    } else {
+        1.0
+    };
+    assert!(ys[0].abs() < 1e-6, "ys[0]={}", ys[0]);
+    assert!(ys[1].abs() < 1e-6, "ys[1]={}", ys[1]);
+    assert!((ys[2] - s2 * 1.0).abs() < 1e-6, "ys[2]={}", ys[2]);
+    assert!((ys[3] + s2).abs() < 1e-6, "ys[3]={}", ys[3]);
+}
+
+// ─── similarity ──────────────────────────────────────────────────────────────
+
+fn make_row(entry_id: i64, vec: Vec<f64>, title: &str, category: &str) -> similarity::Row {
+    let blob: Vec<u8> = vec.iter().flat_map(|&v| (v as f32).to_le_bytes()).collect();
+    let n = vec.iter().map(|x| x * x).sum::<f64>().sqrt();
+    similarity::Row {
+        source_id: entry_id,
+        entry_id,
+        title: title.to_string(),
+        category: category.to_string(),
+        dims: vec.len(),
+        blob,
+        norm: n,
+        vec,
+    }
+}
+
+#[test]
+fn similarity_fingerprint_golden() {
+    // Same golden as the unit test: single row, entry_id=1, dims=2, blob=pack('<ff',1.0,2.0),
+    // title="test", category="pattern".
+    // Expected SHA-256 verified with Python.
+    let row = similarity::Row {
+        source_id: 1,
+        entry_id: 1,
+        title: "test".to_string(),
+        category: "pattern".to_string(),
+        vec: vec![1.0, 2.0],
+        norm: (5.0_f64).sqrt(),
+        dims: 2,
+        blob: vec![0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x40],
+    };
+    assert_eq!(
+        similarity::fingerprint_rows(&[row]),
+        "42552434afcb6e905bb05876d26893efe8f4a534d01d1114e38a9b94dfd6882a"
+    );
+}
+
+#[test]
+fn similarity_dedup_keeps_first() {
+    let rows = vec![
+        make_row(5, vec![1.0, 0.0], "first", "p"),
+        make_row(5, vec![0.0, 1.0], "dup", "p"),
+        make_row(6, vec![0.5, 0.5], "other", "p"),
+    ];
+    let d = similarity::dedup_rows(rows);
+    assert_eq!(d.len(), 2);
+    assert_eq!(d[0].title, "first");
+    assert_eq!(d[1].entry_id, 6);
+}
+
+#[test]
+fn similarity_build_top_neighbors_pair_count_and_order() {
+    let rows = [
+        make_row(1, vec![1.0, 0.0], "a", "p"),
+        make_row(2, vec![1.0, 0.0], "b", "p"), // cosine 1.0 with src
+        make_row(3, vec![0.0, 1.0], "c", "p"), // cosine 0.0 with src
+    ];
+    let (neighbors, pairs) = similarity::build_top_neighbors(&rows[0], &rows, 10);
+    assert_eq!(pairs, 2);
+    assert_eq!(neighbors[0].id, 2);
+    assert!((neighbors[0].score - 1.0).abs() < 1e-6);
+    assert_eq!(neighbors[1].id, 3);
+}
+
+#[test]
+fn similarity_compute_neighbors_pairs_cap_skips_last() {
+    // 4 rows → pairs_per_source = 3; max_pairs=9 → allowed=3, skipped=[4]
+    let rows: Vec<similarity::Row> = (1..=4)
+        .map(|i| make_row(i, vec![i as f64, 0.0], "t", "p"))
+        .collect();
+    let (map, skipped, _) = similarity::compute_neighbors(&rows, &[1, 2, 3, 4], 5, 9);
+    assert!(map.contains_key(&1) && map.contains_key(&2) && map.contains_key(&3));
+    assert!(!map.contains_key(&4));
+    assert_eq!(skipped, vec![4i64]);
+}
+
+// ─── communities ─────────────────────────────────────────────────────────────
+
+fn ce(id: i64, title: &str, cat: &str, wing: &str) -> communities::Entry {
+    communities::Entry {
+        id,
+        title: title.to_string(),
+        category: cat.to_string(),
+        wing: wing.to_string(),
+    }
+}
+fn cr(src: i64, tgt: i64, rtype: &str) -> communities::RelationEdge {
+    communities::RelationEdge {
+        source_id: src,
+        target_id: tgt,
+        relation_type: rtype.to_string(),
+    }
+}
+
+#[test]
+fn communities_empty_relations_returns_empty() {
+    let entries = vec![ce(1, "A", "p", "b"), ce(2, "B", "m", "f")];
+    assert!(communities::find_communities(&entries, &[], 2).is_empty());
+}
+
+#[test]
+fn communities_self_loop_ignored() {
+    let entries = vec![ce(1, "A", "p", "b"), ce(2, "B", "m", "f")];
+    let rels = vec![cr(1, 1, "self")];
+    assert!(communities::find_communities(&entries, &rels, 2).is_empty());
+}
+
+#[test]
+fn communities_missing_endpoint_ignored() {
+    let entries = vec![ce(1, "A", "p", "b")];
+    let rels = vec![cr(1, 99, "x")]; // 99 not in entries
+    assert!(communities::find_communities(&entries, &rels, 2).is_empty());
+}
+
+#[test]
+fn communities_two_components_sorted_by_entry_count_then_id() {
+    let entries = vec![
+        ce(1, "A", "pattern", "backend"),
+        ce(2, "B", "mistake", "frontend"),
+        ce(3, "C", "decision", "backend"),
+        ce(4, "D", "pattern", "backend"),
+    ];
+    let rels = vec![cr(1, 2, "related"), cr(3, 4, "similar")];
+    let comms = communities::find_communities(&entries, &rels, 2);
+    assert_eq!(comms.len(), 2);
+    assert_eq!(comms[0].id, "c-1");
+    assert_eq!(comms[1].id, "c-3");
+}
+
+#[test]
+fn communities_representative_entries_by_degree_then_id() {
+    // entries 1,2,3 → entry 2 is hub (degree 2), entries 1 and 3 have degree 1.
+    let entries = vec![
+        ce(1, "A", "p", "b"),
+        ce(2, "B", "m", "f"),
+        ce(3, "C", "d", "b"),
+    ];
+    let rels = vec![cr(1, 2, "r"), cr(2, 3, "r")];
+    let comms = communities::find_communities(&entries, &rels, 2);
+    assert_eq!(comms.len(), 1);
+    let c = &comms[0];
+    assert_eq!(c.representative_entries[0].0, 2, "hub should be first");
+    assert_eq!(
+        c.representative_entries[1].0, 1,
+        "id 1 < id 3 for equal degree"
+    );
+    assert_eq!(c.representative_entries[2].0, 3);
+}
+
+#[test]
+fn communities_tie_ordering_by_id() {
+    let entries: Vec<communities::Entry> = (1..=6).map(|i| ce(i, "X", "p", "b")).collect();
+    let rels = vec![cr(1, 2, "x"), cr(3, 4, "x"), cr(5, 6, "x")];
+    let comms = communities::find_communities(&entries, &rels, 2);
+    assert_eq!(comms.len(), 3);
+    assert_eq!(comms[0].id, "c-1");
+    assert_eq!(comms[1].id, "c-3");
+    assert_eq!(comms[2].id, "c-5");
+}


### PR DESCRIPTION
## Summary
- Adds #452 PR-A: pure Rust browse algorithm helpers for projection, similarity, and community detection.
- Keeps handlers, DB loading, cache I/O, MD5 graph IDs, and API parity fixtures out of scope for follow-up PRs.
- Exposes `browse::algo` without enabling browse-server; server-specific browse modules remain feature-gated.

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test browse::algo` — 32 passed / 0 failed
- `cargo test --test browse_algo_test` — 14 passed / 0 failed
- `cargo test` — 1,147 passed / 0 failed
- `cargo build --no-default-features`
- `cargo test --no-default-features browse::algo` — 32 passed / 0 failed
- `cargo test --no-default-features --test browse_algo_test` — 14 passed / 0 failed

## Review evidence
- Independent verification gate passed.
- Opus code review verdict: CLEAN.
- Opus confidence tiebreaker: promotable as-is with confidence 1.0; remaining notes are PR-B/C follow-ups only.

Closes part of #452 (PR-A algorithms only).