### PR TITLE
feat(#452): add Rust GET /api/graph/similarity endpoint

### DIFF
--- a/sk-rust/src/browse/algo/similarity.rs
+++ b/sk-rust/src/browse/algo/similarity.rs
@@ -184,6 +184,27 @@ pub fn compute_neighbors(
     (neighbors_map, skipped_ids, computed_pairs)
 }
 
+/// Decode a little-endian f32 BLOB to `Vec<f64>`.
+///
+/// Returns an empty vec when `blob.len() / 4 < dims`, matching Python's
+/// `_decode_vector`: `if n < n_dims: return []`.
+pub fn decode_vector_le_f32(blob: &[u8], dims: usize) -> Vec<f64> {
+    if blob.len() / 4 < dims {
+        return vec![];
+    }
+    (0..dims)
+        .map(|i| {
+            let b = [
+                blob[i * 4],
+                blob[i * 4 + 1],
+                blob[i * 4 + 2],
+                blob[i * 4 + 3],
+            ];
+            f32::from_le_bytes(b) as f64
+        })
+        .collect()
+}
+
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -359,5 +380,34 @@ mod tests {
         let (map, skipped, _) = compute_neighbors(&rows, &source_ids, 5, 100_000);
         assert!(map.is_empty());
         assert!(skipped.is_empty());
+    }
+
+    // ── decode_vector_le_f32 ───────────────────────────────────────────────────
+
+    #[test]
+    fn decode_vector_le_f32_basic() {
+        // 1.0f32 LE = [0x00,0x00,0x80,0x3f], 2.0f32 LE = [0x00,0x00,0x00,0x40]
+        let blob: Vec<u8> = [1.0f32, 2.0f32]
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
+        let v = decode_vector_le_f32(&blob, 2);
+        assert!((v[0] - 1.0).abs() < 1e-6);
+        assert!((v[1] - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn decode_vector_le_f32_too_short_returns_empty() {
+        let blob = [0u8; 4]; // only 1 float
+        let v = decode_vector_le_f32(&blob, 2); // asks for 2 floats
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn decode_vector_le_f32_exact_length() {
+        let blob: Vec<u8> = [0.5f32].iter().flat_map(|v| v.to_le_bytes()).collect();
+        let v = decode_vector_le_f32(&blob, 1);
+        assert_eq!(v.len(), 1);
+        assert!((v[0] - 0.5).abs() < 1e-6);
     }
 }

--- a/sk-rust/src/browse/api/mod.rs
+++ b/sk-rust/src/browse/api/mod.rs
@@ -6,5 +6,6 @@ pub mod insights;
 pub mod live;
 pub mod operator;
 pub mod sessions;
+pub mod similarity;
 pub mod subprocess_proxy;
 pub mod workflow;

--- a/sk-rust/src/browse/api/similarity.rs
+++ b/sk-rust/src/browse/api/similarity.rs
@@ -1,0 +1,374 @@
+//! `GET /api/graph/similarity` handler (issue #452).
+//!
+//! Parity with `browse/routes/graph.py::handle_api_graph_similarity` and
+//! `browse/core/similarity.py::get_similarity`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{RawQuery, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde_json::{json, Value};
+
+use crate::browse::algo::similarity::{
+    compute_neighbors, decode_vector_le_f32, dedup_rows, fingerprint_rows, unique_entry_ids, Row,
+    CACHE_NEIGHBORS, MAX_COMPUTE_PAIRS, MAX_K, MAX_REQUESTED_ENTRY_IDS,
+};
+use crate::browse::db::BrowseDb;
+use crate::browse::server::ServerConfig;
+
+// ── Cache path ─────────────────────────────────────────────────────────────────
+
+fn default_cache_path() -> PathBuf {
+    if let Ok(p) = std::env::var("BROWSE_SIMILARITY_CACHE_PATH") {
+        return PathBuf::from(p);
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".copilot")
+        .join("session-state")
+        .join("embeddings_similarity_cache.json")
+}
+
+fn resolve_cache_path(config: &ServerConfig) -> PathBuf {
+    config
+        .similarity_cache_path
+        .clone()
+        .unwrap_or_else(default_cache_path)
+}
+
+// ── Query parsing ─────────────────────────────────────────────────────────────
+
+/// Decode percent-encoded characters (e.g. `%2C` → `,`, `%20` → ` `).
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                out.push((((h << 4) | l) as u8) as char);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(if bytes[i] == b'+' { ' ' } else { bytes[i] as char });
+        i += 1;
+    }
+    out
+}
+
+/// Parse a raw query string into a map of key → [values].
+///
+/// Handles repeated keys (`entry_id=1&entry_id=2`) which axum's `Query`
+/// extractor doesn't support natively for `Vec` without special serde.
+/// Values are percent-decoded so `%2C` becomes `,` for CSV splitting.
+fn parse_raw_query(raw: &str) -> HashMap<String, Vec<String>> {
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    for pair in raw.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let (k, v) = match pair.find('=') {
+            Some(pos) => (&pair[..pos], &pair[pos + 1..]),
+            None => (pair, ""),
+        };
+        map.entry(k.to_string())
+            .or_default()
+            .push(percent_decode(v));
+    }
+    map
+}
+
+/// Parse `entry_id` values: flatten CSV, filter positive ints, de-dupe, preserve order.
+fn parse_entry_ids(raw_values: &[String]) -> Vec<i64> {
+    let mut all: Vec<i64> = Vec::new();
+    for v in raw_values {
+        for part in v.split(',') {
+            let part = part.trim();
+            if let Ok(n) = part.parse::<i64>() {
+                all.push(n);
+            }
+        }
+    }
+    // unique_entry_ids filters non-positive and deduplicates while preserving order.
+    unique_entry_ids(&all)
+}
+
+// ── Cache I/O ─────────────────────────────────────────────────────────────────
+
+fn load_cache(path: &PathBuf) -> Option<Value> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let v: Value = serde_json::from_str(&text).ok()?;
+    if v.get("fingerprint").is_some() && v.get("neighbors").is_some() {
+        Some(v)
+    } else {
+        None
+    }
+}
+
+/// Write cache atomically via a `.tmp` side file + rename.
+/// Swallows all I/O errors with debug logs.
+fn save_cache(data: &Value, path: &PathBuf) {
+    let dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        tracing::debug!("similarity cache: create_dir_all failed: {e}");
+        return;
+    }
+    // Append ".tmp" to the full path (mirrors Python's `.with_suffix(suffix + ".tmp")`).
+    let tmp = {
+        let mut s = path.as_os_str().to_os_string();
+        s.push(".tmp");
+        PathBuf::from(s)
+    };
+    let text = match serde_json::to_string(data) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::debug!("similarity cache: serialize failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = std::fs::write(&tmp, &text) {
+        tracing::debug!("similarity cache: write tmp failed: {e}");
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        tracing::debug!("similarity cache: rename failed: {e}");
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
+// ── Row loading ───────────────────────────────────────────────────────────────
+
+/// Load, decode, and deduplicate embedding rows from the DB.
+///
+/// Mirrors Python `_load_rows`: decodes f32 LE blobs, applies title/category
+/// defaults, skips rows with bad dims/blob, deduplicates by source_id.
+fn load_rows(db: &BrowseDb) -> Vec<Row> {
+    let raw = match db.list_embeddings_for_similarity() {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!("similarity: db error: {e}");
+            return vec![];
+        }
+    };
+    let mut rows: Vec<Row> = Vec::with_capacity(raw.len());
+    for (_id, source_id, dims_raw, blob, title_opt, category_opt) in raw {
+        let dims = dims_raw as usize;
+        if dims == 0 || blob.is_empty() {
+            continue;
+        }
+        let vec = decode_vector_le_f32(&blob, dims);
+        if vec.is_empty() {
+            continue;
+        }
+        let norm = vec.iter().map(|x| x * x).sum::<f64>().sqrt();
+        let title: String = title_opt
+            .unwrap_or_else(|| format!("entry-{source_id}"))
+            .chars()
+            .take(200)
+            .collect();
+        let category = category_opt.unwrap_or_else(|| "unknown".to_string());
+        rows.push(Row {
+            source_id,
+            entry_id: source_id,
+            title,
+            category,
+            vec,
+            norm,
+            dims,
+            blob,
+        });
+    }
+    dedup_rows(rows)
+}
+
+// ── Core logic ────────────────────────────────────────────────────────────────
+
+/// Compute similarity results — pure function over DB + cache path.
+///
+/// Mirrors `browse/core/similarity.py::get_similarity` exactly:
+/// - empty DB → abbreviated meta (no fingerprint/computed/skipped/degraded)
+/// - cache hit → `cached: true`, `computed_pairs: 0`
+/// - partial hit → recompute missing, merge, save, `cached: false`
+fn get_similarity_inner(db: &BrowseDb, wanted: Vec<i64>, k: usize, cache_path: PathBuf) -> Value {
+    let rows = load_rows(db);
+    let embedding_count = rows.len();
+
+    if embedding_count == 0 {
+        let results: Vec<Value> = wanted
+            .iter()
+            .map(|&eid| json!({"entry_id": eid, "neighbors": []}))
+            .collect();
+        return json!({
+            "results": results,
+            "meta": {
+                "method": "cosine_knn",
+                "k": k,
+                "embedding_count": 0,
+                "cached": false,
+                "invalidation": "sha256(source_id,dimensions,vector,title,category)",
+                "cache_scope": "per_entry_topk",
+                "max_cached_k": CACHE_NEIGHBORS,
+            }
+        });
+    }
+
+    let fingerprint = fingerprint_rows(&rows);
+    let cache = load_cache(&cache_path);
+    let cache_valid = cache
+        .as_ref()
+        .and_then(|c| c["fingerprint"].as_str())
+        .map(|f| f == fingerprint)
+        .unwrap_or(false);
+
+    // Seed all_neighbors from cache when valid.
+    let mut all_neighbors: HashMap<String, Vec<Value>> = if cache_valid {
+        cache
+            .as_ref()
+            .and_then(|c| c["neighbors"].as_object())
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, v)| v.as_array().map(|arr| (k.clone(), arr.clone())))
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        HashMap::new()
+    };
+
+    let missing_entry_ids: Vec<i64> = wanted
+        .iter()
+        .filter(|&&eid| !all_neighbors.contains_key(&eid.to_string()))
+        .copied()
+        .collect();
+
+    let mut skipped_entry_ids: Vec<i64> = vec![];
+    let mut computed_pairs: usize = 0;
+
+    if !missing_entry_ids.is_empty() {
+        let (computed_map, skipped, pairs) = compute_neighbors(
+            &rows,
+            &missing_entry_ids,
+            CACHE_NEIGHBORS,
+            MAX_COMPUTE_PAIRS,
+        );
+        computed_pairs = pairs;
+        skipped_entry_ids = skipped;
+
+        for (source_id, neighbors) in computed_map {
+            let neighbor_values: Vec<Value> = neighbors
+                .into_iter()
+                .map(|n| {
+                    json!({
+                        "id": n.id,
+                        "title": n.title,
+                        "category": n.category,
+                        "score": n.score,
+                    })
+                })
+                .collect();
+            all_neighbors.insert(source_id.to_string(), neighbor_values);
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        // Build a serde_json::Value for the neighbors map to avoid BTreeMap ordering issues.
+        let neighbors_value: serde_json::Map<String, Value> = all_neighbors
+            .iter()
+            .map(|(k, v)| (k.clone(), Value::Array(v.clone())))
+            .collect();
+
+        let cache_data = json!({
+            "fingerprint": fingerprint,
+            "count": embedding_count,
+            "neighbors": neighbors_value,
+            "generated_at": now,
+            "max_cached_k": CACHE_NEIGHBORS,
+        });
+        save_cache(&cache_data, &cache_path);
+    }
+
+    let cached = cache_valid && missing_entry_ids.is_empty();
+
+    let results: Vec<Value> = wanted
+        .iter()
+        .map(|&eid| {
+            let key = eid.to_string();
+            let all_for_entry = all_neighbors.get(&key).cloned().unwrap_or_default();
+            let neighbors: Vec<Value> = all_for_entry.into_iter().take(k).collect();
+            json!({"entry_id": eid, "neighbors": neighbors})
+        })
+        .collect();
+
+    json!({
+        "results": results,
+        "meta": {
+            "method": "cosine_knn",
+            "k": k,
+            "embedding_count": embedding_count,
+            "cached": cached,
+            "invalidation": "sha256(source_id,dimensions,vector,title,category)",
+            "fingerprint_prefix": &fingerprint[..16.min(fingerprint.len())],
+            "cache_scope": "per_entry_topk",
+            "max_cached_k": CACHE_NEIGHBORS,
+            "computed_pairs": computed_pairs,
+            "degraded": !skipped_entry_ids.is_empty(),
+            "skipped_entry_ids": skipped_entry_ids,
+        }
+    })
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+/// `GET /api/graph/similarity`
+///
+/// Mirrors `browse/routes/graph.py::handle_api_graph_similarity`.
+///
+/// Query params:
+/// - `entry_id` — repeated and/or CSV; positive ints only; de-duped; capped at 200.
+/// - `k` — neighbor count (default 5, clamped 1..=50).
+pub async fn handler(
+    State(db): State<Arc<BrowseDb>>,
+    State(config): State<Arc<ServerConfig>>,
+    RawQuery(raw_query): RawQuery,
+) -> Response {
+    let qs = raw_query.unwrap_or_default();
+    let params = parse_raw_query(&qs);
+
+    let entry_id_values: Vec<String> = params.get("entry_id").cloned().unwrap_or_default();
+    let entry_ids_all = parse_entry_ids(&entry_id_values);
+    let wanted: Vec<i64> = entry_ids_all
+        .into_iter()
+        .take(MAX_REQUESTED_ENTRY_IDS)
+        .collect();
+
+    let k_raw = params
+        .get("k")
+        .and_then(|v| v.first())
+        .cloned()
+        .unwrap_or_default();
+    let k: usize = k_raw.parse::<i64>().unwrap_or(5).clamp(1, MAX_K as i64) as usize;
+
+    let cache_path = resolve_cache_path(&config);
+
+    let result =
+        tokio::task::spawn_blocking(move || get_similarity_inner(&db, wanted, k, cache_path)).await;
+
+    match result {
+        Ok(data) => (StatusCode::OK, axum::Json(data)).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}

--- a/sk-rust/src/browse/api/similarity.rs
+++ b/sk-rust/src/browse/api/similarity.rs
@@ -57,7 +57,11 @@ fn percent_decode(s: &str) -> String {
                 continue;
             }
         }
-        out.push(if bytes[i] == b'+' { ' ' } else { bytes[i] as char });
+        out.push(if bytes[i] == b'+' {
+            ' '
+        } else {
+            bytes[i] as char
+        });
         i += 1;
     }
     out

--- a/sk-rust/src/browse/db.rs
+++ b/sk-rust/src/browse/db.rs
@@ -1104,6 +1104,57 @@ impl BrowseDb {
             .collect();
         Ok(rows)
     }
+
+    /// Fetch all embedding rows needed by `GET /api/graph/similarity`.
+    ///
+    /// SQL mirrors Python `_load_rows`:
+    /// ```sql
+    /// SELECT e.id, e.source_id, e.dimensions, e.vector, ke.title, ke.category
+    /// FROM embeddings e
+    /// LEFT JOIN knowledge_entries ke ON ke.id = e.source_id
+    /// WHERE e.source_type = 'knowledge' AND e.vector IS NOT NULL
+    /// ORDER BY e.source_id ASC, e.id DESC
+    /// ```
+    ///
+    /// Returns `Ok(vec![])` when the `embeddings` table does not exist.
+    #[allow(clippy::type_complexity)]
+    pub fn list_embeddings_for_similarity(
+        &self,
+    ) -> anyhow::Result<Vec<(i64, i64, i64, Vec<u8>, Option<String>, Option<String>)>> {
+        let conn = self.read_pool.get()?;
+        // Guard: return empty when embeddings table is absent.
+        let exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='embeddings'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        if exists == 0 {
+            return Ok(vec![]);
+        }
+        let mut stmt = conn.prepare(
+            "SELECT e.id, e.source_id, e.dimensions, e.vector, ke.title, ke.category \
+             FROM embeddings e \
+             LEFT JOIN knowledge_entries ke ON ke.id = e.source_id \
+             WHERE e.source_type = 'knowledge' AND e.vector IS NOT NULL \
+             ORDER BY e.source_id ASC, e.id DESC",
+        )?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, i64>(1)?,
+                    r.get::<_, i64>(2)?,
+                    r.get::<_, Vec<u8>>(3)?,
+                    r.get::<_, Option<String>>(4)?,
+                    r.get::<_, Option<String>>(5)?,
+                ))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
 }
 
 #[cfg(test)]

--- a/sk-rust/src/browse/server.rs
+++ b/sk-rust/src/browse/server.rs
@@ -38,6 +38,10 @@ pub struct ServerConfig {
     pub cors_origins: Vec<String>,
     /// Whether to trust `X-Forwarded-*` / `X-Forwarded-Ssl` proxy headers.
     pub trusted_proxy: bool,
+    /// Override path for the similarity cache JSON file.
+    /// `None` → falls back to `BROWSE_SIMILARITY_CACHE_PATH` env var or
+    /// `~/.copilot/session-state/embeddings_similarity_cache.json`.
+    pub similarity_cache_path: Option<std::path::PathBuf>,
 }
 
 impl Default for ServerConfig {
@@ -49,6 +53,7 @@ impl Default for ServerConfig {
             static_root: std::path::PathBuf::new(),
             cors_origins: Vec::new(),
             trusted_proxy: false,
+            similarity_cache_path: None,
         }
     }
 }
@@ -76,6 +81,9 @@ impl ServerConfig {
                 .unwrap_or_default(),
             cors_origins,
             trusted_proxy,
+            similarity_cache_path: std::env::var("BROWSE_SIMILARITY_CACHE_PATH")
+                .ok()
+                .map(std::path::PathBuf::from),
         }
     }
 }
@@ -145,6 +153,10 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/api/graph/communities",
             get(crate::browse::api::graph::communities_handler),
+        )
+        .route(
+            "/api/graph/similarity",
+            get(crate::browse::api::similarity::handler),
         )
         // ── Operator API (issue #451 PR-A) ──────────────────────────────
         .route(

--- a/sk-rust/tests/browse_server_test.rs
+++ b/sk-rust/tests/browse_server_test.rs
@@ -58,6 +58,7 @@ fn open_config() -> Arc<ServerConfig> {
         static_root: std::path::PathBuf::new(),
         cors_origins: vec!["https://allowed.example".to_string()],
         trusted_proxy: false,
+        similarity_cache_path: None,
     })
 }
 

--- a/sk-rust/tests/browse_similarity_api_test.rs
+++ b/sk-rust/tests/browse_similarity_api_test.rs
@@ -1,0 +1,645 @@
+//! Integration tests for `GET /api/graph/similarity` (issue #452).
+//!
+//! All tests set `BROWSE_SIMILARITY_CACHE_PATH` to a tempfile path to avoid
+//! touching the real `~/.copilot/session-state/` directory.
+
+#![cfg(feature = "browse-server")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use rusqlite::Connection;
+use tower::ServiceExt;
+
+use sk::browse::db::{BrowseDb, BrowseDbConfig};
+use sk::browse::server::{app, AppState, ServerConfig};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn counter() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    CTR.fetch_add(1, Ordering::SeqCst)
+}
+
+fn temp_path(label: &str) -> std::path::PathBuf {
+    let n = counter();
+    std::env::temp_dir().join(format!("sk_sim_test_{label}_{n}_{}.db", std::process::id()))
+}
+
+fn seeded_db(label: &str, sql: &str) -> (std::path::PathBuf, Arc<BrowseDb>) {
+    let path = temp_path(label);
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(sql).unwrap();
+    }
+    let cfg = BrowseDbConfig {
+        path: path.clone(),
+        checkpoint_interval: None,
+        ..Default::default()
+    };
+    (
+        path,
+        Arc::new(BrowseDb::new_without_checkpoint(cfg).unwrap()),
+    )
+}
+
+#[allow(dead_code)]
+fn test_app(db: Arc<BrowseDb>) -> axum::Router {
+    app(AppState::new(Arc::new(ServerConfig::default()), db))
+}
+
+/// Build a test router with a specific similarity cache path (no env-var races).
+fn test_app_with_cache(db: Arc<BrowseDb>, cache_path: &str) -> axum::Router {
+    let config = ServerConfig {
+        similarity_cache_path: Some(std::path::PathBuf::from(cache_path)),
+        ..ServerConfig::default()
+    };
+    app(AppState::new(Arc::new(config), db))
+}
+
+/// Issue `GET /api/graph/similarity?{qs}` and return (status, body).
+async fn get_sim(db: Arc<BrowseDb>, qs: &str, cache_path: &str) -> (StatusCode, serde_json::Value) {
+    let uri = if qs.is_empty() {
+        "/api/graph/similarity".to_string()
+    } else {
+        format!("/api/graph/similarity?{qs}")
+    };
+    let response = test_app_with_cache(db, cache_path)
+        .oneshot(Request::builder().uri(&uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    (status, body)
+}
+
+/// Unique temp file path for a cache JSON (not a DB).
+fn temp_cache_path(label: &str) -> String {
+    let n = counter();
+    std::env::temp_dir()
+        .join(format!(
+            "sk_sim_cache_{label}_{n}_{}.json",
+            std::process::id()
+        ))
+        .to_string_lossy()
+        .to_string()
+}
+
+// ── Base DB SQL ───────────────────────────────────────────────────────────────
+
+/// Minimal DB: schema_version + knowledge_entries only (no embeddings table).
+const NO_EMBEDDINGS_TABLE_SQL: &str = "PRAGMA journal_mode=WAL;\
+    CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');\
+    CREATE TABLE IF NOT EXISTS knowledge_entries (\
+      id INTEGER PRIMARY KEY AUTOINCREMENT,\
+      category TEXT NOT NULL DEFAULT '',\
+      title TEXT NOT NULL DEFAULT '',\
+      content TEXT NOT NULL DEFAULT '',\
+      tags TEXT NOT NULL DEFAULT '',\
+      wing TEXT, room TEXT,\
+      confidence REAL NOT NULL DEFAULT 0.5,\
+      deleted_at INTEGER\
+    );\
+    INSERT INTO schema_version VALUES (1,'test');";
+
+/// DB with embeddings table but no rows.
+const EMPTY_EMBEDDINGS_SQL: &str = "PRAGMA journal_mode=WAL;\
+    CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');\
+    CREATE TABLE IF NOT EXISTS knowledge_entries (\
+      id INTEGER PRIMARY KEY AUTOINCREMENT,\
+      category TEXT NOT NULL DEFAULT '',\
+      title TEXT NOT NULL DEFAULT '',\
+      content TEXT NOT NULL DEFAULT '',\
+      tags TEXT NOT NULL DEFAULT '',\
+      wing TEXT, room TEXT,\
+      confidence REAL NOT NULL DEFAULT 0.5,\
+      deleted_at INTEGER\
+    );\
+    CREATE TABLE IF NOT EXISTS embeddings (\
+      id INTEGER PRIMARY KEY AUTOINCREMENT,\
+      source_id INTEGER NOT NULL,\
+      source_type TEXT NOT NULL DEFAULT 'knowledge',\
+      dimensions INTEGER NOT NULL,\
+      vector BLOB\
+    );\
+    INSERT INTO schema_version VALUES (1,'test');";
+
+// ── Helper: encode f32 LE blob ─────────────────────────────────────────────────
+
+fn f32_blob(values: &[f32]) -> Vec<u8> {
+    values.iter().flat_map(|v| v.to_le_bytes()).collect()
+}
+
+/// Build SQL to create the full DB schema with embeddings and a set of entries/embeddings.
+///
+/// `entries` is a list of `(id, title, category)`.
+/// `embeddings` is a list of `(id, source_id, dims, f32_values)`.
+fn build_full_db_sql(
+    entries: &[(i64, &str, &str)],
+    embeds: &[(i64, i64, i64, Vec<f32>)],
+) -> String {
+    let mut sql = "PRAGMA journal_mode=WAL;\
+        CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, name TEXT DEFAULT '');\
+        CREATE TABLE IF NOT EXISTS knowledge_entries (\
+          id INTEGER PRIMARY KEY,\
+          category TEXT NOT NULL DEFAULT '',\
+          title TEXT NOT NULL DEFAULT '',\
+          content TEXT NOT NULL DEFAULT '',\
+          tags TEXT NOT NULL DEFAULT '',\
+          wing TEXT, room TEXT,\
+          confidence REAL NOT NULL DEFAULT 0.5,\
+          deleted_at INTEGER\
+        );\
+        CREATE TABLE IF NOT EXISTS embeddings (\
+          id INTEGER PRIMARY KEY,\
+          source_id INTEGER NOT NULL,\
+          source_type TEXT NOT NULL DEFAULT 'knowledge',\
+          dimensions INTEGER NOT NULL,\
+          vector BLOB\
+        );\
+        INSERT INTO schema_version VALUES (1,'test');"
+        .to_string();
+
+    for (id, title, cat) in entries {
+        sql.push_str(&format!(
+            "INSERT INTO knowledge_entries (id, title, category, content, tags) VALUES ({id}, '{title}', '{cat}', '', '');",
+        ));
+    }
+    for (id, src, dims, vals) in embeds {
+        let blob = f32_blob(vals);
+        // Encode blob as hex for SQL literal X'...'
+        let hex: String = blob.iter().map(|b| format!("{b:02X}")).collect();
+        sql.push_str(&format!(
+            "INSERT INTO embeddings (id, source_id, source_type, dimensions, vector) \
+             VALUES ({id}, {src}, 'knowledge', {dims}, X'{hex}');",
+        ));
+    }
+    sql
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Empty DB (no embeddings table) → abbreviated meta, no fingerprint/computed/skipped/degraded.
+#[tokio::test]
+async fn empty_db_abbreviated_meta() {
+    let (_, db) = seeded_db("empty_meta", NO_EMBEDDINGS_TABLE_SQL);
+    let cache = temp_cache_path("empty_meta");
+    let (status, body) = get_sim(db, "entry_id=1&k=3", &cache).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let meta = &body["meta"];
+    assert_eq!(meta["method"], "cosine_knn");
+    assert_eq!(meta["k"], 3);
+    assert_eq!(meta["embedding_count"], 0);
+    assert_eq!(meta["cached"], false);
+    assert_eq!(
+        meta["invalidation"],
+        "sha256(source_id,dimensions,vector,title,category)"
+    );
+    assert_eq!(meta["cache_scope"], "per_entry_topk");
+    assert_eq!(meta["max_cached_k"], 50);
+    // Abbreviated meta must NOT contain these fields.
+    assert!(
+        meta.get("fingerprint_prefix").is_none(),
+        "no fingerprint_prefix in empty meta"
+    );
+    assert!(
+        meta.get("computed_pairs").is_none(),
+        "no computed_pairs in empty meta"
+    );
+    assert!(
+        meta.get("skipped_entry_ids").is_none(),
+        "no skipped_entry_ids in empty meta"
+    );
+    assert!(meta.get("degraded").is_none(), "no degraded in empty meta");
+}
+
+/// Missing embeddings table returns empty results for all requested IDs.
+#[tokio::test]
+async fn missing_embeddings_table_returns_empty() {
+    let (_, db) = seeded_db("no_table", NO_EMBEDDINGS_TABLE_SQL);
+    let cache = temp_cache_path("no_table");
+    let (status, body) = get_sim(db, "entry_id=5&entry_id=10", &cache).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let results = body["results"].as_array().unwrap();
+    assert_eq!(results.len(), 2);
+    for r in results {
+        assert_eq!(r["neighbors"].as_array().unwrap().len(), 0);
+    }
+}
+
+/// `k` is clamped to [1, 50]: values below 1 become 1, above 50 become 50.
+#[tokio::test]
+async fn k_clamped_to_1_50() {
+    let entries = vec![(1, "e1", "pattern"), (2, "e2", "mistake")];
+    let embeds = vec![
+        (1, 1i64, 2i64, vec![1.0f32, 0.0f32]),
+        (2, 2i64, 2i64, vec![0.0f32, 1.0f32]),
+    ];
+    let sql = build_full_db_sql(&entries, &embeds);
+    let (_, db) = seeded_db("k_clamp", &sql);
+    let cache = temp_cache_path("k_clamp");
+
+    // k=0 → clamped to 1
+    let (_, body0) = get_sim(Arc::clone(&db), "entry_id=1&k=0", &cache).await;
+    assert_eq!(body0["meta"]["k"], 1);
+
+    // k=100 → clamped to 50
+    let (_, body100) = get_sim(Arc::clone(&db), "entry_id=1&k=100", &cache).await;
+    assert_eq!(body100["meta"]["k"], 50);
+
+    // k=5 → unchanged
+    let (_, body5) = get_sim(Arc::clone(&db), "entry_id=1&k=5", &cache).await;
+    assert_eq!(body5["meta"]["k"], 5);
+}
+
+/// Repeated `entry_id` params and CSV values are parsed, de-duped, order preserved.
+#[tokio::test]
+async fn repeated_and_csv_entry_id_order_preserved() {
+    let (_, db) = seeded_db("csv_ids", EMPTY_EMBEDDINGS_SQL);
+    let cache = temp_cache_path("csv_ids");
+    // entry_id=3&entry_id=1,2&entry_id=3 → unique ordered [3,1,2]
+    let (status, body) = get_sim(db, "entry_id=3&entry_id=1%2C2&entry_id=3", &cache).await;
+    assert_eq!(status, StatusCode::OK);
+    let results = body["results"].as_array().unwrap();
+    // Ordered: 3, 1, 2 (first-seen, deduped)
+    let ids: Vec<i64> = results
+        .iter()
+        .map(|r| r["entry_id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(ids, vec![3, 1, 2]);
+}
+
+/// Non-positive IDs (0, negatives) are filtered out.
+#[tokio::test]
+async fn non_positive_ids_filtered() {
+    let (_, db) = seeded_db("neg_ids", EMPTY_EMBEDDINGS_SQL);
+    let cache = temp_cache_path("neg_ids");
+    let (status, body) = get_sim(db, "entry_id=0&entry_id=-1&entry_id=5", &cache).await;
+    assert_eq!(status, StatusCode::OK);
+    let results = body["results"].as_array().unwrap();
+    // Only id=5 survives
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["entry_id"], 5);
+}
+
+/// Unknown entry ID (not in embeddings) returns empty neighbors.
+#[tokio::test]
+async fn unknown_entry_id_returns_empty_neighbors() {
+    let entries = vec![(1, "e1", "pattern")];
+    let embeds = vec![(1, 1i64, 2i64, vec![1.0f32, 0.0f32])];
+    let sql = build_full_db_sql(&entries, &embeds);
+    let (_, db) = seeded_db("unknown_id", &sql);
+    let cache = temp_cache_path("unknown_id");
+
+    let (status, body) = get_sim(db, "entry_id=999", &cache).await;
+    assert_eq!(status, StatusCode::OK);
+    let results = body["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["entry_id"], 999);
+    assert_eq!(results[0]["neighbors"].as_array().unwrap().len(), 0);
+}
+
+/// Equal-score neighbors: tie-break by smaller entry_id (comes first).
+#[tokio::test]
+async fn tiebreak_by_smaller_id() {
+    // Entry 1: [1,0] — querying for its neighbors
+    // Entry 30 and 20 both have vector [1,0] → cosine = 1.0 for both
+    // Tie-break: 20 < 30, so 20 comes first
+    let entries = vec![
+        (1, "src", "pattern"),
+        (20, "tied-low", "pattern"),
+        (30, "tied-high", "pattern"),
+    ];
+    let embeds = vec![
+        (1, 1i64, 2i64, vec![1.0f32, 0.0f32]),
+        (2, 20i64, 2i64, vec![1.0f32, 0.0f32]),
+        (3, 30i64, 2i64, vec![1.0f32, 0.0f32]),
+    ];
+    let sql = build_full_db_sql(&entries, &embeds);
+    let (_, db) = seeded_db("tiebreak", &sql);
+    let cache = temp_cache_path("tiebreak");
+
+    let (status, body) = get_sim(db, "entry_id=1&k=2", &cache).await;
+    assert_eq!(status, StatusCode::OK);
+    let neighbors = body["results"][0]["neighbors"].as_array().unwrap();
+    assert_eq!(neighbors.len(), 2);
+    assert_eq!(neighbors[0]["id"], 20);
+    assert_eq!(neighbors[1]["id"], 30);
+}
+
+/// Cache is written atomically — no `.tmp` file left after the call.
+#[tokio::test]
+async fn cache_written_atomically_no_tmp_left() {
+    let entries = vec![
+        (1, "e1", "pattern"),
+        (2, "e2", "mistake"),
+        (3, "e3", "decision"),
+    ];
+    let embeds = vec![
+        (1, 1i64, 2i64, vec![1.0f32, 0.0f32]),
+        (2, 2i64, 2i64, vec![0.0f32, 1.0f32]),
+        (3, 3i64, 2i64, vec![0.7f32, 0.7f32]),
+    ];
+    let sql = build_full_db_sql(&entries, &embeds);
+    let (_, db) = seeded_db("atomic", &sql);
+    let cache = temp_cache_path("atomic");
+
+    let (status, _body) = get_sim(db, "entry_id=1", &cache).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Cache file should exist.
+    assert!(
+        std::path::Path::new(&cache).exists(),
+        "cache file must exist after first call"
+    );
+    // No .tmp file should remain.
+    let tmp = format!("{cache}.tmp");
+    assert!(
+        !std::path::Path::new(&tmp).exists(),
+        "no .tmp file should remain after atomic write"
+    );
+}
+
+/// Second identical call sets `meta.cached = true` and `computed_pairs = 0`.
+#[tokio::test]
+async fn second_call_cache_hit() {
+    let entries = vec![
+        (1, "e1", "pattern"),
+        (2, "e2", "mistake"),
+        (3, "e3", "decision"),
+    ];
+    let embeds = vec![
+        (1, 1i64, 2i64, vec![1.0f32, 0.0f32]),
+        (2, 2i64, 2i64, vec![0.0f32, 1.0f32]),
+        (3, 3i64, 2i64, vec![0.7f32, 0.7f32]),
+    ];
+    let sql = build_full_db_sql(&entries, &embeds);
+    let (_, db) = seeded_db("cache_hit", &sql);
+    let cache = temp_cache_path("cache_hit");
+
+    // First call — should compute.
+    let (_, body1) = get_sim(Arc::clone(&db), "entry_id=1", &cache).await;
+    assert_eq!(body1["meta"]["cached"], false);
+
+    // Second call — same DB, same entry_id → cache hit.
+    let (_, body2) = get_sim(Arc::clone(&db), "entry_id=1", &cache).await;
+    assert_eq!(body2["meta"]["cached"], true);
+    assert_eq!(body2["meta"]["computed_pairs"], 0);
+}
+
+/// Cache is invalidated when embedding data changes.
+#[tokio::test]
+async fn cache_invalidated_on_row_change() {
+    let entries = vec![(1, "e1", "pattern"), (2, "e2", "mistake")];
+    let embeds = vec![
+        (1, 1i64, 2i64, vec![1.0f32, 0.0f32]),
+        (2, 2i64, 2i64, vec![0.0f32, 1.0f32]),
+    ];
+    let sql = build_full_db_sql(&entries, &embeds);
+    let (db_path, db) = seeded_db("cache_invalid", &sql);
+    let cache = temp_cache_path("cache_invalid");
+
+    // First call — computes and caches.
+    let (_, body1) = get_sim(Arc::clone(&db), "entry_id=1", &cache).await;
+    assert_eq!(body1["meta"]["cached"], false);
+
+    // Modify the embedding (add a new entry) using a separate connection.
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "INSERT INTO knowledge_entries (id, title, category, content, tags) \
+             VALUES (3, 'e3', 'discovery', '', ''); \
+             INSERT INTO embeddings (id, source_id, source_type, dimensions, vector) \
+             VALUES (3, 3, 'knowledge', 2, X'0000803F00000000');",
+        )
+        .unwrap();
+    }
+
+    // Second call — fingerprint changed → cache miss.
+    let (_, body2) = get_sim(Arc::clone(&db), "entry_id=1", &cache).await;
+    assert_eq!(body2["meta"]["cached"], false);
+}
+
+/// Partial cache hit: second call with a new entry_id recomputes missing IDs
+/// while preserving the cached entry's neighbors.
+#[tokio::test]
+async fn partial_cache_hit() {
+    let entries = vec![
+        (1, "e1", "pattern"),
+        (2, "e2", "mistake"),
+        (3, "e3", "decision"),
+    ];
+    let embeds = vec![
+        (1, 1i64, 2i64, vec![1.0f32, 0.0f32]),
+        (2, 2i64, 2i64, vec![0.0f32, 1.0f32]),
+        (3, 3i64, 2i64, vec![0.7f32, 0.7f32]),
+    ];
+    let sql = build_full_db_sql(&entries, &embeds);
+    let (_, db) = seeded_db("partial_cache", &sql);
+    let cache = temp_cache_path("partial_cache");
+
+    // First call: compute neighbors for entry_id=1.
+    let (_, body1) = get_sim(Arc::clone(&db), "entry_id=1", &cache).await;
+    assert_eq!(body1["meta"]["cached"], false);
+    let neighbors1_first: Vec<i64> = body1["results"][0]["neighbors"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|n| n["id"].as_i64().unwrap())
+        .collect();
+
+    // Second call: request entry_id=1 (cached) AND entry_id=2 (missing).
+    let (_, body2) = get_sim(Arc::clone(&db), "entry_id=1&entry_id=2", &cache).await;
+    // Not fully cached (entry_id=2 was missing).
+    assert_eq!(body2["meta"]["cached"], false);
+    // entry_id=1 neighbors should be the same as before.
+    let neighbors1_second: Vec<i64> = body2["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["entry_id"] == 1)
+        .unwrap()["neighbors"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|n| n["id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(
+        neighbors1_first, neighbors1_second,
+        "cached entry_id=1 neighbors must be preserved"
+    );
+    // entry_id=2 should have neighbors now.
+    let neighbors2: &serde_json::Value = body2["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["entry_id"] == 2)
+        .unwrap();
+    assert!(
+        !neighbors2["neighbors"].as_array().unwrap().is_empty(),
+        "entry_id=2 should have computed neighbors"
+    );
+}
+
+/// Python parity golden: known unit vectors → exact neighbor ids and scores within ±0.001.
+///
+/// Vectors (unit vectors):
+///   e1 = [1.0, 0.0]
+///   e2 = [0.6, 0.8]   cosine(e1,e2) = 0.6
+///   e3 = [0.0, 1.0]   cosine(e1,e3) = 0.0
+///   e4 = [0.8, 0.6]   cosine(e1,e4) = 0.8
+///
+/// For e1, top-3 neighbors: e4(0.8), e2(0.6), e3(0.0).
+#[tokio::test]
+async fn python_parity_golden_scores() {
+    let entries = vec![
+        (1, "e1", "pattern"),
+        (2, "e2", "mistake"),
+        (3, "e3", "decision"),
+        (4, "e4", "discovery"),
+    ];
+    let embeds = vec![
+        (1, 1i64, 2i64, vec![1.0f32, 0.0f32]),
+        (2, 2i64, 2i64, vec![0.6f32, 0.8f32]),
+        (3, 3i64, 2i64, vec![0.0f32, 1.0f32]),
+        (4, 4i64, 2i64, vec![0.8f32, 0.6f32]),
+    ];
+    let sql = build_full_db_sql(&entries, &embeds);
+    let (_, db) = seeded_db("golden", &sql);
+    let cache = temp_cache_path("golden");
+
+    let (status, body) = get_sim(db, "entry_id=1&k=3", &cache).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let results = body["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    let neighbors = results[0]["neighbors"].as_array().unwrap();
+    assert_eq!(neighbors.len(), 3);
+
+    // Expected: e4 (0.8), e2 (0.6), e3 (0.0) — exact IDs and scores within 0.001.
+    assert_eq!(neighbors[0]["id"], 4);
+    assert!(
+        (neighbors[0]["score"].as_f64().unwrap() - 0.8).abs() < 0.001,
+        "e4 score expected ~0.8, got {}",
+        neighbors[0]["score"]
+    );
+    assert_eq!(neighbors[1]["id"], 2);
+    assert!(
+        (neighbors[1]["score"].as_f64().unwrap() - 0.6).abs() < 0.001,
+        "e2 score expected ~0.6, got {}",
+        neighbors[1]["score"]
+    );
+    assert_eq!(neighbors[2]["id"], 3);
+    assert!(
+        (neighbors[2]["score"].as_f64().unwrap() - 0.0).abs() < 0.001,
+        "e3 score expected ~0.0, got {}",
+        neighbors[2]["score"]
+    );
+}
+
+/// Degraded mode: pair budget exceeded → `degraded=true`, `skipped_entry_ids` non-empty.
+///
+/// With 4 rows, pairs_per_source = 3. max_pairs = 3 allows only 1 source.
+/// Requesting 2 sources: 1 computed, 1 skipped → degraded=true.
+#[tokio::test]
+async fn degraded_over_pair_budget() {
+    // 4 rows → pairs_per_source = 3
+    // MAX_COMPUTE_PAIRS would be too large; we bypass it by seeding exactly enough rows
+    // for the Python math: max_pairs=3 → allowed=max(1,3/3)=1.
+    // We cannot set max_pairs from the handler directly, but we can construct a case
+    // where the default 250_000 pairs budget is exceeded by having enough rows.
+    // Instead, test the algo layer: inject 250_001 fake rows to force degraded.
+    // But that's too many. Use a different approach:
+    // The handler uses MAX_COMPUTE_PAIRS=250_000 with pairs_per_source=(N-1).
+    // To force degraded we need N * requested_sources > 250_000.
+    // With N=251 rows and 2 requested sources: pairs_per_source=250, 250_000/250=1000 allowed.
+    // That won't work. Let's verify the algo is tested separately (it is in browse_algo_test.rs).
+    // For the integration test, just verify the meta fields are present and correct when not degraded.
+    // The degraded=true path requires manipulating MAX_COMPUTE_PAIRS which is a const.
+    // We verify non-degraded shape here; the algo unit test covers the degraded budget logic.
+    let entries = vec![(1, "e1", "pattern"), (2, "e2", "mistake")];
+    let embeds = vec![
+        (1, 1i64, 2i64, vec![1.0f32, 0.0f32]),
+        (2, 2i64, 2i64, vec![0.0f32, 1.0f32]),
+    ];
+    let sql = build_full_db_sql(&entries, &embeds);
+    let (_, db) = seeded_db("degraded", &sql);
+    let cache = temp_cache_path("degraded");
+
+    let (status, body) = get_sim(db, "entry_id=1", &cache).await;
+    assert_eq!(status, StatusCode::OK);
+    // Non-degraded case: degraded=false, skipped_entry_ids=[]
+    assert_eq!(body["meta"]["degraded"], false);
+    assert_eq!(
+        body["meta"]["skipped_entry_ids"].as_array().unwrap().len(),
+        0
+    );
+    assert!(body["meta"]["computed_pairs"].as_i64().unwrap() >= 0);
+}
+
+/// `meta.skipped_entry_ids` and `meta.degraded` are present in non-empty response.
+#[tokio::test]
+async fn non_empty_meta_has_all_fields() {
+    let entries = vec![(1, "e1", "pattern"), (2, "e2", "mistake")];
+    let embeds = vec![
+        (1, 1i64, 2i64, vec![1.0f32, 0.0f32]),
+        (2, 2i64, 2i64, vec![0.0f32, 1.0f32]),
+    ];
+    let sql = build_full_db_sql(&entries, &embeds);
+    let (_, db) = seeded_db("all_fields", &sql);
+    let cache = temp_cache_path("all_fields");
+
+    let (status, body) = get_sim(db, "entry_id=1&k=2", &cache).await;
+    assert_eq!(status, StatusCode::OK);
+    let meta = &body["meta"];
+    assert_eq!(meta["method"], "cosine_knn");
+    assert!(meta["k"].is_number());
+    assert!(meta["embedding_count"].is_number());
+    assert!(meta["cached"].is_boolean());
+    assert_eq!(
+        meta["invalidation"],
+        "sha256(source_id,dimensions,vector,title,category)"
+    );
+    assert!(meta["fingerprint_prefix"].is_string());
+    assert_eq!(meta["fingerprint_prefix"].as_str().unwrap().len(), 16);
+    assert_eq!(meta["cache_scope"], "per_entry_topk");
+    assert_eq!(meta["max_cached_k"], 50);
+    assert!(meta["computed_pairs"].is_number());
+    assert!(meta["degraded"].is_boolean());
+    assert!(meta["skipped_entry_ids"].is_array());
+}
+
+/// Title defaults to `entry-{source_id}` when `knowledge_entries` row is absent.
+#[tokio::test]
+async fn title_default_when_no_ke_row() {
+    // Insert embedding but no matching knowledge_entries row.
+    let sql = format!(
+        "{}{}",
+        EMPTY_EMBEDDINGS_SQL,
+        "INSERT INTO embeddings (id, source_id, source_type, dimensions, vector) \
+         VALUES (1, 42, 'knowledge', 2, X'0000803F00000000');\
+         INSERT INTO embeddings (id, source_id, source_type, dimensions, vector) \
+         VALUES (2, 43, 'knowledge', 2, X'0000003F0000003F');"
+    );
+    let (_, db) = seeded_db("title_default", &sql);
+    let cache = temp_cache_path("title_default");
+
+    let (status, body) = get_sim(db, "entry_id=42&k=1", &cache).await;
+    assert_eq!(status, StatusCode::OK);
+    let neighbors = body["results"][0]["neighbors"].as_array().unwrap();
+    if !neighbors.is_empty() {
+        let title = neighbors[0]["title"].as_str().unwrap();
+        assert_eq!(
+            title, "entry-43",
+            "title must default to entry-{{source_id}}"
+        );
+        let category = neighbors[0]["category"].as_str().unwrap();
+        assert_eq!(category, "unknown", "category must default to 'unknown'");
+    }
+}

--- a/sk-rust/tests/browse_similarity_api_test.rs
+++ b/sk-rust/tests/browse_similarity_api_test.rs
@@ -1,7 +1,8 @@
 //! Integration tests for `GET /api/graph/similarity` (issue #452).
 //!
-//! All tests set `BROWSE_SIMILARITY_CACHE_PATH` to a tempfile path to avoid
-//! touching the real `~/.copilot/session-state/` directory.
+//! All tests inject `ServerConfig.similarity_cache_path` with a unique tempfile
+//! path to avoid touching the real `~/.copilot/session-state/` directory and to
+//! prevent env-var races between parallel test threads.
 
 #![cfg(feature = "browse-server")]
 
@@ -543,26 +544,15 @@ async fn python_parity_golden_scores() {
     );
 }
 
-/// Degraded mode: pair budget exceeded → `degraded=true`, `skipped_entry_ids` non-empty.
+/// Non-degraded meta shape with a small DB (pair budget far from exceeded).
 ///
-/// With 4 rows, pairs_per_source = 3. max_pairs = 3 allows only 1 source.
-/// Requesting 2 sources: 1 computed, 1 skipped → degraded=true.
+/// The `degraded=true` path requires exceeding `MAX_COMPUTE_PAIRS` (250 000), which
+/// cannot be forced from integration tests because the constant is not injectable.
+/// That path is covered by the algo unit tests in `browse_algo_test.rs`.
+/// This test verifies the non-degraded response shape: `degraded=false`,
+/// `skipped_entry_ids` is an empty array, and `computed_pairs` is a non-negative integer.
 #[tokio::test]
-async fn degraded_over_pair_budget() {
-    // 4 rows → pairs_per_source = 3
-    // MAX_COMPUTE_PAIRS would be too large; we bypass it by seeding exactly enough rows
-    // for the Python math: max_pairs=3 → allowed=max(1,3/3)=1.
-    // We cannot set max_pairs from the handler directly, but we can construct a case
-    // where the default 250_000 pairs budget is exceeded by having enough rows.
-    // Instead, test the algo layer: inject 250_001 fake rows to force degraded.
-    // But that's too many. Use a different approach:
-    // The handler uses MAX_COMPUTE_PAIRS=250_000 with pairs_per_source=(N-1).
-    // To force degraded we need N * requested_sources > 250_000.
-    // With N=251 rows and 2 requested sources: pairs_per_source=250, 250_000/250=1000 allowed.
-    // That won't work. Let's verify the algo is tested separately (it is in browse_algo_test.rs).
-    // For the integration test, just verify the meta fields are present and correct when not degraded.
-    // The degraded=true path requires manipulating MAX_COMPUTE_PAIRS which is a const.
-    // We verify non-degraded shape here; the algo unit test covers the degraded budget logic.
+async fn non_degraded_meta_shape_small_db() {
     let entries = vec![(1, "e1", "pattern"), (2, "e2", "mistake")];
     let embeds = vec![
         (1, 1i64, 2i64, vec![1.0f32, 0.0f32]),


### PR DESCRIPTION
## Summary

Implements the Rust GET /api/graph/similarity endpoint with full parity to the Python rowse/core/similarity.py::get_similarity function.

## Changes

- **lgo/similarity.rs**: decode_vector_le_f32 — decodes f32 LE blobs to Vec<f64> for cosine computation
- **db.rs**: list_embeddings_for_similarity — loads all embedding rows (guards against missing table)
- **pi/similarity.rs** (new): full handler with cache I/O, query parsing, core similarity logic
  - Cosine kNN with fingerprint-based JSON disk cache (atomic write via .tmp + rename)
  - Partial/full cache hit detection; degraded mode when pair budget exceeded
  - percent_decode for query values (%2C → , for CSV entry IDs)
  - Cache path injected via ServerConfig.similarity_cache_path (race-free tests)
- **server.rs**: route wired at /api/graph/similarity; ServerConfig.similarity_cache_path field added
- **	ests/browse_similarity_api_test.rs** (new): 15 integration tests (all passing)

## Verification

\\\
cargo check --features browse-server                                  ✓
cargo clippy --all-targets --features browse-server -- -D warnings   ✓ (0 warnings)
cargo test --features browse-server --test browse_similarity_api_test ✓ 15/15 pass
\\\

Closes part of #452 (graph similarity endpoint only).