### PR TITLE
chore(#459): add advisory frontend lint scope

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,18 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{ts,tsx,js,jsx,mjs,cjs,json,yml,yaml,css,scss,html}]
+indent_style = space
+indent_size = 2
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -189,6 +189,8 @@ Hooks **fail-open**: if a hook crashes or is unavailable, the guarded operation 
 | Rust | `cargo fmt --all -- --check && cargo clippy -- -D warnings && cargo test` |
 | remote-terminal | `npm test && npm run lint && npm run lint:clean` |
 
+`pnpm lint:all` is an advisory wider-scope variant covering `e2e/` and `scripts/` in addition to `src/`; it is not wired into CI.
+
 **Closeout:** attach command output (not just assertions) · `sk learn` before `task_complete` · subagents handoff with `--status DONE --changed-file <file> --learn`.
 
 ## Testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **chore(quality):** add language-specific `.editorconfig` indent rules and advisory `pnpm lint:all` script (issue #459 PR-A; Rust/Python/global-any tightening deferred behind #450–#453).
+
 ### Added
 - **Cron DB maintenance tasks (#464):** `cron-tasks.py` gains two new scheduled templates:
   `wal-checkpoint` (daily `PRAGMA wal_checkpoint(TRUNCATE)` at 04:00) and `vacuum` (weekly

--- a/browse-ui/AGENTS.md
+++ b/browse-ui/AGENTS.md
@@ -5,3 +5,9 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+## Lint scope
+
+`pnpm lint` covers `src/` only and is the blocking CI gate.
+`pnpm lint:all` is advisory and additionally covers `e2e/` and `scripts/`; it is not wired into CI.
+Run `pnpm lint:all` locally before touching test or build scripts outside `src/`.

--- a/browse-ui/package.json
+++ b/browse-ui/package.json
@@ -9,6 +9,7 @@
     "release:check": "node scripts/release-check.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
+    "lint:all": "eslint src e2e scripts",
     "format": "prettier --write src",
     "format:check": "prettier --check src",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Adds #459 PR-A safe subset: language-specific `.editorconfig` indent rules and an advisory `pnpm lint:all` script for browse-ui.
- Documents the advisory lint scope in Copilot/AGENTS guidance and CHANGELOG.
- Does not change CI, ESLint rule severity, Ruff, Rust linting, hooks, or runtime code.

## Deferred
- Rust `[lints.clippy]` and `rustfmt.toml` are deferred until after #450 lands.
- Ruff rule expansion is deferred behind #451-#453.
- Global `no-explicit-any` promotion is deferred; current `src/` has 42 warnings.

## Verification
- `./node_modules/.bin/eslint src` — 0 errors, 115 warnings
- `pnpm lint:all` — 0 errors, 116 warnings
- `pnpm typecheck`
- `pnpm format:check`
- `python test_fixes.py` — 272 passed / 0 failed

## Review evidence
- Opus initial review found a Markdown table placement blocker; fixed.
- Opus rereview verdict: CLEAN.
- Independent verification gate passed.

Closes part of #459 (PR-A frontend + metadata only).