### PR TITLE
Add fail-open learn inbox for locked DB

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -12,6 +12,7 @@
 sk briefing "implement user CRUD"        # → briefing.py
 sk query "docker error"                  # → query-session.py
 sk learn --mistake "Title" "Description" # → learn.py
+sk learn --flush-inbox                   # replay queued learn writes after DB lock contention
 sk tentacle create api-export --scope "src/api/*.py" --desc "Export API"  # → tentacle.py
 sk tentacle split planner --into research builder reviewer                # → tentacle.py
 sk tentacle auto add on-push --command "sk tentacle status"              # → tentacle.py
@@ -582,6 +583,11 @@ learn --relate "addPatient Lambda" "writes_to" "dataTable"
 # Bulk import
 learn --from-file notes.md  # Format: ## category: Title
 
+# Recover writes queued when SQLite stayed locked after retries
+learn --flush-inbox
+learn --flush-inbox --limit 25
+learn --flush-inbox --json
+
 # View
 learn --list               # Recent entries
 learn --stats              # Knowledge base statistics
@@ -589,6 +595,11 @@ learn --stats              # Knowledge base statistics
 # JSON output (machine-readable; emits JSON object with id, title, category, tags, etc.)
 learn --mistake "Title" "Description" --json
 ```
+
+When a single-entry `learn` write still hits SQLite `database is locked` after
+the built-in retry window, it is queued under `SK_LEARN_INBOX` if set, otherwise
+`~/.copilot/session-state/learn-inbox`. Set `SK_LEARN_QUEUE_ON_LOCK=0` to fail
+instead of queueing.
 
 ## Palace Concepts (Wing/Room)
 

--- a/learn.py
+++ b/learn.py
@@ -27,6 +27,7 @@ Usage:
     python learn.py --relate "addPatient Lambda" "writes_to" "dataTable"
 
     python learn.py --from-file notes.md          # Bulk import from markdown
+    python learn.py --flush-inbox                 # Replay entries queued while DB was locked
     python learn.py --list                        # List recent entries
     python learn.py --stats                       # Show knowledge stats
 
@@ -55,6 +56,7 @@ if os.name == "nt":
 TOOLS_DIR = Path(__file__).parent
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
 DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
+LEARN_INBOX = Path(os.environ.get("SK_LEARN_INBOX", str(SESSION_STATE / "learn-inbox"))).expanduser()
 
 
 def _emit_knowledge_event_fail_open(event_type: str, data: dict) -> None:
@@ -77,6 +79,92 @@ def _emit_knowledge_event_fail_open(event_type: str, data: dict) -> None:
         )
     except Exception:
         return
+
+
+def _queue_learn_payload(payload: dict) -> Path:
+    """Persist a learn write for later replay when SQLite is temporarily locked."""
+    LEARN_INBOX.mkdir(parents=True, exist_ok=True)
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    name = f"{time.strftime('%Y%m%dT%H%M%S')}-{time.time_ns()}-{digest}.json"
+    final_path = LEARN_INBOX / name
+    tmp_path = LEARN_INBOX / f".{name}.tmp"
+    tmp_path.write_text(raw + "\n", encoding="utf-8")
+    os.replace(tmp_path, final_path)
+    return final_path
+
+
+def _build_learn_payload(argv: list[str], entry_kwargs: dict) -> dict:
+    return {
+        "schema_version": 1,
+        "queued_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "reason": "database_locked",
+        "argv": list(argv),
+        "entry": entry_kwargs,
+    }
+
+
+def _replay_queued_payload(payload: dict) -> int:
+    entry = dict(payload.get("entry") or {})
+    entry_id = _write_learn_entry(entry)
+    if entry_id >= 0 and entry.get("category") == "pattern":
+        _emit_knowledge_event_fail_open(
+            "pattern_learned",
+            {
+                "entry_id": entry_id,
+                "title": entry.get("title", ""),
+                "task_id": entry.get("task_id", ""),
+                "wing": entry.get("wing", ""),
+                "room": entry.get("room", ""),
+                "priority": entry.get("priority") or "P2",
+                "confidence": entry.get("confidence"),
+            },
+        )
+    return entry_id
+
+
+def _write_learn_entry(entry_kwargs: dict) -> int:
+    """Write an entry through the standard retry path, preserving CLI call shape."""
+    entry = dict(entry_kwargs)
+    category = entry.pop("category")
+    title = entry.pop("title")
+    content = entry.pop("content")
+    return with_retry(add_entry, category, title, content, **entry)
+
+
+def flush_learn_inbox(limit: int = 100) -> dict:
+    """Replay queued learn writes in FIFO order."""
+    if not LEARN_INBOX.exists():
+        return {"status": "ok", "processed": 0, "remaining": 0, "failed": 0}
+
+    files = sorted(LEARN_INBOX.glob("*.json"))
+    processed = 0
+    failed = 0
+    busy = False
+
+    for path in files[: max(0, limit)]:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            _replay_queued_payload(payload)
+            path.unlink()
+            processed += 1
+        except sqlite3.OperationalError as exc:
+            if _is_busy_error(exc):
+                busy = True
+                break
+            failed += 1
+            path.rename(path.with_suffix(path.suffix + ".failed"))
+        except Exception:
+            failed += 1
+            path.rename(path.with_suffix(path.suffix + ".failed"))
+
+    remaining = len(list(LEARN_INBOX.glob("*.json"))) if LEARN_INBOX.exists() else 0
+    return {
+        "status": "busy" if busy else "ok",
+        "processed": processed,
+        "remaining": remaining,
+        "failed": failed,
+    }
 
 
 # Wing auto-detection rules: tag patterns → wing
@@ -1599,6 +1687,25 @@ def main():
         show_stats()
         return
 
+    if "--flush-inbox" in args:
+        limit = 100
+        if "--limit" in args:
+            idx = args.index("--limit")
+            limit = int(args[idx + 1]) if idx + 1 < len(args) else 100
+        result = flush_learn_inbox(limit)
+        if "--json" in args:
+            print(json.dumps(result, indent=2))
+        else:
+            print(
+                "Learn inbox flush: "
+                f"{result['processed']} processed, {result['remaining']} remaining, {result['failed']} failed"
+            )
+            if result["status"] == "busy":
+                print("  DB still busy; retry later.", file=sys.stderr)
+        if result["status"] == "busy" or result["failed"]:
+            sys.exit(1)
+        return
+
     if "--from-file" in args:
         idx = args.index("--from-file")
         if idx + 1 < len(args):
@@ -1912,39 +2019,65 @@ def main():
         else:
             print(f"Recording {category}...")
 
-    entry_id = with_retry(
-        add_entry,
-        category,
-        title,
-        content,
-        tags=tags,
-        session_id=session_id,
-        confidence=confidence,
-        wing=wing,
-        room=room,
-        facts=facts,
-        skip_gate=skip_gate,
-        skip_scan=skip_scan,
-        task_id=task_id,
-        affected_files=affected_files,
-        source_file=source_file,
-        start_line=start_line,
-        end_line=end_line,
-        code_language=code_language,
-        code_snippet=code_snippet,
-        code_location_set=code_location_set,
-        quiet=json_mode,
-        error_type=error_type,
-        root_cause=root_cause,
-        severity=severity,
-        fix_steps=fix_steps,
-        valence=valence,
-        intensity=intensity,
-        priority=priority,
-        agent_id=agent_id,
-        certainty=certainty,
-        caveats=caveats,
-    )
+    entry_kwargs = {
+        "category": category,
+        "title": title,
+        "content": content,
+        "tags": tags,
+        "session_id": session_id,
+        "confidence": confidence,
+        "wing": wing,
+        "room": room,
+        "facts": facts,
+        "skip_gate": skip_gate,
+        "skip_scan": skip_scan,
+        "task_id": task_id,
+        "affected_files": affected_files,
+        "source_file": source_file,
+        "start_line": start_line,
+        "end_line": end_line,
+        "code_language": code_language,
+        "code_snippet": code_snippet,
+        "code_location_set": code_location_set,
+        "quiet": json_mode,
+        "error_type": error_type,
+        "root_cause": root_cause,
+        "severity": severity,
+        "fix_steps": fix_steps,
+        "valence": valence,
+        "intensity": intensity,
+        "priority": priority,
+        "agent_id": agent_id,
+        "certainty": certainty,
+        "caveats": caveats,
+    }
+
+    try:
+        entry_id = _write_learn_entry(entry_kwargs)
+    except sqlite3.OperationalError as exc:
+        if _is_busy_error(exc) and os.environ.get("SK_LEARN_QUEUE_ON_LOCK", "1") != "0":
+            queued_path = _queue_learn_payload(_build_learn_payload(args, entry_kwargs))
+            if json_mode:
+                print(
+                    json.dumps(
+                        {
+                            "status": "queued",
+                            "reason": "database_locked",
+                            "queue_path": str(queued_path),
+                            "flush_command": "sk learn --flush-inbox",
+                        },
+                        indent=2,
+                        ensure_ascii=False,
+                    )
+                )
+            else:
+                print(
+                    f"  DB busy after retries; queued learn entry for later flush: {queued_path.name}",
+                    file=sys.stderr,
+                )
+                print("  Run `sk learn --flush-inbox` to replay queued entries.", file=sys.stderr)
+            return
+        raise
 
     if entry_id >= 0 and category == "pattern":
         _emit_knowledge_event_fail_open(

--- a/learn.py
+++ b/learn.py
@@ -94,17 +94,29 @@ def _queue_learn_payload(payload: dict) -> Path:
     return final_path
 
 
-def _build_learn_payload(argv: list[str], entry_kwargs: dict) -> dict:
+def _build_learn_payload(
+    argv: list[str],
+    entry_kwargs: dict,
+    *,
+    update_cerebrum: bool = False,
+    cerebrum_output: str = "CEREBRUM.md",
+    cerebrum_sections: str | None = None,
+) -> dict:
     return {
         "schema_version": 1,
         "queued_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
         "reason": "database_locked",
         "argv": list(argv),
         "entry": entry_kwargs,
+        "cerebrum": {
+            "update": update_cerebrum,
+            "output": cerebrum_output,
+            "sections": cerebrum_sections,
+        },
     }
 
 
-def _replay_queued_payload(payload: dict) -> int:
+def _replay_queued_payload(payload: dict) -> tuple[int, int]:
     entry = dict(payload.get("entry") or {})
     entry_id = _write_learn_entry(entry)
     if entry_id >= 0 and entry.get("category") == "pattern":
@@ -120,7 +132,15 @@ def _replay_queued_payload(payload: dict) -> int:
                 "confidence": entry.get("confidence"),
             },
         )
-    return entry_id
+    cerebrum_rc = 0
+    cerebrum = payload.get("cerebrum") or {}
+    if entry_id >= 0 and cerebrum.get("update"):
+        cerebrum_rc = _auto_update_cerebrum(
+            cerebrum.get("output") or "CEREBRUM.md",
+            cerebrum.get("sections"),
+            json_mode=True,
+        )
+    return entry_id, cerebrum_rc
 
 
 def _write_learn_entry(entry_kwargs: dict) -> int:
@@ -135,19 +155,22 @@ def _write_learn_entry(entry_kwargs: dict) -> int:
 def flush_learn_inbox(limit: int = 100) -> dict:
     """Replay queued learn writes in FIFO order."""
     if not LEARN_INBOX.exists():
-        return {"status": "ok", "processed": 0, "remaining": 0, "failed": 0}
+        return {"status": "ok", "processed": 0, "remaining": 0, "failed": 0, "cerebrum_failed": 0}
 
     files = sorted(LEARN_INBOX.glob("*.json"))
     processed = 0
     failed = 0
+    cerebrum_failed = 0
     busy = False
 
     for path in files[: max(0, limit)]:
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
-            _replay_queued_payload(payload)
+            _, cerebrum_rc = _replay_queued_payload(payload)
             path.unlink()
             processed += 1
+            if cerebrum_rc != 0:
+                cerebrum_failed += 1
         except sqlite3.OperationalError as exc:
             if _is_busy_error(exc):
                 busy = True
@@ -164,6 +187,7 @@ def flush_learn_inbox(limit: int = 100) -> dict:
         "processed": processed,
         "remaining": remaining,
         "failed": failed,
+        "cerebrum_failed": cerebrum_failed,
     }
 
 
@@ -1702,7 +1726,9 @@ def main():
             )
             if result["status"] == "busy":
                 print("  DB still busy; retry later.", file=sys.stderr)
-        if result["status"] == "busy" or result["failed"]:
+            if result.get("cerebrum_failed"):
+                print("  Cerebrum refresh failed for one or more replayed entries.", file=sys.stderr)
+        if result["status"] == "busy" or result["failed"] or result.get("cerebrum_failed"):
             sys.exit(1)
         return
 
@@ -2056,7 +2082,15 @@ def main():
         entry_id = _write_learn_entry(entry_kwargs)
     except sqlite3.OperationalError as exc:
         if _is_busy_error(exc) and os.environ.get("SK_LEARN_QUEUE_ON_LOCK", "1") != "0":
-            queued_path = _queue_learn_payload(_build_learn_payload(args, entry_kwargs))
+            queued_path = _queue_learn_payload(
+                _build_learn_payload(
+                    args,
+                    entry_kwargs,
+                    update_cerebrum=update_cerebrum,
+                    cerebrum_output=cerebrum_output,
+                    cerebrum_sections=cerebrum_sections,
+                )
+            )
             if json_mode:
                 print(
                     json.dumps(

--- a/tests/test_learn_cerebrum_autoupdate.py
+++ b/tests/test_learn_cerebrum_autoupdate.py
@@ -629,8 +629,6 @@ def test_from_file_no_entries_exits_nonzero():
 def test_import_from_file_not_found_uses_stderr():
     """File-not-found diagnostics should go to stderr, not stdout."""
     captured_out = io.StringIO()
-    captured_out = io.StringIO()
-    captured_out = io.StringIO()
     captured_err = io.StringIO()
     with unittest.mock.patch("sys.stdout", captured_out), unittest.mock.patch("sys.stderr", captured_err):
         rv = learn.import_from_file("nonexistent.md")
@@ -839,23 +837,65 @@ def test_flush_inbox_replays_and_removes_payload():
             "code_location_set": False, "quiet": True, "error_type": "", "root_cause": "", "severity": "",
             "fix_steps": "", "valence": "", "intensity": None, "priority": "", "agent_id": "",
             "certainty": "", "caveats": "",
-        })
+        }, update_cerebrum=True, cerebrum_output="OUT.md", cerebrum_sections="mistakes")
         replayed = {}
+        auto_updated = {}
 
         def fake_with_retry(func, *args, **kwargs):
             replayed["title"] = args[1]
             return 123
 
+        def fake_auto_update(output_path, sections, *, json_mode=False):
+            auto_updated["output"] = output_path
+            auto_updated["sections"] = sections
+            auto_updated["json_mode"] = json_mode
+            return 0
+
         with ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(learn, "LEARN_INBOX", inbox))
             stack.enter_context(unittest.mock.patch.object(learn, "with_retry", fake_with_retry))
             stack.enter_context(unittest.mock.patch.object(learn, "_emit_knowledge_event_fail_open", lambda *a, **k: None))
+            stack.enter_context(unittest.mock.patch.object(learn, "_auto_update_cerebrum", fake_auto_update))
             learn._queue_learn_payload(payload)
             result = learn.flush_learn_inbox()
 
         test("flush_inbox: processed queued payload", result["processed"] == 1)
         test("flush_inbox: no remaining queued payload", result["remaining"] == 0)
         test("flush_inbox: replayed title preserved", replayed.get("title") == "Replay title")
+        test("flush_inbox: replays cerebrum output", auto_updated.get("output") == "OUT.md")
+        test("flush_inbox: replays cerebrum sections", auto_updated.get("sections") == "mistakes")
+        test("flush_inbox: keeps flush stdout clean", auto_updated.get("json_mode") is True)
+
+
+def test_flush_inbox_unlinks_after_cerebrum_failure():
+    """A successful DB replay must not be retried just because cerebrum export failed."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        inbox = Path(tmpdir) / "learn-inbox"
+        payload = learn._build_learn_payload(["--pattern", "Replay title", "Replay body"], {
+            "category": "pattern", "title": "Replay title", "content": "Replay body",
+            "tags": "", "session_id": "sess", "confidence": None, "wing": "devops", "room": "tooling",
+            "facts": [], "skip_gate": True, "skip_scan": True, "task_id": "", "affected_files": [],
+            "source_file": "", "start_line": 0, "end_line": 0, "code_language": "", "code_snippet": "",
+            "code_location_set": False, "quiet": True, "error_type": "", "root_cause": "", "severity": "",
+            "fix_steps": "", "valence": "", "intensity": None, "priority": "", "agent_id": "",
+            "certainty": "", "caveats": "",
+        }, update_cerebrum=True)
+
+        def fake_with_retry(func, *args, **kwargs):
+            return 123
+
+        with ExitStack() as stack:
+            stack.enter_context(unittest.mock.patch.object(learn, "LEARN_INBOX", inbox))
+            stack.enter_context(unittest.mock.patch.object(learn, "with_retry", fake_with_retry))
+            stack.enter_context(unittest.mock.patch.object(learn, "_emit_knowledge_event_fail_open", lambda *a, **k: None))
+            stack.enter_context(unittest.mock.patch.object(learn, "_auto_update_cerebrum", lambda *a, **k: 7))
+            learn._queue_learn_payload(payload)
+            result = learn.flush_learn_inbox()
+
+        test("flush_inbox_cerebrum_fail: DB replay counted processed", result["processed"] == 1)
+        test("flush_inbox_cerebrum_fail: queue file removed after DB replay", result["remaining"] == 0)
+        test("flush_inbox_cerebrum_fail: DB replay not marked failed", result["failed"] == 0)
+        test("flush_inbox_cerebrum_fail: cerebrum failure counted separately", result["cerebrum_failed"] == 1)
 
 
 # ===========================================================================
@@ -906,6 +946,7 @@ def _run_all():
     test_from_file_cerebrum_output_no_swallow()
     test_learn_queues_entry_when_db_locked()
     test_flush_inbox_replays_and_removes_payload()
+    test_flush_inbox_unlinks_after_cerebrum_failure()
 
     print(f"\n  {_PASS} passed, {_FAIL} failed\n")
     return _FAIL

--- a/tests/test_learn_cerebrum_autoupdate.py
+++ b/tests/test_learn_cerebrum_autoupdate.py
@@ -33,6 +33,7 @@ Scenarios covered:
 
 import importlib.util
 import io
+import json
 import os
 import sqlite3
 import subprocess
@@ -628,6 +629,8 @@ def test_from_file_no_entries_exits_nonzero():
 def test_import_from_file_not_found_uses_stderr():
     """File-not-found diagnostics should go to stderr, not stdout."""
     captured_out = io.StringIO()
+    captured_out = io.StringIO()
+    captured_out = io.StringIO()
     captured_err = io.StringIO()
     with unittest.mock.patch("sys.stdout", captured_out), unittest.mock.patch("sys.stderr", captured_err):
         rv = learn.import_from_file("nonexistent.md")
@@ -789,6 +792,72 @@ def test_from_file_cerebrum_output_no_swallow():
     test("from_file_no_swallow: exit code None (success)", code is None)
 
 
+def test_learn_queues_entry_when_db_locked():
+    """A locked DB queues the learn request instead of losing it."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        inbox = Path(tmpdir) / "learn-inbox"
+
+        def busy_with_retry(func, *args, **kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        captured_out = io.StringIO()
+        captured_err = io.StringIO()
+        exit_code = None
+        with ExitStack() as stack:
+            stack.enter_context(unittest.mock.patch.object(learn, "LEARN_INBOX", inbox))
+            stack.enter_context(unittest.mock.patch.object(learn, "with_retry", busy_with_retry))
+            stack.enter_context(unittest.mock.patch("sys.stdout", captured_out))
+            stack.enter_context(unittest.mock.patch("sys.stderr", captured_err))
+            stack.enter_context(unittest.mock.patch.object(sys, "argv", [
+                "learn.py", "--decision", "Queued lock test", "Queue this when locked.",
+                "--tags", "sqlite,queue", "--wing", "devops", "--room", "tooling",
+            ]))
+            try:
+                learn.main()
+            except SystemExit as exc:
+                exit_code = exc.code
+
+        queued = list(inbox.glob("*.json"))
+        payload = json.loads(queued[0].read_text(encoding="utf-8")) if queued else {}
+        entry = payload.get("entry", {})
+        test("learn_inbox_lock: exits normally after queueing", exit_code is None)
+        test("learn_inbox_lock: one queued payload written", len(queued) == 1)
+        test("learn_inbox_lock: payload category preserved", entry.get("category") == "decision")
+        test("learn_inbox_lock: payload title preserved", entry.get("title") == "Queued lock test")
+        test("learn_inbox_lock: stderr mentions flush command", "flush-inbox" in captured_err.getvalue())
+
+
+def test_flush_inbox_replays_and_removes_payload():
+    """Queued entries replay through add_entry and are removed after success."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        inbox = Path(tmpdir) / "learn-inbox"
+        payload = learn._build_learn_payload(["--pattern", "Replay title", "Replay body"], {
+            "category": "pattern", "title": "Replay title", "content": "Replay body",
+            "tags": "", "session_id": "sess", "confidence": None, "wing": "devops", "room": "tooling",
+            "facts": [], "skip_gate": True, "skip_scan": True, "task_id": "", "affected_files": [],
+            "source_file": "", "start_line": 0, "end_line": 0, "code_language": "", "code_snippet": "",
+            "code_location_set": False, "quiet": True, "error_type": "", "root_cause": "", "severity": "",
+            "fix_steps": "", "valence": "", "intensity": None, "priority": "", "agent_id": "",
+            "certainty": "", "caveats": "",
+        })
+        replayed = {}
+
+        def fake_with_retry(func, *args, **kwargs):
+            replayed["title"] = args[1]
+            return 123
+
+        with ExitStack() as stack:
+            stack.enter_context(unittest.mock.patch.object(learn, "LEARN_INBOX", inbox))
+            stack.enter_context(unittest.mock.patch.object(learn, "with_retry", fake_with_retry))
+            stack.enter_context(unittest.mock.patch.object(learn, "_emit_knowledge_event_fail_open", lambda *a, **k: None))
+            learn._queue_learn_payload(payload)
+            result = learn.flush_learn_inbox()
+
+        test("flush_inbox: processed queued payload", result["processed"] == 1)
+        test("flush_inbox: no remaining queued payload", result["remaining"] == 0)
+        test("flush_inbox: replayed title preserved", replayed.get("title") == "Replay title")
+
+
 # ===========================================================================
 # Entry point
 # ===========================================================================
@@ -835,6 +904,8 @@ def _run_all():
     test_cerebrum_output_flag_no_content_pollution()
     test_cerebrum_sections_flag_no_value()
     test_from_file_cerebrum_output_no_swallow()
+    test_learn_queues_entry_when_db_locked()
+    test_flush_inbox_replays_and_removes_payload()
 
     print(f"\n  {_PASS} passed, {_FAIL} failed\n")
     return _FAIL


### PR DESCRIPTION
## Summary
- Queue single-entry learn writes to a durable inbox when SQLite remains locked after retries
- Add sk learn --flush-inbox to replay queued entries later
- Cover queue-on-lock and flush-replay paths with focused regressions

## Tests
- python -m py_compile learn.py tests\test_learn_cerebrum_autoupdate.py
- ruff check learn.py tests\test_learn_cerebrum_autoupdate.py
- python tests\test_learn_cerebrum_autoupdate.py
- python test_security.py
- python test_fixes.py
