### PR TITLE
feat(#452): add Rust GET /api/graph/evidence endpoint

### DIFF
--- a/sk-rust/src/browse/api/graph.rs
+++ b/sk-rust/src/browse/api/graph.rs
@@ -1,10 +1,12 @@
-//! `GET /api/graph` and `GET /api/graph/communities` handlers (issue #452).
+//! `GET /api/graph`, `GET /api/graph/communities`, and `GET /api/graph/evidence`
+//! handlers (issue #452).
 //!
 //! - `GET /api/graph` (PR-C): legacy entity-relation graph.  Returns
 //!   `{ nodes, edges, truncated }` mirroring `browse/routes/graph.py::_build_graph_data`.
 //! - `GET /api/graph/communities` (PR-B): community detection over entries.
+//! - `GET /api/graph/evidence` (PR-D): evidence graph backed by `knowledge_relations`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use axum::extract::{Query, State};
@@ -369,4 +371,153 @@ pub async fn communities_handler(State(db): State<Arc<BrowseDb>>) -> Response {
                 .into_response()
         }
     }
+}
+
+// ── Evidence handler (PR-D) ───────────────────────────────────────────────────
+
+/// Query parameters accepted by `GET /api/graph/evidence`.
+#[derive(Debug, Deserialize, Default)]
+pub struct EvidenceParams {
+    /// Comma-separated wing filter values.
+    pub wing: Option<String>,
+    /// Comma-separated room filter values.
+    pub room: Option<String>,
+    /// Comma-separated category/kind filter values.
+    pub kind: Option<String>,
+    /// Comma-separated `relation_type` filter values.
+    pub relation_type: Option<String>,
+    /// Maximum entries to return (default 500, clamped 1-500).
+    pub limit: Option<String>,
+}
+
+/// `GET /api/graph/evidence` — evidence graph backed by `knowledge_relations`.
+///
+/// Mirrors `browse/routes/graph.py::handle_api_graph_evidence` and
+/// `_build_evidence_graph_data` exactly.
+pub async fn evidence_handler(
+    State(db): State<Arc<BrowseDb>>,
+    Query(params): Query<EvidenceParams>,
+) -> Response {
+    let wing_str = params.wing.unwrap_or_default();
+    let room_str = params.room.unwrap_or_default();
+    let kind_str = params.kind.unwrap_or_default();
+    let rt_str = params.relation_type.unwrap_or_default();
+    let limit_raw = params.limit.unwrap_or_default();
+
+    let limit: i64 = limit_raw.parse::<i64>().unwrap_or(500);
+    let limit = limit.clamp(1, 500);
+
+    let wings = csv_values(&wing_str);
+    let rooms = csv_values(&room_str);
+    let kinds = csv_values(&kind_str);
+    let relation_types = csv_values(&rt_str);
+
+    match tokio::task::spawn_blocking(move || {
+        build_evidence_graph_data(&db, wings, rooms, kinds, relation_types, limit)
+    })
+    .await
+    {
+        Ok(Ok(body)) => (StatusCode::OK, Json(body)).into_response(),
+        Ok(Err(e)) => {
+            tracing::warn!("graph/evidence: db error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "db error"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::warn!("graph/evidence: spawn_blocking error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Empty-payload sentinel returned when `knowledge_entries` table is absent.
+fn empty_evidence_payload() -> Value {
+    json!({
+        "nodes": [],
+        "edges": [],
+        "truncated": false,
+        "meta": {
+            "edge_source": "knowledge_relations",
+            "relation_types": [],
+        },
+    })
+}
+
+/// Build the `/api/graph/evidence` payload from the DB.
+///
+/// Mirrors Python `_build_evidence_graph_data`.
+fn build_evidence_graph_data(
+    db: &BrowseDb,
+    wings: Vec<String>,
+    rooms: Vec<String>,
+    kinds: Vec<String>,
+    relation_types: Vec<String>,
+    limit: i64,
+) -> anyhow::Result<Value> {
+    // Guard: if knowledge_entries table absent return empty payload.
+    if !db.knowledge_entries_table_exists()? {
+        return Ok(empty_evidence_payload());
+    }
+
+    let entry_rows = db.list_knowledge_entries_for_graph(&wings, &rooms, &kinds, limit + 1)?;
+
+    let truncated = entry_rows.len() as i64 > limit;
+    let entry_rows: Vec<_> = entry_rows.into_iter().take(limit as usize).collect();
+
+    let mut nodes: Vec<Value> = Vec::with_capacity(entry_rows.len());
+    let mut entry_ids: Vec<i64> = Vec::with_capacity(entry_rows.len());
+
+    for (eid, raw_cat, raw_title, raw_wing, raw_room) in &entry_rows {
+        let cat = if raw_cat.is_empty() {
+            "unknown".to_string()
+        } else {
+            raw_cat.clone()
+        };
+        let label: String = raw_title.chars().take(80).collect();
+        entry_ids.push(*eid);
+        nodes.push(json!({
+            "id": format!("e-{eid}"),
+            "kind": "entry",
+            "label": label,
+            "wing": raw_wing,
+            "room": raw_room,
+            "category": cat,
+            "color": category_color(&cat),
+        }));
+    }
+
+    let rel_rows =
+        db.list_knowledge_relations_for_evidence(&entry_ids, &relation_types, limit * 4)?;
+
+    let mut relation_types_seen: BTreeSet<String> = BTreeSet::new();
+    let mut edges: Vec<Value> = Vec::new();
+
+    for (src_id, tgt_id, rel_type, confidence) in rel_rows {
+        relation_types_seen.insert(rel_type.clone());
+        edges.push(json!({
+            "source": format!("e-{src_id}"),
+            "target": format!("e-{tgt_id}"),
+            "relation_type": rel_type,
+            "confidence": confidence,
+        }));
+    }
+
+    let relation_types_list: Vec<&str> = relation_types_seen.iter().map(String::as_str).collect();
+
+    Ok(json!({
+        "nodes": nodes,
+        "edges": edges,
+        "truncated": truncated,
+        "meta": {
+            "edge_source": "knowledge_relations",
+            "relation_types": relation_types_list,
+        },
+    }))
 }

--- a/sk-rust/src/browse/db.rs
+++ b/sk-rust/src/browse/db.rs
@@ -1104,6 +1104,137 @@ impl BrowseDb {
             .collect();
         Ok(rows)
     }
+
+    /// Returns `true` when the `knowledge_entries` table exists in sqlite_master.
+    pub fn knowledge_entries_table_exists(&self) -> anyhow::Result<bool> {
+        let conn = self.read_pool.get()?;
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='knowledge_entries'",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// Fetch knowledge relations for `GET /api/graph/evidence`.
+    ///
+    /// - Returns `Ok(vec![])` when `entry_ids` is empty.
+    /// - Returns `Ok(vec![])` when the `knowledge_relations` table is absent.
+    /// - Probes schema to determine `source`/`target` column names and whether
+    ///   `confidence` exists; only allowlisted column names are interpolated.
+    /// - Filters: both endpoints must be in `entry_ids`; optional
+    ///   `relation_types` IN filter; ordered `kr.id ASC LIMIT limit`.
+    ///
+    /// Returns `(source_id, target_id, relation_type, confidence)`.
+    pub fn list_knowledge_relations_for_evidence(
+        &self,
+        entry_ids: &[i64],
+        relation_types: &[String],
+        limit: i64,
+    ) -> anyhow::Result<Vec<(i64, i64, String, f64)>> {
+        if entry_ids.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let conn = self.read_pool.get()?;
+
+        // Check table existence.
+        let table_exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='table' AND name='knowledge_relations'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        if table_exists == 0 {
+            return Ok(vec![]);
+        }
+
+        // Probe columns via pragma_table_info.
+        use std::collections::HashSet;
+        let columns: HashSet<String> = {
+            let mut stmt =
+                conn.prepare("SELECT name FROM pragma_table_info('knowledge_relations')")?;
+            let rows: HashSet<String> = stmt
+                .query_map([], |r| r.get::<_, String>(0))?
+                .filter_map(|r| r.ok())
+                .collect();
+            rows
+        };
+
+        // Determine allowlisted source/target column names.
+        let (source_col, target_col) =
+            if columns.contains("source_id") && columns.contains("target_id") {
+                ("source_id", "target_id")
+            } else if columns.contains("source_entry_id") && columns.contains("target_entry_id") {
+                ("source_entry_id", "target_entry_id")
+            } else {
+                return Ok(vec![]);
+            };
+
+        // confidence expression — allowlisted literal or column reference.
+        let confidence_expr = if columns.contains("confidence") {
+            "COALESCE(kr.confidence, 0.8)"
+        } else {
+            "0.8"
+        };
+
+        let entry_ph = entry_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+
+        let rt_clause = if !relation_types.is_empty() {
+            let rt_ph = relation_types
+                .iter()
+                .map(|_| "?")
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("AND kr.relation_type IN ({rt_ph}) ")
+        } else {
+            String::new()
+        };
+
+        // Only allowlisted identifiers are interpolated; all values are bound params.
+        let sql = format!(
+            "SELECT kr.{source_col}, kr.{target_col}, kr.relation_type, \
+                    {confidence_expr} AS confidence \
+             FROM knowledge_relations kr \
+             WHERE kr.{source_col} IN ({entry_ph}) \
+               AND kr.{target_col} IN ({entry_ph}) \
+             {rt_clause}\
+             ORDER BY kr.id ASC LIMIT ?"
+        );
+
+        // Build params: entry_ids twice, relation_type strings, limit.
+        use rusqlite::types::Value;
+        let mut params: Vec<Value> = Vec::new();
+        for &id in entry_ids {
+            params.push(Value::Integer(id));
+        }
+        for &id in entry_ids {
+            params.push(Value::Integer(id));
+        }
+        for rt in relation_types {
+            params.push(Value::Text(rt.clone()));
+        }
+        params.push(Value::Integer(limit));
+
+        let dyn_refs: Vec<&dyn rusqlite::ToSql> =
+            params.iter().map(|v| v as &dyn rusqlite::ToSql).collect();
+
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(dyn_refs.as_slice(), |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, i64>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, f64>(3)?,
+                ))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
 }
 
 #[cfg(test)]

--- a/sk-rust/src/browse/server.rs
+++ b/sk-rust/src/browse/server.rs
@@ -140,11 +140,15 @@ pub fn app(state: AppState) -> Router {
             get(crate::browse::api::sessions::detail_handler),
         )
         .route("/api/compare", get(crate::browse::api::compare::handler))
-        // ── Graph API (issue #452 PR-B, PR-C) ───────────────────────────
+        // ── Graph API (issue #452 PR-B, PR-C, PR-D) ─────────────────────────
         .route("/api/graph", get(crate::browse::api::graph::graph_handler))
         .route(
             "/api/graph/communities",
             get(crate::browse::api::graph::communities_handler),
+        )
+        .route(
+            "/api/graph/evidence",
+            get(crate::browse::api::graph::evidence_handler),
         )
         // ── Operator API (issue #451 PR-A) ──────────────────────────────
         .route(

--- a/sk-rust/tests/browse_graph_evidence_api_test.rs
+++ b/sk-rust/tests/browse_graph_evidence_api_test.rs
@@ -1,0 +1,319 @@
+//! Integration tests for `GET /api/graph/evidence` (issue #452 PR-D).
+//!
+//! Tests drive the full Axum router via `tower::ServiceExt::oneshot`.
+//! Fixture SQL is in `tests/fixtures/browse_graph_evidence.sql`.
+//! Golden JSON is in `tests/fixtures/browse_graph_evidence.golden.json`.
+//!
+//! To regenerate the golden file run:
+//!   python -c "
+//!   import sqlite3, json, sys
+//!   sys.path.insert(0, '.')
+//!   conn = sqlite3.connect(':memory:')
+//!   conn.executescript(open('tests/fixtures/browse_graph_evidence.sql').read())
+//!   from browse.routes.graph import _build_evidence_graph_data
+//!   print(json.dumps(_build_evidence_graph_data(conn,'','','','',500), indent=2))
+//!   "
+
+#![cfg(feature = "browse-server")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use rusqlite::Connection;
+use tower::ServiceExt;
+
+use sk::browse::db::{BrowseDb, BrowseDbConfig};
+use sk::browse::server::{app, AppState, ServerConfig};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn counter() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    CTR.fetch_add(1, Ordering::SeqCst)
+}
+
+fn seeded_db_from_sql(label: &str, sql: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
+    let n = counter();
+    let path = std::env::temp_dir().join(format!(
+        "sk_evidence_api_{label}_{n}_{}.db",
+        std::process::id()
+    ));
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(sql).unwrap();
+    }
+    let cfg = BrowseDbConfig {
+        path: path.clone(),
+        checkpoint_interval: None,
+        ..Default::default()
+    };
+    (
+        path,
+        Arc::new(BrowseDb::new_without_checkpoint(cfg).unwrap()),
+    )
+}
+
+fn test_app_state(db: Arc<BrowseDb>) -> AppState {
+    AppState::new(Arc::new(ServerConfig::default()), db)
+}
+
+/// Issue a GET request to `/api/graph/evidence` with the given query string.
+async fn get_evidence(state: AppState, qs: &str) -> (StatusCode, serde_json::Value) {
+    let uri = if qs.is_empty() {
+        "/api/graph/evidence".to_string()
+    } else {
+        format!("/api/graph/evidence?{qs}")
+    };
+    let response = app(state)
+        .oneshot(Request::builder().uri(&uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    (status, body)
+}
+
+const FIXTURE_SQL: &str = include_str!("fixtures/browse_graph_evidence.sql");
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// 200 JSON response with `meta.edge_source == "knowledge_relations"`.
+#[tokio::test]
+async fn returns_200_with_correct_meta_edge_source() {
+    let (_, db) = seeded_db_from_sql("meta", FIXTURE_SQL);
+    let (status, body) = get_evidence(test_app_state(db), "").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["meta"]["edge_source"], "knowledge_relations");
+}
+
+/// All edges have `relation_type` (string) and numeric `confidence`;
+/// all nodes have `kind == "entry"`.
+#[tokio::test]
+async fn edge_and_node_shape() {
+    let (_, db) = seeded_db_from_sql("shape", FIXTURE_SQL);
+    let (_, body) = get_evidence(test_app_state(db), "").await;
+
+    let nodes = body["nodes"].as_array().unwrap();
+    for node in nodes {
+        assert_eq!(
+            node["kind"], "entry",
+            "all nodes must have kind=entry, got: {node}"
+        );
+    }
+
+    let edges = body["edges"].as_array().unwrap();
+    assert!(!edges.is_empty(), "expected at least one edge");
+    for edge in edges {
+        assert!(
+            edge["relation_type"].is_string(),
+            "edge must have relation_type string: {edge}"
+        );
+        assert!(
+            edge["confidence"].is_number(),
+            "edge must have numeric confidence: {edge}"
+        );
+    }
+}
+
+/// Golden byte/semantic parity with `browse_graph_evidence.golden.json`.
+#[tokio::test]
+async fn golden_parity_with_fixture() {
+    let (_, db) = seeded_db_from_sql("golden", FIXTURE_SQL);
+    let (status, body) = get_evidence(test_app_state(db), "limit=500").await;
+    assert_eq!(status, StatusCode::OK);
+
+    let golden_str = include_str!("fixtures/browse_graph_evidence.golden.json");
+    let golden: serde_json::Value = serde_json::from_str(golden_str).unwrap();
+
+    assert_eq!(
+        body,
+        golden,
+        "Rust /api/graph/evidence diverges from golden.\nGot:      {}\nExpected: {}",
+        serde_json::to_string_pretty(&body).unwrap_or_default(),
+        serde_json::to_string_pretty(&golden).unwrap_or_default(),
+    );
+}
+
+/// `relation_type=TAG_OVERLAP` narrows edges and `meta.relation_types == ["TAG_OVERLAP"]`.
+#[tokio::test]
+async fn filter_by_relation_type_narrows_edges() {
+    let (_, db) = seeded_db_from_sql("rt_filter", FIXTURE_SQL);
+    let (status, body) = get_evidence(test_app_state(db), "relation_type=TAG_OVERLAP").await;
+    assert_eq!(status, StatusCode::OK);
+
+    let edges = body["edges"].as_array().unwrap();
+    for edge in edges {
+        assert_eq!(
+            edge["relation_type"], "TAG_OVERLAP",
+            "all edges must have relation_type TAG_OVERLAP after filter: {edge}"
+        );
+    }
+
+    let relation_types = body["meta"]["relation_types"].as_array().unwrap();
+    assert_eq!(
+        *relation_types,
+        vec![serde_json::json!("TAG_OVERLAP")],
+        "meta.relation_types must be [\"TAG_OVERLAP\"]"
+    );
+}
+
+/// Missing `knowledge_entries` table returns empty payload with correct structure.
+#[tokio::test]
+async fn missing_knowledge_entries_table_returns_empty() {
+    let sql = "PRAGMA journal_mode=WAL;\
+        CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');";
+    let (_, db) = seeded_db_from_sql("no_ke", sql);
+    let (status, body) = get_evidence(test_app_state(db), "").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["nodes"], serde_json::json!([]));
+    assert_eq!(body["edges"], serde_json::json!([]));
+    assert_eq!(body["truncated"], false);
+    assert_eq!(body["meta"]["edge_source"], "knowledge_relations");
+    assert_eq!(body["meta"]["relation_types"], serde_json::json!([]));
+}
+
+/// Missing `knowledge_relations` table returns entries and empty edges.
+#[tokio::test]
+async fn missing_knowledge_relations_table_returns_entries_empty_edges() {
+    let sql = "PRAGMA journal_mode=WAL;\
+        CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');\
+        CREATE TABLE IF NOT EXISTS knowledge_entries (\
+          id INTEGER PRIMARY KEY, category TEXT NOT NULL DEFAULT '',\
+          title TEXT NOT NULL DEFAULT '', content TEXT NOT NULL DEFAULT '',\
+          tags TEXT NOT NULL DEFAULT '', wing TEXT, room TEXT,\
+          confidence REAL NOT NULL DEFAULT 0.5, deleted_at INTEGER\
+        );\
+        INSERT INTO knowledge_entries (id, category, title, content, tags, wing, room)\
+          VALUES (1, 'pattern', 'Auth Pattern', '', '', 'backend', 'auth'),\
+                 (2, 'mistake', 'Login Bug', '', '', 'backend', 'auth');";
+    let (_, db) = seeded_db_from_sql("no_kr", sql);
+    let (status, body) = get_evidence(test_app_state(db), "").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["nodes"].as_array().unwrap().len(), 2);
+    assert_eq!(body["edges"], serde_json::json!([]));
+    assert_eq!(body["meta"]["relation_types"], serde_json::json!([]));
+}
+
+/// Schema without `confidence` column defaults to `0.8` numeric confidence.
+#[tokio::test]
+async fn schema_without_confidence_column_uses_default_08() {
+    let sql = "PRAGMA journal_mode=WAL;\
+        CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');\
+        CREATE TABLE IF NOT EXISTS knowledge_entries (\
+          id INTEGER PRIMARY KEY, category TEXT NOT NULL DEFAULT '',\
+          title TEXT NOT NULL DEFAULT '', content TEXT NOT NULL DEFAULT '',\
+          tags TEXT NOT NULL DEFAULT '', wing TEXT, room TEXT,\
+          confidence REAL NOT NULL DEFAULT 0.5, deleted_at INTEGER\
+        );\
+        CREATE TABLE IF NOT EXISTS knowledge_relations (\
+          id INTEGER PRIMARY KEY AUTOINCREMENT,\
+          source_id INTEGER NOT NULL,\
+          target_id INTEGER NOT NULL,\
+          relation_type TEXT NOT NULL DEFAULT ''\
+        );\
+        INSERT INTO knowledge_entries (id, category, title, content, tags, wing, room)\
+          VALUES (1, 'pattern', 'Entry A', '', '', 'backend', 'auth'),\
+                 (2, 'mistake', 'Entry B', '', '', 'backend', 'auth');\
+        INSERT INTO knowledge_relations (source_id, target_id, relation_type)\
+          VALUES (1, 2, 'TAG_OVERLAP');";
+    let (_, db) = seeded_db_from_sql("no_conf", sql);
+    let (status, body) = get_evidence(test_app_state(db), "").await;
+    assert_eq!(status, StatusCode::OK);
+
+    let edges = body["edges"].as_array().unwrap();
+    assert_eq!(edges.len(), 1, "expected 1 edge");
+    let conf = edges[0]["confidence"].as_f64().unwrap();
+    assert!(
+        (conf - 0.8).abs() < 1e-9,
+        "default confidence must be 0.8, got {conf}"
+    );
+}
+
+/// Legacy `source_entry_id`/`target_entry_id` schema variant emits edges.
+#[tokio::test]
+async fn legacy_source_entry_id_schema_emits_edges() {
+    let sql = "PRAGMA journal_mode=WAL;\
+        CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');\
+        CREATE TABLE IF NOT EXISTS knowledge_entries (\
+          id INTEGER PRIMARY KEY, category TEXT NOT NULL DEFAULT '',\
+          title TEXT NOT NULL DEFAULT '', content TEXT NOT NULL DEFAULT '',\
+          tags TEXT NOT NULL DEFAULT '', wing TEXT, room TEXT,\
+          confidence REAL NOT NULL DEFAULT 0.5, deleted_at INTEGER\
+        );\
+        CREATE TABLE IF NOT EXISTS knowledge_relations (\
+          id INTEGER PRIMARY KEY AUTOINCREMENT,\
+          source_entry_id INTEGER NOT NULL,\
+          target_entry_id INTEGER NOT NULL,\
+          relation_type TEXT NOT NULL DEFAULT '',\
+          confidence REAL\
+        );\
+        INSERT INTO knowledge_entries (id, category, title, content, tags, wing, room)\
+          VALUES (10, 'pattern', 'Entry X', '', '', 'backend', 'auth'),\
+                 (11, 'mistake', 'Entry Y', '', '', 'backend', 'auth');\
+        INSERT INTO knowledge_relations (source_entry_id, target_entry_id, relation_type, confidence)\
+          VALUES (10, 11, 'RESOLVED_BY', 0.75);";
+    let (_, db) = seeded_db_from_sql("legacy", sql);
+    let (status, body) = get_evidence(test_app_state(db), "").await;
+    assert_eq!(status, StatusCode::OK);
+
+    let edges = body["edges"].as_array().unwrap();
+    assert_eq!(edges.len(), 1, "expected 1 edge from legacy schema");
+    assert_eq!(edges[0]["source"], "e-10");
+    assert_eq!(edges[0]["target"], "e-11");
+    assert_eq!(edges[0]["relation_type"], "RESOLVED_BY");
+    let conf = edges[0]["confidence"].as_f64().unwrap();
+    assert!(
+        (conf - 0.75).abs() < 1e-9,
+        "confidence must be 0.75, got {conf}"
+    );
+}
+
+/// `limit=2` truncates entries and sets `truncated=true`.
+#[tokio::test]
+async fn limit_2_truncates_and_sets_truncated_true() {
+    let (_, db) = seeded_db_from_sql("lim2", FIXTURE_SQL);
+    let (status, body) = get_evidence(test_app_state(db), "limit=2").await;
+    assert_eq!(status, StatusCode::OK);
+
+    assert_eq!(
+        body["truncated"], true,
+        "expected truncated=true for limit=2 (fixture has 5 entries)"
+    );
+    let nodes = body["nodes"].as_array().unwrap();
+    assert_eq!(
+        nodes.len(),
+        2,
+        "expected exactly 2 nodes for limit=2, got {}",
+        nodes.len()
+    );
+}
+
+/// Edges are only emitted when BOTH endpoints are in the filtered visible entry set.
+#[tokio::test]
+async fn edges_only_when_both_endpoints_visible() {
+    // Filter to wing=frontend: only entries 102 and 103 are visible.
+    // Relations in fixture:
+    //   id=1: 100→101 RESOLVED_BY  — both backend, NOT visible
+    //   id=2: 101→102 TAG_OVERLAP  — 101 backend (NOT visible), 102 frontend → excluded
+    //   id=3: 100→103 SAME_SESSION — 100 backend (NOT visible) → excluded
+    // Expected: no edges.
+    let (_, db) = seeded_db_from_sql("vis_filter", FIXTURE_SQL);
+    let (status, body) = get_evidence(test_app_state(db), "wing=frontend").await;
+    assert_eq!(status, StatusCode::OK);
+
+    let nodes = body["nodes"].as_array().unwrap();
+    assert_eq!(nodes.len(), 2, "expected 2 frontend entries");
+    for n in nodes {
+        assert_eq!(n["wing"], "frontend", "all nodes must be frontend");
+    }
+
+    let edges = body["edges"].as_array().unwrap();
+    assert!(
+        edges.is_empty(),
+        "no edges expected when both endpoints not in visible set, got: {edges:?}"
+    );
+}

--- a/sk-rust/tests/fixtures/browse_graph_evidence.golden.json
+++ b/sk-rust/tests/fixtures/browse_graph_evidence.golden.json
@@ -1,0 +1,78 @@
+{
+  "nodes": [
+    {
+      "id": "e-104",
+      "kind": "entry",
+      "label": "Lint Tool",
+      "wing": "backend",
+      "room": "devops",
+      "category": "tool",
+      "color": "#20c997"
+    },
+    {
+      "id": "e-103",
+      "kind": "entry",
+      "label": "CSS Discovery",
+      "wing": "frontend",
+      "room": "ui",
+      "category": "discovery",
+      "color": "#cc5de8"
+    },
+    {
+      "id": "e-102",
+      "kind": "entry",
+      "label": "UI Decision",
+      "wing": "frontend",
+      "room": "ui",
+      "category": "decision",
+      "color": "#339af0"
+    },
+    {
+      "id": "e-101",
+      "kind": "entry",
+      "label": "Auth Pattern",
+      "wing": "backend",
+      "room": "auth",
+      "category": "pattern",
+      "color": "#51cf66"
+    },
+    {
+      "id": "e-100",
+      "kind": "entry",
+      "label": "Auth Bug",
+      "wing": "backend",
+      "room": "auth",
+      "category": "mistake",
+      "color": "#ff6b6b"
+    }
+  ],
+  "edges": [
+    {
+      "source": "e-100",
+      "target": "e-101",
+      "relation_type": "RESOLVED_BY",
+      "confidence": 0.88
+    },
+    {
+      "source": "e-101",
+      "target": "e-102",
+      "relation_type": "TAG_OVERLAP",
+      "confidence": 0.55
+    },
+    {
+      "source": "e-100",
+      "target": "e-103",
+      "relation_type": "SAME_SESSION",
+      "confidence": 0.7
+    }
+  ],
+  "truncated": false,
+  "meta": {
+    "edge_source": "knowledge_relations",
+    "relation_types": [
+      "RESOLVED_BY",
+      "SAME_SESSION",
+      "TAG_OVERLAP"
+    ]
+  }
+}

--- a/sk-rust/tests/fixtures/browse_graph_evidence.sql
+++ b/sk-rust/tests/fixtures/browse_graph_evidence.sql
@@ -1,0 +1,65 @@
+-- Seed data for browse_graph_evidence_api_test.rs
+-- Fixture: 5 knowledge_entries across 2 wings (backend, frontend),
+--          3 rooms (auth, ui, devops), 5 categories;
+--          knowledge_relations with (id, source_id, target_id, relation_type, confidence)
+--          including RESOLVED_BY 0.88, TAG_OVERLAP 0.55, SAME_SESSION 0.70.
+--
+-- Golden JSON was computed by running Python _build_evidence_graph_data against
+-- this fixture with no filters and limit=500.  Regenerate with:
+--   python -c "
+--   import sqlite3, json, sys
+--   sys.path.insert(0, '.')
+--   conn = sqlite3.connect(':memory:')
+--   conn.executescript(open('tests/fixtures/browse_graph_evidence.sql').read())
+--   from browse.routes.graph import _build_evidence_graph_data
+--   print(json.dumps(_build_evidence_graph_data(conn,'','','','',500), indent=2))
+--   "
+
+PRAGMA journal_mode=WAL;
+
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER NOT NULL,
+    name    TEXT DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS knowledge_entries (
+    id          INTEGER PRIMARY KEY,
+    category    TEXT NOT NULL DEFAULT '',
+    title       TEXT NOT NULL DEFAULT '',
+    content     TEXT NOT NULL DEFAULT '',
+    tags        TEXT NOT NULL DEFAULT '',
+    wing        TEXT,
+    room        TEXT,
+    confidence  REAL NOT NULL DEFAULT 0.5,
+    deleted_at  INTEGER
+);
+
+-- knowledge_relations uses source_id/target_id (canonical schema)
+CREATE TABLE IF NOT EXISTS knowledge_relations (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id     INTEGER NOT NULL,
+    target_id     INTEGER NOT NULL,
+    relation_type TEXT NOT NULL DEFAULT '',
+    confidence    REAL
+);
+
+INSERT INTO schema_version (version, name) VALUES (1, 'test');
+
+-- 5 entries: 2 wings (backend, frontend), 3 rooms (auth, ui, devops), 5 categories
+INSERT INTO knowledge_entries (id, category, title, content, tags, wing, room)
+VALUES
+    (100, 'mistake',   'Auth Bug',      '', '', 'backend',  'auth'),
+    (101, 'pattern',   'Auth Pattern',  '', '', 'backend',  'auth'),
+    (102, 'decision',  'UI Decision',   '', '', 'frontend', 'ui'),
+    (103, 'discovery', 'CSS Discovery', '', '', 'frontend', 'ui'),
+    (104, 'tool',      'Lint Tool',     '', '', 'backend',  'devops');
+
+-- 3 relations covering the 3 required relation_types:
+--   id=1: 100→101 RESOLVED_BY 0.88  (backend→backend, same wing)
+--   id=2: 101→102 TAG_OVERLAP  0.55  (backend→frontend, cross-wing)
+--   id=3: 100→103 SAME_SESSION 0.70  (backend→frontend, cross-wing)
+INSERT INTO knowledge_relations (id, source_id, target_id, relation_type, confidence)
+VALUES
+    (1, 100, 101, 'RESOLVED_BY',  0.88),
+    (2, 101, 102, 'TAG_OVERLAP',  0.55),
+    (3, 100, 103, 'SAME_SESSION', 0.70);


### PR DESCRIPTION
Closes part of #452 (PR-D /api/graph/evidence only). See branch for full implementation.