### PR TITLE
docs(harness/H-010): Harness Engineering 7 principles in AGENTS.md with AI notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,23 @@ python3 run_all_tests.py    # full suite
 
 For `browse-ui/` changes: `cd browse-ui && pnpm typecheck && pnpm lint && pnpm format:check && pnpm test && pnpm build` (and `pnpm test:e2e` when runtime/operator surfaces change materially)
 
+## 🛡️ Harness Engineering Principles
+
+<!-- AI: Read this table before every task. Apply each principle as a checklist gate. -->
+
+| # | Principle | Rule | <!-- AI: enforcement note --> |
+|---|-----------|------|-------------------------------|
+| 1 | **No-Ship-Bugs** | CODE→COMPILE→TEST→VERIFY→COMMIT. Never commit without passing tests. | <!-- AI: run test_security.py && test_fixes.py before any commit --> |
+| 2 | **Follow-Workflow** | Clarify→Plan→Execute→Verify→Close. No skipping phases. | <!-- AI: check WORKFLOW.md or use PLAN→BUILD→TEST→VERIFY→COMMIT if absent --> |
+| 3 | **Quality-Over-Speed** | Multi-platform = no shortcuts. Verify on all surfaces. | <!-- AI: run all surface gates (Python + browse-ui + Rust) before closeout --> |
+| 4 | **Tentacle-Orchestration** | ≥3 files or ≥2 modules → tentacle required. | <!-- AI: count changed files; if ≥3, create tentacle before editing --> |
+| 5 | **No-Abandon** | confidence < 1.0 = research loop, never BLOCKED. Fix or delegate. | <!-- AI: never write BLOCKED; create research-<topic> tentacle instead --> |
+| 6 | **Rules-First** | Read AGENTS.md before every task. | <!-- AI: this table IS the rules — re-read on each new task --> |
+| 7 | **Knowledge-Recording** | `sk learn` after every bug fix or new pattern. | <!-- AI: call sk learn --mistake or --pattern before task_complete --> |
+
+> Canonical source: `templates/copilot-instructions.md § 🛡️ Harness Engineering — 7 Nguyên tắc`  
+> Full rule details: [docs/AGENT-RULES.md](docs/AGENT-RULES.md)
+
 ## Hard Boundaries
 
 - NEVER interpolate user input into SQL strings

--- a/docs/AGENT-RULES.md
+++ b/docs/AGENT-RULES.md
@@ -4,6 +4,20 @@
 >
 > These rules are **non-negotiable** and apply to every agent — main session, sub-agent, explore, task, or general-purpose. They are also enforced via `.github/copilot-instructions.md` (injected into every Copilot CLI session) and partially enforced at the hook level.
 
+## Harness Engineering Principles
+
+The 7 Harness Engineering principles are documented in `AGENTS.md § 🛡️ Harness Engineering Principles` with AI enforcement annotations. These principles govern all agent work in this project:
+
+1. **No-Ship-Bugs** — never commit without passing tests
+2. **Follow-Workflow** — Clarify→Plan→Execute→Verify→Close
+3. **Quality-Over-Speed** — verify all surfaces before closeout
+4. **Tentacle-Orchestration** — ≥3 files/≥2 modules requires tentacle
+5. **No-Abandon** — research loop instead of BLOCKED
+6. **Rules-First** — read AGENTS.md before every task
+7. **Knowledge-Recording** — `sk learn` after every fix
+
+See also: `templates/copilot-instructions.md` for the original Vietnamese source.
+
 ## Rule 1 — Investigate Before Acting
 
 **NEVER modify code without reading it first.** Before any edit:

--- a/sk.py
+++ b/sk.py
@@ -125,8 +125,8 @@ _DIRECT: dict[str, str] = {
     "audit-hooks": "audit-hooks.py",
     "audit-instructions": "audit-instructions.py",
     "improvement-signals": "improvement-signals.py",
-    "status": "statusline.py",       # show session token usage + quota summary
-    "statusline": "statusline.py",   # alias for status
+    "status": "statusline.py",  # show session token usage + quota summary
+    "statusline": "statusline.py",  # alias for status
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}


### PR DESCRIPTION
## Summary
Add 7 Harness Engineering principles to AGENTS.md with `<- AWS, Docker AI: -->` enforcement annotations, plus cross-reference in docs/AGENT-RULES.md.

## Changes
- `AGENTS.md` — new `## 🛡️ Harness Engineering Principles` section (18 lines)
- `docs/AGENT-RULES.md` — new `## Harness Engineering Principles` cross-ref section

## Verification
```
✅ tests/test_quality_gates.py: 366/366 passed
```

Closes #628