### PR TITLE
ci(#459): run browse-ui lint:all as advisory CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,10 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Lint (full scope, advisory - issue #459)
+        continue-on-error: true
+        run: pnpm lint:all
+
       - name: Format check
         run: pnpm format:check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - **chore(quality):** add language-specific `.editorconfig` indent rules and advisory `pnpm lint:all` script (issue #459 PR-A; Rust/Python/global-any tightening deferred behind #450–#453).
+- **ci(#459):** run pnpm lint:all (src + e2e + scripts) as advisory CI step in browse-ui job.
 
 ### Added
 - **Rust workflow health proxy endpoint (#453 PR-B):** `GET /api/workflow/health` wired into the

--- a/browse-ui/AGENTS.md
+++ b/browse-ui/AGENTS.md
@@ -9,5 +9,5 @@ This version has breaking changes — APIs, conventions, and file structure may 
 ## Lint scope
 
 `pnpm lint` covers `src/` only and is the blocking CI gate.
-`pnpm lint:all` is advisory and additionally covers `e2e/` and `scripts/`; it is not wired into CI.
+`pnpm lint:all` is advisory and additionally covers `e2e/` and `scripts/`; CI now runs it as an advisory step (continue-on-error: true) in the browse-ui job (issue #459).
 Run `pnpm lint:all` locally before touching test or build scripts outside `src/`.


### PR DESCRIPTION
## ci(#459): run browse-ui lint:all as advisory CI step

Closes #459 | Prior slices: #500 (PR-A: lint:all script + editorconfig), #502 (PR-B: no-any tightening deferred)

### What this PR does

Inserts exactly one new step in the rowse-ui CI job immediately after the existing Lint step:

`yaml
- name: Lint (full scope, advisory - issue #459)
  continue-on-error: true
  run: pnpm lint:all
`

pnpm lint:all runs ESLint over src/, 2e/, and scripts/ — wider than the blocking pnpm lint (src-only) gate wired in PR #500.

### pnpm lint:all output (local verification)

> **Note:** On Windows with --ignore-scripts install, pnpm lint:all exits non-zero because ESLint binary isn't in PATH. Direct invocation via 
ode_modules\.bin\eslint src e2e scripts produces:

`
✖ 116 problems (0 errors, 116 warnings)
`

**0 errors — only warnings.** No regressions introduced.

### Verification gates

- [x] git diff --name-only lists exactly: .github/workflows/ci.yml, CHANGELOG.md, rowse-ui/AGENTS.md
- [x] Exactly one lint:all step in workflow; has continue-on-error: true
- [x] ESLint (node_modules): 0 errors, 116 warnings
- [x] python test_security.py — 12 passed, 0 failed
- [x] python test_fixes.py — 272 passed, 0 failed

### Deferred (out of scope for this PR)

- Ruff ignore removal (Python lint tightening)
- [lints.clippy] enforcement (Rust)
- Promotion of pnpm lint:all from advisory to blocking CI gate
- Pre-commit hook symmetry with lint:all

### Safety statement

No rule severities or ignores changed. No source files touched. CI cannot regress from this change because the new step is continue-on-error: true.