### PR TITLE
Fix sk learn queue latency under DB locks

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -596,10 +596,11 @@ learn --stats              # Knowledge base statistics
 learn --mistake "Title" "Description" --json
 ```
 
-When a single-entry `learn` write still hits SQLite `database is locked` after
-the built-in retry window, it is queued under `SK_LEARN_INBOX` if set, otherwise
+When a single-entry `learn` write hits SQLite `database is locked`, it uses a
+short busy timeout and is queued under `SK_LEARN_INBOX` if set, otherwise
 `~/.copilot/session-state/learn-inbox`. Set `SK_LEARN_QUEUE_ON_LOCK=0` to fail
-instead of queueing.
+instead of queueing, or tune the fast-fail window with `SK_LEARN_BUSY_TIMEOUT_MS`
+(default: `250`).
 
 ## Palace Concepts (Wing/Room)
 

--- a/learn.py
+++ b/learn.py
@@ -57,6 +57,8 @@ TOOLS_DIR = Path(__file__).parent
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
 DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 LEARN_INBOX = Path(os.environ.get("SK_LEARN_INBOX", str(SESSION_STATE / "learn-inbox"))).expanduser()
+DEFAULT_DB_BUSY_TIMEOUT_MS = 30_000
+DEFAULT_LEARN_QUEUE_BUSY_TIMEOUT_MS = 250
 
 
 def _emit_knowledge_event_fail_open(event_type: str, data: dict) -> None:
@@ -143,13 +145,28 @@ def _replay_queued_payload(payload: dict) -> tuple[int, int]:
     return entry_id, cerebrum_rc
 
 
-def _write_learn_entry(entry_kwargs: dict) -> int:
+def _write_learn_entry(
+    entry_kwargs: dict,
+    *,
+    max_attempts: int = 5,
+    base_delay: float = 0.5,
+    db_busy_timeout_ms: int | None = None,
+) -> int:
     """Write an entry through the standard retry path, preserving CLI call shape."""
     entry = dict(entry_kwargs)
     category = entry.pop("category")
     title = entry.pop("title")
     content = entry.pop("content")
-    return with_retry(add_entry, category, title, content, **entry)
+    return with_retry(
+        add_entry,
+        category,
+        title,
+        content,
+        max_attempts=max_attempts,
+        base_delay=base_delay,
+        db_busy_timeout_ms=db_busy_timeout_ms,
+        **entry,
+    )
 
 
 def flush_learn_inbox(limit: int = 100) -> dict:
@@ -836,20 +853,33 @@ def _auto_update_cerebrum(output_path: str, sections: str | None, *, json_mode: 
         return 1
 
 
-def get_db() -> sqlite3.Connection:
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+def _learn_queue_on_lock_enabled() -> bool:
+    return os.environ.get("SK_LEARN_QUEUE_ON_LOCK", "1") != "0"
+
+
+def _learn_queue_busy_timeout_ms() -> int:
+    return max(0, _env_int("SK_LEARN_BUSY_TIMEOUT_MS", DEFAULT_LEARN_QUEUE_BUSY_TIMEOUT_MS))
+
+
+def get_db(busy_timeout_ms: int | None = None) -> sqlite3.Connection:
     if not DB_PATH.exists():
         print("Error: Knowledge DB not found. Run build-session-index.py first.", file=sys.stderr)
         sys.exit(1)
-    # Per-connection timeout (seconds) for SQLite-level busy waiting before
-    # raising OperationalError. Combined with PRAGMA busy_timeout below.
-    # 30s is enough to ride out batch flushes from watch-sessions.py indexer
-    # service on multi-hundred-MB knowledge databases.
-    db = sqlite3.connect(str(DB_PATH), timeout=30.0)
+    timeout_ms = DEFAULT_DB_BUSY_TIMEOUT_MS if busy_timeout_ms is None else max(0, int(busy_timeout_ms))
+    # Per-connection timeout controls SQLite-level busy waiting before raising
+    # OperationalError. Normal fail-open learn writes use a short timeout and
+    # queue quickly; explicit flush/replay keeps the longer default window.
+    db = sqlite3.connect(str(DB_PATH), timeout=timeout_ms / 1000.0)
     db.row_factory = sqlite3.Row
-    # WAL mode for concurrent reads; busy_timeout lets writers retry up to 30 s
-    # before failing with SQLITE_BUSY when the indexer or sync is also writing.
+    db.execute(f"PRAGMA busy_timeout={timeout_ms}")
     db.execute("PRAGMA journal_mode=WAL")
-    db.execute("PRAGMA busy_timeout=30000")
     return db
 
 
@@ -942,6 +972,7 @@ def add_entry(
     agent_id: str = "",
     certainty: str = "",
     caveats: str = "",
+    db_busy_timeout_ms: int | None = None,
 ) -> int:
     """Add a knowledge entry to the database. Returns entry ID.
 
@@ -957,7 +988,7 @@ def add_entry(
     credential leaks, and invisible Unicode. Matching entries are REJECTED unless
     --skip-scan is passed (for documenting injection patterns themselves).
     """
-    db = get_db()
+    db = get_db(db_busy_timeout_ms)
     ke_columns = {row[1] for row in db.execute("PRAGMA table_info(knowledge_entries)").fetchall()}
     has_code_location_columns = all(
         c in ke_columns for c in ("source_file", "start_line", "end_line", "code_language", "code_snippet")
@@ -2079,9 +2110,14 @@ def main():
     }
 
     try:
-        entry_id = _write_learn_entry(entry_kwargs)
+        queue_on_lock = _learn_queue_on_lock_enabled()
+        entry_id = _write_learn_entry(
+            entry_kwargs,
+            max_attempts=1 if queue_on_lock else 5,
+            db_busy_timeout_ms=_learn_queue_busy_timeout_ms() if queue_on_lock else None,
+        )
     except sqlite3.OperationalError as exc:
-        if _is_busy_error(exc) and os.environ.get("SK_LEARN_QUEUE_ON_LOCK", "1") != "0":
+        if _is_busy_error(exc) and queue_on_lock:
             queued_path = _queue_learn_payload(
                 _build_learn_payload(
                     args,
@@ -2106,7 +2142,7 @@ def main():
                 )
             else:
                 print(
-                    f"  DB busy after retries; queued learn entry for later flush: {queued_path.name}",
+                    f"  DB busy; queued learn entry for later flush: {queued_path.name}",
                     file=sys.stderr,
                 )
                 print("  Run `sk learn --flush-inbox` to replay queued entries.", file=sys.stderr)

--- a/sk-rust/src/commands/learn.rs
+++ b/sk-rust/src/commands/learn.rs
@@ -8,7 +8,12 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 
 use crate::config::{python_exe, resolve_home_dir, resolve_tools_dir};
-use crate::db::write::{insert_or_update_entry, open_writable, rebuild_fts, NewEntry};
+use crate::db::write::{
+    insert_or_update_entry, open_writable_with_busy_timeout, rebuild_fts, NewEntry,
+};
+
+const DEFAULT_LEARN_DB_BUSY_TIMEOUT_MS: u64 = 30_000;
+const DEFAULT_LEARN_QUEUE_BUSY_TIMEOUT_MS: u64 = 250;
 
 /// Entry point called from main's dispatch for the `learn` command.
 pub fn run_learn_command(args: &[String]) -> ExitCode {
@@ -188,7 +193,7 @@ fn execute_learn(params: LearnParams) -> ExitCode {
         facts_json,
     };
 
-    let conn = match open_writable(None) {
+    let conn = match open_writable_with_busy_timeout(None, learn_write_busy_timeout_ms()) {
         Ok(c) => c,
         Err(e) => {
             if is_busy_error(&e) && queue_on_lock_enabled() {
@@ -242,6 +247,16 @@ fn queue_on_lock_enabled() -> bool {
     std::env::var("SK_LEARN_QUEUE_ON_LOCK").map_or(true, |value| value != "0")
 }
 
+fn learn_write_busy_timeout_ms() -> u64 {
+    if !queue_on_lock_enabled() {
+        return DEFAULT_LEARN_DB_BUSY_TIMEOUT_MS;
+    }
+    std::env::var("SK_LEARN_BUSY_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_LEARN_QUEUE_BUSY_TIMEOUT_MS)
+}
+
 fn is_busy_error(err: &rusqlite::Error) -> bool {
     match err {
         rusqlite::Error::SqliteFailure(sqlite_err, _) => {
@@ -285,7 +300,7 @@ fn queue_learn_params(params: &LearnParams) -> ExitCode {
     match write_learn_payload(params) {
         Ok(path) => {
             eprintln!(
-                "  DB busy after retries; queued learn entry for later flush: {}",
+                "  DB busy; queued learn entry for later flush: {}",
                 path.file_name()
                     .and_then(|name| name.to_str())
                     .unwrap_or("queued learn entry")

--- a/sk-rust/src/db/write.rs
+++ b/sk-rust/src/db/write.rs
@@ -1,21 +1,27 @@
 use rusqlite::{Connection, OpenFlags, OptionalExtension, Result};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::connection::knowledge_db_path;
 
 /// Open a read-write connection to knowledge.db with WAL mode.
 pub fn open_writable(path: Option<PathBuf>) -> Result<Connection> {
+    open_writable_with_busy_timeout(path, 30_000)
+}
+
+/// Open a read-write connection with a caller-controlled SQLite busy timeout.
+pub fn open_writable_with_busy_timeout(
+    path: Option<PathBuf>,
+    busy_timeout_ms: u64,
+) -> Result<Connection> {
     let path = path.unwrap_or_else(knowledge_db_path);
     let conn = Connection::open_with_flags(
         &path,
         OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
-    conn.execute_batch(
-        "PRAGMA journal_mode=WAL;
-         PRAGMA busy_timeout=30000;",
-    )?;
+    conn.busy_timeout(Duration::from_millis(busy_timeout_ms))?;
+    conn.execute_batch("PRAGMA journal_mode=WAL;")?;
     Ok(conn)
 }
 

--- a/sk-rust/tests/integration_test.rs
+++ b/sk-rust/tests/integration_test.rs
@@ -320,6 +320,88 @@ print("FLUSH_DELEGATED")
 }
 
 #[test]
+fn learn_queues_quickly_when_db_is_locked() {
+    use std::fs;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let test_dir = std::env::temp_dir().join(format!("sk_learn_locked_queue_{unique}"));
+    let _guard = TempTree(test_dir.clone());
+    let db_path = test_dir.join("knowledge.db");
+    let inbox = test_dir.join("learn-inbox");
+    fs::create_dir_all(&test_dir).unwrap();
+
+    let locker = rusqlite::Connection::open(&db_path).unwrap();
+    locker
+        .execute_batch(
+            r#"
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE knowledge_entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                category TEXT NOT NULL,
+                title TEXT NOT NULL,
+                stable_id TEXT,
+                content TEXT,
+                tags TEXT,
+                confidence REAL,
+                session_id TEXT,
+                occurrence_count INTEGER DEFAULT 1,
+                first_seen TEXT,
+                last_seen TEXT,
+                wing TEXT,
+                room TEXT,
+                facts TEXT,
+                est_tokens INTEGER
+            );
+            BEGIN IMMEDIATE;
+            "#,
+        )
+        .unwrap();
+
+    let start = Instant::now();
+    sk().args([
+        "learn",
+        "--decision",
+        "locked db queues",
+        "A locked knowledge DB should queue the learn entry without waiting for the long DB retry window.",
+        "--tags",
+        "sqlite,locks",
+        "--wing",
+        "devops",
+        "--room",
+        "tooling",
+    ])
+    .env("SK_DB", &db_path)
+    .env("SK_LEARN_INBOX", &inbox)
+    .env("SK_LEARN_BUSY_TIMEOUT_MS", "1")
+    .assert()
+    .success()
+    .stderr(predicate::str::contains("queued learn entry"));
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "locked DB learn should queue quickly, took {}ms",
+        elapsed.as_millis()
+    );
+    let queued_count = fs::read_dir(&inbox)
+        .unwrap()
+        .filter(|entry| {
+            entry
+                .as_ref()
+                .ok()
+                .and_then(|entry| entry.path().extension().map(|ext| ext == "json"))
+                .unwrap_or(false)
+        })
+        .count();
+    assert_eq!(queued_count, 1);
+    locker.execute_batch("ROLLBACK;").unwrap();
+}
+
+#[test]
 fn watch_once_honors_home_override() {
     use std::fs;
 

--- a/sk-rust/tests/integration_test.rs
+++ b/sk-rust/tests/integration_test.rs
@@ -376,6 +376,7 @@ fn learn_queues_quickly_when_db_is_locked() {
     ])
     .env("SK_DB", &db_path)
     .env("SK_LEARN_INBOX", &inbox)
+    .env("SK_LEARN_QUEUE_ON_LOCK", "1")
     .env("SK_LEARN_BUSY_TIMEOUT_MS", "1")
     .assert()
     .success()


### PR DESCRIPTION
## Summary
- make single-entry `sk learn` writes queue quickly when SQLite is locked instead of waiting for the long DB busy window
- keep the old 30s timeout when queue-on-lock is disabled and for explicit inbox replay
- document `SK_LEARN_BUSY_TIMEOUT_MS` and add a locked-DB integration regression test

## Validation
- `python -m py_compile learn.py`
- `python tests\test_learn_cerebrum_autoupdate.py`
- `cd sk-rust && cargo fmt --check`
- `cd sk-rust && cargo test learn_queues_quickly_when_db_is_locked -- --nocapture`
- `cd sk-rust && cargo clippy --features browse-server --all-targets --no-deps -- -D warnings`