### PR TITLE
feat(#453): add Rust knowledge insights proxy endpoint

### DIFF
--- a/sk-rust/src/browse/api/insights.rs
+++ b/sk-rust/src/browse/api/insights.rs
@@ -1,0 +1,92 @@
+//! `GET /api/knowledge/insights` handler (issue #453 PR-C).
+//!
+//! Proxies `knowledge-health.py --insights --json` through the subprocess_proxy helper.
+//! Response on success: the parsed JSON object from knowledge-health.py.
+//! Response on failure: error envelope with codes INSIGHTS_UNAVAILABLE,
+//! INSIGHTS_ERROR, INSIGHTS_TIMEOUT, INSIGHTS_PARSE_ERROR.
+
+#![cfg(feature = "browse-server")]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json, Response};
+use serde_json::Value;
+
+use crate::browse::api::subprocess_proxy::{
+    run_python_script, subprocess_error_response, DEFAULT_TIMEOUT,
+};
+use crate::browse::server::ServerConfig;
+
+const INSIGHTS_TIMEOUT: Duration = DEFAULT_TIMEOUT;
+
+// ── Tools dir resolution ──────────────────────────────────────────────────────
+
+/// Resolve the copilot tools directory without using `dirs` (which is dev-only).
+///
+/// Priority:
+/// 1. `COPILOT_TOOLS_DIR` env var (explicit override, validated to exist).
+/// 2. Platform home dir via env vars → `~/.copilot/tools`.
+fn tools_dir() -> Option<PathBuf> {
+    // 1. Explicit override.
+    if let Ok(d) = std::env::var("COPILOT_TOOLS_DIR") {
+        let p = PathBuf::from(d);
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+
+    // 2. Platform home via env vars.
+    let home = if cfg!(windows) {
+        std::env::var("USERPROFILE").ok().or_else(|| {
+            std::env::var("HOMEDRIVE").ok().and_then(|drive| {
+                std::env::var("HOMEPATH")
+                    .ok()
+                    .map(|path| format!("{drive}{path}"))
+            })
+        })
+    } else {
+        std::env::var("HOME").ok()
+    };
+
+    home.map(|h| PathBuf::from(h).join(".copilot").join("tools"))
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+/// `GET /api/knowledge/insights` — proxy `knowledge-health.py --insights --json`.
+pub async fn handle_knowledge_insights(State(_config): State<Arc<ServerConfig>>) -> Response {
+    let Some(tdir) = tools_dir() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "cannot determine tools directory",
+                "code": "INSIGHTS_UNAVAILABLE",
+            })),
+        )
+            .into_response();
+    };
+
+    let script = tdir.join("knowledge-health.py");
+
+    match run_python_script(
+        &script,
+        &["--insights", "--json"],
+        Some(&tdir),
+        INSIGHTS_TIMEOUT,
+    )
+    .await
+    {
+        Ok(output) => (StatusCode::OK, Json(Value::Object(output.data))).into_response(),
+        Err(err) => subprocess_error_response(
+            err,
+            "INSIGHTS_UNAVAILABLE",
+            "INSIGHTS_ERROR",
+            "INSIGHTS_TIMEOUT",
+            "INSIGHTS_PARSE_ERROR",
+        ),
+    }
+}

--- a/sk-rust/src/browse/api/mod.rs
+++ b/sk-rust/src/browse/api/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod compare;
 pub mod graph;
+pub mod insights;
 pub mod live;
 pub mod operator;
 pub mod sessions;

--- a/sk-rust/src/browse/server.rs
+++ b/sk-rust/src/browse/server.rs
@@ -170,6 +170,11 @@ pub fn app(state: AppState) -> Router {
             "/api/workflow/health",
             get(crate::browse::api::workflow::handle_workflow_health),
         )
+        // ── Knowledge Insights API (issue #453 PR-C) ─────────────────────
+        .route(
+            "/api/knowledge/insights",
+            get(crate::browse::api::insights::handle_knowledge_insights),
+        )
         .fallback(serve_static)
         .with_state(state.clone())
         // innermost middleware — auth

--- a/sk-rust/tests/insights_proxy_test.rs
+++ b/sk-rust/tests/insights_proxy_test.rs
@@ -1,0 +1,160 @@
+//! Route-level tests for the knowledge insights proxy (issue #453 PR-C).
+//! Clones route-level tests from workflow_proxy_test.rs; generic subprocess_proxy
+//! tests are not duplicated here.
+#![cfg(feature = "browse-server")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use rusqlite::Connection;
+use tower::ServiceExt;
+
+use sk::browse::api::subprocess_proxy::resolve_python;
+use sk::browse::db::{BrowseDb, BrowseDbConfig};
+use sk::browse::server::{app, AppState, ServerConfig};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn mk_db() -> BrowseDb {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!("sk_ins_test_{}_{}.db", std::process::id(), n));
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;\
+             CREATE TABLE IF NOT EXISTS knowledge_entries (\
+               id INTEGER PRIMARY KEY AUTOINCREMENT,\
+               category TEXT NOT NULL DEFAULT '',\
+               title TEXT NOT NULL DEFAULT '',\
+               content TEXT NOT NULL DEFAULT '',\
+               tags TEXT NOT NULL DEFAULT '',\
+               wing TEXT, room TEXT,\
+               confidence REAL NOT NULL DEFAULT 0.5,\
+               deleted_at INTEGER\
+             );\
+             CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');",
+        )
+        .unwrap();
+    }
+    let cfg = BrowseDbConfig {
+        path,
+        checkpoint_interval: None,
+        ..Default::default()
+    };
+    BrowseDb::new_without_checkpoint(cfg).unwrap()
+}
+
+fn test_state_with_config(config: ServerConfig) -> AppState {
+    AppState::new(Arc::new(config), Arc::new(mk_db()))
+}
+
+// ── Insights route tests ──────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial_test::serial(env_copilot_tools_dir)]
+async fn test_insights_route_returns_503_when_script_missing() {
+    // Point COPILOT_TOOLS_DIR at a directory that exists but has no knowledge-health.py.
+    let tmp = std::env::temp_dir();
+    let mut config = ServerConfig::default();
+
+    // Save and restore COPILOT_TOOLS_DIR so sibling serial tests see a consistent value.
+    let prev = std::env::var("COPILOT_TOOLS_DIR").ok();
+    std::env::set_var("COPILOT_TOOLS_DIR", tmp.to_str().unwrap());
+    config.server_token = String::new(); // disable auth
+
+    let state = test_state_with_config(config);
+    let response = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/insights")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Restore before any assert (so we don't leak on panic).
+    match prev {
+        Some(v) => std::env::set_var("COPILOT_TOOLS_DIR", v),
+        None => std::env::remove_var("COPILOT_TOOLS_DIR"),
+    }
+
+    // script not found in tmp → 503
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["code"], "INSIGHTS_UNAVAILABLE");
+}
+
+#[tokio::test]
+#[serial_test::serial(env_copilot_tools_dir)]
+async fn test_insights_live_parity() {
+    // Locate tools dir: prefer COPILOT_TOOLS_DIR env, then ~/.copilot/tools via dirs.
+    let tools_dir = if let Ok(d) = std::env::var("COPILOT_TOOLS_DIR") {
+        let p = std::path::PathBuf::from(d);
+        if p.is_dir() {
+            Some(p)
+        } else {
+            None
+        }
+    } else {
+        dirs::home_dir().map(|h| h.join(".copilot").join("tools"))
+    };
+
+    let Some(tdir) = tools_dir else {
+        eprintln!("skipping test_insights_live_parity: cannot determine tools dir");
+        return;
+    };
+
+    let script = tdir.join("knowledge-health.py");
+    if !script.exists() {
+        eprintln!(
+            "skipping test_insights_live_parity: {} not found",
+            script.display()
+        );
+        return;
+    }
+
+    let py = resolve_python().await;
+    if py.is_none() {
+        eprintln!("skipping test_insights_live_parity: no Python interpreter found");
+        return;
+    }
+
+    use sk::browse::api::subprocess_proxy::run_python_script;
+    use std::time::Duration;
+
+    let result = run_python_script(
+        &script,
+        &["--insights", "--json"],
+        Some(&tdir),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    match result {
+        Ok(output) => {
+            for key in &[
+                "generated_at",
+                "summary",
+                "overview",
+                "quality_alerts",
+                "recommended_actions",
+                "entries",
+            ] {
+                assert!(
+                    output.data.contains_key(*key),
+                    "live parity: missing key '{key}'"
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("live parity: knowledge-health.py --insights failed (non-fatal): {e:?}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/knowledge/insights` Rust proxy endpoint, mirroring the Python `browse/api/insights.py` handler. Structurally cloned from the already-merged workflow health proxy (PR #505).

Closes #453 (PR-C)

## Changes

- `sk-rust/src/browse/api/insights.rs`: New handler proxying `knowledge-health.py --insights --json` via `subprocess_proxy`. Error codes: `INSIGHTS_UNAVAILABLE`, `INSIGHTS_ERROR`, `INSIGHTS_TIMEOUT`, `INSIGHTS_PARSE_ERROR`.
- `sk-rust/src/browse/api/mod.rs`: Add `pub mod insights;`
- `sk-rust/src/browse/server.rs`: Wire `GET /api/knowledge/insights` into `app()` after the workflow route block (inherits existing auth middleware)
- `sk-rust/tests/insights_proxy_test.rs`: Route-level tests only (503-when-script-missing + live parity). Generic subprocess_proxy tests remain in workflow_proxy_test.rs.

## Design Notes

- Structurally identical to PR #505 (workflow health proxy). `tools_dir()` helper copied verbatim (DRY refactor deferred intentionally per spec).
- Args (`--insights`, `--json`) are static literals; no shell invocation.
- Timeout: `INSIGHTS_TIMEOUT = DEFAULT_TIMEOUT`. No new deps, feature flags, or DB writes.
- Golden fixture referenced: `tests/fixtures/api/knowledge_insights_503.json`

## Verification

cargo fmt --check OK, cargo clippy -D warnings OK, cargo test --features browse-server OK (test_insights_route_returns_503_when_script_missing and test_insights_live_parity both pass), cargo check OK, cargo check --no-default-features OK.