### PR TITLE
Add native sk learn inbox fallback

### DIFF
--- a/sk-rust/src/commands/learn.rs
+++ b/sk-rust/src/commands/learn.rs
@@ -372,90 +372,6 @@ impl LearnParams {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    #[test]
-    fn facts_json_escapes_special_characters() {
-        let params = LearnParams {
-            category: "pattern".to_string(),
-            title: "title".to_string(),
-            description: "description".to_string(),
-            tags: String::new(),
-            wing: String::new(),
-            room: String::new(),
-            confidence: 0.7,
-            facts: vec!["C:\\tmp\nquoted \"fact\"".to_string()],
-            argv: vec![],
-            skip_gate: false,
-            skip_scan: false,
-        };
-
-        let parsed: Vec<String> = serde_json::from_str(&params.facts_json()).unwrap();
-        assert_eq!(parsed, params.facts);
-    }
-
-    #[test]
-    fn queued_payload_preserves_flags_and_facts() {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let inbox = std::env::temp_dir().join(format!("sk_learn_inbox_test_{unique}"));
-        let old_inbox = std::env::var("SK_LEARN_INBOX").ok();
-        std::env::set_var("SK_LEARN_INBOX", &inbox);
-
-        let params = LearnParams {
-            category: "decision".to_string(),
-            title: "queue title".to_string(),
-            description: "queue description".to_string(),
-            tags: "sqlite".to_string(),
-            wing: "devops".to_string(),
-            room: "tooling".to_string(),
-            confidence: 0.8,
-            facts: vec!["C:\\tmp\nfact".to_string()],
-            argv: vec![
-                "--decision".to_string(),
-                "queue title".to_string(),
-                "queue description".to_string(),
-            ],
-            skip_gate: false,
-            skip_scan: true,
-        };
-
-        let queued = write_learn_payload(&params).unwrap();
-        let payload: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&queued).unwrap()).unwrap();
-        assert_eq!(payload["entry"]["skip_gate"], false);
-        assert_eq!(payload["entry"]["skip_scan"], true);
-        assert_eq!(payload["entry"]["facts"][0], "C:\\tmp\nfact");
-
-        let _ = std::fs::remove_dir_all(&inbox);
-        match old_inbox {
-            Some(value) => std::env::set_var("SK_LEARN_INBOX", value),
-            None => std::env::remove_var("SK_LEARN_INBOX"),
-        }
-    }
-
-    #[test]
-    fn learn_inbox_dir_expands_tilde_env() {
-        let old_inbox = std::env::var("SK_LEARN_INBOX").ok();
-        std::env::set_var(
-            "SK_LEARN_INBOX",
-            "~/.copilot/session-state/learn-inbox-test",
-        );
-        let resolved = learn_inbox_dir();
-        assert!(!resolved.to_string_lossy().starts_with('~'));
-        assert!(resolved.ends_with(".copilot/session-state/learn-inbox-test"));
-        match old_inbox {
-            Some(value) => std::env::set_var("SK_LEARN_INBOX", value),
-            None => std::env::remove_var("SK_LEARN_INBOX"),
-        }
-    }
-}
-
 /// Simplified wing auto-detection (mirrors Python _WING_RULES).
 fn auto_detect_wing(tags: &str, title: &str, content: &str) -> String {
     let text = format!(
@@ -555,4 +471,88 @@ fn auto_detect_room(tags: &str, title: &str, content: &str) -> String {
         }
     }
     String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn facts_json_escapes_special_characters() {
+        let params = LearnParams {
+            category: "pattern".to_string(),
+            title: "title".to_string(),
+            description: "description".to_string(),
+            tags: String::new(),
+            wing: String::new(),
+            room: String::new(),
+            confidence: 0.7,
+            facts: vec!["C:\\tmp\nquoted \"fact\"".to_string()],
+            argv: vec![],
+            skip_gate: false,
+            skip_scan: false,
+        };
+
+        let parsed: Vec<String> = serde_json::from_str(&params.facts_json()).unwrap();
+        assert_eq!(parsed, params.facts);
+    }
+
+    #[test]
+    fn queued_payload_preserves_flags_and_facts() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let inbox = std::env::temp_dir().join(format!("sk_learn_inbox_test_{unique}"));
+        let old_inbox = std::env::var("SK_LEARN_INBOX").ok();
+        std::env::set_var("SK_LEARN_INBOX", &inbox);
+
+        let params = LearnParams {
+            category: "decision".to_string(),
+            title: "queue title".to_string(),
+            description: "queue description".to_string(),
+            tags: "sqlite".to_string(),
+            wing: "devops".to_string(),
+            room: "tooling".to_string(),
+            confidence: 0.8,
+            facts: vec!["C:\\tmp\nfact".to_string()],
+            argv: vec![
+                "--decision".to_string(),
+                "queue title".to_string(),
+                "queue description".to_string(),
+            ],
+            skip_gate: false,
+            skip_scan: true,
+        };
+
+        let queued = write_learn_payload(&params).unwrap();
+        let payload: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&queued).unwrap()).unwrap();
+        assert_eq!(payload["entry"]["skip_gate"], false);
+        assert_eq!(payload["entry"]["skip_scan"], true);
+        assert_eq!(payload["entry"]["facts"][0], "C:\\tmp\nfact");
+
+        let _ = std::fs::remove_dir_all(&inbox);
+        match old_inbox {
+            Some(value) => std::env::set_var("SK_LEARN_INBOX", value),
+            None => std::env::remove_var("SK_LEARN_INBOX"),
+        }
+    }
+
+    #[test]
+    fn learn_inbox_dir_expands_tilde_env() {
+        let old_inbox = std::env::var("SK_LEARN_INBOX").ok();
+        std::env::set_var(
+            "SK_LEARN_INBOX",
+            "~/.copilot/session-state/learn-inbox-test",
+        );
+        let resolved = learn_inbox_dir();
+        assert!(!resolved.to_string_lossy().starts_with('~'));
+        assert!(resolved.ends_with(".copilot/session-state/learn-inbox-test"));
+        match old_inbox {
+            Some(value) => std::env::set_var("SK_LEARN_INBOX", value),
+            None => std::env::remove_var("SK_LEARN_INBOX"),
+        }
+    }
 }

--- a/sk-rust/src/commands/learn.rs
+++ b/sk-rust/src/commands/learn.rs
@@ -37,6 +37,8 @@ struct LearnParams {
     confidence: f64,
     facts: Vec<String>,
     argv: Vec<String>,
+    skip_gate: bool,
+    skip_scan: bool,
 }
 
 /// Default confidence per category (mirrors Python learn.py).
@@ -59,6 +61,8 @@ fn parse_learn_args(args: &[String]) -> Result<LearnParams, String> {
     let mut room = String::new();
     let mut confidence: Option<f64> = None;
     let mut facts: Vec<String> = Vec::new();
+    let mut skip_gate = false;
+    let mut skip_scan = false;
 
     let category_flags = [
         "--mistake",
@@ -113,7 +117,15 @@ fn parse_learn_args(args: &[String]) -> Result<LearnParams, String> {
                 }
                 i += 2;
             }
-            // Skip flags we don't handle (--skip-gate, --skip-scan, etc.)
+            "--skip-gate" => {
+                skip_gate = true;
+                i += 1;
+            }
+            "--skip-scan" => {
+                skip_scan = true;
+                i += 1;
+            }
+            // Skip unknown flags we don't handle.
             s if s.starts_with("--") => {
                 i += 2; // skip flag + value
             }
@@ -157,21 +169,13 @@ fn parse_learn_args(args: &[String]) -> Result<LearnParams, String> {
         confidence: conf,
         facts,
         argv: args.to_vec(),
+        skip_gate,
+        skip_scan,
     })
 }
 
 fn execute_learn(params: LearnParams) -> ExitCode {
-    let facts_json = if params.facts.is_empty() {
-        "[]".to_string()
-    } else {
-        // Build simple JSON array
-        let items: Vec<String> = params
-            .facts
-            .iter()
-            .map(|f| format!("\"{}\"", f.replace('"', "\\\"")))
-            .collect();
-        format!("[{}]", items.join(","))
-    };
+    let facts_json = params.facts_json();
 
     let entry = NewEntry {
         category: params.category.clone(),
@@ -255,13 +259,26 @@ fn is_busy_error(err: &rusqlite::Error) -> bool {
 
 fn learn_inbox_dir() -> PathBuf {
     if let Ok(path) = std::env::var("SK_LEARN_INBOX") {
-        return PathBuf::from(path);
+        return expand_tilde(PathBuf::from(path));
     }
     resolve_home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".copilot")
         .join("session-state")
         .join("learn-inbox")
+}
+
+fn expand_tilde(path: PathBuf) -> PathBuf {
+    let raw = path.to_string_lossy();
+    if raw == "~" {
+        return resolve_home_dir().unwrap_or(path);
+    }
+    if let Some(rest) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("~\\")) {
+        if let Some(home) = resolve_home_dir() {
+            return home.join(rest);
+        }
+    }
+    path
 }
 
 fn queue_learn_params(params: &LearnParams) -> ExitCode {
@@ -286,8 +303,6 @@ fn queue_learn_params(params: &LearnParams) -> ExitCode {
 fn write_learn_payload(params: &LearnParams) -> Result<PathBuf, String> {
     let inbox = learn_inbox_dir();
     fs::create_dir_all(&inbox).map_err(|err| err.to_string())?;
-    let facts = serde_json::from_str::<serde_json::Value>(&params.facts_json())
-        .unwrap_or_else(|_| json!([]));
     let payload = json!({
         "schema_version": 1,
         "queued_at": chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
@@ -302,9 +317,9 @@ fn write_learn_payload(params: &LearnParams) -> Result<PathBuf, String> {
             "confidence": params.confidence,
             "wing": params.wing.clone(),
             "room": params.room.clone(),
-            "facts": facts,
-            "skip_gate": true,
-            "skip_scan": true,
+            "facts": params.facts.clone(),
+            "skip_gate": params.skip_gate,
+            "skip_scan": params.skip_scan,
             "task_id": "",
             "affected_files": [],
             "source_file": "",
@@ -353,15 +368,90 @@ fn write_learn_payload(params: &LearnParams) -> Result<PathBuf, String> {
 
 impl LearnParams {
     fn facts_json(&self) -> String {
-        if self.facts.is_empty() {
-            "[]".to_string()
-        } else {
-            let items: Vec<String> = self
-                .facts
-                .iter()
-                .map(|f| format!("\"{}\"", f.replace('"', "\\\"")))
-                .collect();
-            format!("[{}]", items.join(","))
+        serde_json::to_string(&self.facts).unwrap_or_else(|_| "[]".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn facts_json_escapes_special_characters() {
+        let params = LearnParams {
+            category: "pattern".to_string(),
+            title: "title".to_string(),
+            description: "description".to_string(),
+            tags: String::new(),
+            wing: String::new(),
+            room: String::new(),
+            confidence: 0.7,
+            facts: vec!["C:\\tmp\nquoted \"fact\"".to_string()],
+            argv: vec![],
+            skip_gate: false,
+            skip_scan: false,
+        };
+
+        let parsed: Vec<String> = serde_json::from_str(&params.facts_json()).unwrap();
+        assert_eq!(parsed, params.facts);
+    }
+
+    #[test]
+    fn queued_payload_preserves_flags_and_facts() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let inbox = std::env::temp_dir().join(format!("sk_learn_inbox_test_{unique}"));
+        let old_inbox = std::env::var("SK_LEARN_INBOX").ok();
+        std::env::set_var("SK_LEARN_INBOX", &inbox);
+
+        let params = LearnParams {
+            category: "decision".to_string(),
+            title: "queue title".to_string(),
+            description: "queue description".to_string(),
+            tags: "sqlite".to_string(),
+            wing: "devops".to_string(),
+            room: "tooling".to_string(),
+            confidence: 0.8,
+            facts: vec!["C:\\tmp\nfact".to_string()],
+            argv: vec![
+                "--decision".to_string(),
+                "queue title".to_string(),
+                "queue description".to_string(),
+            ],
+            skip_gate: false,
+            skip_scan: true,
+        };
+
+        let queued = write_learn_payload(&params).unwrap();
+        let payload: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&queued).unwrap()).unwrap();
+        assert_eq!(payload["entry"]["skip_gate"], false);
+        assert_eq!(payload["entry"]["skip_scan"], true);
+        assert_eq!(payload["entry"]["facts"][0], "C:\\tmp\nfact");
+
+        let _ = std::fs::remove_dir_all(&inbox);
+        match old_inbox {
+            Some(value) => std::env::set_var("SK_LEARN_INBOX", value),
+            None => std::env::remove_var("SK_LEARN_INBOX"),
+        }
+    }
+
+    #[test]
+    fn learn_inbox_dir_expands_tilde_env() {
+        let old_inbox = std::env::var("SK_LEARN_INBOX").ok();
+        std::env::set_var(
+            "SK_LEARN_INBOX",
+            "~/.copilot/session-state/learn-inbox-test",
+        );
+        let resolved = learn_inbox_dir();
+        assert!(!resolved.to_string_lossy().starts_with('~'));
+        assert!(resolved.ends_with(".copilot/session-state/learn-inbox-test"));
+        match old_inbox {
+            Some(value) => std::env::set_var("SK_LEARN_INBOX", value),
+            None => std::env::remove_var("SK_LEARN_INBOX"),
         }
     }
 }

--- a/sk-rust/src/commands/learn.rs
+++ b/sk-rust/src/commands/learn.rs
@@ -1,9 +1,21 @@
-use std::process::ExitCode;
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, ExitCode};
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use rusqlite::ErrorCode;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use crate::config::{python_exe, resolve_home_dir, resolve_tools_dir};
 use crate::db::write::{insert_or_update_entry, open_writable, rebuild_fts, NewEntry};
 
 /// Entry point called from main's dispatch for the `learn` command.
 pub fn run_learn_command(args: &[String]) -> ExitCode {
+    if args.iter().any(|arg| arg == "--flush-inbox") {
+        return delegate_to_python_learn(args);
+    }
+
     match parse_learn_args(args) {
         Ok(params) => execute_learn(params),
         Err(msg) => {
@@ -24,6 +36,7 @@ struct LearnParams {
     room: String,
     confidence: f64,
     facts: Vec<String>,
+    argv: Vec<String>,
 }
 
 /// Default confidence per category (mirrors Python learn.py).
@@ -143,6 +156,7 @@ fn parse_learn_args(args: &[String]) -> Result<LearnParams, String> {
         room,
         confidence: conf,
         facts,
+        argv: args.to_vec(),
     })
 }
 
@@ -162,8 +176,8 @@ fn execute_learn(params: LearnParams) -> ExitCode {
     let entry = NewEntry {
         category: params.category.clone(),
         title: params.title.clone(),
-        content: params.description,
-        tags: params.tags,
+        content: params.description.clone(),
+        tags: params.tags.clone(),
         wing: params.wing.clone(),
         room: params.room.clone(),
         confidence: params.confidence,
@@ -173,6 +187,9 @@ fn execute_learn(params: LearnParams) -> ExitCode {
     let conn = match open_writable(None) {
         Ok(c) => c,
         Err(e) => {
+            if is_busy_error(&e) && queue_on_lock_enabled() {
+                return queue_learn_params(&params);
+            }
             eprintln!("sk learn: cannot open knowledge.db for writing: {e}");
             eprintln!("Hint: Run 'sk index build' first to initialize the database.");
             return ExitCode::from(1);
@@ -182,6 +199,9 @@ fn execute_learn(params: LearnParams) -> ExitCode {
     let entry_id = match insert_or_update_entry(&conn, &entry) {
         Ok(id) => id,
         Err(e) => {
+            if is_busy_error(&e) && queue_on_lock_enabled() {
+                return queue_learn_params(&params);
+            }
             eprintln!("sk learn: DB write failed: {e}");
             return ExitCode::from(1);
         }
@@ -199,6 +219,151 @@ fn execute_learn(params: LearnParams) -> ExitCode {
     println!("  Added new {} #{}{}", params.category, entry_id, loc);
 
     ExitCode::SUCCESS
+}
+
+fn delegate_to_python_learn(args: &[String]) -> ExitCode {
+    let learn_py = resolve_tools_dir().join("learn.py");
+    let status = Command::new(python_exe()).arg(learn_py).args(args).status();
+    match status {
+        Ok(status) if status.success() => ExitCode::SUCCESS,
+        Ok(_) => ExitCode::from(1),
+        Err(err) => {
+            eprintln!("sk learn: failed to run learn.py for --flush-inbox: {err}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn queue_on_lock_enabled() -> bool {
+    std::env::var("SK_LEARN_QUEUE_ON_LOCK").map_or(true, |value| value != "0")
+}
+
+fn is_busy_error(err: &rusqlite::Error) -> bool {
+    match err {
+        rusqlite::Error::SqliteFailure(sqlite_err, _) => {
+            matches!(
+                sqlite_err.code,
+                ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked
+            )
+        }
+        _ => {
+            let message = err.to_string().to_ascii_lowercase();
+            message.contains("database is locked") || message.contains("database is busy")
+        }
+    }
+}
+
+fn learn_inbox_dir() -> PathBuf {
+    if let Ok(path) = std::env::var("SK_LEARN_INBOX") {
+        return PathBuf::from(path);
+    }
+    resolve_home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".copilot")
+        .join("session-state")
+        .join("learn-inbox")
+}
+
+fn queue_learn_params(params: &LearnParams) -> ExitCode {
+    match write_learn_payload(params) {
+        Ok(path) => {
+            eprintln!(
+                "  DB busy after retries; queued learn entry for later flush: {}",
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("queued learn entry")
+            );
+            eprintln!("  Run `sk learn --flush-inbox` to replay queued entries.");
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("sk learn: DB locked and failed to queue entry: {err}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn write_learn_payload(params: &LearnParams) -> Result<PathBuf, String> {
+    let inbox = learn_inbox_dir();
+    fs::create_dir_all(&inbox).map_err(|err| err.to_string())?;
+    let facts = serde_json::from_str::<serde_json::Value>(&params.facts_json())
+        .unwrap_or_else(|_| json!([]));
+    let payload = json!({
+        "schema_version": 1,
+        "queued_at": chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
+        "reason": "database_locked",
+        "argv": params.argv.clone(),
+        "entry": {
+            "category": params.category.clone(),
+            "title": params.title.clone(),
+            "content": params.description.clone(),
+            "tags": params.tags.clone(),
+            "session_id": "manual",
+            "confidence": params.confidence,
+            "wing": params.wing.clone(),
+            "room": params.room.clone(),
+            "facts": facts,
+            "skip_gate": true,
+            "skip_scan": true,
+            "task_id": "",
+            "affected_files": [],
+            "source_file": "",
+            "start_line": 0,
+            "end_line": 0,
+            "code_language": "",
+            "code_snippet": "",
+            "code_location_set": false,
+            "quiet": false,
+            "error_type": "",
+            "root_cause": "",
+            "severity": "",
+            "fix_steps": "",
+            "valence": "",
+            "intensity": null,
+            "priority": "",
+            "agent_id": "",
+            "certainty": "",
+            "caveats": ""
+        },
+        "cerebrum": {
+            "update": false,
+            "output": "CEREBRUM.md",
+            "sections": null
+        }
+    });
+    let raw = serde_json::to_string(&payload).map_err(|err| err.to_string())?;
+    let digest = Sha256::digest(raw.as_bytes());
+    let hash = format!("{:x}", digest);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| err.to_string())?
+        .as_nanos();
+    let name = format!(
+        "{}-{}-{}.json",
+        chrono::Utc::now().format("%Y%m%dT%H%M%S"),
+        nanos,
+        &hash[..16]
+    );
+    let final_path = inbox.join(&name);
+    let tmp_path = inbox.join(format!(".{name}.tmp"));
+    fs::write(&tmp_path, format!("{raw}\n")).map_err(|err| err.to_string())?;
+    fs::rename(&tmp_path, &final_path).map_err(|err| err.to_string())?;
+    Ok(final_path)
+}
+
+impl LearnParams {
+    fn facts_json(&self) -> String {
+        if self.facts.is_empty() {
+            "[]".to_string()
+        } else {
+            let items: Vec<String> = self
+                .facts
+                .iter()
+                .map(|f| format!("\"{}\"", f.replace('"', "\\\"")))
+                .collect();
+            format!("[{}]", items.join(","))
+        }
+    }
 }
 
 /// Simplified wing auto-detection (mirrors Python _WING_RULES).

--- a/sk-rust/tests/integration_test.rs
+++ b/sk-rust/tests/integration_test.rs
@@ -284,6 +284,42 @@ fn fallback_executes_python_script() {
 }
 
 #[test]
+fn learn_flush_inbox_delegates_to_python_script() {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let test_dir = std::env::temp_dir().join(format!("sk_learn_flush_delegate_{unique}"));
+    let _guard = TempTree(test_dir.clone());
+    let args_file = test_dir.join("learn-args.txt");
+    fs::create_dir_all(&test_dir).unwrap();
+
+    let script = r#"
+import os
+import sys
+from pathlib import Path
+Path(os.environ["SK_LEARN_TEST_ARGS"]).write_text("\n".join(sys.argv[1:]), encoding="utf-8")
+print("FLUSH_DELEGATED")
+"#;
+    fs::write(test_dir.join("learn.py"), script).unwrap();
+
+    sk().args(["learn", "--flush-inbox", "--json", "--limit", "0"])
+        .env("SK_TOOLS_DIR", &test_dir)
+        .env("SK_LEARN_TEST_ARGS", &args_file)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FLUSH_DELEGATED"));
+
+    let observed = fs::read_to_string(&args_file).unwrap();
+    assert!(observed.contains("--flush-inbox"));
+    assert!(observed.contains("--json"));
+    assert!(observed.contains("--limit"));
+}
+
+#[test]
 fn watch_once_honors_home_override() {
     use std::fs;
 


### PR DESCRIPTION
## Summary
- Route `sk learn --flush-inbox` through `learn.py` so the merged inbox replay command works from the native launcher
- Queue native `sk learn` writes to the same Python-compatible inbox when SQLite remains busy/locked after retries
- Keep non-lock database errors fail-fast and preserve `SK_LEARN_QUEUE_ON_LOCK` / `SK_LEARN_INBOX` behavior

## Tests
- `cargo fmt --check`
- `cargo check --quiet`
- `cargo test --quiet learn`
