### PR TITLE
feat(#451): add Rust operator session CRUD endpoints

### DIFF
--- a/sk-rust/Cargo.lock
+++ b/sk-rust/Cargo.lock
@@ -455,6 +455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +559,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1654,6 +1671,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scheduled-thread-pool"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1693,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -1741,6 +1773,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,6 +1847,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "dirs",
+ "dunce",
  "hmac",
  "http-body-util",
  "notify",
@@ -1801,6 +1860,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serial_test",
  "sha1",
  "sha2",
  "tempfile",
@@ -1809,6 +1869,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2170,6 +2231,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "rand 0.10.1",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/sk-rust/Cargo.toml
+++ b/sk-rust/Cargo.toml
@@ -32,6 +32,8 @@ browse-server  = [
     "dep:tokio",
     "dep:tokio-stream",
     "dep:rand",
+    "dep:uuid",
+    "dep:dunce",
     "tokio/rt-multi-thread",
     "tokio/macros",
     "tokio/signal",
@@ -72,6 +74,9 @@ r2d2        = { version = "0.8", optional = true }
 r2d2_sqlite = { version = "0.24", optional = true }
 tokio-stream = { version = "0.1", features = ["sync"], optional = true }
 rand        = { version = "0.9", optional = true }
+uuid        = { version = "1", features = ["v4", "serde"], optional = true }
+# dunce avoids \\?\ extended-length prefix leaking into stored paths on Windows.
+dunce       = { version = "1", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2"
@@ -81,6 +86,7 @@ rusqlite  = { version = "0.31", features = ["bundled"] }
 tower     = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile  = "3"
+serial_test = "3"
 
 [[bin]]
 name = "sk"

--- a/sk-rust/src/browse/api/mod.rs
+++ b/sk-rust/src/browse/api/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod compare;
 pub mod live;
+pub mod operator;
 pub mod sessions;

--- a/sk-rust/src/browse/api/operator.rs
+++ b/sk-rust/src/browse/api/operator.rs
@@ -1,0 +1,302 @@
+//! `/api/operator/*` route handlers (issue #451 PR-A).
+//!
+//! Endpoints wired here:
+//! - `GET  /api/operator/capabilities`
+//! - `POST /api/operator/sessions`
+//! - `GET  /api/operator/sessions`
+//! - `GET  /api/operator/sessions/:id`
+//! - `PATCH /api/operator/sessions/:id`
+//! - `DELETE /api/operator/sessions/:id`
+//! - `POST /api/operator/sessions/:id/delete`
+//!
+//! Auth is enforced by the router-level `auth_middleware`; handlers do not
+//! re-check credentials.  Blocking filesystem operations are wrapped in
+//! `tokio::task::spawn_blocking`.
+
+use axum::body::Bytes;
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde_json::{json, Value};
+
+use crate::browse::operator::console::{
+    create_session, delete_session, get_session, list_sessions, update_session,
+    CreateSessionParams, UpdateError,
+};
+
+// ── Error / success helpers ────────────────────────────────────────────────────
+
+fn json_err(msg: &str, code: &str, status: StatusCode) -> Response {
+    (status, Json(json!({ "error": msg, "code": code }))).into_response()
+}
+
+fn json_ok_val(val: Value) -> Response {
+    (StatusCode::OK, Json(val)).into_response()
+}
+
+// ── Capabilities ───────────────────────────────────────────────────────────────
+
+/// `GET /api/operator/capabilities` — static host capability descriptor.
+///
+/// Shape is fixed per `hostCapabilitiesSchema` in the frontend
+/// (browse-ui/src/lib/api/schemas.ts).
+pub async fn handle_capabilities() -> impl IntoResponse {
+    Json(json!({
+        "cli_kind": "copilot",
+        "version": "1",
+        "protocol": "v2",
+        "supported_modes": ["interactive", "plan", "autopilot"],
+        "supported_features": [
+            "chat",
+            "sessions",
+            "search",
+            "graph",
+            "insights",
+            "diagnostics",
+            "models",
+            "suggest",
+            "preview",
+            "diff",
+        ],
+    }))
+}
+
+// ── Session CRUD ───────────────────────────────────────────────────────────────
+
+/// `POST /api/operator/sessions` — create a new operator session.
+pub async fn handle_create_session(body: Bytes) -> Response {
+    let data: Value = if body.is_empty() {
+        Value::Object(Default::default())
+    } else {
+        match serde_json::from_slice(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                return json_err(
+                    &format!("invalid JSON: {e}"),
+                    "BAD_JSON",
+                    StatusCode::BAD_REQUEST,
+                );
+            }
+        }
+    };
+
+    let obj = match data.as_object() {
+        Some(o) => o,
+        None => {
+            return json_err(
+                "request body must be a JSON object",
+                "BAD_BODY",
+                StatusCode::BAD_REQUEST,
+            );
+        }
+    };
+
+    let name = str_field(obj, "name", 128);
+    let model = str_field(obj, "model", 64);
+    let mode = str_field(obj, "mode", 64);
+    let workspace = str_field(obj, "workspace", 4096);
+
+    let add_dirs_raw = obj.get("add_dirs");
+    let add_dirs: Vec<String> = match add_dirs_raw {
+        None => vec![],
+        Some(Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .filter(|s| !s.trim().is_empty())
+            .collect(),
+        Some(_) => {
+            return json_err(
+                "add_dirs must be a list",
+                "BAD_PARAM",
+                StatusCode::BAD_REQUEST,
+            );
+        }
+    };
+
+    let params = CreateSessionParams {
+        name,
+        model,
+        mode,
+        workspace,
+        add_dirs,
+    };
+
+    match tokio::task::spawn_blocking(|| create_session(params)).await {
+        Ok(Ok(session)) => json_ok_val(serde_json::to_value(session).unwrap_or(Value::Null)),
+        Ok(Err(msg)) => json_err(&msg, "PATH_VIOLATION", StatusCode::FORBIDDEN),
+        Err(e) => json_err(
+            &format!("internal error: {e}"),
+            "INTERNAL",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ),
+    }
+}
+
+/// `GET /api/operator/sessions` — list all sessions (newest-first).
+pub async fn handle_list_sessions() -> Response {
+    match tokio::task::spawn_blocking(list_sessions).await {
+        Ok(sessions) => {
+            let count = sessions.len();
+            let arr = serde_json::to_value(sessions).unwrap_or(Value::Array(vec![]));
+            json_ok_val(json!({ "sessions": arr, "count": count }))
+        }
+        Err(e) => json_err(
+            &format!("internal error: {e}"),
+            "INTERNAL",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ),
+    }
+}
+
+/// `GET /api/operator/sessions/:id` — fetch a single session.
+pub async fn handle_get_session(Path(session_id): Path<String>) -> Response {
+    let id_for_err = session_id.clone();
+    match tokio::task::spawn_blocking(move || get_session(&session_id)).await {
+        Ok(Some(session)) => json_ok_val(serde_json::to_value(session).unwrap_or(Value::Null)),
+        Ok(None) => json_err(
+            &format!("session '{id_for_err}' not found"),
+            "SESSION_NOT_FOUND",
+            StatusCode::NOT_FOUND,
+        ),
+        Err(e) => json_err(
+            &format!("internal error: {e}"),
+            "INTERNAL",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ),
+    }
+}
+
+// Workaround: capture session_id string before moving into closure for the 404 message.
+fn not_found_msg(id: &str) -> String {
+    format!("session '{id}' not found")
+}
+
+/// `DELETE /api/operator/sessions/:id` — delete a session.
+pub async fn handle_delete_session(Path(session_id): Path<String>) -> Response {
+    let msg = not_found_msg(&session_id);
+    let id_clone = session_id.clone();
+    match tokio::task::spawn_blocking(move || delete_session(&id_clone)).await {
+        Ok(true) => json_ok_val(json!({ "deleted": true, "session_id": session_id })),
+        Ok(false) => json_err(&msg, "SESSION_NOT_FOUND", StatusCode::NOT_FOUND),
+        Err(e) => json_err(
+            &format!("internal error: {e}"),
+            "INTERNAL",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ),
+    }
+}
+
+/// `POST /api/operator/sessions/:id/delete` — browser-safe delete alias.
+pub async fn handle_delete_session_post(Path(session_id): Path<String>) -> Response {
+    let msg = not_found_msg(&session_id);
+    let id_clone = session_id.clone();
+    match tokio::task::spawn_blocking(move || delete_session(&id_clone)).await {
+        Ok(true) => json_ok_val(json!({ "deleted": true, "session_id": session_id })),
+        Ok(false) => json_err(&msg, "SESSION_NOT_FOUND", StatusCode::NOT_FOUND),
+        Err(e) => json_err(
+            &format!("internal error: {e}"),
+            "INTERNAL",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ),
+    }
+}
+
+/// `PATCH /api/operator/sessions/:id` — update mutable fields.
+///
+/// Body must be a JSON object with at least one of `name`, `model`, `mode`.
+/// `mode` is validated against `interactive | plan | autopilot`.
+/// Returns 409 when an active run is in progress (dormant until PR-B).
+pub async fn handle_update_session(Path(session_id): Path<String>, body: Bytes) -> Response {
+    if body.is_empty() {
+        return json_err(
+            "at least one mutable field (name, model, mode) must be provided",
+            "BAD_PARAM",
+            StatusCode::BAD_REQUEST,
+        );
+    }
+
+    let data: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            return json_err(
+                &format!("invalid JSON: {e}"),
+                "BAD_JSON",
+                StatusCode::BAD_REQUEST,
+            );
+        }
+    };
+
+    let obj = match data.as_object() {
+        Some(o) => o,
+        None => {
+            return json_err(
+                "request body must be a JSON object",
+                "BAD_BODY",
+                StatusCode::BAD_REQUEST,
+            );
+        }
+    };
+
+    let has_name = obj.contains_key("name");
+    let has_model = obj.contains_key("model");
+    let has_mode = obj.contains_key("mode");
+
+    if !has_name && !has_model && !has_mode {
+        return json_err(
+            "at least one mutable field (name, model, mode) must be provided",
+            "BAD_PARAM",
+            StatusCode::BAD_REQUEST,
+        );
+    }
+
+    let name_val = has_name.then(|| str_field(obj, "name", 128));
+    let model_val = has_model.then(|| str_field(obj, "model", 64));
+    let mode_val = has_mode.then(|| str_field(obj, "mode", 64));
+
+    let nf_msg = not_found_msg(&session_id);
+    let active_run_msg =
+        format!("session '{session_id}' has an active run; wait for it to finish before updating");
+    let id_clone = session_id.clone();
+
+    match tokio::task::spawn_blocking(move || {
+        update_session(
+            &id_clone,
+            name_val.as_deref(),
+            model_val.as_deref(),
+            mode_val.as_deref(),
+        )
+    })
+    .await
+    {
+        Ok(Ok(updated)) => json_ok_val(serde_json::to_value(updated).unwrap_or(Value::Null)),
+        Ok(Err(UpdateError::NotFound)) => {
+            json_err(&nf_msg, "SESSION_NOT_FOUND", StatusCode::NOT_FOUND)
+        }
+        Ok(Err(UpdateError::BadMode)) => json_err(
+            "mode must be one of: interactive, plan, autopilot",
+            "BAD_MODE",
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(Err(UpdateError::ActiveRun)) => {
+            json_err(&active_run_msg, "SESSION_ACTIVE_RUN", StatusCode::CONFLICT)
+        }
+        Err(e) => json_err(
+            &format!("internal error: {e}"),
+            "INTERNAL",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ),
+    }
+}
+
+// ── Field extraction helpers ───────────────────────────────────────────────────
+
+fn str_field(obj: &serde_json::Map<String, Value>, key: &str, max_len: usize) -> String {
+    obj.get(key)
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .chars()
+        .take(max_len)
+        .collect()
+}

--- a/sk-rust/src/browse/api/operator.rs
+++ b/sk-rust/src/browse/api/operator.rs
@@ -21,7 +21,7 @@ use axum::Json;
 use serde_json::{json, Value};
 
 use crate::browse::operator::console::{
-    create_session, delete_session, get_session, list_sessions, update_session,
+    create_session, delete_session, get_session, list_sessions, update_session, CreateError,
     CreateSessionParams, UpdateError,
 };
 
@@ -124,7 +124,12 @@ pub async fn handle_create_session(body: Bytes) -> Response {
 
     match tokio::task::spawn_blocking(|| create_session(params)).await {
         Ok(Ok(session)) => json_ok_val(serde_json::to_value(session).unwrap_or(Value::Null)),
-        Ok(Err(msg)) => json_err(&msg, "PATH_VIOLATION", StatusCode::FORBIDDEN),
+        Ok(Err(CreateError::PathViolation(msg))) => {
+            json_err(&msg, "PATH_VIOLATION", StatusCode::FORBIDDEN)
+        }
+        Ok(Err(CreateError::Io(msg))) => {
+            json_err(&msg, "INTERNAL", StatusCode::INTERNAL_SERVER_ERROR)
+        }
         Err(e) => json_err(
             &format!("internal error: {e}"),
             "INTERNAL",
@@ -178,6 +183,8 @@ pub async fn handle_delete_session(Path(session_id): Path<String>) -> Response {
     let id_clone = session_id.clone();
     match tokio::task::spawn_blocking(move || delete_session(&id_clone)).await {
         Ok(true) => json_ok_val(json!({ "deleted": true, "session_id": session_id })),
+        // false: invalid UUID, file missing, or I/O failure — mirrors Python delete_session
+        // returning False on OSError; changing this requires coordinated Python/Rust work.
         Ok(false) => json_err(&msg, "SESSION_NOT_FOUND", StatusCode::NOT_FOUND),
         Err(e) => json_err(
             &format!("internal error: {e}"),
@@ -193,6 +200,8 @@ pub async fn handle_delete_session_post(Path(session_id): Path<String>) -> Respo
     let id_clone = session_id.clone();
     match tokio::task::spawn_blocking(move || delete_session(&id_clone)).await {
         Ok(true) => json_ok_val(json!({ "deleted": true, "session_id": session_id })),
+        // false: invalid UUID, file missing, or I/O failure — mirrors Python delete_session
+        // returning False on OSError; changing this requires coordinated Python/Rust work.
         Ok(false) => json_err(&msg, "SESSION_NOT_FOUND", StatusCode::NOT_FOUND),
         Err(e) => json_err(
             &format!("internal error: {e}"),
@@ -280,6 +289,9 @@ pub async fn handle_update_session(Path(session_id): Path<String>, body: Bytes) 
         ),
         Ok(Err(UpdateError::ActiveRun)) => {
             json_err(&active_run_msg, "SESSION_ACTIVE_RUN", StatusCode::CONFLICT)
+        }
+        Ok(Err(UpdateError::Io(msg))) => {
+            json_err(&msg, "INTERNAL", StatusCode::INTERNAL_SERVER_ERROR)
         }
         Err(e) => json_err(
             &format!("internal error: {e}"),

--- a/sk-rust/src/browse/mod.rs
+++ b/sk-rust/src/browse/mod.rs
@@ -18,6 +18,7 @@ pub mod db;
 #[cfg(feature = "browse-server")]
 pub mod db_debug_log;
 pub mod importers;
+#[cfg(feature = "browse-server")]
 pub mod operator;
 #[cfg(feature = "browse-server")]
 pub mod server;

--- a/sk-rust/src/browse/operator/console.rs
+++ b/sk-rust/src/browse/operator/console.rs
@@ -242,12 +242,23 @@ fn lenient_canonicalize(path: &Path) -> Option<PathBuf> {
 
 // ── Error types ────────────────────────────────────────────────────────────────
 
+/// Error codes returned by `create_session`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CreateError {
+    /// `workspace` or an `add_dir` path is not confined to `~/`.
+    PathViolation(String),
+    /// A filesystem operation failed (creating the sessions dir or writing JSON).
+    Io(String),
+}
+
 /// Error codes returned by `update_session`.
 #[derive(Debug, PartialEq, Eq)]
 pub enum UpdateError {
     NotFound,
     BadMode,
     ActiveRun,
+    /// A filesystem operation failed (creating the sessions dir or writing JSON).
+    Io(String),
 }
 
 // ── Session CRUD ───────────────────────────────────────────────────────────────
@@ -264,15 +275,21 @@ pub struct CreateSessionParams {
 
 /// Create and persist a new operator session.
 ///
-/// Returns `Err(message)` if `workspace` or any `add_dir` is outside `~/`.
-pub fn create_session(params: CreateSessionParams) -> Result<Session, String> {
+/// Returns `Err(CreateError::PathViolation)` if `workspace` or any `add_dir`
+/// is outside `~/`, and `Err(CreateError::Io)` if persistence fails.
+pub fn create_session(params: CreateSessionParams) -> Result<Session, CreateError> {
     let id = Uuid::new_v4().to_string();
     let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
 
     let ws_path = if !params.workspace.trim().is_empty() {
         confine_path(&params.workspace)
             .map(|p| p.to_string_lossy().into_owned())
-            .ok_or_else(|| format!("workspace path '{}' is not under ~/", params.workspace))?
+            .ok_or_else(|| {
+                CreateError::PathViolation(format!(
+                    "workspace path '{}' is not under ~/",
+                    params.workspace
+                ))
+            })?
     } else {
         String::new()
     };
@@ -283,7 +300,9 @@ pub fn create_session(params: CreateSessionParams) -> Result<Session, String> {
         if d.is_empty() {
             continue;
         }
-        let p = confine_path(d).ok_or_else(|| format!("add_dir path '{d}' is not under ~/"))?;
+        let p = confine_path(d).ok_or_else(|| {
+            CreateError::PathViolation(format!("add_dir path '{d}' is not under ~/"))
+        })?;
         validated_dirs.push(p.to_string_lossy().into_owned());
     }
 
@@ -301,8 +320,9 @@ pub fn create_session(params: CreateSessionParams) -> Result<Session, String> {
         resume_ready: false,
     };
 
-    let dir = sessions_dir().map_err(|e| e.to_string())?;
-    write_json_atomic(&dir.join(format!("{id}.json")), &session).map_err(|e| e.to_string())?;
+    let dir = sessions_dir().map_err(|e| CreateError::Io(e.to_string()))?;
+    write_json_atomic(&dir.join(format!("{id}.json")), &session)
+        .map_err(|e| CreateError::Io(e.to_string()))?;
 
     Ok(session)
 }
@@ -355,6 +375,10 @@ pub fn get_session(session_id: &str) -> Option<Session> {
 }
 
 /// Delete a session file.  Returns `true` if the file existed and was removed.
+///
+/// Intentionally mirrors Python `browse/core/operator_console.py::delete_session`:
+/// `OSError` maps to `False`, so the route surfaces 404 `SESSION_NOT_FOUND`.
+/// Changing this contract requires coordinated Python/Rust contract work.
 pub fn delete_session(session_id: &str) -> bool {
     if !is_valid_uuid4(session_id) {
         return false;
@@ -415,9 +439,9 @@ pub fn update_session(
     }
     session.updated_at = now;
 
-    let dir = sessions_dir().map_err(|_| UpdateError::NotFound)?;
+    let dir = sessions_dir().map_err(|e| UpdateError::Io(e.to_string()))?;
     write_json_atomic(&dir.join(format!("{session_id}.json")), &session)
-        .map_err(|_| UpdateError::NotFound)?;
+        .map_err(|e| UpdateError::Io(e.to_string()))?;
 
     Ok(session)
 }

--- a/sk-rust/src/browse/operator/console.rs
+++ b/sk-rust/src/browse/operator/console.rs
@@ -1,0 +1,513 @@
+//! Operator console — session CRUD, path confinement and model normalisation
+//! (issue #451 PR-A).
+//!
+//! Design invariants (mirroring Python operator_console.py):
+//! - Sessions live at `state_dir()/sessions/{uuid}.json`.
+//! - JSON file writes are atomic: write to `.tmp` then rename.
+//! - Corrupt JSON on list is skipped with `tracing::warn!`.
+//! - `list_sessions()` returns newest-first by `created_at`.
+//! - `confine_path` rejects empty, outside-home, traversal, symlink/junction escapes.
+//! - `normalize_model_id` converts hyphenated version suffixes to dotted form.
+//! - POST accepts any mode; PATCH validates against `interactive`, `plan`, `autopilot`.
+//! - `has_active_run` is dormant for PR-A — TODO(#451 PR-B).
+
+use std::fs;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use chrono::Utc;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ── Session struct ─────────────────────────────────────────────────────────────
+
+/// A browser-managed Copilot operator session persisted to disk as JSON.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Session {
+    pub id: String,
+    pub name: String,
+    pub model: String,
+    pub mode: String,
+    pub workspace: String,
+    pub add_dirs: Vec<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub run_count: u64,
+    pub last_run_id: Option<String>,
+    pub resume_ready: bool,
+}
+
+// ── UUID4 validation ───────────────────────────────────────────────────────────
+
+fn uuid4_re() -> &'static Regex {
+    use std::sync::OnceLock;
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$")
+            .expect("uuid4 regex is valid")
+    })
+}
+
+/// Return `true` if `s` is a well-formed UUID v4 string (lowercase hex).
+pub(crate) fn is_valid_uuid4(s: &str) -> bool {
+    !s.is_empty() && uuid4_re().is_match(s)
+}
+
+// ── Model normalisation ────────────────────────────────────────────────────────
+
+fn model_alias_re() -> &'static Regex {
+    use std::sync::OnceLock;
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^((?:claude-(?:sonnet|opus|haiku)|gpt)-\d)-(\d{1,2})((?:-.+)?)$")
+            .expect("model alias regex is valid")
+    })
+}
+
+/// Normalise a legacy hyphenated model version suffix to the dotted form.
+///
+/// e.g. `claude-sonnet-4-6` → `claude-sonnet-4.6`
+pub fn normalize_model_id(model: &str) -> String {
+    let s = model.trim();
+    if s.is_empty() {
+        return String::new();
+    }
+    if let Some(caps) = model_alias_re().captures(s) {
+        return format!("{}.{}{}", &caps[1], &caps[2], &caps[3]);
+    }
+    s.to_string()
+}
+
+// ── State directories ──────────────────────────────────────────────────────────
+
+/// Return the operator-console state root.
+///
+/// Honours the `COPILOT_OPERATOR_STATE` env var; falls back to
+/// `~/.copilot/session-state/operator-console`.
+pub fn state_dir() -> PathBuf {
+    if let Ok(env) = std::env::var("COPILOT_OPERATOR_STATE") {
+        if !env.trim().is_empty() {
+            return PathBuf::from(env.trim());
+        }
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".copilot")
+        .join("session-state")
+        .join("operator-console")
+}
+
+/// Return (and create) the sessions sub-directory.
+pub fn sessions_dir() -> io::Result<PathBuf> {
+    let d = state_dir().join("sessions");
+    fs::create_dir_all(&d)?;
+    Ok(d)
+}
+
+// ── Path confinement ───────────────────────────────────────────────────────────
+
+/// Resolve `raw` and return `Some(path)` only if the result is strictly under
+/// the user's home directory.  Returns `None` for:
+/// - empty strings
+/// - paths that resolve outside `~`
+/// - traversal attempts (`../`)
+/// - symlinks / junctions that escape home
+///
+/// Mirrors Python `Path.expanduser().resolve(strict=False).relative_to(home)`:
+/// - tilde expansion handled explicitly
+/// - `..` components normalised before canonicalisation
+/// - lenient resolution: for partly-nonexistent paths the deepest existing
+///   ancestor is canonicalised and the non-existent suffix is re-appended
+pub fn confine_path(raw: &str) -> Option<PathBuf> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let home = dirs::home_dir()?;
+    let home_canon = lenient_canonicalize(&home)?;
+
+    let expanded = expand_tilde(raw, &home)?;
+
+    // Normalise away `.` and `..` before canonicalisation to block traversal
+    // via non-existent-suffix paths (e.g. `~/nonexistent/../../etc/passwd`).
+    let normalized = normalize_path_components(&expanded);
+
+    // Lenient canonicalise (follows symlinks for existing components, handles
+    // partly-nonexistent paths).
+    let resolved = lenient_canonicalize(&normalized)?;
+
+    // Must be strictly under home — symlink following already done above.
+    resolved.strip_prefix(&home_canon).ok()?;
+
+    Some(resolved)
+}
+
+/// Expand a leading `~` to the supplied `home` path.
+/// Returns `None` for `~username` forms (not supported).
+/// On Windows, `~\subdir` is accepted in addition to `~/subdir`.
+fn expand_tilde(raw: &str, home: &Path) -> Option<PathBuf> {
+    if raw == "~" {
+        Some(home.to_path_buf())
+    } else if let Some(rest) = raw.strip_prefix("~/") {
+        Some(home.join(rest))
+    } else if cfg!(windows) && raw.starts_with(r"~\") {
+        // Windows backslash separator: `~\subdir` → `home\subdir`
+        Some(home.join(&raw[2..]))
+    } else if raw.starts_with('~') {
+        // ~user form — not supported
+        None
+    } else {
+        // Absolute or relative path: pass through; relative paths are
+        // resolved against CWD just as Python's Path(raw).resolve() does.
+        let p = PathBuf::from(raw);
+        if p.is_absolute() {
+            Some(p)
+        } else {
+            std::env::current_dir().ok().map(|cwd| cwd.join(raw))
+        }
+    }
+}
+
+/// Normalise path components by resolving `.` and `..` lexically,
+/// without touching the filesystem.
+fn normalize_path_components(path: &Path) -> PathBuf {
+    let mut parts: Vec<Component> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => match parts.last() {
+                Some(Component::Prefix(_)) | Some(Component::RootDir) => {
+                    // Cannot go above root/prefix — ignore the `..`.
+                }
+                Some(Component::ParentDir) | None => {
+                    // Relative path going above start — keep `..`
+                    parts.push(component);
+                }
+                Some(_) => {
+                    parts.pop();
+                }
+            },
+            other => parts.push(other),
+        }
+    }
+    parts.iter().collect()
+}
+
+/// Canonicalise `path`, handling partly-nonexistent paths by walking up to the
+/// deepest existing ancestor, canonicalising it (following any symlinks), then
+/// re-appending the non-existent suffix.
+///
+/// Returns `None` only when no existing ancestor can be found at all.
+fn lenient_canonicalize(path: &Path) -> Option<PathBuf> {
+    // Fast path: full canonicalization works when path exists.
+    if let Ok(c) = dunce::canonicalize(path) {
+        return Some(c);
+    }
+
+    // Walk up the path to find the deepest existing ancestor.
+    let mut existing = path.to_path_buf();
+    let mut suffix = PathBuf::new();
+
+    while let Some(parent) = existing.parent() {
+        if parent == existing {
+            break;
+        }
+        let Some(file_name) = existing.file_name() else {
+            break;
+        };
+        let file_name = file_name.to_owned();
+        // Prepend file_name to suffix
+        let new_suffix = PathBuf::from(&file_name).join(&suffix);
+        suffix = new_suffix;
+        existing = parent.to_path_buf();
+
+        if existing.exists() {
+            break;
+        }
+    }
+
+    if !existing.exists() {
+        return None;
+    }
+
+    let canon = dunce::canonicalize(&existing).ok()?;
+    if suffix.as_os_str().is_empty() {
+        Some(canon)
+    } else {
+        Some(canon.join(&suffix))
+    }
+}
+
+// ── Error types ────────────────────────────────────────────────────────────────
+
+/// Error codes returned by `update_session`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum UpdateError {
+    NotFound,
+    BadMode,
+    ActiveRun,
+}
+
+// ── Session CRUD ───────────────────────────────────────────────────────────────
+
+/// Parameters for creating a new session.
+pub struct CreateSessionParams {
+    pub name: String,
+    pub model: String,
+    /// Accepted verbatim (any non-empty trimmed string ≤ 64 chars).
+    pub mode: String,
+    pub workspace: String,
+    pub add_dirs: Vec<String>,
+}
+
+/// Create and persist a new operator session.
+///
+/// Returns `Err(message)` if `workspace` or any `add_dir` is outside `~/`.
+pub fn create_session(params: CreateSessionParams) -> Result<Session, String> {
+    let id = Uuid::new_v4().to_string();
+    let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+
+    let ws_path = if !params.workspace.trim().is_empty() {
+        confine_path(&params.workspace)
+            .map(|p| p.to_string_lossy().into_owned())
+            .ok_or_else(|| format!("workspace path '{}' is not under ~/", params.workspace))?
+    } else {
+        String::new()
+    };
+
+    let mut validated_dirs = Vec::new();
+    for d in &params.add_dirs {
+        let d = d.trim();
+        if d.is_empty() {
+            continue;
+        }
+        let p = confine_path(d).ok_or_else(|| format!("add_dir path '{d}' is not under ~/"))?;
+        validated_dirs.push(p.to_string_lossy().into_owned());
+    }
+
+    let session = Session {
+        id: id.clone(),
+        name: params.name.trim().chars().take(128).collect(),
+        model: normalize_model_id(&params.model).chars().take(64).collect(),
+        mode: params.mode.trim().chars().take(64).collect(),
+        workspace: ws_path,
+        add_dirs: validated_dirs,
+        created_at: now.clone(),
+        updated_at: now,
+        run_count: 0,
+        last_run_id: None,
+        resume_ready: false,
+    };
+
+    let dir = sessions_dir().map_err(|e| e.to_string())?;
+    write_json_atomic(&dir.join(format!("{id}.json")), &session).map_err(|e| e.to_string())?;
+
+    Ok(session)
+}
+
+/// List all sessions, newest-first by `created_at`.
+///
+/// Corrupt JSON files are skipped with a `tracing::warn!` log.
+pub fn list_sessions() -> Vec<Session> {
+    let dir = match sessions_dir() {
+        Ok(d) => d,
+        Err(_) => return vec![],
+    };
+
+    let entries = match fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return vec![],
+    };
+
+    let mut sessions = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        match read_session_file(&path) {
+            Ok(Some(s)) => sessions.push(s),
+            Ok(None) => {}
+            Err(_) => {
+                tracing::warn!(
+                    "operator: skipping corrupt session file: {}",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    sessions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    sessions
+}
+
+/// Load a session by ID.  Returns `None` if the ID is invalid or the file is
+/// missing/corrupt.
+pub fn get_session(session_id: &str) -> Option<Session> {
+    if !is_valid_uuid4(session_id) {
+        return None;
+    }
+    let dir = sessions_dir().ok()?;
+    let path = dir.join(format!("{session_id}.json"));
+    read_session_file(&path).ok().flatten()
+}
+
+/// Delete a session file.  Returns `true` if the file existed and was removed.
+pub fn delete_session(session_id: &str) -> bool {
+    if !is_valid_uuid4(session_id) {
+        return false;
+    }
+    let dir = match sessions_dir() {
+        Ok(d) => d,
+        Err(_) => return false,
+    };
+    let path = dir.join(format!("{session_id}.json"));
+    if !path.exists() {
+        return false;
+    }
+    fs::remove_file(&path).is_ok()
+}
+
+/// Update mutable fields on an existing session.
+///
+/// - `name`  — optional; stored after trim + truncation to 128 chars.
+/// - `model` — optional; normalised via `normalize_model_id`.
+/// - `mode`  — optional; **validated** against `interactive | plan | autopilot`.
+///
+/// Returns the updated session on success, or an `UpdateError` variant.
+pub fn update_session(
+    session_id: &str,
+    name: Option<&str>,
+    model: Option<&str>,
+    mode: Option<&str>,
+) -> Result<Session, UpdateError> {
+    if !is_valid_uuid4(session_id) {
+        return Err(UpdateError::NotFound);
+    }
+
+    let mut session = get_session(session_id).ok_or(UpdateError::NotFound)?;
+
+    // Dormant for PR-A; will check in-memory registry in PR-B.
+    if has_active_run(session_id) {
+        return Err(UpdateError::ActiveRun);
+    }
+
+    // Validate mode before mutating (PATCH-only restriction).
+    if let Some(m) = mode {
+        let m = m.trim();
+        if !matches!(m, "interactive" | "plan" | "autopilot") {
+            return Err(UpdateError::BadMode);
+        }
+    }
+
+    let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+
+    if let Some(n) = name {
+        session.name = n.trim().chars().take(128).collect();
+    }
+    if let Some(m) = model {
+        session.model = normalize_model_id(m.trim()).chars().take(64).collect();
+    }
+    if let Some(m) = mode {
+        session.mode = m.trim().chars().take(64).collect();
+    }
+    session.updated_at = now;
+
+    let dir = sessions_dir().map_err(|_| UpdateError::NotFound)?;
+    write_json_atomic(&dir.join(format!("{session_id}.json")), &session)
+        .map_err(|_| UpdateError::NotFound)?;
+
+    Ok(session)
+}
+
+/// Check whether the session has a currently-active (non-terminal) run.
+///
+/// Dormant for PR-A — the in-memory run registry will be wired in PR-B.
+// TODO(#451 PR-B): wire to the active-run registry.
+fn has_active_run(_session_id: &str) -> bool {
+    false
+}
+
+// ── I/O helpers ────────────────────────────────────────────────────────────────
+
+fn read_session_file(path: &Path) -> io::Result<Option<Session>> {
+    let text = match fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    let session: Session =
+        serde_json::from_str(&text).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    Ok(Some(session))
+}
+
+/// Atomically write `value` as pretty JSON to `path` via a `.tmp` rename.
+fn write_json_atomic(path: &Path, value: &impl Serialize) -> io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    let json = serde_json::to_string_pretty(value)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    fs::write(&tmp, json.as_bytes())?;
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+// ── Unit tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_valid_uuid4_ok() {
+        assert!(is_valid_uuid4("550e8400-e29b-41d4-a716-446655440000"));
+        // variant byte must be [89ab]
+        let id = Uuid::new_v4().to_string();
+        assert!(is_valid_uuid4(&id));
+    }
+
+    #[test]
+    fn test_is_valid_uuid4_rejects_bad() {
+        assert!(!is_valid_uuid4(""));
+        assert!(!is_valid_uuid4("not-a-uuid"));
+        // version 3, not 4
+        assert!(!is_valid_uuid4("550e8400-e29b-31d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn test_normalize_model_id_hyphenated() {
+        assert_eq!(normalize_model_id("claude-sonnet-4-6"), "claude-sonnet-4.6");
+        assert_eq!(normalize_model_id("claude-opus-4-7"), "claude-opus-4.7");
+        assert_eq!(normalize_model_id("claude-haiku-4-5"), "claude-haiku-4.5");
+        assert_eq!(normalize_model_id("gpt-4-1"), "gpt-4.1");
+    }
+
+    #[test]
+    fn test_normalize_model_id_no_change() {
+        assert_eq!(normalize_model_id("claude-sonnet-4.6"), "claude-sonnet-4.6");
+        assert_eq!(normalize_model_id("gpt-4.1"), "gpt-4.1");
+        assert_eq!(normalize_model_id(""), "");
+    }
+
+    #[test]
+    fn test_normalize_model_id_with_suffix() {
+        assert_eq!(
+            normalize_model_id("claude-sonnet-4-5-20250219"),
+            "claude-sonnet-4.5-20250219"
+        );
+    }
+
+    #[test]
+    fn test_confine_path_empty_returns_none() {
+        assert!(confine_path("").is_none());
+        assert!(confine_path("   ").is_none());
+    }
+
+    #[test]
+    fn test_confine_path_tilde_home() {
+        // `~` alone should resolve to home — which is under home.
+        let result = confine_path("~");
+        assert!(result.is_some(), "~ should resolve to home");
+    }
+}

--- a/sk-rust/src/browse/operator/mod.rs
+++ b/sk-rust/src/browse/operator/mod.rs
@@ -1,6 +1,9 @@
-//! Rust port of `browse/core/operator_actions.py` and related operator helpers.
+//! Operator module — session CRUD console and operator actions.
 //!
-//! Operator actions are read-only, copy-safe diagnostic command suggestions
-//! shown in the browse UI settings page. They are NEVER browser-executed.
+//! - `console` — session lifecycle, path confinement, model normalization
+//!   (issue #451 PR-A)
+//! - `actions` — read-only diagnostic command suggestions for the browse UI
+//!   settings page (NEVER browser-executed)
 
 pub mod actions;
+pub mod console;

--- a/sk-rust/src/browse/server.rs
+++ b/sk-rust/src/browse/server.rs
@@ -11,7 +11,7 @@ use axum::extract::{FromRef, Request, State};
 use axum::http::{HeaderName, HeaderValue};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Json, Response};
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
 use serde_json::{json, Value};
 use tower_http::trace::TraceLayer;
@@ -140,6 +140,26 @@ pub fn app(state: AppState) -> Router {
             get(crate::browse::api::sessions::detail_handler),
         )
         .route("/api/compare", get(crate::browse::api::compare::handler))
+        // ── Operator API (issue #451 PR-A) ──────────────────────────────
+        .route(
+            "/api/operator/capabilities",
+            get(crate::browse::api::operator::handle_capabilities),
+        )
+        .route(
+            "/api/operator/sessions",
+            post(crate::browse::api::operator::handle_create_session)
+                .get(crate::browse::api::operator::handle_list_sessions),
+        )
+        .route(
+            "/api/operator/sessions/:id",
+            get(crate::browse::api::operator::handle_get_session)
+                .patch(crate::browse::api::operator::handle_update_session)
+                .delete(crate::browse::api::operator::handle_delete_session),
+        )
+        .route(
+            "/api/operator/sessions/:id/delete",
+            post(crate::browse::api::operator::handle_delete_session_post),
+        )
         .fallback(serve_static)
         .with_state(state.clone())
         // innermost middleware — auth

--- a/sk-rust/tests/browse_operator_crud.rs
+++ b/sk-rust/tests/browse_operator_crud.rs
@@ -16,6 +16,7 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use serial_test::serial;
+use tempfile::NamedTempFile;
 use tempfile::TempDir;
 use tower::ServiceExt;
 
@@ -867,4 +868,79 @@ fn test_active_run_conflict_409_placeholder() {
     // update_session returns UpdateError::ActiveRun, and that the HTTP handler
     // returns 409 SESSION_ACTIVE_RUN.
     unimplemented!("wire active-run registry in PR-B");
+}
+
+/// API: POST /api/operator/sessions returns 500 INTERNAL when the sessions dir
+/// cannot be created (COPILOT_OPERATOR_STATE points to a regular file).
+#[tokio::test]
+#[serial]
+async fn test_http_create_session_io_failure_500() {
+    // A regular file at the state path means `sessions_dir()` / `create_dir_all`
+    // cannot create `{state}/sessions/` — deterministic I/O failure on all platforms.
+    let blocking_file = NamedTempFile::new().unwrap();
+    std::env::set_var("COPILOT_OPERATOR_STATE", blocking_file.path());
+
+    let state = AppState::new(
+        Arc::new(ServerConfig {
+            port: 0,
+            server_token: String::new(),
+            ..ServerConfig::default()
+        }),
+        mk_db(),
+    );
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/operator/sessions")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"name":"io-fail"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let v = body_json(r).await;
+    assert_eq!(v["code"], "INTERNAL");
+}
+
+/// API: PATCH /api/operator/sessions/:id returns 500 INTERNAL when the atomic
+/// write fails.  A directory placed at the `.tmp` path blocks `fs::write`
+/// deterministically on all platforms.
+#[tokio::test]
+#[serial]
+async fn test_http_update_session_io_failure_500() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    // Create a real session so get_session succeeds inside update_session.
+    let session = create_session(make_create_params("io_update")).unwrap();
+
+    // Block the atomic write: place a directory where write_json_atomic writes its .tmp file.
+    let sessions_path = dir.path().join("sessions");
+    let tmp_block = sessions_path.join(format!("{}.tmp", session.id));
+    std::fs::create_dir_all(&tmp_block).unwrap();
+
+    let state = open_state_for_http(&dir);
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/api/operator/sessions/{}", session.id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"name":"blocked"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Clean up the blocking directory.
+    let _ = std::fs::remove_dir(&tmp_block);
+
+    assert_eq!(r.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let v = body_json(r).await;
+    assert_eq!(v["code"], "INTERNAL");
 }

--- a/sk-rust/tests/browse_operator_crud.rs
+++ b/sk-rust/tests/browse_operator_crud.rs
@@ -1,0 +1,870 @@
+//! Integration tests for the operator session CRUD API (issue #451 PR-A).
+//!
+//! Tests drive:
+//! 1. `console` unit functions directly (session lifecycle, path confinement,
+//!    model normalisation).
+//! 2. Full Axum router via `tower::ServiceExt::oneshot` (HTTP contract).
+//!
+//! Because `COPILOT_OPERATOR_STATE` is a process-wide env var, all tests that
+//! touch it must run serially — annotated with `#[serial]`.
+
+#![cfg(feature = "browse-server")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serial_test::serial;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+use sk::browse::db::{BrowseDb, BrowseDbConfig};
+use sk::browse::operator::console::{
+    confine_path, create_session, delete_session, get_session, list_sessions, normalize_model_id,
+    update_session, CreateSessionParams,
+};
+use sk::browse::server::{app, AppState, ServerConfig};
+
+// ── Test helpers ───────────────────────────────────────────────────────────────
+
+/// Set `COPILOT_OPERATOR_STATE` to a temp dir and return it (so it stays live).
+fn setup_state(dir: &TempDir) {
+    std::env::set_var("COPILOT_OPERATOR_STATE", dir.path());
+}
+
+/// Create a minimal in-memory `BrowseDb` for HTTP integration tests.
+fn mk_db() -> Arc<BrowseDb> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!("sk_op_int_{}_{}.db", std::process::id(), n));
+    {
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;\
+             CREATE TABLE IF NOT EXISTS knowledge_entries (\
+               id INTEGER PRIMARY KEY AUTOINCREMENT,\
+               category TEXT NOT NULL DEFAULT '',\
+               title TEXT NOT NULL DEFAULT '',\
+               content TEXT NOT NULL DEFAULT '',\
+               tags TEXT NOT NULL DEFAULT '',\
+               wing TEXT, room TEXT,\
+               confidence REAL NOT NULL DEFAULT 0.5,\
+               deleted_at INTEGER\
+             );\
+             CREATE TABLE IF NOT EXISTS migration_log (version INTEGER NOT NULL);",
+        )
+        .unwrap();
+    }
+    let cfg = BrowseDbConfig {
+        path,
+        checkpoint_interval: None,
+        ..Default::default()
+    };
+    Arc::new(BrowseDb::new_without_checkpoint(cfg).unwrap())
+}
+
+fn open_state_for_http(state_dir: &TempDir) -> AppState {
+    setup_state(state_dir);
+    AppState::new(
+        Arc::new(ServerConfig {
+            port: 0,
+            server_token: String::new(),
+            ..ServerConfig::default()
+        }),
+        mk_db(),
+    )
+}
+
+fn secured_state_for_http(state_dir: &TempDir, token: &str) -> AppState {
+    setup_state(state_dir);
+    AppState::new(
+        Arc::new(ServerConfig {
+            port: 0,
+            server_token: token.to_string(),
+            ..ServerConfig::default()
+        }),
+        mk_db(),
+    )
+}
+
+/// Parse response body as `serde_json::Value`.
+async fn body_json(r: axum::response::Response) -> serde_json::Value {
+    let bytes = r.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+fn make_create_params(name: &str) -> CreateSessionParams {
+    CreateSessionParams {
+        name: name.to_string(),
+        model: String::new(),
+        mode: String::new(),
+        workspace: String::new(),
+        add_dirs: vec![],
+    }
+}
+
+// ── Console unit tests ─────────────────────────────────────────────────────────
+
+/// OC1: create_session returns a valid session dict with required fields.
+#[test]
+#[serial]
+fn test_create_basic_uuid4_fields_preserved() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    let session = create_session(CreateSessionParams {
+        name: "my session".to_string(),
+        model: "claude-sonnet-4.6".to_string(),
+        mode: "agent".to_string(),
+        workspace: String::new(),
+        add_dirs: vec![],
+    })
+    .unwrap();
+
+    // UUID v4 form
+    let uuid_re =
+        regex::Regex::new(r"^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$")
+            .unwrap();
+    assert!(
+        uuid_re.is_match(&session.id),
+        "id must be UUID v4: {}",
+        session.id
+    );
+
+    // Fields preserved
+    assert_eq!(session.name, "my session");
+    assert_eq!(session.model, "claude-sonnet-4.6");
+    // mode="agent" accepted on POST (no validation)
+    assert_eq!(session.mode, "agent");
+    assert_eq!(session.run_count, 0);
+    assert!(session.last_run_id.is_none());
+    assert!(!session.resume_ready);
+    assert!(!session.created_at.is_empty());
+    assert_eq!(session.created_at, session.updated_at);
+}
+
+/// OC2: create_session rejects workspace outside ~/
+#[test]
+#[serial]
+fn test_workspace_outside_home_rejected() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    // Use a path that is definitely outside home on all platforms.
+    #[cfg(windows)]
+    let outside = "C:\\Windows\\System32".to_string();
+    #[cfg(not(windows))]
+    let outside = "/etc".to_string();
+
+    let result = create_session(CreateSessionParams {
+        name: String::new(),
+        model: String::new(),
+        mode: String::new(),
+        workspace: outside,
+        add_dirs: vec![],
+    });
+    assert!(result.is_err(), "workspace outside home must be rejected");
+}
+
+/// OC3: create_session rejects add_dirs outside ~/
+#[test]
+#[serial]
+fn test_add_dirs_outside_home_rejected() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    #[cfg(windows)]
+    let outside = "C:\\Windows\\System32".to_string();
+    #[cfg(not(windows))]
+    let outside = "/etc".to_string();
+
+    let result = create_session(CreateSessionParams {
+        name: String::new(),
+        model: String::new(),
+        mode: String::new(),
+        workspace: String::new(),
+        add_dirs: vec![outside],
+    });
+    assert!(result.is_err(), "add_dir outside home must be rejected");
+}
+
+/// OC4: confine_path returns None for paths above ~/
+#[test]
+fn test_confine_path_above_home_returns_none() {
+    // /etc or C:\Windows are definitely outside home.
+    #[cfg(unix)]
+    assert!(confine_path("/etc/passwd").is_none());
+    #[cfg(windows)]
+    assert!(confine_path("C:\\Windows\\System32").is_none());
+
+    // Traversal attempt: ~/../../etc
+    assert!(confine_path("~/../../etc").is_none());
+}
+
+/// OC5: confine_path returns None for traversal attempts
+#[test]
+fn test_confine_path_traversal_returns_none() {
+    assert!(confine_path("~/../etc").is_none());
+    assert!(confine_path("~/../..").is_none());
+    // Absolute traversal via suffix
+    let home = dirs::home_dir().unwrap();
+    let traversal = home
+        .join("nonexistent")
+        .join("..")
+        .join("..")
+        .join("etc")
+        .to_string_lossy()
+        .into_owned();
+    assert!(confine_path(&traversal).is_none());
+}
+
+/// OC6: confine_path accepts valid not-yet-existing subdir under home
+#[test]
+fn test_confine_path_valid_nonexistent_subdir_accepted() {
+    let home = dirs::home_dir().unwrap();
+    // Use a clearly nonexistent deep path
+    let phantom = home
+        .join("_sk_test_phantom_451_nonexistent")
+        .join("subdir_a");
+    let raw = phantom.to_string_lossy();
+
+    let result = confine_path(&raw);
+    assert!(
+        result.is_some(),
+        "nonexistent subdir under home must be accepted: {raw}"
+    );
+    let resolved = result.unwrap();
+    let resolved_str = resolved.to_string_lossy().to_lowercase();
+    let home_str = home.to_string_lossy().to_lowercase();
+
+    // Regression: dunce::canonicalize must never emit \\?\ extended-length
+    // prefixes into stored paths on Windows (std::fs::canonicalize does).
+    #[cfg(windows)]
+    assert!(
+        !resolved_str.starts_with("\\\\?\\"),
+        "resolved path must not contain \\\\?\\ prefix: {resolved_str}"
+    );
+
+    assert!(
+        resolved_str.starts_with(&home_str),
+        "resolved path must be under home: {resolved_str} vs {home_str}"
+    );
+}
+
+/// OC6b (Windows): `~\subdir` expands and confines identically to `~/subdir`.
+///
+/// Regression for #451 PR-A: Windows users may naturally type `~\subdir`;
+/// the path must be accepted and produce no `\\?\` prefix in the stored value.
+#[test]
+#[cfg(windows)]
+fn test_confine_path_tilde_backslash_windows() {
+    let home = dirs::home_dir().unwrap();
+
+    let forward = confine_path("~/_sk451_win_slash_test");
+    let backward = confine_path(r"~\_sk451_win_slash_test");
+
+    // Both representations must produce the same result.
+    assert_eq!(
+        forward, backward,
+        "`~/subdir` and `~\\subdir` must expand identically on Windows"
+    );
+
+    // If home is accessible, both must resolve (non-existent subdir is fine).
+    if home.exists() {
+        assert!(
+            backward.is_some(),
+            r"`~\subdir` must be accepted when home exists"
+        );
+        if let Some(p) = backward {
+            let s = p.to_string_lossy();
+            // Regression: dunce must strip the \\?\ UNC prefix.
+            assert!(
+                !s.starts_with("\\\\?\\"),
+                "`~\\` expanded path must not have \\\\?\\ prefix: {s}"
+            );
+        }
+    }
+}
+
+/// Symlink escape inside home is blocked on Unix; Windows junction handled or skipped.
+#[test]
+fn test_symlink_escape_blocked() {
+    let home = dirs::home_dir().unwrap();
+
+    #[cfg(unix)]
+    {
+        // Create a temp dir inside home so it's under home.
+        // The symlink points to /tmp (outside home).
+        match tempfile::Builder::new().prefix("_sk451_").tempdir_in(&home) {
+            Ok(home_temp) => {
+                let link = home_temp.path().join("escape_link");
+                if std::os::unix::fs::symlink("/tmp", &link).is_ok() {
+                    let result = confine_path(&link.to_string_lossy());
+                    assert!(
+                        result.is_none(),
+                        "symlink pointing outside home must be rejected"
+                    );
+                }
+                // home_temp is dropped here; cleanup is automatic.
+            }
+            Err(_) => {
+                // Can't create temp dir in home; skip.
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        // Try creating a junction inside home that points to C:\ (outside home).
+        match tempfile::Builder::new().prefix("_sk451_").tempdir_in(&home) {
+            Ok(home_temp) => {
+                let junction_path = home_temp.path().join("escape_junction");
+                // Use C:\ (root of system drive) as target — definitely outside home
+                let target = std::path::PathBuf::from("C:\\");
+                let status = std::process::Command::new("cmd")
+                    .args([
+                        "/C",
+                        "mklink",
+                        "/J",
+                        junction_path.to_string_lossy().as_ref(),
+                        target.to_string_lossy().as_ref(),
+                    ])
+                    .output();
+                if let Ok(out) = status {
+                    if out.status.success() {
+                        let result = confine_path(&junction_path.to_string_lossy());
+                        assert!(
+                            result.is_none(),
+                            "junction pointing outside home must be rejected"
+                        );
+                    }
+                    // If junction creation failed (permissions etc.) — skip.
+                }
+            }
+            Err(_) => {
+                // Can't create temp dir in home; skip.
+            }
+        }
+    }
+}
+
+/// list_sessions returns newest-first ordering.
+#[test]
+#[serial]
+fn test_list_newest_first() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    let s1 = create_session(make_create_params("first")).unwrap();
+    // Small sleep to ensure different timestamps.
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    let s2 = create_session(make_create_params("second")).unwrap();
+
+    let sessions = list_sessions();
+    assert_eq!(sessions.len(), 2);
+    // newest first: s2.created_at > s1.created_at
+    assert_eq!(sessions[0].id, s2.id, "newest session must be first");
+    assert_eq!(sessions[1].id, s1.id, "oldest session must be last");
+}
+
+/// get_session returns None for invalid/missing ID.
+#[test]
+#[serial]
+fn test_get_missing_returns_none() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    assert!(get_session("not-a-uuid").is_none());
+    assert!(get_session("00000000-0000-4000-8000-000000000000").is_none());
+}
+
+/// delete and delete-alias remove file and return contract.
+#[test]
+#[serial]
+fn test_delete_removes_session() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    let session = create_session(make_create_params("to_delete")).unwrap();
+    assert!(get_session(&session.id).is_some());
+
+    assert!(delete_session(&session.id));
+    assert!(get_session(&session.id).is_none());
+    // Second delete returns false (already gone)
+    assert!(!delete_session(&session.id));
+}
+
+/// update: name, model normalisation, mode update.
+#[test]
+#[serial]
+fn test_update_name_model_mode() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    let session = create_session(make_create_params("original")).unwrap();
+
+    let updated = update_session(
+        &session.id,
+        Some("renamed"),
+        Some("claude-sonnet-4-6"),
+        Some("plan"),
+    )
+    .unwrap();
+
+    assert_eq!(updated.name, "renamed");
+    // Model normalisation applied on update
+    assert_eq!(updated.model, "claude-sonnet-4.6");
+    assert_eq!(updated.mode, "plan");
+    assert!(updated.updated_at > session.updated_at);
+}
+
+/// update with empty body (no fields) → BAD_PARAM handled at handler level.
+/// Console-level: update with none fields returns NotFound (nothing to do).
+#[test]
+#[serial]
+fn test_update_no_fields_not_found_on_empty_id() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    // Invalid ID => NotFound
+    let result = update_session("bad-id", None, None, None);
+    assert!(result.is_err());
+}
+
+/// update unknown session → NOT_FOUND.
+#[test]
+#[serial]
+fn test_update_unknown_session_not_found() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    use sk::browse::operator::console::UpdateError;
+    let result = update_session(
+        "00000000-0000-4000-8000-000000000001",
+        Some("name"),
+        None,
+        None,
+    );
+    assert_eq!(result.unwrap_err(), UpdateError::NotFound);
+}
+
+/// update invalid mode → BAD_MODE.
+#[test]
+#[serial]
+fn test_update_invalid_mode_bad_mode() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    use sk::browse::operator::console::UpdateError;
+    let session = create_session(make_create_params("mode_test")).unwrap();
+
+    let result = update_session(&session.id, None, None, Some("agent"));
+    assert_eq!(
+        result.unwrap_err(),
+        UpdateError::BadMode,
+        "'agent' must be invalid on PATCH"
+    );
+}
+
+// ── HTTP integration tests ─────────────────────────────────────────────────────
+
+/// API: capabilities shape is exactly correct.
+#[tokio::test]
+#[serial]
+async fn test_http_capabilities_shape() {
+    let dir = TempDir::new().unwrap();
+    let state = open_state_for_http(&dir);
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/operator/capabilities")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::OK);
+    let v = body_json(r).await;
+
+    assert_eq!(v["cli_kind"], "copilot");
+    assert_eq!(v["version"], "1");
+    assert_eq!(v["protocol"], "v2");
+    assert_eq!(
+        v["supported_modes"],
+        serde_json::json!(["interactive", "plan", "autopilot"])
+    );
+    let features = v["supported_features"].as_array().unwrap();
+    for expected in &[
+        "chat",
+        "sessions",
+        "search",
+        "graph",
+        "insights",
+        "diagnostics",
+        "models",
+        "suggest",
+        "preview",
+        "diff",
+    ] {
+        assert!(
+            features.iter().any(|f| f.as_str() == Some(expected)),
+            "supported_features must contain '{expected}'"
+        );
+    }
+}
+
+/// API1: POST /api/operator/sessions returns 200 with session dict.
+#[tokio::test]
+#[serial]
+async fn test_http_create_session_200() {
+    let dir = TempDir::new().unwrap();
+    let state = open_state_for_http(&dir);
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/operator/sessions")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"name":"test","mode":"interactive"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::OK);
+    let v = body_json(r).await;
+    assert!(!v["id"].as_str().unwrap_or("").is_empty());
+    assert_eq!(v["name"], "test");
+    assert_eq!(v["mode"], "interactive");
+    assert_eq!(v["run_count"], 0);
+}
+
+/// API2: POST /api/operator/sessions rejects workspace outside home (403).
+#[tokio::test]
+#[serial]
+async fn test_http_create_session_bad_workspace_403() {
+    let dir = TempDir::new().unwrap();
+    let state = open_state_for_http(&dir);
+
+    #[cfg(windows)]
+    let outside = "C:\\Windows\\System32".to_string();
+    #[cfg(not(windows))]
+    let outside = "/etc".to_string();
+
+    let body = serde_json::json!({ "workspace": outside }).to_string();
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/operator/sessions")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::FORBIDDEN);
+    let v = body_json(r).await;
+    assert_eq!(v["code"], "PATH_VIOLATION");
+}
+
+/// API3: GET /api/operator/sessions returns sessions list.
+#[tokio::test]
+#[serial]
+async fn test_http_list_sessions() {
+    let dir = TempDir::new().unwrap();
+    let state = open_state_for_http(&dir);
+    setup_state(&dir); // ensure console uses same dir
+
+    // Create one session via console
+    create_session(make_create_params("listed")).unwrap();
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/operator/sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::OK);
+    let v = body_json(r).await;
+    assert!(v["sessions"].is_array());
+    assert!(v["count"].as_u64().unwrap_or(0) >= 1);
+}
+
+/// API4+5: GET /api/operator/sessions/{id} returns session or 404.
+#[tokio::test]
+#[serial]
+async fn test_http_get_session_and_404() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+    let state = open_state_for_http(&dir);
+
+    let session = create_session(make_create_params("get_test")).unwrap();
+    let router = app(state);
+
+    // Found
+    let r = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/operator/sessions/{}", session.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    let v = body_json(r).await;
+    assert_eq!(v["id"], session.id.as_str());
+
+    // Not found
+    let r2 = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/operator/sessions/00000000-0000-4000-8000-000000000000")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), StatusCode::NOT_FOUND);
+    let v2 = body_json(r2).await;
+    assert_eq!(v2["code"], "SESSION_NOT_FOUND");
+}
+
+/// API9b: DELETE /api/operator/sessions/{id} returns deleted=true.
+#[tokio::test]
+#[serial]
+async fn test_http_delete_session() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+    let state = open_state_for_http(&dir);
+
+    let session = create_session(make_create_params("del_http")).unwrap();
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/api/operator/sessions/{}", session.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::OK);
+    let v = body_json(r).await;
+    assert_eq!(v["deleted"], true);
+    assert_eq!(v["session_id"], session.id.as_str());
+}
+
+/// API9: POST /api/operator/sessions/{id}/delete (alias) returns deleted=true.
+#[tokio::test]
+#[serial]
+async fn test_http_delete_session_post_alias() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+    let state = open_state_for_http(&dir);
+
+    let session = create_session(make_create_params("del_alias")).unwrap();
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/operator/sessions/{}/delete", session.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::OK);
+    let v = body_json(r).await;
+    assert_eq!(v["deleted"], true);
+}
+
+/// PATCH: update returns updated session.
+#[tokio::test]
+#[serial]
+async fn test_http_patch_session_ok() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+    let state = open_state_for_http(&dir);
+
+    let session = create_session(make_create_params("patch_me")).unwrap();
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/api/operator/sessions/{}", session.id))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "name": "patched", "mode": "plan" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::OK);
+    let v = body_json(r).await;
+    assert_eq!(v["name"], "patched");
+    assert_eq!(v["mode"], "plan");
+}
+
+/// PATCH with empty body → 400 BAD_PARAM.
+#[tokio::test]
+#[serial]
+async fn test_http_patch_empty_body_400() {
+    let dir = TempDir::new().unwrap();
+    let state = open_state_for_http(&dir);
+    setup_state(&dir);
+
+    let session = create_session(make_create_params("patch_empty")).unwrap();
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/api/operator/sessions/{}", session.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+    let v = body_json(r).await;
+    assert_eq!(v["code"], "BAD_PARAM");
+}
+
+/// PATCH unknown session → 404.
+#[tokio::test]
+#[serial]
+async fn test_http_patch_unknown_404() {
+    let dir = TempDir::new().unwrap();
+    let state = open_state_for_http(&dir);
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/api/operator/sessions/00000000-0000-4000-8000-000000000000")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"name":"x"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::NOT_FOUND);
+    let v = body_json(r).await;
+    assert_eq!(v["code"], "SESSION_NOT_FOUND");
+}
+
+/// PATCH with invalid mode → 400 BAD_MODE.
+#[tokio::test]
+#[serial]
+async fn test_http_patch_invalid_mode_400() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+    let state = open_state_for_http(&dir);
+
+    let session = create_session(make_create_params("mode_test")).unwrap();
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/api/operator/sessions/{}", session.id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"mode":"agent"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+    let v = body_json(r).await;
+    assert_eq!(v["code"], "BAD_MODE");
+}
+
+/// SEC1: PATCH without token → 401 via auth middleware.
+#[tokio::test]
+#[serial]
+async fn test_http_patch_without_token_401() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+    let state = secured_state_for_http(&dir, "supersecret");
+
+    let session = create_session(make_create_params("auth_test")).unwrap();
+
+    let r = app(state)
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/api/operator/sessions/{}", session.id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"name":"x"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// Model normalisation: hyphenated alias normalised on create.
+#[test]
+#[serial]
+fn test_model_normalisation_on_create() {
+    let dir = TempDir::new().unwrap();
+    setup_state(&dir);
+
+    let session = create_session(CreateSessionParams {
+        name: String::new(),
+        model: "claude-sonnet-4-6".to_string(),
+        mode: String::new(),
+        workspace: String::new(),
+        add_dirs: vec![],
+    })
+    .unwrap();
+
+    assert_eq!(session.model, "claude-sonnet-4.6");
+}
+
+/// normalize_model_id unit tests.
+#[test]
+fn test_normalize_model_id_variants() {
+    assert_eq!(normalize_model_id("claude-sonnet-4-6"), "claude-sonnet-4.6");
+    assert_eq!(normalize_model_id("claude-opus-4-7"), "claude-opus-4.7");
+    assert_eq!(normalize_model_id("gpt-4-1"), "gpt-4.1");
+    assert_eq!(normalize_model_id("gpt-4.1"), "gpt-4.1");
+    assert_eq!(normalize_model_id(""), "");
+    assert_eq!(normalize_model_id("  "), "");
+}
+
+/// Ignored placeholder: OC52/API30 — active-run 409 conflict deferred to #451 PR-B.
+///
+/// This test verifies the wire-up once PR-B lands and replaces the dormant stub.
+#[test]
+#[ignore = "deferred to #451 PR-B: active-run registry not yet wired"]
+fn test_active_run_conflict_409_placeholder() {
+    // TODO(#451 PR-B): set up an active run in the registry and verify that
+    // update_session returns UpdateError::ActiveRun, and that the HTTP handler
+    // returns 409 SESSION_ACTIVE_RUN.
+    unimplemented!("wire active-run registry in PR-B");
+}


### PR DESCRIPTION
Implements Rust operator session CRUD + capabilities endpoints (issue #451 PR-A). See branch for full implementation. Verification: 29 tests passed, clippy clean, fmt clean.