### PR TITLE
feat(#451): port operator debug-log redaction to Rust (PR-B)

### DIFF
--- a/sk-rust/src/browse/operator/mod.rs
+++ b/sk-rust/src/browse/operator/mod.rs
@@ -4,6 +4,9 @@
 //!   (issue #451 PR-A)
 //! - `actions` — read-only diagnostic command suggestions for the browse UI
 //!   settings page (NEVER browser-executed)
+//! - `redaction` — allowlist-first `BrowseDebugEntry` redaction helper
+//!   (issue #451 PR-B)
 
 pub mod actions;
 pub mod console;
+pub mod redaction;

--- a/sk-rust/src/browse/operator/redaction.rs
+++ b/sk-rust/src/browse/operator/redaction.rs
@@ -258,6 +258,13 @@ fn redact_attrs(raw_attrs: Option<&Value>) -> (Map<String, Value>, bool) {
                         }
                     }
                     Value::Number(_) | Value::Bool(_) | Value::Null => {
+                        // route and session_uuid must be strings; non-string scalars
+                        // are rejected to match Python `_redact_attrs` where
+                        // `not isinstance(v, str)` rejects both keys.
+                        if k == "route" || k == "session_uuid" {
+                            redacted = true;
+                            continue;
+                        }
                         out.insert(k.clone(), v.clone());
                     }
                     _ => {

--- a/sk-rust/src/browse/operator/redaction.rs
+++ b/sk-rust/src/browse/operator/redaction.rs
@@ -1,0 +1,503 @@
+//! Allowlist-first `BrowseDebugEntry` redaction helper (issue #451 PR-B).
+//!
+//! Write-time policy: only fields in the top-level allowlist are passed
+//! through; every unknown key is dropped and the `redacted` flag is set.
+//! The `attrs` field is further constrained to a flat scalar allowlist
+//! (no nested dicts/lists).
+//!
+//! Free-text fields (`message`) and allowlisted string attrs are
+//! additionally scrubbed for bearer tokens, URL query-string tokens,
+//! and path-embedded usernames.
+//!
+//! All exceptions inside `redact_entry` fail closed: a minimal sentinel
+//! value is returned on any unexpected panic.
+//!
+//! Port of `browse/core/redaction.py`.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde_json::{Map, Value};
+
+// ── Limits ────────────────────────────────────────────────────────────────────
+
+const MESSAGE_MAX: usize = 2048;
+
+// ── Enum allowlists ───────────────────────────────────────────────────────────
+
+fn is_valid_kind(s: &str) -> bool {
+    matches!(
+        s,
+        "session_start"
+            | "turn_start"
+            | "llm_request"
+            | "tool_call"
+            | "hook"
+            | "subagent"
+            | "agent_response"
+            | "error"
+            | "generic"
+            | "raw"
+    )
+}
+
+fn is_valid_level(s: &str) -> bool {
+    matches!(s, "debug" | "info" | "warn" | "error")
+}
+
+fn is_valid_source(s: &str) -> bool {
+    matches!(
+        s,
+        "cli"
+            | "hook"
+            | "browse"
+            | "vscode"
+            | "operator_console"
+            | "hook_runner"
+            | "sk_watch"
+            | "unknown"
+    )
+}
+
+fn is_valid_status(s: &str) -> bool {
+    matches!(s, "ok" | "error" | "cancelled")
+}
+
+// ── Top-level field allowlist ─────────────────────────────────────────────────
+
+fn is_top_level_key(k: &str) -> bool {
+    matches!(
+        k,
+        "idx"
+            | "timestamp"
+            | "kind"
+            | "level"
+            | "source"
+            | "message"
+            | "tool_name"
+            | "duration_ms"
+            | "span_id"
+            | "parent_span_id"
+            | "status"
+            | "attrs"
+            | "redacted"
+    )
+}
+
+// ── Attrs allowlist ───────────────────────────────────────────────────────────
+
+fn is_attrs_key(k: &str) -> bool {
+    matches!(
+        k,
+        "schema_version"
+            | "session_uuid"
+            | "model"
+            | "route"
+            | "status_code"
+            | "exit_code"
+            | "event_count"
+            | "bytes_in"
+            | "bytes_out"
+            | "tokens_in"
+            | "tokens_out"
+            | "attempt"
+            | "cache_hit"
+            | "truncated"
+            | "error_category"
+            | "latency_ms"
+            | "queue_depth"
+    )
+}
+
+// ── Compiled regex accessors ──────────────────────────────────────────────────
+
+fn tool_name_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^[a-zA-Z0-9_.\-]{1,64}$").expect("tool_name regex is valid"))
+}
+
+fn span_id_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^[0-9a-f]{16}$").expect("span_id regex is valid"))
+}
+
+fn iso_utc_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$")
+            .expect("iso_utc regex is valid")
+    })
+}
+
+fn session_uuid_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+            .expect("session_uuid regex is valid")
+    })
+}
+
+fn route_query_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\?").expect("route_query regex is valid"))
+}
+
+fn bearer_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)\bbearer\s+\S+").expect("bearer regex is valid"))
+}
+
+fn win_path_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)([A-Za-z]:[/\\]Users[/\\])[^/\\\s]+").expect("win_path regex is valid")
+    })
+}
+
+fn unix_path_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(/home/)[^/\s]+").expect("unix_path regex is valid"))
+}
+
+fn macos_path_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(/Users/)[^/\s]+").expect("macos_path regex is valid"))
+}
+
+fn url_query_token_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)([?&]\w*(?:token|key|secret|auth)\w*=)[^\s&]+")
+            .expect("url_query_token regex is valid")
+    })
+}
+
+fn jwt_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
+            .expect("jwt regex is valid")
+    })
+}
+
+// ── Text redaction ────────────────────────────────────────────────────────────
+
+fn redact_text(text: &str) -> String {
+    let s = bearer_re().replace_all(text, "[REDACTED]");
+    let s = url_query_token_re().replace_all(&s, "${1}[REDACTED]");
+    let s = win_path_re().replace_all(&s, "${1}[REDACTED]");
+    let s = unix_path_re().replace_all(&s, "${1}[REDACTED]");
+    let s = macos_path_re().replace_all(&s, "${1}[REDACTED]");
+    // JWT fallback: catches compact JWTs not caught by bearer/URL patterns.
+    // PARITY-NOTE: Python applies `browse.core.operator_console.redact_secrets` as a
+    // defence-in-depth pass after pattern redaction.  This Rust port omits that
+    // optional import; bearer/JWT/URL-query pattern redaction is applied locally instead.
+    let s = jwt_re().replace_all(&s, "[REDACTED]");
+    s.into_owned()
+}
+
+fn redact_route_text(text: &str) -> String {
+    let s = bearer_re().replace_all(text, "[REDACTED]");
+    let s = url_query_token_re().replace_all(&s, "${1}[REDACTED]");
+    // JWT fallback applied before redact_secrets would run.
+    // PARITY-NOTE: Python applies `browse.core.operator_console.redact_secrets` as a
+    // defence-in-depth pass after pattern redaction.  This Rust port omits that
+    // optional import; bearer/JWT/URL-query pattern redaction is applied locally instead.
+    let s = jwt_re().replace_all(&s, "[REDACTED]");
+    s.into_owned()
+}
+
+// ── Attrs validation ──────────────────────────────────────────────────────────
+
+fn redact_attrs(raw_attrs: Option<&Value>) -> (Map<String, Value>, bool) {
+    match raw_attrs {
+        None => (Map::new(), false),
+        Some(Value::Null) => (Map::new(), false),
+        Some(Value::Object(map)) => {
+            let mut out = Map::new();
+            let mut redacted = false;
+            for (k, v) in map {
+                if !is_attrs_key(k) {
+                    redacted = true;
+                    continue;
+                }
+                // Reject nested objects/arrays
+                if matches!(v, Value::Object(_) | Value::Array(_)) {
+                    redacted = true;
+                    continue;
+                }
+                // Only allow scalar types
+                match v {
+                    Value::String(s) => {
+                        if k == "route" {
+                            if route_query_re().is_match(s) {
+                                redacted = true;
+                                continue;
+                            }
+                            let clean = redact_route_text(s);
+                            if clean != *s {
+                                redacted = true;
+                            }
+                            out.insert(k.clone(), Value::String(clean));
+                        } else if k == "session_uuid" {
+                            if !session_uuid_re().is_match(s) {
+                                redacted = true;
+                                continue;
+                            }
+                            let clean = redact_text(s);
+                            if clean != *s {
+                                redacted = true;
+                            }
+                            out.insert(k.clone(), Value::String(clean));
+                        } else {
+                            let clean = redact_text(s);
+                            if clean != *s {
+                                redacted = true;
+                            }
+                            out.insert(k.clone(), Value::String(clean));
+                        }
+                    }
+                    Value::Number(_) | Value::Bool(_) | Value::Null => {
+                        out.insert(k.clone(), v.clone());
+                    }
+                    _ => {
+                        redacted = true;
+                    }
+                }
+            }
+            (out, redacted)
+        }
+        Some(_) => (Map::new(), true),
+    }
+}
+
+// ── Core field validators ─────────────────────────────────────────────────────
+
+fn validate_core_fields(entry: &Map<String, Value>, out: &mut Map<String, Value>) -> bool {
+    let mut redacted = false;
+
+    // idx
+    match entry.get("idx") {
+        Some(Value::Number(n)) if n.as_i64().map(|i| i >= 0).unwrap_or(false) => {
+            out.insert("idx".into(), Value::Number(n.clone()));
+        }
+        _ => {
+            out.insert("idx".into(), Value::Number(0.into()));
+            redacted = true;
+        }
+    }
+
+    // timestamp: absent or null → pass through as null; string matching ISO UTC → pass; else redact
+    match entry.get("timestamp") {
+        None | Some(Value::Null) => {
+            out.insert("timestamp".into(), Value::Null);
+        }
+        Some(Value::String(s)) if iso_utc_re().is_match(s) => {
+            out.insert("timestamp".into(), Value::String(s.clone()));
+        }
+        _ => {
+            out.insert("timestamp".into(), Value::Null);
+            redacted = true;
+        }
+    }
+
+    // kind
+    match entry.get("kind") {
+        Some(Value::String(s)) if is_valid_kind(s) => {
+            out.insert("kind".into(), Value::String(s.clone()));
+        }
+        None => {
+            out.insert("kind".into(), Value::String("generic".into()));
+        }
+        _ => {
+            out.insert("kind".into(), Value::String("generic".into()));
+            redacted = true;
+        }
+    }
+
+    // level: absent or null → null; valid → pass; invalid → null + redact
+    match entry.get("level") {
+        None | Some(Value::Null) => {
+            out.insert("level".into(), Value::Null);
+        }
+        Some(Value::String(s)) if is_valid_level(s) => {
+            out.insert("level".into(), Value::String(s.clone()));
+        }
+        _ => {
+            out.insert("level".into(), Value::Null);
+            redacted = true;
+        }
+    }
+
+    // source
+    match entry.get("source") {
+        Some(Value::String(s)) if is_valid_source(s) => {
+            out.insert("source".into(), Value::String(s.clone()));
+        }
+        _ => {
+            out.insert("source".into(), Value::String("unknown".into()));
+            redacted = true;
+        }
+    }
+
+    redacted
+}
+
+fn validate_payload_fields(entry: &Map<String, Value>, out: &mut Map<String, Value>) -> bool {
+    let mut redacted = false;
+
+    // message
+    if let Some(raw_msg) = entry.get("message") {
+        let original = match raw_msg {
+            Value::String(s) => {
+                let truncated: String = s.chars().take(MESSAGE_MAX).collect();
+                if truncated.len() < s.len() {
+                    redacted = true;
+                }
+                truncated
+            }
+            _ => {
+                redacted = true;
+                raw_msg.to_string().chars().take(MESSAGE_MAX).collect()
+            }
+        };
+        let clean = redact_text(&original);
+        if clean != original {
+            redacted = true;
+        }
+        out.insert("message".into(), Value::String(clean));
+    }
+
+    // tool_name
+    if let Some(raw_tn) = entry.get("tool_name") {
+        match raw_tn {
+            Value::String(s) if tool_name_re().is_match(s) => {
+                out.insert("tool_name".into(), Value::String(s.clone()));
+            }
+            _ => {
+                redacted = true;
+            }
+        }
+    }
+
+    // duration_ms
+    if let Some(raw_dur) = entry.get("duration_ms") {
+        match raw_dur {
+            Value::Bool(_) => {
+                redacted = true;
+            }
+            Value::Number(n) => {
+                let valid = if let Some(f) = n.as_f64() {
+                    f.is_finite() && f >= 0.0
+                } else {
+                    false
+                };
+                if valid {
+                    out.insert("duration_ms".into(), Value::Number(n.clone()));
+                } else {
+                    redacted = true;
+                }
+            }
+            _ => {
+                redacted = true;
+            }
+        }
+    }
+
+    // span_id, parent_span_id
+    for span_key in &["span_id", "parent_span_id"] {
+        if let Some(raw_span) = entry.get(*span_key) {
+            match raw_span {
+                Value::String(s) if span_id_re().is_match(s) => {
+                    out.insert((*span_key).into(), Value::String(s.clone()));
+                }
+                _ => {
+                    redacted = true;
+                }
+            }
+        }
+    }
+
+    // status
+    if let Some(raw_status) = entry.get("status") {
+        match raw_status {
+            Value::String(s) if is_valid_status(s) => {
+                out.insert("status".into(), Value::String(s.clone()));
+            }
+            _ => {
+                redacted = true;
+            }
+        }
+    }
+
+    redacted
+}
+
+// ── Main redaction logic ──────────────────────────────────────────────────────
+
+fn sentinel(raw: &Value) -> Value {
+    let idx = if let Value::Object(map) = raw {
+        match map.get("idx") {
+            Some(Value::Number(n)) if n.as_i64().map(|i| i >= 0).unwrap_or(false) => {
+                Value::Number(n.clone())
+            }
+            _ => Value::Number(0.into()),
+        }
+    } else {
+        Value::Number(0.into())
+    };
+    let mut m = Map::new();
+    m.insert("idx".into(), idx);
+    m.insert("kind".into(), Value::String("generic".into()));
+    m.insert("level".into(), Value::String("error".into()));
+    m.insert("source".into(), Value::String("unknown".into()));
+    m.insert("attrs".into(), Value::Object(Map::new()));
+    m.insert("redacted".into(), Value::Bool(true));
+    Value::Object(m)
+}
+
+fn redact_entry_impl(raw: &Value) -> Value {
+    let entry = match raw {
+        Value::Object(map) => map,
+        _ => {
+            // Treat non-object as empty object
+            let empty = Map::new();
+            let mut out = Map::new();
+            let mut redacted = validate_core_fields(&empty, &mut out);
+            redacted = validate_payload_fields(&empty, &mut out) || redacted;
+            let (attrs_out, attrs_redacted) = redact_attrs(None);
+            out.insert("attrs".into(), Value::Object(attrs_out));
+            out.insert("redacted".into(), Value::Bool(redacted || attrs_redacted));
+            return Value::Object(out);
+        }
+    };
+
+    let mut out = Map::new();
+    let mut redacted = validate_core_fields(entry, &mut out);
+    redacted = validate_payload_fields(entry, &mut out) || redacted;
+
+    let (attrs_out, attrs_redacted) = redact_attrs(entry.get("attrs"));
+    out.insert("attrs".into(), Value::Object(attrs_out));
+
+    // Any unknown top-level key triggers redacted=true
+    let has_unknown_keys = entry.keys().any(|k| !is_top_level_key(k));
+    if attrs_redacted || has_unknown_keys {
+        redacted = true;
+    }
+
+    out.insert("redacted".into(), Value::Bool(redacted));
+    Value::Object(out)
+}
+
+/// Redact a raw JSON debug entry.
+///
+/// Applies allowlist-first field filtering, enum validation, text scrubbing
+/// for bearer tokens / JWTs / URL query tokens / path usernames, and attrs
+/// scalar-only enforcement.
+///
+/// Fails closed: any unexpected panic returns a minimal sentinel object with
+/// `redacted: true`.
+pub fn redact_entry(raw: &Value) -> Value {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| redact_entry_impl(raw)));
+    result.unwrap_or_else(|_| sentinel(raw))
+}

--- a/sk-rust/tests/browse_operator_redaction.rs
+++ b/sk-rust/tests/browse_operator_redaction.rs
@@ -714,3 +714,108 @@ fn test_array_in_attrs_value_rejected() {
     );
     assert!(redacted_flag(&out));
 }
+
+// ── 20. Non-string route rejected (matches Python _redact_attrs isinstance check) ──
+
+#[test]
+fn test_route_integer_rejected() {
+    let entry = json!({
+        "idx": 20,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": { "route": 42 }
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        out["attrs"].get("route").is_none(),
+        "Integer route should be dropped"
+    );
+    assert!(redacted_flag(&out), "redacted flag must be true");
+}
+
+#[test]
+fn test_route_bool_rejected() {
+    let entry = json!({
+        "idx": 20,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": { "route": true }
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        out["attrs"].get("route").is_none(),
+        "Bool route should be dropped"
+    );
+    assert!(redacted_flag(&out), "redacted flag must be true");
+}
+
+#[test]
+fn test_route_null_rejected() {
+    let entry = json!({
+        "idx": 20,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": { "route": null }
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        out["attrs"].get("route").is_none(),
+        "Null route should be dropped"
+    );
+    assert!(redacted_flag(&out), "redacted flag must be true");
+}
+
+#[test]
+fn test_session_uuid_integer_rejected() {
+    let entry = json!({
+        "idx": 20,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": { "session_uuid": 123 }
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        out["attrs"].get("session_uuid").is_none(),
+        "Integer session_uuid should be dropped"
+    );
+    assert!(redacted_flag(&out), "redacted flag must be true");
+}
+
+#[test]
+fn test_session_uuid_null_rejected() {
+    let entry = json!({
+        "idx": 20,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": { "session_uuid": null }
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        out["attrs"].get("session_uuid").is_none(),
+        "Null session_uuid should be dropped"
+    );
+    assert!(redacted_flag(&out), "redacted flag must be true");
+}
+
+// Negative control: valid string route and UUID pass through unchanged.
+#[test]
+fn test_valid_string_route_passes() {
+    let entry = json!({
+        "idx": 20,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": { "route": "/api/sessions" }
+    });
+    let out = redact_entry(&entry);
+    assert_eq!(
+        out["attrs"]["route"], "/api/sessions",
+        "Valid string route should pass through"
+    );
+    assert!(!redacted_flag(&out));
+}

--- a/sk-rust/tests/browse_operator_redaction.rs
+++ b/sk-rust/tests/browse_operator_redaction.rs
@@ -1,0 +1,716 @@
+//! Integration tests for operator debug-log redaction (issue #451 PR-B).
+//!
+//! Covers all acceptance criteria from the PR spec.
+
+#![cfg(feature = "browse-server")]
+
+use serde_json::{json, Value};
+use sk::browse::operator::redaction::redact_entry;
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+fn minimal_valid() -> Value {
+    json!({
+        "idx": 1,
+        "timestamp": "2024-01-15T12:00:00Z",
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": {}
+    })
+}
+
+fn redacted_flag(v: &Value) -> bool {
+    v["redacted"].as_bool().unwrap_or(false)
+}
+
+fn message_str(v: &Value) -> &str {
+    v["message"].as_str().unwrap_or("")
+}
+
+// ── 1. Bearer token in message → [REDACTED] ───────────────────────────────────
+
+#[test]
+fn test_bearer_token_redacted() {
+    let entry = json!({
+        "idx": 1,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "message": "Authorization: Bearer eyABC123secret",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        message_str(&out).contains("[REDACTED]"),
+        "Bearer token should be redacted"
+    );
+    assert!(!message_str(&out).contains("eyABC123secret"));
+    assert!(redacted_flag(&out));
+}
+
+// ── 2. JWT in message → [REDACTED] ────────────────────────────────────────────
+
+#[test]
+fn test_jwt_redacted() {
+    let entry = json!({
+        "idx": 2,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "message": "token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        message_str(&out).contains("[REDACTED]"),
+        "JWT should be redacted"
+    );
+    assert!(!message_str(&out).contains("eyJhbGciOiJIUzI1NiJ9"));
+    assert!(redacted_flag(&out));
+}
+
+// ── 3. URL query tokens redacted ──────────────────────────────────────────────
+
+#[test]
+fn test_url_query_token_redacted() {
+    for msg in &[
+        "https://example.com/api?token=abc123",
+        "https://example.com/api?key=abc123",
+        "https://example.com/api?secret=abc123",
+        "https://example.com/api?auth=abc123",
+    ] {
+        let entry = json!({
+            "idx": 3,
+            "kind": "generic",
+            "level": "info",
+            "source": "cli",
+            "message": msg,
+            "attrs": {}
+        });
+        let out = redact_entry(&entry);
+        assert!(
+            message_str(&out).contains("[REDACTED]"),
+            "URL query token should be redacted in: {msg}"
+        );
+        assert!(
+            !message_str(&out).contains("abc123"),
+            "Token value leaked in: {msg}"
+        );
+        assert!(redacted_flag(&out));
+    }
+}
+
+// ── 4. Windows path username redacted ─────────────────────────────────────────
+
+#[test]
+fn test_windows_path_username_redacted() {
+    let entry = json!({
+        "idx": 4,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "message": r"Loading config from C:\Users\alice\.copilot\config.json",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        message_str(&out).contains("[REDACTED]"),
+        "Windows username should be redacted"
+    );
+    assert!(!message_str(&out).contains("alice"), "Username leaked");
+    assert!(redacted_flag(&out));
+}
+
+// ── 5. Unix path username redacted ────────────────────────────────────────────
+
+#[test]
+fn test_unix_path_username_redacted() {
+    let entry = json!({
+        "idx": 5,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "message": "Loading config from /home/bob/.copilot/config.json",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        message_str(&out).contains("[REDACTED]"),
+        "Unix username should be redacted"
+    );
+    assert!(!message_str(&out).contains("bob"), "Username leaked");
+    assert!(redacted_flag(&out));
+}
+
+// ── 6. macOS path username redacted ───────────────────────────────────────────
+
+#[test]
+fn test_macos_path_username_redacted() {
+    let entry = json!({
+        "idx": 6,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "message": "Loading config from /Users/carol/.copilot/config.json",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        message_str(&out).contains("[REDACTED]"),
+        "macOS username should be redacted"
+    );
+    assert!(!message_str(&out).contains("carol"), "Username leaked");
+    assert!(redacted_flag(&out));
+}
+
+// ── 7. Unknown top-level keys dropped + redacted: true ────────────────────────
+
+#[test]
+fn test_unknown_top_level_keys_dropped() {
+    let entry = json!({
+        "idx": 7,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": {},
+        "secret_field": "should_be_dropped",
+        "another_unknown": 42
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        out.get("secret_field").is_none(),
+        "Unknown key should be dropped"
+    );
+    assert!(
+        out.get("another_unknown").is_none(),
+        "Unknown key should be dropped"
+    );
+    assert!(redacted_flag(&out));
+}
+
+// ── 8. Unknown attrs keys dropped + redacted: true ────────────────────────────
+
+#[test]
+fn test_unknown_attrs_keys_dropped() {
+    let entry = json!({
+        "idx": 8,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": {
+            "model": "claude-3",
+            "evil_key": "should_be_dropped"
+        }
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        out["attrs"].get("evil_key").is_none(),
+        "Unknown attrs key should be dropped"
+    );
+    assert_eq!(out["attrs"]["model"], "claude-3");
+    assert!(redacted_flag(&out));
+}
+
+// ── 9. Non-object attrs → {} + redacted: true ────────────────────────────────
+
+#[test]
+fn test_non_object_attrs_replaced() {
+    for bad_attrs in &[json!("a string"), json!(42), json!(true), json!([1, 2, 3])] {
+        let entry = json!({
+            "idx": 9,
+            "kind": "generic",
+            "level": "info",
+            "source": "cli",
+            "attrs": bad_attrs
+        });
+        let out = redact_entry(&entry);
+        assert_eq!(
+            out["attrs"],
+            json!({}),
+            "Non-object attrs should become {{}}"
+        );
+        assert!(
+            redacted_flag(&out),
+            "Non-object attrs should set redacted=true"
+        );
+    }
+}
+
+// ── 10. Message > 2048 chars truncated ────────────────────────────────────────
+
+#[test]
+fn test_message_truncated_at_2048() {
+    let long_msg: String = "x".repeat(3000);
+    let entry = json!({
+        "idx": 10,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "message": long_msg,
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    let msg = message_str(&out);
+    assert!(
+        msg.len() <= 2048,
+        "Message should be truncated to 2048 chars, got {}",
+        msg.len()
+    );
+    assert!(redacted_flag(&out));
+}
+
+// ── 11. Route with ? in attrs rejected ────────────────────────────────────────
+
+#[test]
+fn test_route_with_query_string_rejected() {
+    let entry = json!({
+        "idx": 11,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": {
+            "route": "/api/sessions?token=abc"
+        }
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        out["attrs"].get("route").is_none(),
+        "Route with ? should be dropped"
+    );
+    assert!(redacted_flag(&out));
+}
+
+// ── 12. Invalid kind/level/source/status replaced + redacted: true ────────────
+
+#[test]
+fn test_invalid_kind_replaced() {
+    let entry = json!({
+        "idx": 12,
+        "kind": "malicious_kind",
+        "level": "info",
+        "source": "cli",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert_eq!(out["kind"], "generic", "Invalid kind should become generic");
+    assert!(redacted_flag(&out));
+}
+
+#[test]
+fn test_invalid_level_replaced() {
+    let entry = json!({
+        "idx": 12,
+        "kind": "generic",
+        "level": "critical",
+        "source": "cli",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert_eq!(
+        out["level"],
+        Value::Null,
+        "Invalid level should become null"
+    );
+    assert!(redacted_flag(&out));
+}
+
+#[test]
+fn test_invalid_source_replaced() {
+    let entry = json!({
+        "idx": 12,
+        "kind": "generic",
+        "level": "info",
+        "source": "attacker_source",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert_eq!(
+        out["source"], "unknown",
+        "Invalid source should become unknown"
+    );
+    assert!(redacted_flag(&out));
+}
+
+#[test]
+fn test_invalid_status_dropped() {
+    let entry = json!({
+        "idx": 12,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "status": "pending",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        out.get("status").is_none(),
+        "Invalid status should be dropped"
+    );
+    assert!(redacted_flag(&out));
+}
+
+// ── 13. Invalid tool_name (fails regex) dropped ───────────────────────────────
+
+#[test]
+fn test_invalid_tool_name_dropped() {
+    for bad_name in &["has spaces!", "../traversal", "a".repeat(65).as_str(), ""] {
+        let entry = json!({
+            "idx": 13,
+            "kind": "tool_call",
+            "level": "info",
+            "source": "cli",
+            "tool_name": bad_name,
+            "attrs": {}
+        });
+        let out = redact_entry(&entry);
+        assert!(
+            out.get("tool_name").is_none(),
+            "Invalid tool_name '{bad_name}' should be dropped"
+        );
+        assert!(redacted_flag(&out));
+    }
+}
+
+#[test]
+fn test_valid_tool_name_kept() {
+    let entry = json!({
+        "idx": 13,
+        "kind": "tool_call",
+        "level": "info",
+        "source": "cli",
+        "tool_name": "bash_exec",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert_eq!(out["tool_name"], "bash_exec");
+}
+
+// ── 14. Invalid span_id dropped ───────────────────────────────────────────────
+
+#[test]
+fn test_invalid_span_id_dropped() {
+    for bad_span in &[
+        "notenoughchars",
+        "UPPERCASE1234567",
+        "too-long-span-id-value",
+    ] {
+        let entry = json!({
+            "idx": 14,
+            "kind": "generic",
+            "level": "info",
+            "source": "cli",
+            "span_id": bad_span,
+            "parent_span_id": bad_span,
+            "attrs": {}
+        });
+        let out = redact_entry(&entry);
+        assert!(
+            out.get("span_id").is_none(),
+            "Invalid span_id '{bad_span}' should be dropped"
+        );
+        assert!(
+            out.get("parent_span_id").is_none(),
+            "Invalid parent_span_id '{bad_span}' should be dropped"
+        );
+        assert!(redacted_flag(&out));
+    }
+}
+
+#[test]
+fn test_valid_span_id_kept() {
+    let entry = json!({
+        "idx": 14,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "span_id": "abcdef1234567890",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert_eq!(out["span_id"], "abcdef1234567890");
+}
+
+// ── 15. Invalid timestamp dropped ────────────────────────────────────────────
+
+#[test]
+fn test_invalid_timestamp_replaced_with_null() {
+    // The ISO UTC regex validates format only, not calendar correctness.
+    // Only structurally malformed timestamps are rejected.
+    for bad_ts in &["not-a-date", "2024-01-01", "12345678"] {
+        let entry = json!({
+            "idx": 15,
+            "kind": "generic",
+            "level": "info",
+            "source": "cli",
+            "timestamp": bad_ts,
+            "attrs": {}
+        });
+        let out = redact_entry(&entry);
+        assert_eq!(
+            out["timestamp"],
+            Value::Null,
+            "Invalid timestamp '{bad_ts}' should become null"
+        );
+        assert!(redacted_flag(&out));
+    }
+}
+
+#[test]
+fn test_valid_timestamp_kept() {
+    let entry = json!({
+        "idx": 15,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "timestamp": "2024-01-15T12:00:00Z",
+        "attrs": {}
+    });
+    let out = redact_entry(&entry);
+    assert_eq!(out["timestamp"], "2024-01-15T12:00:00Z");
+}
+
+// ── 16. Invalid session_uuid in attrs dropped ─────────────────────────────────
+
+#[test]
+fn test_invalid_session_uuid_dropped() {
+    for bad_uuid in &["not-a-uuid", "12345678-1234-1234-1234-12345678901z", ""] {
+        let entry = json!({
+            "idx": 16,
+            "kind": "generic",
+            "level": "info",
+            "source": "cli",
+            "attrs": {
+                "session_uuid": bad_uuid
+            }
+        });
+        let out = redact_entry(&entry);
+        assert!(
+            out["attrs"].get("session_uuid").is_none(),
+            "Invalid session_uuid '{bad_uuid}' should be dropped"
+        );
+        assert!(redacted_flag(&out));
+    }
+}
+
+#[test]
+fn test_valid_session_uuid_kept() {
+    let entry = json!({
+        "idx": 16,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": {
+            "session_uuid": "12345678-1234-1234-1234-123456789abc"
+        }
+    });
+    let out = redact_entry(&entry);
+    assert_eq!(
+        out["attrs"]["session_uuid"],
+        "12345678-1234-1234-1234-123456789abc"
+    );
+}
+
+// ── 17. Empty/null input → minimal output without panic ──────────────────────
+
+#[test]
+fn test_null_input_no_panic() {
+    let out = redact_entry(&Value::Null);
+    // Should return a valid JSON object with at least idx, kind, source, attrs, redacted
+    assert!(out.is_object());
+    assert!(out.get("idx").is_some());
+    assert!(out.get("kind").is_some());
+    assert!(out.get("attrs").is_some());
+    assert!(out.get("redacted").is_some());
+}
+
+#[test]
+fn test_empty_object_no_panic() {
+    let out = redact_entry(&json!({}));
+    assert!(out.is_object());
+    assert_eq!(out["kind"], "generic");
+    assert_eq!(out["source"], "unknown");
+    assert_eq!(out["attrs"], json!({}));
+    // Empty object: idx missing → redacted
+    assert!(redacted_flag(&out));
+}
+
+// ── 18. Deep nested attacker payload → no panic, no leak ─────────────────────
+
+#[test]
+fn test_deeply_nested_attrs_no_panic_no_leak() {
+    let nested = json!({
+        "level1": {
+            "level2": {
+                "level3": {
+                    "level4": "deep_secret"
+                }
+            }
+        }
+    });
+    let entry = json!({
+        "idx": 18,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": nested
+    });
+    let out = redact_entry(&entry);
+    // Should not panic, nested object attrs → {} + redacted
+    assert!(out.is_object());
+    assert_eq!(out["attrs"], json!({}));
+    assert!(redacted_flag(&out));
+    // No leaked nested content
+    let out_str = out.to_string();
+    assert!(!out_str.contains("deep_secret"), "Nested secret leaked");
+}
+
+#[test]
+fn test_deeply_nested_message_no_leak() {
+    // Non-string message (array of nested objects) → coerced to string, truncated, scrubbed
+    let entry = json!({
+        "idx": 18,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "message": {"nested": {"secret": "bearer abcxyz"}},
+        "attrs": {}
+    });
+    // Should not panic
+    let out = redact_entry(&entry);
+    assert!(out.is_object());
+    assert!(
+        !out["message"].as_str().unwrap_or("").contains("abcxyz"),
+        "Secret leaked from non-string message"
+    );
+}
+
+// ── 19. PARITY-NOTE comment present in redaction.rs ──────────────────────────
+
+#[test]
+fn test_parity_note_comment_exists_in_source() {
+    // This test reads the source file to verify the PARITY-NOTE comment is present.
+    // It intentionally checks the documentation contract, not runtime behavior.
+    let src = include_str!("../src/browse/operator/redaction.rs");
+    assert!(
+        src.contains("PARITY-NOTE"),
+        "redaction.rs must contain a PARITY-NOTE comment near omitted redact_secrets"
+    );
+    assert!(
+        src.contains("redact_secrets"),
+        "redaction.rs must mention redact_secrets in the PARITY-NOTE"
+    );
+}
+
+// ── Additional: valid clean entry passes through without redaction ────────────
+
+#[test]
+fn test_clean_entry_not_redacted() {
+    let entry = minimal_valid();
+    let out = redact_entry(&entry);
+    assert!(!redacted_flag(&out), "Clean entry should not be redacted");
+    assert_eq!(out["idx"], 1);
+    assert_eq!(out["kind"], "generic");
+    assert_eq!(out["level"], "info");
+    assert_eq!(out["source"], "cli");
+}
+
+// ── Additional: absent attrs (no attrs key) → {} no redaction ────────────────
+
+#[test]
+fn test_absent_attrs_no_redaction() {
+    let entry = json!({
+        "idx": 0,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli"
+    });
+    let out = redact_entry(&entry);
+    assert_eq!(out["attrs"], json!({}));
+    // No unknown keys, attrs absent = not redacted by attrs
+    // But idx=0 is valid (>=0), so overall should not be redacted
+    assert!(!redacted_flag(&out));
+}
+
+// ── Additional: null attrs → {} no redaction ─────────────────────────────────
+
+#[test]
+fn test_null_attrs_no_redaction() {
+    let entry = json!({
+        "idx": 1,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": null
+    });
+    let out = redact_entry(&entry);
+    assert_eq!(out["attrs"], json!({}));
+    assert!(!redacted_flag(&out));
+}
+
+// ── Additional: valid attrs scalar values pass through ───────────────────────
+
+#[test]
+fn test_valid_attrs_pass_through() {
+    let entry = json!({
+        "idx": 1,
+        "kind": "llm_request",
+        "level": "info",
+        "source": "cli",
+        "attrs": {
+            "model": "claude-sonnet-4.6",
+            "tokens_in": 100,
+            "tokens_out": 200,
+            "cache_hit": false,
+            "latency_ms": 350.5
+        }
+    });
+    let out = redact_entry(&entry);
+    assert_eq!(out["attrs"]["model"], "claude-sonnet-4.6");
+    assert_eq!(out["attrs"]["tokens_in"], 100);
+    assert_eq!(out["attrs"]["tokens_out"], 200);
+    assert_eq!(out["attrs"]["cache_hit"], false);
+    assert!(!redacted_flag(&out));
+}
+
+// ── Additional: nested object in attrs value rejected ────────────────────────
+
+#[test]
+fn test_nested_object_in_attrs_value_rejected() {
+    let entry = json!({
+        "idx": 1,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": {
+            "model": {"nested": "value"}
+        }
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        out["attrs"].get("model").is_none(),
+        "Nested attrs value should be dropped"
+    );
+    assert!(redacted_flag(&out));
+}
+
+// ── Additional: array in attrs value rejected ────────────────────────────────
+
+#[test]
+fn test_array_in_attrs_value_rejected() {
+    let entry = json!({
+        "idx": 1,
+        "kind": "generic",
+        "level": "info",
+        "source": "cli",
+        "attrs": {
+            "tokens_in": [1, 2, 3]
+        }
+    });
+    let out = redact_entry(&entry);
+    assert!(
+        out["attrs"].get("tokens_in").is_none(),
+        "Array attrs value should be dropped"
+    );
+    assert!(redacted_flag(&out));
+}


### PR DESCRIPTION
Closes #451 (PR-B scope). Port browse/core/redaction.py to Rust as pure library module. PR-A #501 shipped CRUD. Source of truth: browse/core/redaction.py. PARITY-NOTE: redact_secrets omitted. Verification: 34/34 tests pass, clippy clean, fmt clean.