### PR TITLE
feat(#452): add Rust graph communities endpoint

### DIFF
--- a/sk-rust/src/browse/api/graph.rs
+++ b/sk-rust/src/browse/api/graph.rs
@@ -1,0 +1,143 @@
+//! `GET /api/graph/communities` handler (issue #452 PR-B).
+//!
+//! Loads all knowledge entries and relations, runs the community-detection
+//! algorithm, and returns `{ "communities": [...] }`.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json, Response};
+use serde_json::{json, Value};
+
+use crate::browse::algo::communities::{find_communities, Entry, RelationEdge};
+use crate::browse::db::BrowseDb;
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+/// `GET /api/graph/communities` — community detection over knowledge entries.
+///
+/// JSON contract:
+/// ```json
+/// { "communities": [ { "id", "entry_count", "top_categories", "wings",
+///                       "top_relation_types", "representative_entries" } ] }
+/// ```
+/// Returns `{ "communities": [] }` when the DB has no entries, no relations,
+/// or when the relations table is absent.
+pub async fn communities_handler(State(db): State<Arc<BrowseDb>>) -> Response {
+    match tokio::task::spawn_blocking(move || {
+        let entry_rows = db.list_knowledge_entries_for_communities()?;
+        let relation_rows = db.list_knowledge_relations_for_communities()?;
+
+        let entries: Vec<Entry> = entry_rows
+            .into_iter()
+            .map(|(id, title, category, wing)| {
+                let title = if title.is_empty() {
+                    format!("entry-{id}")
+                } else {
+                    title.chars().take(200).collect()
+                };
+                let category = {
+                    let s = category.trim().to_string();
+                    if s.is_empty() {
+                        "unknown".to_string()
+                    } else {
+                        s
+                    }
+                };
+                let wing = {
+                    let s = wing.trim().to_string();
+                    if s.is_empty() {
+                        "unknown".to_string()
+                    } else {
+                        s
+                    }
+                };
+                Entry {
+                    id,
+                    title,
+                    category,
+                    wing,
+                }
+            })
+            .collect();
+
+        let relations: Vec<RelationEdge> = relation_rows
+            .into_iter()
+            .filter_map(|(src, tgt, rtype)| {
+                // Skip NULL/zero source or target (shouldn't happen but guard it)
+                if src == 0 || tgt == 0 {
+                    return None;
+                }
+                let rtype = {
+                    let s = rtype.trim().to_string();
+                    if s.is_empty() {
+                        "unknown".to_string()
+                    } else {
+                        s
+                    }
+                };
+                Some(RelationEdge {
+                    source_id: src,
+                    target_id: tgt,
+                    relation_type: rtype,
+                })
+            })
+            .collect();
+
+        let communities = find_communities(&entries, &relations, 2);
+
+        let json_communities: Vec<Value> = communities
+            .iter()
+            .map(|c| {
+                let top_categories: Vec<Value> = c
+                    .top_categories
+                    .iter()
+                    .map(|(name, count)| json!({"name": name, "count": count}))
+                    .collect();
+                let top_relation_types: Vec<Value> = c
+                    .top_relation_types
+                    .iter()
+                    .map(|(rtype, count)| json!({"type": rtype, "count": count}))
+                    .collect();
+                let representative_entries: Vec<Value> = c
+                    .representative_entries
+                    .iter()
+                    .map(|(id, title, category)| {
+                        json!({"id": id, "title": title, "category": category})
+                    })
+                    .collect();
+                json!({
+                    "id": c.id,
+                    "entry_count": c.entry_count,
+                    "top_categories": top_categories,
+                    "wings": c.wings,
+                    "top_relation_types": top_relation_types,
+                    "representative_entries": representative_entries,
+                })
+            })
+            .collect();
+
+        Ok::<Value, anyhow::Error>(json!({"communities": json_communities}))
+    })
+    .await
+    {
+        Ok(Ok(body)) => (StatusCode::OK, Json(body)).into_response(),
+        Ok(Err(e)) => {
+            tracing::warn!("communities: db error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "db error"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::warn!("communities: spawn_blocking error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal error"})),
+            )
+                .into_response()
+        }
+    }
+}

--- a/sk-rust/src/browse/api/mod.rs
+++ b/sk-rust/src/browse/api/mod.rs
@@ -1,6 +1,7 @@
 //! API route handlers for the browse HTTP server.
 
 pub mod compare;
+pub mod graph;
 pub mod live;
 pub mod operator;
 pub mod sessions;

--- a/sk-rust/src/browse/db.rs
+++ b/sk-rust/src/browse/db.rs
@@ -939,6 +939,68 @@ impl BrowseDb {
             .collect();
         Ok(rows)
     }
+
+    /// Fetch all knowledge entries for community detection.
+    ///
+    /// Returns `(id, title, category, wing)` ordered by id ASC.
+    /// Returns `Ok(vec![])` if the table is absent.
+    pub fn list_knowledge_entries_for_communities(
+        &self,
+    ) -> anyhow::Result<Vec<(i64, String, String, String)>> {
+        let conn = self.read_pool.get()?;
+        let mut stmt = match conn.prepare(
+            "SELECT id, \
+                    COALESCE(title,''), \
+                    COALESCE(category,''), \
+                    COALESCE(wing,'') \
+             FROM knowledge_entries \
+             ORDER BY id ASC",
+        ) {
+            Ok(s) => s,
+            Err(_) => return Ok(vec![]),
+        };
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                ))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
+
+    /// Fetch all knowledge relations for community detection.
+    ///
+    /// Returns `(source_id, target_id, relation_type)` ordered by id ASC.
+    /// Returns `Ok(vec![])` if the table is absent.
+    pub fn list_knowledge_relations_for_communities(
+        &self,
+    ) -> anyhow::Result<Vec<(i64, i64, String)>> {
+        let conn = self.read_pool.get()?;
+        let mut stmt = match conn.prepare(
+            "SELECT source_id, target_id, COALESCE(relation_type,'unknown') \
+             FROM knowledge_relations \
+             ORDER BY id ASC",
+        ) {
+            Ok(s) => s,
+            Err(_) => return Ok(vec![]),
+        };
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, i64>(1)?,
+                    r.get::<_, String>(2)?,
+                ))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────

--- a/sk-rust/src/browse/server.rs
+++ b/sk-rust/src/browse/server.rs
@@ -140,6 +140,11 @@ pub fn app(state: AppState) -> Router {
             get(crate::browse::api::sessions::detail_handler),
         )
         .route("/api/compare", get(crate::browse::api::compare::handler))
+        // ── Graph API (issue #452 PR-B) ──────────────────────────────────
+        .route(
+            "/api/graph/communities",
+            get(crate::browse::api::graph::communities_handler),
+        )
         // ── Operator API (issue #451 PR-A) ──────────────────────────────
         .route(
             "/api/operator/capabilities",

--- a/sk-rust/tests/browse_communities_api_test.rs
+++ b/sk-rust/tests/browse_communities_api_test.rs
@@ -1,0 +1,163 @@
+//! Integration tests for `GET /api/graph/communities` (issue #452 PR-B).
+//!
+//! Tests drive the full Axum router via `tower::ServiceExt::oneshot`.
+//! Fixture SQL is in `tests/fixtures/browse_communities.sql`.
+
+#![cfg(feature = "browse-server")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use rusqlite::Connection;
+use tower::ServiceExt;
+
+use sk::browse::db::{BrowseDb, BrowseDbConfig};
+use sk::browse::server::{app, AppState, ServerConfig};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn counter() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    CTR.fetch_add(1, Ordering::SeqCst)
+}
+
+/// Open a BrowseDb seeded with the given SQL.
+fn seeded_db_from_sql(label: &str, sql: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
+    let n = counter();
+    let path =
+        std::env::temp_dir().join(format!("sk_comm_api_{label}_{n}_{}.db", std::process::id()));
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(sql).unwrap();
+    }
+    let cfg = BrowseDbConfig {
+        path: path.clone(),
+        checkpoint_interval: None,
+        ..Default::default()
+    };
+    (
+        path,
+        Arc::new(BrowseDb::new_without_checkpoint(cfg).unwrap()),
+    )
+}
+
+fn test_app_state(db: Arc<BrowseDb>) -> AppState {
+    AppState::new(Arc::new(ServerConfig::default()), db)
+}
+
+async fn get_communities(state: AppState) -> (StatusCode, serde_json::Value) {
+    let response = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/graph/communities")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    (status, body)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Empty DB (no knowledge_entries rows) → {"communities": []}
+#[tokio::test]
+async fn empty_db_returns_empty_communities() {
+    let (_, db) = seeded_db_from_sql(
+        "empty",
+        "PRAGMA journal_mode=WAL;\
+         CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');\
+         CREATE TABLE IF NOT EXISTS knowledge_entries (\
+           id INTEGER PRIMARY KEY AUTOINCREMENT,\
+           category TEXT NOT NULL DEFAULT '',\
+           title TEXT NOT NULL DEFAULT '',\
+           content TEXT NOT NULL DEFAULT '',\
+           tags TEXT NOT NULL DEFAULT '',\
+           wing TEXT, room TEXT,\
+           confidence REAL NOT NULL DEFAULT 0.5,\
+           deleted_at INTEGER\
+         );\
+         CREATE TABLE IF NOT EXISTS knowledge_relations (\
+           id INTEGER PRIMARY KEY AUTOINCREMENT,\
+           source_id INTEGER,\
+           target_id INTEGER,\
+           relation_type TEXT NOT NULL\
+         );\
+         INSERT INTO schema_version VALUES (1,'test');",
+    );
+    let (status, body) = get_communities(test_app_state(db)).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["communities"], serde_json::json!([]));
+}
+
+/// Missing relations table → {"communities": []}
+#[tokio::test]
+async fn missing_relations_table_returns_empty() {
+    let (_, db) = seeded_db_from_sql(
+        "norel",
+        "PRAGMA journal_mode=WAL;\
+         CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');\
+         CREATE TABLE IF NOT EXISTS knowledge_entries (\
+           id INTEGER PRIMARY KEY AUTOINCREMENT,\
+           category TEXT NOT NULL DEFAULT '',\
+           title TEXT NOT NULL DEFAULT '',\
+           content TEXT NOT NULL DEFAULT '',\
+           tags TEXT NOT NULL DEFAULT '',\
+           wing TEXT, room TEXT,\
+           confidence REAL NOT NULL DEFAULT 0.5,\
+           deleted_at INTEGER\
+         );\
+         INSERT INTO schema_version VALUES (1,'test');\
+         INSERT INTO knowledge_entries (id,category,title,content,tags,wing)\
+           VALUES (1,'pattern','Entry A','','','backend');\
+         INSERT INTO knowledge_entries (id,category,title,content,tags,wing)\
+           VALUES (2,'pattern','Entry B','','','backend');",
+    );
+    let (status, body) = get_communities(test_app_state(db)).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["communities"], serde_json::json!([]));
+}
+
+/// Full golden-parity test using the fixture SQL.
+/// The response must equal browse_communities.golden.json exactly.
+#[tokio::test]
+async fn golden_parity_with_fixture() {
+    let fixture_sql = include_str!("fixtures/browse_communities.sql");
+    let (_, db) = seeded_db_from_sql("golden", fixture_sql);
+    let (status, body) = get_communities(test_app_state(db)).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let golden_str = include_str!("fixtures/browse_communities.golden.json");
+    let golden: serde_json::Value = serde_json::from_str(golden_str).unwrap();
+
+    assert_eq!(
+        body,
+        golden,
+        "Rust response diverges from golden.\nGot:      {}\nExpected: {}",
+        serde_json::to_string_pretty(&body).unwrap_or_default(),
+        serde_json::to_string_pretty(&golden).unwrap_or_default(),
+    );
+}
+
+/// Two communities must be returned in order: larger first, then smaller.
+#[tokio::test]
+async fn two_communities_sort_order() {
+    let fixture_sql = include_str!("fixtures/browse_communities.sql");
+    let (_, db) = seeded_db_from_sql("sort", fixture_sql);
+    let (status, body) = get_communities(test_app_state(db)).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let comms = body["communities"].as_array().unwrap();
+    assert_eq!(comms.len(), 2, "expected 2 communities");
+    // Larger community first
+    assert_eq!(comms[0]["id"], "c-1");
+    assert_eq!(comms[0]["entry_count"], 3);
+    assert_eq!(comms[1]["id"], "c-4");
+    assert_eq!(comms[1]["entry_count"], 2);
+}

--- a/sk-rust/tests/fixtures/browse_communities.golden.json
+++ b/sk-rust/tests/fixtures/browse_communities.golden.json
@@ -1,0 +1,39 @@
+{
+  "communities": [
+    {
+      "id": "c-1",
+      "entry_count": 3,
+      "top_categories": [
+        {"name": "decision", "count": 1},
+        {"name": "mistake", "count": 1},
+        {"name": "pattern", "count": 1}
+      ],
+      "wings": ["backend"],
+      "top_relation_types": [
+        {"type": "related", "count": 2},
+        {"type": "similar", "count": 1}
+      ],
+      "representative_entries": [
+        {"id": 1, "title": "Auth Pattern", "category": "pattern"},
+        {"id": 2, "title": "Login Fix", "category": "mistake"},
+        {"id": 3, "title": "Token Decision", "category": "decision"}
+      ]
+    },
+    {
+      "id": "c-4",
+      "entry_count": 2,
+      "top_categories": [
+        {"name": "mistake", "count": 1},
+        {"name": "pattern", "count": 1}
+      ],
+      "wings": ["frontend"],
+      "top_relation_types": [
+        {"type": "related", "count": 1}
+      ],
+      "representative_entries": [
+        {"id": 4, "title": "UI Component", "category": "pattern"},
+        {"id": 5, "title": "CSS Mistake", "category": "mistake"}
+      ]
+    }
+  ]
+}

--- a/sk-rust/tests/fixtures/browse_communities.sql
+++ b/sk-rust/tests/fixtures/browse_communities.sql
@@ -1,0 +1,56 @@
+-- Seed data for browse_communities_api_test.rs
+-- Produces exactly 2 communities: c-1 (3 entries) and c-4 (2 entries)
+
+PRAGMA journal_mode=WAL;
+
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER NOT NULL,
+    name    TEXT DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS knowledge_entries (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    category    TEXT NOT NULL DEFAULT '',
+    title       TEXT NOT NULL DEFAULT '',
+    content     TEXT NOT NULL DEFAULT '',
+    tags        TEXT NOT NULL DEFAULT '',
+    wing        TEXT,
+    room        TEXT,
+    confidence  REAL NOT NULL DEFAULT 0.5,
+    deleted_at  INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS knowledge_relations (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id       INTEGER,
+    target_id       INTEGER,
+    relation_type   TEXT NOT NULL,
+    confidence      REAL DEFAULT 0.8
+);
+
+INSERT INTO schema_version (version, name) VALUES (1, 'test');
+
+-- Community 1 (c-1): entries 1, 2, 3 — all backend wing
+INSERT INTO knowledge_entries (id, category, title, content, tags, wing, room)
+VALUES
+    (1, 'pattern',  'Auth Pattern',     'auth content',     '', 'backend',  'auth'),
+    (2, 'mistake',  'Login Fix',        'login content',    '', 'backend',  'auth'),
+    (3, 'decision', 'Token Decision',   'token content',    '', 'backend',  'auth');
+
+-- Community 2 (c-4): entries 4, 5 — frontend wing
+INSERT INTO knowledge_entries (id, category, title, content, tags, wing, room)
+VALUES
+    (4, 'pattern',  'UI Component',  'ui content',  '', 'frontend', 'ui'),
+    (5, 'mistake',  'CSS Mistake',   'css content', '', 'frontend', 'ui');
+
+-- Relations for community 1: triangle (1-2, 2-3, 1-3)
+INSERT INTO knowledge_relations (id, source_id, target_id, relation_type)
+VALUES
+    (1, 1, 2, 'related'),
+    (2, 2, 3, 'related'),
+    (3, 1, 3, 'similar');
+
+-- Relations for community 2: single edge (4-5)
+INSERT INTO knowledge_relations (id, source_id, target_id, relation_type)
+VALUES
+    (4, 4, 5, 'related');


### PR DESCRIPTION
## Summary

PR-B of issue #452: adds /api/graph/communities endpoint to the Rust browse server.

## Context

- Issue: #452 [Rust] Browse Graph + Embeddings + Communities APIs
- PR-A (#499, commit `01fa6a1`) already shipped pure Rust algo helpers (projection, similarity, communities) — no I/O, no DB.
- This PR-B wires the communities algo to a real HTTP endpoint with DB loading and golden-parity tests.

## Endpoint contract

**GET /api/graph/communities**

`json
{
  "communities": [
    {
      "id": "c-{min_entry_id}",
      "entry_count": 3,
      "top_categories": [{"name": "decision", "count": 1}, ...],
      "wings": ["backend"],
      "top_relation_types": [{"type": "related", "count": 2}, ...],
      "representative_entries": [{"id": 1, "title": "Auth Pattern", "category": "pattern"}, ...]
    }
  ]
}
`

- Outer sort: (-entry_count, id asc)
- Top lists: at most 3 entries, Python-parity ordering (-count, name asc)
- min_entry_count = 2
- Missing knowledge_relations table → {"communities": []}
- Empty entries → {"communities": []}

## Changes

| File | Change |
|------|--------|
| sk-rust/src/browse/api/graph.rs | New — communities_handler |
| sk-rust/src/browse/api/mod.rs | Add pub mod graph; |
| sk-rust/src/browse/server.rs | Register GET /api/graph/communities |
| sk-rust/src/browse/db.rs | Add list_knowledge_entries_for_communities + list_knowledge_relations_for_communities |
| sk-rust/tests/browse_communities_api_test.rs | New — 4 integration tests |
| sk-rust/tests/fixtures/browse_communities.sql | New — deterministic seed (2 communities) |
| sk-rust/tests/fixtures/browse_communities.golden.json | New — Python-verified golden output |

## Verification evidence

`
cargo fmt --all -- --check                                  PASS (exit 0)
cargo clippy --all-targets --features browse-server         PASS (exit 0, 0 warnings)
cargo test --test browse_algo_test                          14 passed / 0 failed
cargo test --test browse_communities_api_test               4 passed / 0 failed
cargo test --all --features browse-server                   1025+ passed / 0 failed
Python parity: get_communities(seed) == golden.json         EXACT MATCH
`

## Golden generation

Golden was generated by running `browse.core.communities.get_communities` (Python reference implementation) against the fixture SQL seed in `tests/fixtures/browse_communities.sql`. The Rust `golden_parity_with_fixture` test asserts byte-exact JSON equality.

## Deferred endpoints (future PRs)

- /api/graph — full knowledge graph
- /api/graph/evidence — evidence graph
- /api/graph/similarity — similarity graph
- /api/embeddings/points — embedding projections

## Notes

- No new Cargo dependencies added
- PR-A algo modules not modified
- `browse-server` feature gate preserved throughout