### PR TITLE
test(#452): add CPython-parity harness for browse projection

### DIFF
--- a/sk-rust/src/browse/algo/projection.rs
+++ b/sk-rust/src/browse/algo/projection.rs
@@ -1,18 +1,24 @@
 //! Pure-Rust port of `browse/core/projection.py` — PCA-to-2D projection.
 //!
-//! No I/O, no cache, no DB, no RNG dependency.
+//! No I/O, no cache, no DB.
 //!
-//! ## Known parity differences from Python
+//! ## CPython parity
 //!
-//! 1. **Power-iteration init**: Rust uses a deterministic fixed init vector
-//!    (all-ones normalised, then second standard basis for the deflated pass)
-//!    instead of Python's `random.gauss`-seeded vector.  Eigenvectors may
-//!    therefore differ by sign.
+//! This module matches Python's `projection.pca_2d` output bit-for-bit on
+//! IEEE 754 platforms (verified by the `projection_parity_test` integration
+//! test harness):
 //!
-//! 2. **PCA sample selection**: when `n > PCA_SAMPLE`, Rust takes the *first*
-//!    `PCA_SAMPLE` centered rows; Python uses
-//!    `random.Random(99).sample(range(n), PCA_SAMPLE)`.  Projection
-//!    coordinates may differ numerically for large datasets.
+//! - **Power-iteration init**: uses `cpyrand::Random::new(seed).gauss(0.0, 1.0)`
+//!   for each dimension (seed 1 for e1, seed 2 for e2 on the deflated sample),
+//!   matching Python's `random.Random(seed).gauss(0, 1)`.
+//!
+//! - **PCA sample selection**: when `n > PCA_SAMPLE`, uses
+//!   `cpyrand::Random::new(99).sample_indices(n, PCA_SAMPLE)` preserving the
+//!   CPython `random.sample(range(n), PCA_SAMPLE)` order.
+//!
+//! - **Render-cap**: `sample_render_indices(n, max_render)` uses
+//!   `cpyrand::Random::new(42).sample_indices(n, max_render)` when
+//!   `n > max_render`, matching Python's `random.Random(42).sample(raw, MAX_RENDER)`.
 
 /// Number of rows sampled from the full data to compute eigenvectors.
 pub const PCA_SAMPLE: usize = 500;
@@ -133,8 +139,8 @@ pub fn power_iter(x: &[Vec<f64>], n_iters: usize, init: &[f64]) -> Vec<f64> {
 
 /// Project *vectors* (equal-length rows) to 2D via two-component PCA.
 ///
-/// Mirrors `projection.pca_2d` from Python.  Uses a fixed deterministic init
-/// instead of `random.gauss`; eigenvectors may differ by sign from Python.
+/// Matches `projection.pca_2d` from Python bit-for-bit on IEEE 754 platforms.
+/// Uses `cpyrand` for both power-iteration init and PCA sample selection.
 ///
 /// Returns `(xs, ys)`.
 pub fn pca_2d(vectors: &[Vec<f64>]) -> (Vec<f64>, Vec<f64>) {
@@ -167,24 +173,33 @@ pub fn pca_2d(vectors: &[Vec<f64>]) -> (Vec<f64>, Vec<f64>) {
         .map(|v| v.iter().zip(&mean).map(|(x, m)| x - m).collect())
         .collect();
 
-    // Sample for eigenvector computation (deterministic: first PCA_SAMPLE rows).
+    // Sample for eigenvector computation.
+    // Matches Python: `random.Random(99).sample(range(n), PCA_SAMPLE)`.
+    let sample_buf: Vec<Vec<f64>>;
     let sample: &[Vec<f64>] = if n > PCA_SAMPLE {
-        &centered[..PCA_SAMPLE]
+        let idxs = super::cpyrand::Random::new(99).sample_indices(n, PCA_SAMPLE);
+        sample_buf = idxs.into_iter().map(|i| centered[i].clone()).collect();
+        &sample_buf
     } else {
         &centered
     };
 
-    // First eigenvector: all-ones init (normalised inside power_iter).
-    let init_e1 = vec![1.0_f64; n_dims];
+    // First eigenvector init: matches Python `random.Random(1).gauss(0, 1)` × n_dims.
+    let init_e1: Vec<f64> = {
+        let mut rng = super::cpyrand::Random::new(1);
+        (0..n_dims).map(|_| rng.gauss(0.0, 1.0)).collect()
+    };
     let e1 = power_iter(sample, POWER_ITERS, &init_e1);
     if norm(&e1) < 1e-12 {
         return (vec![0.0_f64; n], vec![0.0_f64; n]);
     }
 
-    // Second eigenvector: deflate then use the second standard basis vector.
+    // Second eigenvector init on the deflated sample: seed 2.
     let sample_d = deflate(sample, &e1);
-    let mut init_e2 = vec![0.0_f64; n_dims];
-    init_e2[1] = 1.0; // second standard basis
+    let init_e2: Vec<f64> = {
+        let mut rng = super::cpyrand::Random::new(2);
+        (0..n_dims).map(|_| rng.gauss(0.0, 1.0)).collect()
+    };
     let e2 = power_iter(&sample_d, POWER_ITERS, &init_e2);
 
     let xs: Vec<f64> = centered.iter().map(|row| dot(row, &e1)).collect();
@@ -195,6 +210,23 @@ pub fn pca_2d(vectors: &[Vec<f64>]) -> (Vec<f64>, Vec<f64>) {
     };
 
     (xs, ys)
+}
+
+/// Return rendering-cap indices for *n* points capped at *max_render*.
+///
+/// When `n > max_render`, selects `max_render` indices via
+/// `cpyrand::Random::new(42).sample_indices(n, max_render)`, matching
+/// Python's `random.Random(42).sample(raw, MAX_RENDER)`.
+/// When `n <= max_render`, returns the identity range `0..n`.
+///
+/// The endpoint may call this to determine which subset to render without
+/// changing projection order or any cache/HTTP behaviour.
+pub fn sample_render_indices(n: usize, max_render: usize) -> Vec<usize> {
+    if n > max_render {
+        super::cpyrand::Random::new(42).sample_indices(n, max_render)
+    } else {
+        (0..n).collect()
+    }
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────

--- a/sk-rust/tests/projection_parity_test.rs
+++ b/sk-rust/tests/projection_parity_test.rs
@@ -1,0 +1,194 @@
+//! CPython-parity harness for `browse::algo::projection`.
+//!
+//! All golden values were produced by running `gen_golden.py` against
+//! `browse/core/projection.py` on Python 3.12 (Windows).  The script is
+//! located at the repo root and is the authoritative source for these
+//! constants.
+//!
+//! ## Coverage
+//! - Small dataset (n=10 < PCA_SAMPLE=500): exercises cpyrand gauss init path.
+//! - Large dataset (n=600 > PCA_SAMPLE=500): exercises cpyrand sample_indices
+//!   (seed 99) PCA sample path.
+//! - Render-cap helper (n=2500, max=2000): proves `sample_render_indices`
+//!   returns `cpyrand::Random::new(42).sample_indices(n, max)` order.
+
+use sk::browse::algo::{cpyrand, projection};
+
+// ── Tolerance ─────────────────────────────────────────────────────────────────
+
+/// Absolute tolerance for coordinate comparison (Python vs Rust pca_2d).
+/// 1e-9 is the spec target; on IEEE 754 Windows platforms we observe exact
+/// bit-level agreement, so this headroom handles any future libm drift.
+const TOL: f64 = 1e-9;
+
+fn assert_near(got: f64, want: f64, label: &str) {
+    let diff = (got - want).abs();
+    assert!(
+        diff <= TOL,
+        "{label}: got={got:.17e} want={want:.17e} diff={diff:.3e} > TOL={TOL:.0e}"
+    );
+}
+
+// ── Vector generation helper ───────────────────────────────────────────────────
+
+/// Generate an `n × dims` matrix using CPython-identical gauss(0,1) values.
+/// Matches `[random.Random(seed).gauss(0,1) for _ in range(n*dims)]` shaped
+/// into rows, so Rust input vectors are bit-for-bit identical to Python's.
+fn make_vecs_gauss(seed: u64, n: usize, dims: usize) -> Vec<Vec<f64>> {
+    let mut rng = cpyrand::Random::new(seed);
+    (0..n)
+        .map(|_| (0..dims).map(|_| rng.gauss(0.0, 1.0)).collect())
+        .collect()
+}
+
+// ── Golden constants: small case (n=10, dims=4, input seed=777) ──────────────
+//
+// Python:
+//   rng = random.Random(777)
+//   vecs = [[rng.gauss(0,1) for _ in range(4)] for _ in range(10)]
+//   xs, ys = pca_2d(vecs)
+//
+// Bits verified with `struct.pack('>d', v).hex()`.
+
+const SMALL_XS: &[f64] = &[
+    f64::from_bits(0xbfd04c044b532beb),
+    f64::from_bits(0x4001645940ecfbc2),
+    f64::from_bits(0xc008a589ca3e69ca),
+    f64::from_bits(0x3fd51d7aaea840e2),
+    f64::from_bits(0xbfba8a17bc252796),
+    f64::from_bits(0x3fb568f66567b2c6),
+    f64::from_bits(0x4001ec87ffe3193c),
+    f64::from_bits(0x3fd9b9ae6eabc8b4),
+    f64::from_bits(0xbff43738dbae4a5c),
+    f64::from_bits(0xbfe0e05a6112d84f),
+];
+
+const SMALL_YS: &[f64] = &[
+    f64::from_bits(0xbff03375c6687b3a),
+    f64::from_bits(0xbfe72ca788ccc9fc),
+    f64::from_bits(0xbfcdfc751ff2209e),
+    f64::from_bits(0x3ff37086a6ec271d),
+    f64::from_bits(0x40046a840ab14d8a),
+    f64::from_bits(0xbff0ea985c382ab7),
+    f64::from_bits(0xbfcdc83520edc33e),
+    f64::from_bits(0x3fd73ca2f81e216a),
+    f64::from_bits(0xbfe42bcc24c1598a),
+    f64::from_bits(0xbfce8ed1c694b2da),
+];
+
+// ── Golden constants: large case (n=600, dims=4, input seed=888) — first 20 ──
+//
+// Python:
+//   rng = random.Random(888)
+//   vecs = [[rng.gauss(0,1) for _ in range(4)] for _ in range(600)]
+//   xs, ys = pca_2d(vecs)
+
+const LARGE_XS_20: &[f64] = &[
+    f64::from_bits(0x3fe75568e12cf286),
+    f64::from_bits(0x3fe84f4dbc62465b),
+    f64::from_bits(0x3ff56db716dacca8),
+    f64::from_bits(0xbfb703dd80a2013d),
+    f64::from_bits(0x3fd9348601fca150),
+    f64::from_bits(0xbff1e90c041afe01),
+    f64::from_bits(0xbffadc94b8636a8f),
+    f64::from_bits(0xbfe5e34df485206f),
+    f64::from_bits(0x3fae75b86556800b),
+    f64::from_bits(0x3ffdc86a7b472045),
+    f64::from_bits(0xbff946a77bf3f9f9),
+    f64::from_bits(0xbfad86883baf1f68),
+    f64::from_bits(0xbfc2d2c7ac34a7b9),
+    f64::from_bits(0xbfeb38bfb25753de),
+    f64::from_bits(0xbfe85cedde3531dd),
+    f64::from_bits(0x4002209e5172d8bf),
+    f64::from_bits(0xbfeedbcae9ce2852),
+    f64::from_bits(0x3fda40c1ed51561a),
+    f64::from_bits(0x3fd67d0636e37cbb),
+    f64::from_bits(0x3ff4c883087531cd),
+];
+
+const LARGE_YS_20: &[f64] = &[
+    f64::from_bits(0x3fe3abd4d24192b8),
+    f64::from_bits(0xbfbc469959f9b9ac),
+    f64::from_bits(0xbffdc87a0b9e355d),
+    f64::from_bits(0x3fe5b7c7a179cd6d),
+    f64::from_bits(0xbfc59dc04807b00f),
+    f64::from_bits(0xbffd1db49873ca69),
+    f64::from_bits(0x3fd7b2a3b616a651),
+    f64::from_bits(0xbff125c5874604c5),
+    f64::from_bits(0x3fa408a2af334272),
+    f64::from_bits(0xbffa414fc009b22e),
+    f64::from_bits(0xbff1633e9417becf),
+    f64::from_bits(0x3ff4d7f137cbc231),
+    f64::from_bits(0x3fe9d3fd4b1037cc),
+    f64::from_bits(0x3ff790f140a544f2),
+    f64::from_bits(0xbff5f53296fc26d2),
+    f64::from_bits(0xbfeabca6ae8ae8bc),
+    f64::from_bits(0xbfea1622317ec86e),
+    f64::from_bits(0x3ff01955361ef1dc),
+    f64::from_bits(0x3fe055c04f6aa84f),
+    f64::from_bits(0xbfe2a45ed0435b1a),
+];
+
+// ── Golden constants: render-cap indices (n=2500, max=2000, seed=42) — first 20
+//
+// Python: `random.Random(42).sample(range(2500), 2000)[:20]`
+const RENDER_CAP_IDX_20: [usize; 20] = [
+    456, 102, 1126, 1003, 914, 571, 419, 2233, 356, 2418, 1728, 130, 122, 383, 895, 952, 2069,
+    2465, 108, 2298,
+];
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Small dataset (n=10 < PCA_SAMPLE): all rows used as sample, so this test
+/// exercises the cpyrand gauss init path for power-iteration eigenvectors.
+#[test]
+fn projection_parity_small_n10_dims4() {
+    let vecs = make_vecs_gauss(777, 10, 4);
+    let (xs, ys) = projection::pca_2d(&vecs);
+
+    assert_eq!(xs.len(), 10, "xs length");
+    assert_eq!(ys.len(), 10, "ys length");
+
+    for i in 0..10 {
+        assert_near(xs[i], SMALL_XS[i], &format!("small xs[{i}]"));
+        assert_near(ys[i], SMALL_YS[i], &format!("small ys[{i}]"));
+    }
+}
+
+/// Large dataset (n=600 > PCA_SAMPLE=500): exercises the cpyrand seed-99
+/// `sample_indices` path for PCA sample selection, then verifies the full
+/// projection output against Python golden.  Checks first 20 coordinates.
+#[test]
+fn projection_parity_large_n600_dims4_sample_path() {
+    let vecs = make_vecs_gauss(888, 600, 4);
+    let (xs, ys) = projection::pca_2d(&vecs);
+
+    assert_eq!(xs.len(), 600, "xs length");
+    assert_eq!(ys.len(), 600, "ys length");
+
+    for i in 0..20 {
+        assert_near(xs[i], LARGE_XS_20[i], &format!("large xs[{i}]"));
+        assert_near(ys[i], LARGE_YS_20[i], &format!("large ys[{i}]"));
+    }
+}
+
+/// Render-cap helper: verifies `sample_render_indices(2500, 2000)` produces
+/// the same first-20 indices as Python's `random.Random(42).sample(range(2500), 2000)`.
+#[test]
+fn projection_parity_render_cap_indices_n2500_max2000() {
+    let got = projection::sample_render_indices(2500, 2000);
+    assert_eq!(got.len(), 2000, "render-cap result length");
+    assert_eq!(
+        &got[..20],
+        &RENDER_CAP_IDX_20,
+        "render-cap first-20 indices must match Python golden"
+    );
+}
+
+/// Identity path: when `n <= max_render`, `sample_render_indices` returns 0..n.
+#[test]
+fn projection_render_cap_identity_when_n_le_max() {
+    let got = projection::sample_render_indices(100, 2000);
+    let expected: Vec<usize> = (0..100).collect();
+    assert_eq!(got, expected, "identity range when n <= max_render");
+}

--- a/sk-rust/tests/projection_parity_test.rs
+++ b/sk-rust/tests/projection_parity_test.rs
@@ -49,32 +49,39 @@ fn make_vecs_gauss(seed: u64, n: usize, dims: usize) -> Vec<Vec<f64>> {
 //   xs, ys = pca_2d(vecs)
 //
 // Bits verified with `struct.pack('>d', v).hex()`.
+//
+// Note: f64::from_bits is not const-stable until Rust 1.83 (MSRV is 1.75),
+// so these are runtime functions instead of const arrays.
 
-const SMALL_XS: &[f64] = &[
-    f64::from_bits(0xbfd04c044b532beb),
-    f64::from_bits(0x4001645940ecfbc2),
-    f64::from_bits(0xc008a589ca3e69ca),
-    f64::from_bits(0x3fd51d7aaea840e2),
-    f64::from_bits(0xbfba8a17bc252796),
-    f64::from_bits(0x3fb568f66567b2c6),
-    f64::from_bits(0x4001ec87ffe3193c),
-    f64::from_bits(0x3fd9b9ae6eabc8b4),
-    f64::from_bits(0xbff43738dbae4a5c),
-    f64::from_bits(0xbfe0e05a6112d84f),
-];
+fn small_xs() -> [f64; 10] {
+    [
+        f64::from_bits(0xbfd04c044b532beb),
+        f64::from_bits(0x4001645940ecfbc2),
+        f64::from_bits(0xc008a589ca3e69ca),
+        f64::from_bits(0x3fd51d7aaea840e2),
+        f64::from_bits(0xbfba8a17bc252796),
+        f64::from_bits(0x3fb568f66567b2c6),
+        f64::from_bits(0x4001ec87ffe3193c),
+        f64::from_bits(0x3fd9b9ae6eabc8b4),
+        f64::from_bits(0xbff43738dbae4a5c),
+        f64::from_bits(0xbfe0e05a6112d84f),
+    ]
+}
 
-const SMALL_YS: &[f64] = &[
-    f64::from_bits(0xbff03375c6687b3a),
-    f64::from_bits(0xbfe72ca788ccc9fc),
-    f64::from_bits(0xbfcdfc751ff2209e),
-    f64::from_bits(0x3ff37086a6ec271d),
-    f64::from_bits(0x40046a840ab14d8a),
-    f64::from_bits(0xbff0ea985c382ab7),
-    f64::from_bits(0xbfcdc83520edc33e),
-    f64::from_bits(0x3fd73ca2f81e216a),
-    f64::from_bits(0xbfe42bcc24c1598a),
-    f64::from_bits(0xbfce8ed1c694b2da),
-];
+fn small_ys() -> [f64; 10] {
+    [
+        f64::from_bits(0xbff03375c6687b3a),
+        f64::from_bits(0xbfe72ca788ccc9fc),
+        f64::from_bits(0xbfcdfc751ff2209e),
+        f64::from_bits(0x3ff37086a6ec271d),
+        f64::from_bits(0x40046a840ab14d8a),
+        f64::from_bits(0xbff0ea985c382ab7),
+        f64::from_bits(0xbfcdc83520edc33e),
+        f64::from_bits(0x3fd73ca2f81e216a),
+        f64::from_bits(0xbfe42bcc24c1598a),
+        f64::from_bits(0xbfce8ed1c694b2da),
+    ]
+}
 
 // ── Golden constants: large case (n=600, dims=4, input seed=888) — first 20 ──
 //
@@ -82,52 +89,59 @@ const SMALL_YS: &[f64] = &[
 //   rng = random.Random(888)
 //   vecs = [[rng.gauss(0,1) for _ in range(4)] for _ in range(600)]
 //   xs, ys = pca_2d(vecs)
+//
+// Note: f64::from_bits is not const-stable until Rust 1.83 (MSRV is 1.75),
+// so these are runtime functions instead of const arrays.
 
-const LARGE_XS_20: &[f64] = &[
-    f64::from_bits(0x3fe75568e12cf286),
-    f64::from_bits(0x3fe84f4dbc62465b),
-    f64::from_bits(0x3ff56db716dacca8),
-    f64::from_bits(0xbfb703dd80a2013d),
-    f64::from_bits(0x3fd9348601fca150),
-    f64::from_bits(0xbff1e90c041afe01),
-    f64::from_bits(0xbffadc94b8636a8f),
-    f64::from_bits(0xbfe5e34df485206f),
-    f64::from_bits(0x3fae75b86556800b),
-    f64::from_bits(0x3ffdc86a7b472045),
-    f64::from_bits(0xbff946a77bf3f9f9),
-    f64::from_bits(0xbfad86883baf1f68),
-    f64::from_bits(0xbfc2d2c7ac34a7b9),
-    f64::from_bits(0xbfeb38bfb25753de),
-    f64::from_bits(0xbfe85cedde3531dd),
-    f64::from_bits(0x4002209e5172d8bf),
-    f64::from_bits(0xbfeedbcae9ce2852),
-    f64::from_bits(0x3fda40c1ed51561a),
-    f64::from_bits(0x3fd67d0636e37cbb),
-    f64::from_bits(0x3ff4c883087531cd),
-];
+fn large_xs_20() -> [f64; 20] {
+    [
+        f64::from_bits(0x3fe75568e12cf286),
+        f64::from_bits(0x3fe84f4dbc62465b),
+        f64::from_bits(0x3ff56db716dacca8),
+        f64::from_bits(0xbfb703dd80a2013d),
+        f64::from_bits(0x3fd9348601fca150),
+        f64::from_bits(0xbff1e90c041afe01),
+        f64::from_bits(0xbffadc94b8636a8f),
+        f64::from_bits(0xbfe5e34df485206f),
+        f64::from_bits(0x3fae75b86556800b),
+        f64::from_bits(0x3ffdc86a7b472045),
+        f64::from_bits(0xbff946a77bf3f9f9),
+        f64::from_bits(0xbfad86883baf1f68),
+        f64::from_bits(0xbfc2d2c7ac34a7b9),
+        f64::from_bits(0xbfeb38bfb25753de),
+        f64::from_bits(0xbfe85cedde3531dd),
+        f64::from_bits(0x4002209e5172d8bf),
+        f64::from_bits(0xbfeedbcae9ce2852),
+        f64::from_bits(0x3fda40c1ed51561a),
+        f64::from_bits(0x3fd67d0636e37cbb),
+        f64::from_bits(0x3ff4c883087531cd),
+    ]
+}
 
-const LARGE_YS_20: &[f64] = &[
-    f64::from_bits(0x3fe3abd4d24192b8),
-    f64::from_bits(0xbfbc469959f9b9ac),
-    f64::from_bits(0xbffdc87a0b9e355d),
-    f64::from_bits(0x3fe5b7c7a179cd6d),
-    f64::from_bits(0xbfc59dc04807b00f),
-    f64::from_bits(0xbffd1db49873ca69),
-    f64::from_bits(0x3fd7b2a3b616a651),
-    f64::from_bits(0xbff125c5874604c5),
-    f64::from_bits(0x3fa408a2af334272),
-    f64::from_bits(0xbffa414fc009b22e),
-    f64::from_bits(0xbff1633e9417becf),
-    f64::from_bits(0x3ff4d7f137cbc231),
-    f64::from_bits(0x3fe9d3fd4b1037cc),
-    f64::from_bits(0x3ff790f140a544f2),
-    f64::from_bits(0xbff5f53296fc26d2),
-    f64::from_bits(0xbfeabca6ae8ae8bc),
-    f64::from_bits(0xbfea1622317ec86e),
-    f64::from_bits(0x3ff01955361ef1dc),
-    f64::from_bits(0x3fe055c04f6aa84f),
-    f64::from_bits(0xbfe2a45ed0435b1a),
-];
+fn large_ys_20() -> [f64; 20] {
+    [
+        f64::from_bits(0x3fe3abd4d24192b8),
+        f64::from_bits(0xbfbc469959f9b9ac),
+        f64::from_bits(0xbffdc87a0b9e355d),
+        f64::from_bits(0x3fe5b7c7a179cd6d),
+        f64::from_bits(0xbfc59dc04807b00f),
+        f64::from_bits(0xbffd1db49873ca69),
+        f64::from_bits(0x3fd7b2a3b616a651),
+        f64::from_bits(0xbff125c5874604c5),
+        f64::from_bits(0x3fa408a2af334272),
+        f64::from_bits(0xbffa414fc009b22e),
+        f64::from_bits(0xbff1633e9417becf),
+        f64::from_bits(0x3ff4d7f137cbc231),
+        f64::from_bits(0x3fe9d3fd4b1037cc),
+        f64::from_bits(0x3ff790f140a544f2),
+        f64::from_bits(0xbff5f53296fc26d2),
+        f64::from_bits(0xbfeabca6ae8ae8bc),
+        f64::from_bits(0xbfea1622317ec86e),
+        f64::from_bits(0x3ff01955361ef1dc),
+        f64::from_bits(0x3fe055c04f6aa84f),
+        f64::from_bits(0xbfe2a45ed0435b1a),
+    ]
+}
 
 // ── Golden constants: render-cap indices (n=2500, max=2000, seed=42) — first 20
 //
@@ -149,9 +163,11 @@ fn projection_parity_small_n10_dims4() {
     assert_eq!(xs.len(), 10, "xs length");
     assert_eq!(ys.len(), 10, "ys length");
 
+    let want_xs = small_xs();
+    let want_ys = small_ys();
     for i in 0..10 {
-        assert_near(xs[i], SMALL_XS[i], &format!("small xs[{i}]"));
-        assert_near(ys[i], SMALL_YS[i], &format!("small ys[{i}]"));
+        assert_near(xs[i], want_xs[i], &format!("small xs[{i}]"));
+        assert_near(ys[i], want_ys[i], &format!("small ys[{i}]"));
     }
 }
 
@@ -166,9 +182,11 @@ fn projection_parity_large_n600_dims4_sample_path() {
     assert_eq!(xs.len(), 600, "xs length");
     assert_eq!(ys.len(), 600, "ys length");
 
+    let want_xs = large_xs_20();
+    let want_ys = large_ys_20();
     for i in 0..20 {
-        assert_near(xs[i], LARGE_XS_20[i], &format!("large xs[{i}]"));
-        assert_near(ys[i], LARGE_YS_20[i], &format!("large ys[{i}]"));
+        assert_near(xs[i], want_xs[i], &format!("large xs[{i}]"));
+        assert_near(ys[i], want_ys[i], &format!("large ys[{i}]"));
     }
 }
 


### PR DESCRIPTION
## Summary

Wires the cpyrand foundation (merged in #514) into projection.rs and adds a golden-value parity test harness.

Does NOT add /api/embeddings/points endpoint (arbiter verdict: WAIT_FOR_PARITY).

## Changes

### sk-rust/src/browse/algo/projection.rs
- cpyrand gauss init for both eigenvectors: replaces fixed all-ones / standard-basis init with cpyrand::Random::new(seed).gauss(0.0, 1.0) x n_dims (seed 1 for e1, seed 2 for e2 on deflated sample), matching Python's random.Random(seed).gauss(0,1).
- cpyrand sample selection: replaces first-N sampling with cpyrand::Random::new(99).sample_indices(n, PCA_SAMPLE) when n > PCA_SAMPLE, preserving CPython random.sample(range(n), PCA_SAMPLE) order.
- New sample_render_indices(n, max_render) public helper: uses cpyrand::Random::new(42).sample_indices(n, max_render) when n > max_render. Endpoint-ready but not wired.
- Updated module doc comment from 'Known parity differences' to 'CPython parity'.

### sk-rust/tests/projection_parity_test.rs (new)
Golden-value parity harness with 4 tests:
- projection_parity_small_n10_dims4: n=10 < PCA_SAMPLE, exercises cpyrand gauss-init path
- projection_parity_large_n600_dims4_sample_path: n=600 > PCA_SAMPLE, exercises seed-99 sample_indices
- projection_parity_render_cap_indices_n2500_max2000: render-cap helper seed-42 first-20 index golden
- projection_render_cap_identity_when_n_le_max: identity path n <= max

Golden values generated by gen_golden.py (Python 3.12, Windows) against browse/core/projection.py.
Tolerance: 1e-9 absolute; observed bit-exact agreement on Windows/IEEE 754.

## Verification

- cargo fmt --all -- --check: PASS
- cargo test projection: PASS (19 tests)
- cargo test --lib cpyrand: PASS (8 tests, PR #514 behaviour unchanged)
- cargo clippy -- -D warnings: PASS (no warnings)
- grep embeddings/points: no matches (endpoint not added)

Depends on: #514 (merged to main as cd13ca7)
Resolves: part of #452 (parity foundation -- endpoint wiring deferred)