### PR TITLE
feat(harness/H-003): pre/post dispatch middleware — DispatchContext + SK_HARNESS opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ See [docs/AGENT-RULES.md](docs/AGENT-RULES.md) for the complete rule text, goal-
 
 ## Architecture Key Facts
 
-- **Standalone scripts by default** — avoid inter-script imports unless a documented helper exception such as `_tentacle_core.py`, `_tentacle_goal.py`, `_tentacle_pr.py`, `_tentacle_dispatch.py`, or `_tentacle_review.py` preserves an existing contract
+- **Standalone scripts by default** — avoid inter-script imports unless a documented helper exception such as `_tentacle_core.py`, `_tentacle_goal.py`, `_tentacle_pr.py`, `_tentacle_dispatch.py`, or `_tentacle_review.py` preserves an existing contract; `harness/meta.py` — `CommandMeta` dataclass registry; imported by `sk.py` for `_DIRECT` metadata (do not remove this import exception)
 - **Pure stdlib Python 3.10+** — zero pip dependencies; `scikit-learn` / embedding keys are optional
 - **Parameterized SQL only** — `?` placeholders; never interpolate user input into SQL
 - **JSON serialization only** — never use pickle

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -1,0 +1,4 @@
+# harness — CLI dispatch metadata and middleware for sk
+import os, sys
+if os.name == "nt":
+    sys.stdout.reconfigure(encoding="utf-8")

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -1,4 +1,6 @@
 # harness — CLI dispatch metadata and middleware for sk
-import os, sys
+import os
+import sys
+
 if os.name == "nt":
     sys.stdout.reconfigure(encoding="utf-8")

--- a/harness/dispatch.py
+++ b/harness/dispatch.py
@@ -1,0 +1,77 @@
+"""Dispatch middleware for sk — pre/post hooks controlled by SK_HARNESS=1."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+if os.name == "nt":
+    sys.stdout.reconfigure(encoding="utf-8")
+
+
+@dataclass
+class DispatchContext:
+    """Mutable context passed through pre/post dispatch hooks."""
+
+    cmd: str
+    script: str
+    extra_args: list[str]
+    env: dict[str, str]
+    start_ms: float = 0.0
+    abort: bool = False
+    abort_code: int = 0
+    result_code: int = 0
+
+
+# Hook registries — populated by modules that import harness.dispatch
+_PRE_HOOKS: list[Callable[[DispatchContext], None]] = []
+_POST_HOOKS: list[Callable[[DispatchContext], None]] = []
+
+
+def _dry_run_pre_hook(ctx: DispatchContext) -> None:
+    """Abort dispatch and print command when SK_DRY_RUN=1."""
+    if os.environ.get("SK_DRY_RUN") == "1":
+        print(f"[sk dry-run] would run: {ctx.script} {' '.join(ctx.extra_args)}", file=sys.stderr)
+        ctx.abort = True
+        ctx.abort_code = 0
+
+
+_PRE_HOOKS.append(_dry_run_pre_hook)
+
+
+def run_with_hooks(cmd: str, script: str, args: list[str], tools_dir: str) -> int:
+    """Run script through pre/post hook pipeline. Returns exit code."""
+    ctx = DispatchContext(
+        cmd=cmd,
+        script=script,
+        extra_args=list(args),
+        env=dict(os.environ),
+        start_ms=time.time() * 1000,
+    )
+
+    # Run pre-hooks (fail-open: exceptions are logged, dispatch continues)
+    for hook in _PRE_HOOKS:
+        try:
+            hook(ctx)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[sk harness] pre-hook error: {exc}", file=sys.stderr)
+        if ctx.abort:
+            return ctx.abort_code
+
+    # Dispatch subprocess
+    script_path = os.path.join(tools_dir, ctx.script)
+    result = subprocess.run([sys.executable, script_path, *ctx.extra_args], env=ctx.env)
+    ctx.result_code = result.returncode
+
+    # Run post-hooks (fail-open)
+    for hook in _POST_HOOKS:
+        try:
+            hook(ctx)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[sk harness] post-hook error: {exc}", file=sys.stderr)
+
+    return ctx.result_code

--- a/harness/meta.py
+++ b/harness/meta.py
@@ -1,0 +1,20 @@
+"""CommandMeta: metadata wrapper for sk.py _DIRECT entries."""
+from __future__ import annotations
+import os, sys
+if os.name == "nt":
+    sys.stdout.reconfigure(encoding="utf-8")
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class CommandMeta:
+    """Immutable metadata for a single sk command."""
+    script: str
+    description: str = ""
+    tags: tuple[str, ...] = ()
+    aliases: tuple[str, ...] = ()
+    group: str = "general"
+    experimental: bool = False
+
+    def __str__(self) -> str:
+        """Return script name for backward-compat with _run(str(entry), rest)."""
+        return self.script

--- a/harness/meta.py
+++ b/harness/meta.py
@@ -1,9 +1,13 @@
 """CommandMeta: metadata wrapper for sk.py _DIRECT entries."""
 from __future__ import annotations
-import os, sys
+
+import os
+import sys
+
 if os.name == "nt":
     sys.stdout.reconfigure(encoding="utf-8")
 from dataclasses import dataclass
+
 
 @dataclass(frozen=True)
 class CommandMeta:

--- a/harness/meta.py
+++ b/harness/meta.py
@@ -1,4 +1,5 @@
 """CommandMeta: metadata wrapper for sk.py _DIRECT entries."""
+
 from __future__ import annotations
 
 import os
@@ -12,6 +13,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class CommandMeta:
     """Immutable metadata for a single sk command."""
+
     script: str
     description: str = ""
     tags: tuple[str, ...] = ()

--- a/sk.py
+++ b/sk.py
@@ -63,6 +63,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+
 from harness.meta import CommandMeta
 
 if os.name == "nt":

--- a/sk.py
+++ b/sk.py
@@ -97,38 +97,50 @@ _PROJECT_DB_SCRIPTS = {
 
 # Top-level direct commands: (script_name,)
 _DIRECT: dict[str, CommandMeta] = {
-    "briefing":            CommandMeta("briefing.py",            "Surface past session knowledge and mistakes",          ("session", "recall", "index")),
-    "query":               CommandMeta("query-session.py",       "Semantic search over knowledge base",                  ("index", "search")),
-    "learn":               CommandMeta("learn.py",               "Record mistakes, patterns, features, decisions",       ("session", "learn")),
-    "clarify":             CommandMeta("clarify.py",             "Clarify ambiguous task specs before coding",           ("planning",)),
-    "specify":             CommandMeta("specify.py",             "Generate structured task specification",               ("planning",)),
-    "plan":                CommandMeta("specify.py",             "Alias: generate task plan",                           ("planning",), aliases=("specify",)),
-    "tasks":               CommandMeta("specify.py",             "Alias: generate task list",                           ("planning",), aliases=("specify",)),
-    "task":                CommandMeta("task.py",                "Track and manage individual tasks",                    ("planning",)),
-    "tentacle":            CommandMeta("tentacle.py",            "Orchestrate multi-agent tentacle workflows",           ("orchestration", "agents")),
-    "install":             CommandMeta("install.py",             "Install or update sk tools and hooks",                 ("install", "setup")),
-    "setup":               CommandMeta("setup-project.py",       "Initialize project for session knowledge",             ("install", "setup")),
-    "update":              CommandMeta("auto-update-tools.py",   "Auto-update all tools from remote",                   ("install", "update")),
-    "browse":              CommandMeta("browse.py",              "Launch browse-ui session explorer",                    ("browse", "ui")),
-    "benchmark":           CommandMeta("benchmark.py",           "Benchmark tool and model performance",                 ("benchmark",)),
-    "retro":               CommandMeta("retro.py",               "Generate retrospective from session history",          ("session", "retro")),
-    "heal":                CommandMeta("copilot-cli-healer.py",  "Diagnose and fix common sk installation issues",       ("install", "doctor")),
-    "doctor":              CommandMeta("install.py",             "Run installation health checks",                       ("install", "doctor")),
-    "watch":               CommandMeta("watch-sessions.py",      "Watch and auto-index new CLI sessions",                ("watch", "index")),
-    "export-buglog":       CommandMeta("buglog-export.py",       "Export bug log entries",                               ("export", "buglog")),
-    "buglog":              CommandMeta("buglog-export.py",       "Alias: export bug log",                               ("export", "buglog"), aliases=("export-buglog",)),
-    "export-cerebrum":     CommandMeta("export-cerebrum.py",     "Export cerebrum knowledge graph",                      ("export", "cerebrum")),
-    "cerebrum":            CommandMeta("export-cerebrum.py",     "Alias: export cerebrum",                              ("export", "cerebrum"), aliases=("export-cerebrum",)),
-    "dream":               CommandMeta("dream.py",               "Generate dream-mode creative session summaries",       ("session", "creative")),
-    "anatomy":             CommandMeta("anatomy-map.py",         "Map codebase anatomy and structure",                   ("index", "map")),
-    "skill-suggest":       CommandMeta("skill-suggest.py",       "Suggest relevant skills for current task",             ("skills",)),
-    "skill-patch":         CommandMeta("skill-patch.py",         "Patch and update installed skills",                   ("skills", "update")),
-    "skill-curator":       CommandMeta("skill-curator.py",       "Curate and manage skill library",                      ("skills",)),
-    "audit-hooks":         CommandMeta("audit-hooks.py",         "Audit hook installation and configuration",            ("hooks", "audit")),
-    "audit-instructions":  CommandMeta("audit-instructions.py",  "Audit agent instruction files",                        ("docs", "audit")),
-    "improvement-signals": CommandMeta("improvement-signals.py", "Surface improvement signal patterns",                  ("session", "analytics")),
-    "status":              CommandMeta("statusline.py",          "Show session token usage and AI cost summary",          ("session", "cost")),
-    "statusline":          CommandMeta("statusline.py",          "Alias: session token usage footer",                   ("session", "cost"), aliases=("status",)),
+    "briefing": CommandMeta(
+        "briefing.py", "Surface past session knowledge and mistakes", ("session", "recall", "index")
+    ),
+    "query": CommandMeta("query-session.py", "Semantic search over knowledge base", ("index", "search")),
+    "learn": CommandMeta("learn.py", "Record mistakes, patterns, features, decisions", ("session", "learn")),
+    "clarify": CommandMeta("clarify.py", "Clarify ambiguous task specs before coding", ("planning",)),
+    "specify": CommandMeta("specify.py", "Generate structured task specification", ("planning",)),
+    "plan": CommandMeta("specify.py", "Alias: generate task plan", ("planning",), aliases=("specify",)),
+    "tasks": CommandMeta("specify.py", "Alias: generate task list", ("planning",), aliases=("specify",)),
+    "task": CommandMeta("task.py", "Track and manage individual tasks", ("planning",)),
+    "tentacle": CommandMeta("tentacle.py", "Orchestrate multi-agent tentacle workflows", ("orchestration", "agents")),
+    "install": CommandMeta("install.py", "Install or update sk tools and hooks", ("install", "setup")),
+    "setup": CommandMeta("setup-project.py", "Initialize project for session knowledge", ("install", "setup")),
+    "update": CommandMeta("auto-update-tools.py", "Auto-update all tools from remote", ("install", "update")),
+    "browse": CommandMeta("browse.py", "Launch browse-ui session explorer", ("browse", "ui")),
+    "benchmark": CommandMeta("benchmark.py", "Benchmark tool and model performance", ("benchmark",)),
+    "retro": CommandMeta("retro.py", "Generate retrospective from session history", ("session", "retro")),
+    "heal": CommandMeta(
+        "copilot-cli-healer.py", "Diagnose and fix common sk installation issues", ("install", "doctor")
+    ),
+    "doctor": CommandMeta("install.py", "Run installation health checks", ("install", "doctor")),
+    "watch": CommandMeta("watch-sessions.py", "Watch and auto-index new CLI sessions", ("watch", "index")),
+    "export-buglog": CommandMeta("buglog-export.py", "Export bug log entries", ("export", "buglog")),
+    "buglog": CommandMeta(
+        "buglog-export.py", "Alias: export bug log", ("export", "buglog"), aliases=("export-buglog",)
+    ),
+    "export-cerebrum": CommandMeta("export-cerebrum.py", "Export cerebrum knowledge graph", ("export", "cerebrum")),
+    "cerebrum": CommandMeta(
+        "export-cerebrum.py", "Alias: export cerebrum", ("export", "cerebrum"), aliases=("export-cerebrum",)
+    ),
+    "dream": CommandMeta("dream.py", "Generate dream-mode creative session summaries", ("session", "creative")),
+    "anatomy": CommandMeta("anatomy-map.py", "Map codebase anatomy and structure", ("index", "map")),
+    "skill-suggest": CommandMeta("skill-suggest.py", "Suggest relevant skills for current task", ("skills",)),
+    "skill-patch": CommandMeta("skill-patch.py", "Patch and update installed skills", ("skills", "update")),
+    "skill-curator": CommandMeta("skill-curator.py", "Curate and manage skill library", ("skills",)),
+    "audit-hooks": CommandMeta("audit-hooks.py", "Audit hook installation and configuration", ("hooks", "audit")),
+    "audit-instructions": CommandMeta("audit-instructions.py", "Audit agent instruction files", ("docs", "audit")),
+    "improvement-signals": CommandMeta(
+        "improvement-signals.py", "Surface improvement signal patterns", ("session", "analytics")
+    ),
+    "status": CommandMeta("statusline.py", "Show session token usage and AI cost summary", ("session", "cost")),
+    "statusline": CommandMeta(
+        "statusline.py", "Alias: session token usage footer", ("session", "cost"), aliases=("status",)
+    ),
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}
@@ -496,8 +508,7 @@ def _run_cron(extra_args: list[str]) -> int:
 
 def _print_help() -> None:
     direct_list = "  " + "\n  ".join(
-        f"sk {cmd:<20} {str(meta.description):<40} {','.join(meta.tags[:2])}"
-        for cmd, meta in _DIRECT.items()
+        f"sk {cmd:<20} {str(meta.description):<40} {','.join(meta.tags[:2])}" for cmd, meta in _DIRECT.items()
     )
     print(
         f"sk {__version__} — copilot-session-knowledge unified CLI\n"

--- a/sk.py
+++ b/sk.py
@@ -64,6 +64,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Ensure sk.py's own directory is on sys.path so `harness` package is importable
+# when sk.py is loaded via importlib (e.g. in tests) rather than run directly.
+_SK_DIR = str(Path(__file__).parent.resolve())
+if _SK_DIR not in sys.path:
+    sys.path.insert(0, _SK_DIR)
+
 from harness.meta import CommandMeta
 
 if os.name == "nt":

--- a/sk.py
+++ b/sk.py
@@ -63,6 +63,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from harness.meta import CommandMeta
 
 if os.name == "nt":
     for _stream in (sys.stdout, sys.stderr):
@@ -94,39 +95,39 @@ _PROJECT_DB_SCRIPTS = {
 # ---------------------------------------------------------------------------
 
 # Top-level direct commands: (script_name,)
-_DIRECT: dict[str, str] = {
-    "briefing": "briefing.py",
-    "query": "query-session.py",
-    "learn": "learn.py",
-    "clarify": "clarify.py",
-    "specify": "specify.py",
-    "plan": "specify.py",
-    "tasks": "specify.py",
-    "task": "task.py",
-    "tentacle": "tentacle.py",
-    "install": "install.py",
-    "setup": "setup-project.py",
-    "update": "auto-update-tools.py",
-    "browse": "browse.py",
-    "benchmark": "benchmark.py",
-    "retro": "retro.py",
-    "heal": "copilot-cli-healer.py",
-    "doctor": "install.py",
-    "watch": "watch-sessions.py",
-    "export-buglog": "buglog-export.py",
-    "buglog": "buglog-export.py",  # alias for export-buglog (backward compat)
-    "export-cerebrum": "export-cerebrum.py",
-    "cerebrum": "export-cerebrum.py",  # alias for export-cerebrum (short form)
-    "dream": "dream.py",
-    "anatomy": "anatomy-map.py",
-    "skill-suggest": "skill-suggest.py",
-    "skill-patch": "skill-patch.py",
-    "skill-curator": "skill-curator.py",
-    "audit-hooks": "audit-hooks.py",
-    "audit-instructions": "audit-instructions.py",
-    "improvement-signals": "improvement-signals.py",
-    "status": "statusline.py",       # show session token usage + quota summary
-    "statusline": "statusline.py",   # alias for status
+_DIRECT: dict[str, CommandMeta] = {
+    "briefing":            CommandMeta("briefing.py",            "Surface past session knowledge and mistakes",          ("session", "recall", "index")),
+    "query":               CommandMeta("query-session.py",       "Semantic search over knowledge base",                  ("index", "search")),
+    "learn":               CommandMeta("learn.py",               "Record mistakes, patterns, features, decisions",       ("session", "learn")),
+    "clarify":             CommandMeta("clarify.py",             "Clarify ambiguous task specs before coding",           ("planning",)),
+    "specify":             CommandMeta("specify.py",             "Generate structured task specification",               ("planning",)),
+    "plan":                CommandMeta("specify.py",             "Alias: generate task plan",                           ("planning",), aliases=("specify",)),
+    "tasks":               CommandMeta("specify.py",             "Alias: generate task list",                           ("planning",), aliases=("specify",)),
+    "task":                CommandMeta("task.py",                "Track and manage individual tasks",                    ("planning",)),
+    "tentacle":            CommandMeta("tentacle.py",            "Orchestrate multi-agent tentacle workflows",           ("orchestration", "agents")),
+    "install":             CommandMeta("install.py",             "Install or update sk tools and hooks",                 ("install", "setup")),
+    "setup":               CommandMeta("setup-project.py",       "Initialize project for session knowledge",             ("install", "setup")),
+    "update":              CommandMeta("auto-update-tools.py",   "Auto-update all tools from remote",                   ("install", "update")),
+    "browse":              CommandMeta("browse.py",              "Launch browse-ui session explorer",                    ("browse", "ui")),
+    "benchmark":           CommandMeta("benchmark.py",           "Benchmark tool and model performance",                 ("benchmark",)),
+    "retro":               CommandMeta("retro.py",               "Generate retrospective from session history",          ("session", "retro")),
+    "heal":                CommandMeta("copilot-cli-healer.py",  "Diagnose and fix common sk installation issues",       ("install", "doctor")),
+    "doctor":              CommandMeta("install.py",             "Run installation health checks",                       ("install", "doctor")),
+    "watch":               CommandMeta("watch-sessions.py",      "Watch and auto-index new CLI sessions",                ("watch", "index")),
+    "export-buglog":       CommandMeta("buglog-export.py",       "Export bug log entries",                               ("export", "buglog")),
+    "buglog":              CommandMeta("buglog-export.py",       "Alias: export bug log",                               ("export", "buglog"), aliases=("export-buglog",)),
+    "export-cerebrum":     CommandMeta("export-cerebrum.py",     "Export cerebrum knowledge graph",                      ("export", "cerebrum")),
+    "cerebrum":            CommandMeta("export-cerebrum.py",     "Alias: export cerebrum",                              ("export", "cerebrum"), aliases=("export-cerebrum",)),
+    "dream":               CommandMeta("dream.py",               "Generate dream-mode creative session summaries",       ("session", "creative")),
+    "anatomy":             CommandMeta("anatomy-map.py",         "Map codebase anatomy and structure",                   ("index", "map")),
+    "skill-suggest":       CommandMeta("skill-suggest.py",       "Suggest relevant skills for current task",             ("skills",)),
+    "skill-patch":         CommandMeta("skill-patch.py",         "Patch and update installed skills",                   ("skills", "update")),
+    "skill-curator":       CommandMeta("skill-curator.py",       "Curate and manage skill library",                      ("skills",)),
+    "audit-hooks":         CommandMeta("audit-hooks.py",         "Audit hook installation and configuration",            ("hooks", "audit")),
+    "audit-instructions":  CommandMeta("audit-instructions.py",  "Audit agent instruction files",                        ("docs", "audit")),
+    "improvement-signals": CommandMeta("improvement-signals.py", "Surface improvement signal patterns",                  ("session", "analytics")),
+    "status":              CommandMeta("statusline.py",          "Show session token usage and AI cost summary",          ("session", "cost")),
+    "statusline":          CommandMeta("statusline.py",          "Alias: session token usage footer",                   ("session", "cost"), aliases=("status",)),
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}
@@ -493,7 +494,10 @@ def _run_cron(extra_args: list[str]) -> int:
 
 
 def _print_help() -> None:
-    direct_list = "  " + "\n  ".join(f"sk {cmd:<12} → {script}" for cmd, script in _DIRECT.items())
+    direct_list = "  " + "\n  ".join(
+        f"sk {cmd:<20} {str(meta.description):<40} {','.join(meta.tags[:2])}"
+        for cmd, meta in _DIRECT.items()
+    )
     print(
         f"sk {__version__} — copilot-session-knowledge unified CLI\n"
         "\nDirect commands:\n"
@@ -539,7 +543,7 @@ def main(argv: list[str] | None = None) -> int:
     if cmd == "init":
         return _run("setup-project.py", ["--init-mode"] + rest)
     if cmd in _DIRECT:
-        return _run(_DIRECT[cmd], rest)
+        return _run(str(_DIRECT[cmd]), rest)
 
     # Grouped namespace?
     if cmd in _GROUPS:

--- a/sk.py
+++ b/sk.py
@@ -352,15 +352,19 @@ def _project_env_for_script(script: str) -> dict[str, str] | None:
     return env
 
 
-def _run(script: str, extra_args: list[str]) -> int:
+def _run(script: str, extra_args: list[str], cmd: str = "") -> int:
     """Delegate to a standalone script via subprocess."""
     tools_dir, from_env = _resolve_tools_dir()
     script_path = tools_dir / script
     if not script_path.exists():
         _print_missing_script_error(tools_dir, script, from_env=from_env)
         return 2
-    cmd = [sys.executable, str(script_path)] + extra_args
-    result = subprocess.run(cmd, env=_project_env_for_script(script))
+    if os.environ.get("SK_HARNESS") == "1":
+        from harness.dispatch import run_with_hooks  # noqa: PLC0415
+
+        return run_with_hooks(cmd, script, extra_args, str(tools_dir))
+    proc_cmd = [sys.executable, str(script_path)] + extra_args
+    result = subprocess.run(proc_cmd, env=_project_env_for_script(script))
     return result.returncode
 
 
@@ -506,6 +510,59 @@ def _run_cron(extra_args: list[str]) -> int:
     return _run("cron-tasks.py", extra_args)
 
 
+_HARNESS_ENV_VARS: dict[str, str] = {
+    "SK_HARNESS": "Enable middleware hooks (0/1)",
+    "SK_DEBUG_TIMING": "Verbose timing to stderr (0/1)",
+    "SK_DRY_RUN": "Print commands without running (0/1)",
+    "SK_TOOLS_DIR": "Override tools directory path",
+}
+
+
+def _run_harness(args: list[str]) -> int:
+    """In-process handler for 'sk harness <subcommand>'."""
+    sub = args[0] if args else "help"
+
+    if sub == "config":
+        return _harness_config(args[1:])
+    # show / check / doctor come in H-004/H-005/H-006
+    print("sk harness subcommands: config, show, check, doctor")
+    print("  sk harness config list|get|set")
+    return 0
+
+
+def _harness_config(args: list[str]) -> int:
+    """Manage harness env vars in-process."""
+    action = args[0] if args else "list"
+
+    if action == "list":
+        for var, desc in _HARNESS_ENV_VARS.items():
+            val = os.environ.get(var, "(unset)")
+            print(f"  {var:<22} = {val:<12}  # {desc}")
+        return 0
+
+    if action == "get":
+        if len(args) < 2:
+            print("Usage: sk harness config get <VAR>", file=sys.stderr)
+            return 1
+        val = os.environ.get(args[1], "(unset)")
+        print(val)
+        return 0
+
+    if action == "set":
+        if len(args) < 3:
+            print("Usage: sk harness config set <VAR> <VALUE>", file=sys.stderr)
+            return 1
+        var, value = args[1], args[2]
+        if var not in _HARNESS_ENV_VARS:
+            print(f"[sk harness] warning: unknown var {var!r}", file=sys.stderr)
+        os.environ[var] = value
+        print(f"{var}={value}")
+        return 0
+
+    print(f"Unknown config action: {action!r}. Use list, get, or set.", file=sys.stderr)
+    return 1
+
+
 def _print_help() -> None:
     direct_list = "  " + "\n  ".join(
         f"sk {cmd:<20} {str(meta.description):<40} {','.join(meta.tags[:2])}" for cmd, meta in _DIRECT.items()
@@ -516,6 +573,7 @@ def _print_help() -> None:
         f"{direct_list}\n"
         "\nGrouped namespaces:\n"
         f"{_help_groups()}\n"
+        "  sk harness config    Manage harness env vars (SK_HARNESS, SK_DRY_RUN, SK_DEBUG_TIMING, SK_TOOLS_DIR)\n"
         "\nUse `sk <command> --help` to see help for a specific script.\n"
         "All direct `python3 ~/.copilot/tools/*.py` invocations still work.\n"
     )
@@ -536,6 +594,8 @@ def main(argv: list[str] | None = None) -> int:
     rest = args[1:]
 
     # Direct command?
+    if cmd == "harness":
+        return _run_harness(rest)
     if cmd == "hooks":
         return _run_hooks(rest)
     if cmd == "project":
@@ -555,7 +615,7 @@ def main(argv: list[str] | None = None) -> int:
     if cmd == "init":
         return _run("setup-project.py", ["--init-mode"] + rest)
     if cmd in _DIRECT:
-        return _run(str(_DIRECT[cmd]), rest)
+        return _run(str(_DIRECT[cmd]), rest, cmd=cmd)
 
     # Grouped namespace?
     if cmd in _GROUPS:


### PR DESCRIPTION
## Summary
Add pre/post dispatch hook pipeline to `sk`, activated via `SK_HARNESS=1`. Zero overhead when disabled (default).

## Changes
- `harness/dispatch.py` — `DispatchContext` dataclass, `_PRE_HOOKS`/`_POST_HOOKS` registries, `run_with_hooks()`, built-in dry-run hook (`SK_DRY_RUN=1`)
- `sk.py` — lazy import of `run_with_hooks` inside `SK_HARNESS=1` branch in `_run()`

## Verification
```
✅ AST: OK | lint+format: OK
✅ test_security.py: 13/13 | test_fixes.py: 285/285
✅ from harness.dispatch import DispatchContext, _PRE_HOOKS → 1 pre-hook registered
```

Closes #621