### PR TITLE
fix(hosted-ui): show deployed build identity

### DIFF
--- a/browse-ui/src/app/settings/page.test.tsx
+++ b/browse-ui/src/app/settings/page.test.tsx
@@ -107,6 +107,10 @@ const baseTentacleData: TentacleStatusResponse = {
 beforeEach(() => {
   // Simulate local browse so diagnostics are enabled for existing tests
   window.history.pushState({}, "", "/v2/settings");
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => new Promise(() => {}))
+  );
   localStorage.clear();
   hostStateMock = { host: LOCAL_HOST, diagnosticsEnabled: true };
   diagnosticsSupported = true;
@@ -115,6 +119,10 @@ beforeEach(() => {
   mockedUseSyncStatus.mockReturnValue(makeIdleQuery() as ReturnType<typeof useSyncStatus>);
   mockedUseScoutStatus.mockReturnValue(makeIdleQuery() as ReturnType<typeof useScoutStatus>);
   mockedUseSkillMetrics.mockReturnValue(makeIdleQuery() as ReturnType<typeof useSkillMetrics>);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 // Dynamic import to avoid issues with "use client" directive in test environment
@@ -385,7 +393,6 @@ describe("SettingsPage — Hosts & connections card", () => {
     await waitFor(() => {
       expect(screen.getByText("My Laptop")).toBeInTheDocument();
     });
-    vi.unstubAllGlobals();
   });
 
   it("shows Restore local button when a remote host is active", async () => {
@@ -401,7 +408,6 @@ describe("SettingsPage — Hosts & connections card", () => {
     await waitFor(() => {
       expect(screen.getByTestId("restore-local-btn")).toBeInTheDocument();
     });
-    vi.unstubAllGlobals();
   });
 });
 
@@ -445,7 +451,6 @@ describe("SettingsPage — mixed-content loopback guard", () => {
     // pna-note shown first (synchronous), then validation-error from probe failure
     await waitFor(() => expect(screen.getByTestId("pna-note")).toBeInTheDocument());
     await waitFor(() => expect(screen.getByTestId("validation-error")).toBeInTheDocument());
-    vi.unstubAllGlobals();
   });
 
   it("shows 'Save anyway' for a loopback URL after probe failure (pna-required is compatible: true)", async () => {
@@ -465,7 +470,6 @@ describe("SettingsPage — mixed-content loopback guard", () => {
     await waitFor(() => expect(screen.getByTestId("validation-error")).toBeInTheDocument());
     // pna-required is compatible: true, so probe fires and fails → "Save anyway" is shown
     expect(screen.getByTestId("skip-validation-btn")).toBeInTheDocument();
-    vi.unstubAllGlobals();
   });
 
   it("shows 'Open the local browse app directly' for the local host row on hosted pages", () => {

--- a/browse-ui/src/app/settings/page.tsx
+++ b/browse-ui/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { Activity, AlertTriangle, CheckCircle2, Moon, Monitor, Sun } from "lucid
 import { useTheme } from "next-themes";
 
 import { Banner } from "@/components/data/banner";
+import { BuildIdentity } from "@/components/ui/build-identity";
 import { DensityToggle } from "@/components/layout/density-toggle";
 import { PaletteToggle } from "@/components/layout/palette-toggle";
 import { HostManagement } from "@/components/hosts/host-management";
@@ -1031,6 +1032,19 @@ export default function SettingsPage() {
         </CardHeader>
         <CardContent>
           <HostManagement data-testid="host-management" />
+        </CardContent>
+      </Card>
+
+      <Card id="build-identity">
+        <CardHeader>
+          <CardTitle>Build identity</CardTitle>
+          <CardDescription>
+            Hosted deployment SHA and build timestamp from <code>/version.json</code>. Reloads from
+            the server on every page visit (no-store).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <BuildIdentity />
         </CardContent>
       </Card>
 

--- a/browse-ui/src/components/ui/build-identity.test.tsx
+++ b/browse-ui/src/components/ui/build-identity.test.tsx
@@ -1,0 +1,188 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+// Dynamic import to handle "use client"
+const { BuildIdentity } = await import("@/components/ui/build-identity");
+
+describe("BuildIdentity", () => {
+  afterEach(() => {
+    document.querySelectorAll("[data-build-identity-test]").forEach((element) => element.remove());
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise(() => {})) // never resolves
+    );
+    render(<BuildIdentity />);
+    expect(screen.getByTestId("build-identity-loading")).toBeInTheDocument();
+  });
+
+  it("renders build hash and builtAt after successful fetch", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            buildHash: "abc1234",
+            builtAt: "2026-01-15T12:00:00.000Z",
+            version: "1.2.3",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    render(<BuildIdentity />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("build-identity")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("build-hash")).toHaveTextContent("abc1234");
+    expect(screen.getByTestId("built-at")).toBeInTheDocument();
+  });
+
+  it("renders the original builtAt value when it is not a valid date", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            buildHash: "abc1234",
+            builtAt: "not-a-date",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    render(<BuildIdentity />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("build-identity")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("built-at")).toHaveTextContent("not-a-date");
+  });
+
+  it("shows error state when fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")));
+
+    render(<BuildIdentity />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("build-identity-error")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("build-identity-error")).toHaveTextContent(
+      "Build identity unavailable: Network error"
+    );
+  });
+
+  it("shows error state when fetch returns non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("Not Found", { status: 404 })));
+
+    render(<BuildIdentity />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("build-identity-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("build-identity-error")).toHaveTextContent("HTTP 404");
+  });
+
+  it("fetches an absolute version.json URL with cache: no-store", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ buildHash: "deadbeef", builtAt: "2026-01-01T00:00:00.000Z" }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      );
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<BuildIdentity />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("build-identity")).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(new URL("/version.json", window.location.origin).href, {
+      cache: "no-store",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("resolves version.json from the Next.js basePath when static assets are prefixed", async () => {
+    const script = document.createElement("script");
+    script.dataset.buildIdentityTest = "true";
+    script.src = "/v2/_next/static/chunks/app.js";
+    document.head.append(script);
+
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ buildHash: "feedbee", builtAt: "2026-01-01T00:00:00.000Z" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<BuildIdentity />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("build-identity")).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL("/v2/version.json", window.location.origin).href,
+      {
+        cache: "no-store",
+        signal: expect.any(AbortSignal),
+      }
+    );
+  });
+
+  it("resolves version.json from an explicit document base URL", async () => {
+    const base = document.createElement("base");
+    base.dataset.buildIdentityTest = "true";
+    base.href = "/preview/";
+    document.head.append(base);
+
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ buildHash: "decaf00", builtAt: "2026-01-01T00:00:00.000Z" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<BuildIdentity />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("build-identity")).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(new URL("version.json", base.href).href, {
+      cache: "no-store",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("aborts the version fetch on unmount", () => {
+    let signal: AbortSignal | undefined;
+    const mockFetch = vi.fn((_url: string, init?: RequestInit) => {
+      signal = init?.signal as AbortSignal | undefined;
+      return new Promise(() => {});
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { unmount } = render(<BuildIdentity />);
+
+    expect(signal?.aborted).toBe(false);
+    unmount();
+    expect(signal?.aborted).toBe(true);
+  });
+});

--- a/browse-ui/src/components/ui/build-identity.tsx
+++ b/browse-ui/src/components/ui/build-identity.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface VersionInfo {
+  version?: string;
+  buildHash: string;
+  builtAt: string;
+  nodeVersion?: string;
+  basePath?: string;
+}
+
+/**
+ * Fetches version.json (no-store) and renders:
+ *   Build {buildHash} · {builtAt formatted}
+ *
+ * Safe: never exposes env vars, branch, actor, or secrets.
+ * Issue #520 — deploy SHA visibility.
+ */
+export function getBuildIdentityUrl(): string {
+  const explicitBase = document.querySelector("base")?.href;
+  if (explicitBase) {
+    return new URL("version.json", explicitBase).href;
+  }
+
+  const nextAsset = document.querySelector<HTMLScriptElement | HTMLLinkElement>(
+    'script[src*="/_next/"],link[href*="/_next/"]'
+  );
+  const nextAssetUrl = nextAsset?.getAttribute("src") ?? nextAsset?.getAttribute("href");
+  if (nextAssetUrl) {
+    const nextAssetPath = new URL(nextAssetUrl, window.location.origin).pathname;
+    const nextMarkerIndex = nextAssetPath.indexOf("/_next/");
+    if (nextMarkerIndex >= 0) {
+      const basePath = nextAssetPath.slice(0, nextMarkerIndex);
+      return new URL(`${basePath}/version.json`, window.location.origin).href;
+    }
+  }
+
+  return new URL("/version.json", window.location.origin).href;
+}
+
+export function BuildIdentity() {
+  const [info, setInfo] = useState<VersionInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch(getBuildIdentityUrl(), { cache: "no-store", signal: controller.signal })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<VersionInfo>;
+      })
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          setInfo(data);
+        }
+      })
+      .catch((e: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(e instanceof Error ? e.message : "Failed to load build info");
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  if (error) {
+    return (
+      <p className="text-muted-foreground text-xs" data-testid="build-identity-error">
+        Build identity unavailable: {error}
+      </p>
+    );
+  }
+
+  if (!info) {
+    return (
+      <p
+        className="text-muted-foreground animate-pulse text-xs"
+        data-testid="build-identity-loading"
+      >
+        Loading build info…
+      </p>
+    );
+  }
+
+  const builtAtDate = new Date(info.builtAt);
+  const formattedDate = Number.isNaN(builtAtDate.getTime())
+    ? info.builtAt
+    : builtAtDate.toLocaleString();
+
+  return (
+    <p className="text-muted-foreground font-mono text-xs" data-testid="build-identity">
+      Build{" "}
+      <span className="text-foreground font-medium" data-testid="build-hash">
+        {info.buildHash}
+      </span>
+      {" · "}
+      <span data-testid="built-at">{formattedDate}</span>
+    </p>
+  );
+}


### PR DESCRIPTION
Closes #520

## Summary
- Adds a Settings build identity card that reads `/version.json` with `cache: no-store`.
- Shows the deployed `buildHash` and `builtAt` timestamp without exposing environment secrets.
- Builds on the existing `main` Firebase cache headers and `verify:deploy` script for HTML/version revalidation.

## Verification
- Main already has green checks for cache/revalidation commit `b924a42` and loopback helper commit `9980066`.
- This branch is based on latest `main` and only changes the Settings build identity UI/test surface.