### PR TITLE
feat(harness/H-002): harness-manifest.json command registry + manifest loader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ See [docs/AGENT-RULES.md](docs/AGENT-RULES.md) for the complete rule text, goal-
 
 ## Architecture Key Facts
 
-- **Standalone scripts by default** — avoid inter-script imports unless a documented helper exception such as `_tentacle_core.py`, `_tentacle_goal.py`, `_tentacle_pr.py`, `_tentacle_dispatch.py`, or `_tentacle_review.py` preserves an existing contract
+- **Standalone scripts by default** — avoid inter-script imports unless a documented helper exception such as `_tentacle_core.py`, `_tentacle_goal.py`, `_tentacle_pr.py`, `_tentacle_dispatch.py`, or `_tentacle_review.py` preserves an existing contract; `harness/meta.py` — `CommandMeta` dataclass registry; imported by `sk.py` for `_DIRECT` metadata (do not remove this import exception)
 - **Pure stdlib Python 3.10+** — zero pip dependencies; `scikit-learn` / embedding keys are optional
 - **Parameterized SQL only** — `?` placeholders; never interpolate user input into SQL
 - **JSON serialization only** — never use pickle

--- a/harness-manifest.json
+++ b/harness-manifest.json
@@ -1,0 +1,661 @@
+{
+  "version": 1,
+  "commands": {
+    "briefing": {
+      "script": "briefing.py",
+      "description": "Surface past session knowledge and mistakes",
+      "tags": [
+        "session",
+        "recall",
+        "index"
+      ],
+      "group": "direct"
+    },
+    "query": {
+      "script": "query-session.py",
+      "description": "Semantic search over knowledge base",
+      "tags": [
+        "index",
+        "search"
+      ],
+      "group": "direct"
+    },
+    "learn": {
+      "script": "learn.py",
+      "description": "Record mistakes, patterns, features, decisions",
+      "tags": [
+        "session",
+        "learn"
+      ],
+      "group": "direct"
+    },
+    "clarify": {
+      "script": "clarify.py",
+      "description": "Clarify ambiguous task specs before coding",
+      "tags": [
+        "planning"
+      ],
+      "group": "direct"
+    },
+    "specify": {
+      "script": "specify.py",
+      "description": "Generate structured task specification",
+      "tags": [
+        "planning"
+      ],
+      "group": "direct"
+    },
+    "plan": {
+      "script": "specify.py",
+      "description": "Alias: generate task plan",
+      "tags": [
+        "planning"
+      ],
+      "group": "direct",
+      "aliases": [
+        "specify"
+      ]
+    },
+    "tasks": {
+      "script": "specify.py",
+      "description": "Alias: generate task list",
+      "tags": [
+        "planning"
+      ],
+      "group": "direct",
+      "aliases": [
+        "specify"
+      ]
+    },
+    "task": {
+      "script": "task.py",
+      "description": "Track and manage individual tasks",
+      "tags": [
+        "planning"
+      ],
+      "group": "direct"
+    },
+    "tentacle": {
+      "script": "tentacle.py",
+      "description": "Orchestrate multi-agent tentacle workflows",
+      "tags": [
+        "orchestration",
+        "agents"
+      ],
+      "group": "direct"
+    },
+    "install": {
+      "script": "install.py",
+      "description": "Install or update sk tools and hooks",
+      "tags": [
+        "install",
+        "setup"
+      ],
+      "group": "direct"
+    },
+    "setup": {
+      "script": "setup-project.py",
+      "description": "Initialize project for session knowledge",
+      "tags": [
+        "install",
+        "setup"
+      ],
+      "group": "direct"
+    },
+    "update": {
+      "script": "auto-update-tools.py",
+      "description": "Auto-update all tools from remote",
+      "tags": [
+        "install",
+        "update"
+      ],
+      "group": "direct"
+    },
+    "browse": {
+      "script": "browse.py",
+      "description": "Launch browse-ui session explorer",
+      "tags": [
+        "browse",
+        "ui"
+      ],
+      "group": "direct"
+    },
+    "benchmark": {
+      "script": "benchmark.py",
+      "description": "Benchmark tool and model performance",
+      "tags": [
+        "benchmark"
+      ],
+      "group": "direct"
+    },
+    "retro": {
+      "script": "retro.py",
+      "description": "Generate retrospective from session history",
+      "tags": [
+        "session",
+        "retro"
+      ],
+      "group": "direct"
+    },
+    "heal": {
+      "script": "copilot-cli-healer.py",
+      "description": "Diagnose and fix common sk installation issues",
+      "tags": [
+        "install",
+        "doctor"
+      ],
+      "group": "direct"
+    },
+    "doctor": {
+      "script": "install.py",
+      "description": "Run installation health checks",
+      "tags": [
+        "install",
+        "doctor"
+      ],
+      "group": "direct"
+    },
+    "watch": {
+      "script": "watch-sessions.py",
+      "description": "Watch and auto-index new CLI sessions",
+      "tags": [
+        "watch",
+        "index"
+      ],
+      "group": "direct"
+    },
+    "export-buglog": {
+      "script": "buglog-export.py",
+      "description": "Export bug log entries",
+      "tags": [
+        "export",
+        "buglog"
+      ],
+      "group": "direct"
+    },
+    "buglog": {
+      "script": "buglog-export.py",
+      "description": "Alias: export bug log",
+      "tags": [
+        "export",
+        "buglog"
+      ],
+      "group": "direct",
+      "aliases": [
+        "export-buglog"
+      ]
+    },
+    "export-cerebrum": {
+      "script": "export-cerebrum.py",
+      "description": "Export cerebrum knowledge graph",
+      "tags": [
+        "export",
+        "cerebrum"
+      ],
+      "group": "direct"
+    },
+    "cerebrum": {
+      "script": "export-cerebrum.py",
+      "description": "Alias: export cerebrum",
+      "tags": [
+        "export",
+        "cerebrum"
+      ],
+      "group": "direct",
+      "aliases": [
+        "export-cerebrum"
+      ]
+    },
+    "dream": {
+      "script": "dream.py",
+      "description": "Generate dream-mode creative session summaries",
+      "tags": [
+        "session",
+        "creative"
+      ],
+      "group": "direct"
+    },
+    "anatomy": {
+      "script": "anatomy-map.py",
+      "description": "Map codebase anatomy and structure",
+      "tags": [
+        "index",
+        "map"
+      ],
+      "group": "direct"
+    },
+    "skill-suggest": {
+      "script": "skill-suggest.py",
+      "description": "Suggest relevant skills for current task",
+      "tags": [
+        "skills"
+      ],
+      "group": "direct"
+    },
+    "skill-patch": {
+      "script": "skill-patch.py",
+      "description": "Patch and update installed skills",
+      "tags": [
+        "skills",
+        "update"
+      ],
+      "group": "direct"
+    },
+    "skill-curator": {
+      "script": "skill-curator.py",
+      "description": "Curate and manage skill library",
+      "tags": [
+        "skills"
+      ],
+      "group": "direct"
+    },
+    "audit-hooks": {
+      "script": "audit-hooks.py",
+      "description": "Audit hook installation and configuration",
+      "tags": [
+        "hooks",
+        "audit"
+      ],
+      "group": "direct"
+    },
+    "audit-instructions": {
+      "script": "audit-instructions.py",
+      "description": "Audit agent instruction files",
+      "tags": [
+        "docs",
+        "audit"
+      ],
+      "group": "direct"
+    },
+    "improvement-signals": {
+      "script": "improvement-signals.py",
+      "description": "Surface improvement signal patterns",
+      "tags": [
+        "session",
+        "analytics"
+      ],
+      "group": "direct"
+    },
+    "status": {
+      "script": "statusline.py",
+      "description": "Show session token usage and AI cost summary",
+      "tags": [
+        "session",
+        "cost"
+      ],
+      "group": "direct"
+    },
+    "statusline": {
+      "script": "statusline.py",
+      "description": "Alias: session token usage footer",
+      "tags": [
+        "session",
+        "cost"
+      ],
+      "group": "direct",
+      "aliases": [
+        "status"
+      ]
+    },
+    "index build": {
+      "script": "build-session-index.py",
+      "description": "index build",
+      "tags": [
+        "index"
+      ],
+      "group": "index"
+    },
+    "index extract": {
+      "script": "extract-knowledge.py",
+      "description": "index extract",
+      "tags": [
+        "index"
+      ],
+      "group": "index"
+    },
+    "index migrate": {
+      "script": "migrate.py",
+      "description": "index migrate",
+      "tags": [
+        "index"
+      ],
+      "group": "index"
+    },
+    "index status": {
+      "script": "index-status.py",
+      "description": "index status",
+      "tags": [
+        "index"
+      ],
+      "group": "index"
+    },
+    "index health": {
+      "script": "knowledge-health.py",
+      "description": "index health",
+      "tags": [
+        "index"
+      ],
+      "group": "index"
+    },
+    "index embed": {
+      "script": "embed.py",
+      "description": "index embed",
+      "tags": [
+        "index"
+      ],
+      "group": "index"
+    },
+    "index tag": {
+      "script": "tag-entries.py",
+      "description": "index tag",
+      "tags": [
+        "index"
+      ],
+      "group": "index"
+    },
+    "sync run": {
+      "script": "sync-daemon.py",
+      "description": "sync run",
+      "tags": [
+        "sync"
+      ],
+      "group": "sync"
+    },
+    "sync config": {
+      "script": "sync-config.py",
+      "description": "sync config",
+      "tags": [
+        "sync"
+      ],
+      "group": "sync"
+    },
+    "sync status": {
+      "script": "sync-status.py",
+      "description": "sync status",
+      "tags": [
+        "sync"
+      ],
+      "group": "sync"
+    },
+    "sync gateway": {
+      "script": "sync-gateway.py",
+      "description": "sync gateway",
+      "tags": [
+        "sync"
+      ],
+      "group": "sync"
+    },
+    "sync merge": {
+      "script": "sync-knowledge.py",
+      "description": "sync merge",
+      "tags": [
+        "sync"
+      ],
+      "group": "sync"
+    },
+    "checkpoint save": {
+      "script": "checkpoint-save.py",
+      "description": "checkpoint save",
+      "tags": [
+        "checkpoint"
+      ],
+      "group": "checkpoint"
+    },
+    "checkpoint restore": {
+      "script": "checkpoint-restore.py",
+      "description": "checkpoint restore",
+      "tags": [
+        "checkpoint"
+      ],
+      "group": "checkpoint"
+    },
+    "checkpoint diff": {
+      "script": "checkpoint-diff.py",
+      "description": "checkpoint diff",
+      "tags": [
+        "checkpoint"
+      ],
+      "group": "checkpoint"
+    },
+    "constitution init": {
+      "script": "constitution.py",
+      "description": "constitution init",
+      "tags": [
+        "constitution"
+      ],
+      "group": "constitution"
+    },
+    "constitution check": {
+      "script": "constitution.py",
+      "description": "constitution check",
+      "tags": [
+        "constitution"
+      ],
+      "group": "constitution"
+    },
+    "constitution amend": {
+      "script": "constitution.py",
+      "description": "constitution amend",
+      "tags": [
+        "constitution"
+      ],
+      "group": "constitution"
+    },
+    "profile build": {
+      "script": "profile-builder.py",
+      "description": "profile build",
+      "tags": [
+        "profile"
+      ],
+      "group": "profile"
+    },
+    "profile import": {
+      "script": "profile-import.py",
+      "description": "profile import",
+      "tags": [
+        "profile"
+      ],
+      "group": "profile"
+    },
+    "profile export": {
+      "script": "profile-export.py",
+      "description": "profile export",
+      "tags": [
+        "profile"
+      ],
+      "group": "profile"
+    },
+    "preset add": {
+      "script": "preset-manager.py",
+      "description": "preset add",
+      "tags": [
+        "preset"
+      ],
+      "group": "preset"
+    },
+    "preset remove": {
+      "script": "preset-manager.py",
+      "description": "preset remove",
+      "tags": [
+        "preset"
+      ],
+      "group": "preset"
+    },
+    "preset list": {
+      "script": "preset-manager.py",
+      "description": "preset list",
+      "tags": [
+        "preset"
+      ],
+      "group": "preset"
+    },
+    "context project": {
+      "script": "project-context.py",
+      "description": "context project",
+      "tags": [
+        "context"
+      ],
+      "group": "context"
+    },
+    "context map": {
+      "script": "codebase-map.py",
+      "description": "context map",
+      "tags": [
+        "context"
+      ],
+      "group": "context"
+    },
+    "context upsert": {
+      "script": "context-blocks.py",
+      "description": "context upsert",
+      "tags": [
+        "context"
+      ],
+      "group": "context"
+    },
+    "context remove": {
+      "script": "context-blocks.py",
+      "description": "context remove",
+      "tags": [
+        "context"
+      ],
+      "group": "context"
+    },
+    "scout run": {
+      "script": "trend-scout.py",
+      "description": "scout run",
+      "tags": [
+        "scout"
+      ],
+      "group": "scout"
+    },
+    "scout config": {
+      "script": "scout-config.py",
+      "description": "scout config",
+      "tags": [
+        "scout"
+      ],
+      "group": "scout"
+    },
+    "scout status": {
+      "script": "scout-status.py",
+      "description": "scout status",
+      "tags": [
+        "scout"
+      ],
+      "group": "scout"
+    },
+    "cron add": {
+      "script": "cron-tasks.py",
+      "description": "cron add",
+      "tags": [
+        "cron"
+      ],
+      "group": "cron"
+    },
+    "cron remove": {
+      "script": "cron-tasks.py",
+      "description": "cron remove",
+      "tags": [
+        "cron"
+      ],
+      "group": "cron"
+    },
+    "cron list": {
+      "script": "cron-tasks.py",
+      "description": "cron list",
+      "tags": [
+        "cron"
+      ],
+      "group": "cron"
+    },
+    "cron run": {
+      "script": "cron-tasks.py",
+      "description": "cron run",
+      "tags": [
+        "cron"
+      ],
+      "group": "cron"
+    },
+    "project add": {
+      "script": "project-registry.py",
+      "description": "project add",
+      "tags": [
+        "project"
+      ],
+      "group": "project"
+    },
+    "project remove": {
+      "script": "project-registry.py",
+      "description": "project remove",
+      "tags": [
+        "project"
+      ],
+      "group": "project"
+    },
+    "project list": {
+      "script": "project-registry.py",
+      "description": "project list",
+      "tags": [
+        "project"
+      ],
+      "group": "project"
+    },
+    "skill catalog": {
+      "script": "skill-catalog.py",
+      "description": "skill catalog",
+      "tags": [
+        "skill"
+      ],
+      "group": "skill"
+    },
+    "skill add": {
+      "script": "skill-catalog.py",
+      "description": "skill add",
+      "tags": [
+        "skill"
+      ],
+      "group": "skill"
+    },
+    "skill remove": {
+      "script": "skill-catalog.py",
+      "description": "skill remove",
+      "tags": [
+        "skill"
+      ],
+      "group": "skill"
+    },
+    "events append": {
+      "script": "events.py",
+      "description": "events append",
+      "tags": [
+        "events"
+      ],
+      "group": "events"
+    },
+    "events status": {
+      "script": "events.py",
+      "description": "events status",
+      "tags": [
+        "events"
+      ],
+      "group": "events"
+    },
+    "events replay": {
+      "script": "events.py",
+      "description": "events replay",
+      "tags": [
+        "events"
+      ],
+      "group": "events"
+    },
+    "events tail": {
+      "script": "events.py",
+      "description": "events tail",
+      "tags": [
+        "events"
+      ],
+      "group": "events"
+    }
+  }
+}

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -1,0 +1,4 @@
+# harness — CLI dispatch metadata and middleware for sk
+import os, sys
+if os.name == "nt":
+    sys.stdout.reconfigure(encoding="utf-8")

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -1,4 +1,6 @@
 # harness — CLI dispatch metadata and middleware for sk
-import os, sys
+import os
+import sys
+
 if os.name == "nt":
     sys.stdout.reconfigure(encoding="utf-8")

--- a/harness/manifest.py
+++ b/harness/manifest.py
@@ -1,0 +1,44 @@
+"""harness/manifest.py — Load and cache the harness command manifest.
+
+Reads ``harness-manifest.json`` once per process (lru_cache) and returns
+``{"version": 1, "commands": {...}}``.  Fail-open: any read or parse error
+returns an empty commands dict rather than raising.
+"""
+
+import json
+import os
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+if os.name == "nt":
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
+_MANIFEST_FILENAME = "harness-manifest.json"
+_EMPTY: dict = {"version": 1, "commands": {}}
+
+
+@lru_cache(maxsize=1)
+def load_manifest(tools_dir: str = "") -> dict:
+    """Return parsed manifest dict, cached after the first call.
+
+    Args:
+        tools_dir: Directory containing ``harness-manifest.json``.
+                   Defaults to the directory containing this file.
+
+    Returns:
+        Dict with keys ``version`` (int) and ``commands`` (dict).
+        On any error, returns ``{"version": 1, "commands": {}}``.
+    """
+    base = Path(tools_dir) if tools_dir else Path(__file__).parent.parent
+    manifest_path = base / _MANIFEST_FILENAME
+    try:
+        with manifest_path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict) or "commands" not in data:
+            return _EMPTY.copy()
+        return data
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return _EMPTY.copy()

--- a/harness/meta.py
+++ b/harness/meta.py
@@ -1,0 +1,20 @@
+"""CommandMeta: metadata wrapper for sk.py _DIRECT entries."""
+from __future__ import annotations
+import os, sys
+if os.name == "nt":
+    sys.stdout.reconfigure(encoding="utf-8")
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class CommandMeta:
+    """Immutable metadata for a single sk command."""
+    script: str
+    description: str = ""
+    tags: tuple[str, ...] = ()
+    aliases: tuple[str, ...] = ()
+    group: str = "general"
+    experimental: bool = False
+
+    def __str__(self) -> str:
+        """Return script name for backward-compat with _run(str(entry), rest)."""
+        return self.script

--- a/harness/meta.py
+++ b/harness/meta.py
@@ -1,9 +1,13 @@
 """CommandMeta: metadata wrapper for sk.py _DIRECT entries."""
 from __future__ import annotations
-import os, sys
+
+import os
+import sys
+
 if os.name == "nt":
     sys.stdout.reconfigure(encoding="utf-8")
 from dataclasses import dataclass
+
 
 @dataclass(frozen=True)
 class CommandMeta:

--- a/harness/meta.py
+++ b/harness/meta.py
@@ -1,4 +1,5 @@
 """CommandMeta: metadata wrapper for sk.py _DIRECT entries."""
+
 from __future__ import annotations
 
 import os
@@ -12,6 +13,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class CommandMeta:
     """Immutable metadata for a single sk command."""
+
     script: str
     description: str = ""
     tags: tuple[str, ...] = ()

--- a/sk.py
+++ b/sk.py
@@ -63,6 +63,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+
 from harness.meta import CommandMeta
 
 if os.name == "nt":

--- a/sk.py
+++ b/sk.py
@@ -97,38 +97,50 @@ _PROJECT_DB_SCRIPTS = {
 
 # Top-level direct commands: (script_name,)
 _DIRECT: dict[str, CommandMeta] = {
-    "briefing":            CommandMeta("briefing.py",            "Surface past session knowledge and mistakes",          ("session", "recall", "index")),
-    "query":               CommandMeta("query-session.py",       "Semantic search over knowledge base",                  ("index", "search")),
-    "learn":               CommandMeta("learn.py",               "Record mistakes, patterns, features, decisions",       ("session", "learn")),
-    "clarify":             CommandMeta("clarify.py",             "Clarify ambiguous task specs before coding",           ("planning",)),
-    "specify":             CommandMeta("specify.py",             "Generate structured task specification",               ("planning",)),
-    "plan":                CommandMeta("specify.py",             "Alias: generate task plan",                           ("planning",), aliases=("specify",)),
-    "tasks":               CommandMeta("specify.py",             "Alias: generate task list",                           ("planning",), aliases=("specify",)),
-    "task":                CommandMeta("task.py",                "Track and manage individual tasks",                    ("planning",)),
-    "tentacle":            CommandMeta("tentacle.py",            "Orchestrate multi-agent tentacle workflows",           ("orchestration", "agents")),
-    "install":             CommandMeta("install.py",             "Install or update sk tools and hooks",                 ("install", "setup")),
-    "setup":               CommandMeta("setup-project.py",       "Initialize project for session knowledge",             ("install", "setup")),
-    "update":              CommandMeta("auto-update-tools.py",   "Auto-update all tools from remote",                   ("install", "update")),
-    "browse":              CommandMeta("browse.py",              "Launch browse-ui session explorer",                    ("browse", "ui")),
-    "benchmark":           CommandMeta("benchmark.py",           "Benchmark tool and model performance",                 ("benchmark",)),
-    "retro":               CommandMeta("retro.py",               "Generate retrospective from session history",          ("session", "retro")),
-    "heal":                CommandMeta("copilot-cli-healer.py",  "Diagnose and fix common sk installation issues",       ("install", "doctor")),
-    "doctor":              CommandMeta("install.py",             "Run installation health checks",                       ("install", "doctor")),
-    "watch":               CommandMeta("watch-sessions.py",      "Watch and auto-index new CLI sessions",                ("watch", "index")),
-    "export-buglog":       CommandMeta("buglog-export.py",       "Export bug log entries",                               ("export", "buglog")),
-    "buglog":              CommandMeta("buglog-export.py",       "Alias: export bug log",                               ("export", "buglog"), aliases=("export-buglog",)),
-    "export-cerebrum":     CommandMeta("export-cerebrum.py",     "Export cerebrum knowledge graph",                      ("export", "cerebrum")),
-    "cerebrum":            CommandMeta("export-cerebrum.py",     "Alias: export cerebrum",                              ("export", "cerebrum"), aliases=("export-cerebrum",)),
-    "dream":               CommandMeta("dream.py",               "Generate dream-mode creative session summaries",       ("session", "creative")),
-    "anatomy":             CommandMeta("anatomy-map.py",         "Map codebase anatomy and structure",                   ("index", "map")),
-    "skill-suggest":       CommandMeta("skill-suggest.py",       "Suggest relevant skills for current task",             ("skills",)),
-    "skill-patch":         CommandMeta("skill-patch.py",         "Patch and update installed skills",                   ("skills", "update")),
-    "skill-curator":       CommandMeta("skill-curator.py",       "Curate and manage skill library",                      ("skills",)),
-    "audit-hooks":         CommandMeta("audit-hooks.py",         "Audit hook installation and configuration",            ("hooks", "audit")),
-    "audit-instructions":  CommandMeta("audit-instructions.py",  "Audit agent instruction files",                        ("docs", "audit")),
-    "improvement-signals": CommandMeta("improvement-signals.py", "Surface improvement signal patterns",                  ("session", "analytics")),
-    "status":              CommandMeta("statusline.py",          "Show session token usage and AI cost summary",          ("session", "cost")),
-    "statusline":          CommandMeta("statusline.py",          "Alias: session token usage footer",                   ("session", "cost"), aliases=("status",)),
+    "briefing": CommandMeta(
+        "briefing.py", "Surface past session knowledge and mistakes", ("session", "recall", "index")
+    ),
+    "query": CommandMeta("query-session.py", "Semantic search over knowledge base", ("index", "search")),
+    "learn": CommandMeta("learn.py", "Record mistakes, patterns, features, decisions", ("session", "learn")),
+    "clarify": CommandMeta("clarify.py", "Clarify ambiguous task specs before coding", ("planning",)),
+    "specify": CommandMeta("specify.py", "Generate structured task specification", ("planning",)),
+    "plan": CommandMeta("specify.py", "Alias: generate task plan", ("planning",), aliases=("specify",)),
+    "tasks": CommandMeta("specify.py", "Alias: generate task list", ("planning",), aliases=("specify",)),
+    "task": CommandMeta("task.py", "Track and manage individual tasks", ("planning",)),
+    "tentacle": CommandMeta("tentacle.py", "Orchestrate multi-agent tentacle workflows", ("orchestration", "agents")),
+    "install": CommandMeta("install.py", "Install or update sk tools and hooks", ("install", "setup")),
+    "setup": CommandMeta("setup-project.py", "Initialize project for session knowledge", ("install", "setup")),
+    "update": CommandMeta("auto-update-tools.py", "Auto-update all tools from remote", ("install", "update")),
+    "browse": CommandMeta("browse.py", "Launch browse-ui session explorer", ("browse", "ui")),
+    "benchmark": CommandMeta("benchmark.py", "Benchmark tool and model performance", ("benchmark",)),
+    "retro": CommandMeta("retro.py", "Generate retrospective from session history", ("session", "retro")),
+    "heal": CommandMeta(
+        "copilot-cli-healer.py", "Diagnose and fix common sk installation issues", ("install", "doctor")
+    ),
+    "doctor": CommandMeta("install.py", "Run installation health checks", ("install", "doctor")),
+    "watch": CommandMeta("watch-sessions.py", "Watch and auto-index new CLI sessions", ("watch", "index")),
+    "export-buglog": CommandMeta("buglog-export.py", "Export bug log entries", ("export", "buglog")),
+    "buglog": CommandMeta(
+        "buglog-export.py", "Alias: export bug log", ("export", "buglog"), aliases=("export-buglog",)
+    ),
+    "export-cerebrum": CommandMeta("export-cerebrum.py", "Export cerebrum knowledge graph", ("export", "cerebrum")),
+    "cerebrum": CommandMeta(
+        "export-cerebrum.py", "Alias: export cerebrum", ("export", "cerebrum"), aliases=("export-cerebrum",)
+    ),
+    "dream": CommandMeta("dream.py", "Generate dream-mode creative session summaries", ("session", "creative")),
+    "anatomy": CommandMeta("anatomy-map.py", "Map codebase anatomy and structure", ("index", "map")),
+    "skill-suggest": CommandMeta("skill-suggest.py", "Suggest relevant skills for current task", ("skills",)),
+    "skill-patch": CommandMeta("skill-patch.py", "Patch and update installed skills", ("skills", "update")),
+    "skill-curator": CommandMeta("skill-curator.py", "Curate and manage skill library", ("skills",)),
+    "audit-hooks": CommandMeta("audit-hooks.py", "Audit hook installation and configuration", ("hooks", "audit")),
+    "audit-instructions": CommandMeta("audit-instructions.py", "Audit agent instruction files", ("docs", "audit")),
+    "improvement-signals": CommandMeta(
+        "improvement-signals.py", "Surface improvement signal patterns", ("session", "analytics")
+    ),
+    "status": CommandMeta("statusline.py", "Show session token usage and AI cost summary", ("session", "cost")),
+    "statusline": CommandMeta(
+        "statusline.py", "Alias: session token usage footer", ("session", "cost"), aliases=("status",)
+    ),
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}
@@ -496,8 +508,7 @@ def _run_cron(extra_args: list[str]) -> int:
 
 def _print_help() -> None:
     direct_list = "  " + "\n  ".join(
-        f"sk {cmd:<20} {str(meta.description):<40} {','.join(meta.tags[:2])}"
-        for cmd, meta in _DIRECT.items()
+        f"sk {cmd:<20} {str(meta.description):<40} {','.join(meta.tags[:2])}" for cmd, meta in _DIRECT.items()
     )
     print(
         f"sk {__version__} — copilot-session-knowledge unified CLI\n"

--- a/sk.py
+++ b/sk.py
@@ -64,6 +64,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Ensure sk.py's own directory is on sys.path so `harness` package is importable
+# when sk.py is loaded via importlib (e.g. in tests) rather than run directly.
+_SK_DIR = str(Path(__file__).parent.resolve())
+if _SK_DIR not in sys.path:
+    sys.path.insert(0, _SK_DIR)
+
 from harness.meta import CommandMeta
 
 if os.name == "nt":

--- a/sk.py
+++ b/sk.py
@@ -63,6 +63,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from harness.meta import CommandMeta
 
 if os.name == "nt":
     for _stream in (sys.stdout, sys.stderr):
@@ -94,39 +95,39 @@ _PROJECT_DB_SCRIPTS = {
 # ---------------------------------------------------------------------------
 
 # Top-level direct commands: (script_name,)
-_DIRECT: dict[str, str] = {
-    "briefing": "briefing.py",
-    "query": "query-session.py",
-    "learn": "learn.py",
-    "clarify": "clarify.py",
-    "specify": "specify.py",
-    "plan": "specify.py",
-    "tasks": "specify.py",
-    "task": "task.py",
-    "tentacle": "tentacle.py",
-    "install": "install.py",
-    "setup": "setup-project.py",
-    "update": "auto-update-tools.py",
-    "browse": "browse.py",
-    "benchmark": "benchmark.py",
-    "retro": "retro.py",
-    "heal": "copilot-cli-healer.py",
-    "doctor": "install.py",
-    "watch": "watch-sessions.py",
-    "export-buglog": "buglog-export.py",
-    "buglog": "buglog-export.py",  # alias for export-buglog (backward compat)
-    "export-cerebrum": "export-cerebrum.py",
-    "cerebrum": "export-cerebrum.py",  # alias for export-cerebrum (short form)
-    "dream": "dream.py",
-    "anatomy": "anatomy-map.py",
-    "skill-suggest": "skill-suggest.py",
-    "skill-patch": "skill-patch.py",
-    "skill-curator": "skill-curator.py",
-    "audit-hooks": "audit-hooks.py",
-    "audit-instructions": "audit-instructions.py",
-    "improvement-signals": "improvement-signals.py",
-    "status": "statusline.py",       # show session token usage + quota summary
-    "statusline": "statusline.py",   # alias for status
+_DIRECT: dict[str, CommandMeta] = {
+    "briefing":            CommandMeta("briefing.py",            "Surface past session knowledge and mistakes",          ("session", "recall", "index")),
+    "query":               CommandMeta("query-session.py",       "Semantic search over knowledge base",                  ("index", "search")),
+    "learn":               CommandMeta("learn.py",               "Record mistakes, patterns, features, decisions",       ("session", "learn")),
+    "clarify":             CommandMeta("clarify.py",             "Clarify ambiguous task specs before coding",           ("planning",)),
+    "specify":             CommandMeta("specify.py",             "Generate structured task specification",               ("planning",)),
+    "plan":                CommandMeta("specify.py",             "Alias: generate task plan",                           ("planning",), aliases=("specify",)),
+    "tasks":               CommandMeta("specify.py",             "Alias: generate task list",                           ("planning",), aliases=("specify",)),
+    "task":                CommandMeta("task.py",                "Track and manage individual tasks",                    ("planning",)),
+    "tentacle":            CommandMeta("tentacle.py",            "Orchestrate multi-agent tentacle workflows",           ("orchestration", "agents")),
+    "install":             CommandMeta("install.py",             "Install or update sk tools and hooks",                 ("install", "setup")),
+    "setup":               CommandMeta("setup-project.py",       "Initialize project for session knowledge",             ("install", "setup")),
+    "update":              CommandMeta("auto-update-tools.py",   "Auto-update all tools from remote",                   ("install", "update")),
+    "browse":              CommandMeta("browse.py",              "Launch browse-ui session explorer",                    ("browse", "ui")),
+    "benchmark":           CommandMeta("benchmark.py",           "Benchmark tool and model performance",                 ("benchmark",)),
+    "retro":               CommandMeta("retro.py",               "Generate retrospective from session history",          ("session", "retro")),
+    "heal":                CommandMeta("copilot-cli-healer.py",  "Diagnose and fix common sk installation issues",       ("install", "doctor")),
+    "doctor":              CommandMeta("install.py",             "Run installation health checks",                       ("install", "doctor")),
+    "watch":               CommandMeta("watch-sessions.py",      "Watch and auto-index new CLI sessions",                ("watch", "index")),
+    "export-buglog":       CommandMeta("buglog-export.py",       "Export bug log entries",                               ("export", "buglog")),
+    "buglog":              CommandMeta("buglog-export.py",       "Alias: export bug log",                               ("export", "buglog"), aliases=("export-buglog",)),
+    "export-cerebrum":     CommandMeta("export-cerebrum.py",     "Export cerebrum knowledge graph",                      ("export", "cerebrum")),
+    "cerebrum":            CommandMeta("export-cerebrum.py",     "Alias: export cerebrum",                              ("export", "cerebrum"), aliases=("export-cerebrum",)),
+    "dream":               CommandMeta("dream.py",               "Generate dream-mode creative session summaries",       ("session", "creative")),
+    "anatomy":             CommandMeta("anatomy-map.py",         "Map codebase anatomy and structure",                   ("index", "map")),
+    "skill-suggest":       CommandMeta("skill-suggest.py",       "Suggest relevant skills for current task",             ("skills",)),
+    "skill-patch":         CommandMeta("skill-patch.py",         "Patch and update installed skills",                   ("skills", "update")),
+    "skill-curator":       CommandMeta("skill-curator.py",       "Curate and manage skill library",                      ("skills",)),
+    "audit-hooks":         CommandMeta("audit-hooks.py",         "Audit hook installation and configuration",            ("hooks", "audit")),
+    "audit-instructions":  CommandMeta("audit-instructions.py",  "Audit agent instruction files",                        ("docs", "audit")),
+    "improvement-signals": CommandMeta("improvement-signals.py", "Surface improvement signal patterns",                  ("session", "analytics")),
+    "status":              CommandMeta("statusline.py",          "Show session token usage and AI cost summary",          ("session", "cost")),
+    "statusline":          CommandMeta("statusline.py",          "Alias: session token usage footer",                   ("session", "cost"), aliases=("status",)),
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}
@@ -493,7 +494,10 @@ def _run_cron(extra_args: list[str]) -> int:
 
 
 def _print_help() -> None:
-    direct_list = "  " + "\n  ".join(f"sk {cmd:<12} → {script}" for cmd, script in _DIRECT.items())
+    direct_list = "  " + "\n  ".join(
+        f"sk {cmd:<20} {str(meta.description):<40} {','.join(meta.tags[:2])}"
+        for cmd, meta in _DIRECT.items()
+    )
     print(
         f"sk {__version__} — copilot-session-knowledge unified CLI\n"
         "\nDirect commands:\n"
@@ -539,7 +543,7 @@ def main(argv: list[str] | None = None) -> int:
     if cmd == "init":
         return _run("setup-project.py", ["--init-mode"] + rest)
     if cmd in _DIRECT:
-        return _run(_DIRECT[cmd], rest)
+        return _run(str(_DIRECT[cmd]), rest)
 
     # Grouped namespace?
     if cmd in _GROUPS:


### PR DESCRIPTION
## Summary
Add `harness-manifest.json` (77 entries, ~9KB) and `harness/manifest.py` with fail-open, cached loader.

## Changes
- `harness/manifest.py`: `load_manifest(tools_dir)` with `lru_cache(maxsize=1)`, fail-open on FileNotFoundError and json.JSONDecodeError
- `harness-manifest.json`: 77 entries (32 direct + 45 group-sub), version 1

## Verification
```
✅ load_manifest() returns {version:1, commands:77}
✅ fail-open: FileNotFoundError → {"version":1,"commands":{}}
✅ test_security.py: 13/13 | test_fixes.py: 285/285 | lint+format: OK
```

Closes #620