### PR TITLE
docs(#578): sk as single entrypoint — replace python3 paths with sk commands

### DIFF
--- a/.github/skills/session-knowledge-creator/SKILL.md
+++ b/.github/skills/session-knowledge-creator/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: session-knowledge-creator
+description: Generate a project-customized session-knowledge skill with enforced AI integration. Use this skill whenever someone says "set up knowledge tracking", "configure session knowledge", "make AI remember things", "set up briefing", or when onboarding a new project that should have cross-session learning. Also use when the user complains that AI keeps forgetting things or repeating past mistakes across sessions.
+---
+
+# Session Knowledge Creator
+
+A meta-skill that analyzes your project and generates a customized session-knowledge integration — including the critical `.instructions.md` enforcement file that makes AI agents actually use it.
+
+## When to Use
+
+- Someone says "set up knowledge tracking", "make AI remember things", or "configure session knowledge"
+- Onboarding a new project where AI should retain context across sessions
+- AI keeps repeating past mistakes or forgetting decisions made earlier
+- A project already uses `briefing.py`/`learn.py` but has no enforcement file
+
+## Why this exists
+
+AI agents ignore session-knowledge tools even when SKILL.md says "MANDATORY". The root cause: SKILL.md is reference-only documentation that AI must actively choose to read. Most don't. The solution is `.instructions.md` files — Copilot CLI auto-injects these into every context, so the AI has no choice but to see the rules.
+
+This skill generates three files that work together:
+1. **SKILL.md** — detailed reference (AI reads on demand)
+2. **`.instructions.md`** — short imperative rules (auto-injected into every context)
+3. **CLAUDE.md patch** — brief pointer to the other two files
+
+## Workflow
+
+### Step 1: Analyze the project
+
+Run these in parallel to understand the project:
+
+```bash
+# Structure
+find . -maxdepth 3 -type d -not -path '*/node_modules/*' -not -path '*/.git/*' | head -40
+
+# Language and framework
+ls package.json pyproject.toml Cargo.toml go.mod pom.xml 2>/dev/null
+cat package.json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print('name:', d.get('name')); print('deps:', list(d.get('dependencies',{}).keys())[:10])" 2>/dev/null
+
+# Existing AI configuration
+ls .github/skills/ .github/instructions/ 2>/dev/null
+head -20 CLAUDE.md 2>/dev/null
+head -20 .github/copilot-instructions.md 2>/dev/null
+cat AGENTS.md 2>/dev/null | head -30
+
+# Tools availability
+ls ~/.copilot/tools/briefing.py ~/.copilot/tools/learn.py 2>/dev/null
+python3 ~/.copilot/tools/learn.py --stats 2>/dev/null | head -10  # or: sk learn --stats
+```
+
+If `briefing.py` or `learn.py` are missing, tell the user to install first:
+```
+git clone https://github.com/magicpro97/copilot-session-knowledge.git ~/.copilot/tools
+```
+
+### Step 2: Build a project profile
+
+From the analysis, determine:
+
+| Field | Where to find it |
+|-------|-----------------|
+| Project name | package.json / pyproject.toml / repo name |
+| Language | File extensions + config files |
+| Domain | README.md / CLAUDE.md description |
+| Key modules | Folder structure |
+| Test command | package.json scripts / Makefile |
+| Custom agents | AGENTS.md |
+
+Also determine **wing/room mappings** — these organize knowledge hierarchically. Wings are top-level categories (matching your project's architecture layers), rooms are specific modules within each wing.
+
+Example mappings for common project types:
+
+- **Next.js e-commerce**: wings = frontend, backend, database, devops; rooms = auth, products, cart, payments
+- **Django blog**: wings = backend, frontend, testing; rooms = posts, users, comments, media
+- **Go microservices**: wings = api-gateway, user-service, order-service, infra; rooms = handlers, repository, config
+
+Derive yours from the actual folder structure.
+
+### Step 3: Generate three files
+
+#### File 1: `.github/instructions/session-knowledge.instructions.md`
+
+This is the most important file — it's auto-injected into every AI context. Keep it short and imperative. Use the template in `references/instructions-template.md`, replacing domain-specific tags with actual project terms.
+
+The file must have `applyTo: "**/*"` in its YAML frontmatter so it loads for all file types.
+It must also include a decision-confidence rule: when a recalled entry or current decision is
+below confidence `1.0`, dispatch research/validation on the strongest available model before
+acting, then record the result with `sk learn`.
+
+#### File 2: `.github/skills/session-knowledge/SKILL.md`
+
+A detailed reference with project-specific examples, wing/room mappings, and workflow integration. Use the template in `references/skill-template.md`, replacing all `<PLACEHOLDER>` values.
+
+The examples matter — use actual domain terms from the project (not generic "DynamoDB" or "patient" examples). This helps AI understand what kind of knowledge to record.
+The generated SKILL.md must explain that low-confidence memory is not a decision source:
+confidence `< 1.0` requires independent research or validation before implementation,
+deletion, merge, or routing decisions.
+
+#### File 3: CLAUDE.md or copilot-instructions.md patch
+
+Add a brief section pointing to the other two files. Keep it short — enforcement comes from the `.instructions.md` file, not from CLAUDE.md:
+
+```markdown
+## Session Knowledge
+
+> Enforced by `.github/instructions/session-knowledge.instructions.md` (auto-loaded).
+> Tools: `sk briefing`, `sk learn`, `sk query`
+> JSON output: `sk briefing "task" --json`, `sk learn ... --json`, `sk query "q" --export json`
+> Details: `.github/skills/session-knowledge/SKILL.md`
+```
+
+### Step 4: Verify
+
+```bash
+sk briefing --wakeup
+# fallback: python3 ~/.copilot/tools/briefing.py --wakeup
+sk briefing "task description" --json    # verify JSON output works
+sk learn --discovery "Setup test" "Session knowledge configured" --tags "setup" --json
+# fallback: python3 ~/.copilot/tools/learn.py --discovery ...
+cat .github/instructions/session-knowledge.instructions.md
+head -5 .github/skills/session-knowledge/SKILL.md
+
+# Validate the generated SKILL.md meets standards (no sk shortcut)
+python3 ~/.copilot/tools/validate-skill.py .github/skills/session-knowledge/SKILL.md
+```
+
+The generated SKILL.md must comply with `~/.copilot/tools/skills/references/skill-standards.md`.
+
+### Step 5: Report
+
+Present a summary showing: project profile, files created, enforcement status, and a test command.
+
+## Reference files
+
+Templates for generated files are in the `references/` directory:
+- `references/instructions-template.md` — `.instructions.md` template
+- `references/skill-template.md` — SKILL.md template
+
+<example>
+**Project:** Next.js e-commerce app
+
+**Profile:** TypeScript | Next.js 14 | Wings: frontend, backend, database | Rooms: auth, products, cart, payments
+
+**Generated files:**
+1. `.github/instructions/session-knowledge.instructions.md` — imperative rules, auto-injected
+2. `.github/skills/session-knowledge/SKILL.md` — full reference with e-commerce domain examples
+3. `CLAUDE.md` patch — 3-line pointer to above files
+
+**Validation:**
+```bash
+python3 ~/.copilot/tools/validate-skill.py .github/skills/session-knowledge/SKILL.md
+# → PASS  .github/skills/session-knowledge/SKILL.md
+```
+</example>

--- a/.github/skills/session-knowledge-creator/references/instructions-template.md
+++ b/.github/skills/session-knowledge-creator/references/instructions-template.md
@@ -1,0 +1,70 @@
+# `.instructions.md` Template
+
+> **Copy this file to** `.github/instructions/session-knowledge.instructions.md`
+> in the target project. Replace `<PLACEHOLDER>` values with project-specific terms.
+> The `applyTo: "**/*"` frontmatter causes Copilot CLI to auto-inject this file
+> into every AI context — enforcement happens automatically.
+
+---
+
+```markdown
+---
+applyTo: "**/*"
+---
+
+# Session Knowledge — <PROJECT_NAME> (AUTO-LOADED)
+
+> Auto-injected into every context. Knowledge tools are NOT optional.
+
+## Before Starting ANY Task
+
+```bash
+sk briefing --auto --compact
+# fallback: python3 ~/.copilot/tools/briefing.py --auto --compact
+```
+
+Read the output — it contains past mistakes to avoid and patterns to follow for
+<PROJECT_NAME>. Pay attention to entries tagged `<KEY_TAG_1>` or `<KEY_TAG_2>`.
+
+## After Completing Work
+
+Record what you learned (choose appropriate type):
+
+```bash
+# After fixing a bug:
+sk learn --mistake "Title" "Root cause and fix" \
+  --tags "<MODULE>,<TECH>" --wing <WING> --room <ROOM>
+
+# After implementing a feature:
+sk learn --feature "Title" "What was built" \
+  --tags "<MODULE>,<TECH>" --wing <WING> --room <ROOM>
+
+# After discovering a useful pattern:
+sk learn --pattern "Title" "What works well" \
+  --tags "<MODULE>,<TECH>"
+# fallback: python3 ~/.copilot/tools/learn.py <type> <args>
+```
+
+## Rules
+
+- ❌ NEVER skip briefing before starting complex work
+- ❌ NEVER skip learn after fixing a non-trivial bug
+- ✅ Use domain tags: `<KEY_TAG_1>`, `<KEY_TAG_2>`, `<KEY_TAG_3>`
+- ✅ Keep entries concise (1-3 sentences max)
+- ✅ Include wing/room for knowledge palace organization
+```
+
+---
+
+## How to customize this template
+
+| Placeholder | What to put there |
+|-------------|-------------------|
+| `<PROJECT_NAME>` | Actual project name (e.g. `NextShop`, `TravelApp`) |
+| `<KEY_TAG_1/2/3>` | Domain tags derived from folder structure (e.g. `auth`, `api`, `ui`) |
+| `<MODULE>` | Module/layer name from project (e.g. `backend`, `frontend`) |
+| `<TECH>` | Technology stack (e.g. `kotlin`, `react`, `django`) |
+| `<WING>` | Top-level architecture wing (e.g. `frontend`, `backend`, `infra`) |
+| `<ROOM>` | Sub-module within the wing (e.g. `auth`, `products`, `payments`) |
+
+Keep the file short (< 60 lines). Enforcement comes from auto-injection, not length.

--- a/.github/skills/session-knowledge-creator/references/skill-template.md
+++ b/.github/skills/session-knowledge-creator/references/skill-template.md
@@ -1,0 +1,115 @@
+# `SKILL.md` Template — Session Knowledge
+
+> **Copy this file to** `.github/skills/session-knowledge/SKILL.md` in the target project.
+> Replace every `<PLACEHOLDER>` with project-specific values before saving.
+> The generated file must pass `python3 ~/.copilot/tools/validate-skill.py` (no sk shortcut for this tool).
+
+---
+
+```markdown
+---
+name: session-knowledge
+description: >-
+  Search past <PROJECT_NAME> Copilot/Claude sessions before complex tasks.
+  Run briefing.py for relevant mistakes, patterns, decisions from <DOMAIN> work.
+  Use when starting <KEY_ACTIVITY_1>, debugging <KEY_ACTIVITY_2>,
+  or making architecture decisions about <KEY_ACTIVITY_3>.
+  Activated by keywords: briefing, past sessions, knowledge base, <KEY_TAG_1>, <KEY_TAG_2>.
+---
+
+# Session Knowledge — <PROJECT_NAME>
+
+Past mistakes and patterns from <PROJECT_NAME> (<LANGUAGE> / <FRAMEWORK>) are indexed
+in a local knowledge base. Use these tools to avoid repeating errors and reuse
+proven solutions specific to this codebase.
+
+## When to Use
+
+- **Starting a complex task** → run briefing.py to surface relevant past experience
+- **Hitting an unfamiliar error** → search for the error message
+- **Making a design decision** → check --decisions for past architectural choices
+- **Working in <KEY_MODULE_1> or <KEY_MODULE_2>** → especially worth a briefing
+
+**Skip** for trivial changes (renaming variables, formatting, etc.)
+
+## Core Commands
+
+```bash
+# Before task — get context
+sk briefing "<task description>" --compact
+# fallback: python3 ~/.copilot/tools/briefing.py "<task description>" --compact
+
+# Search for a specific error
+sk query "<error message>" --verbose
+# fallback: python3 ~/.copilot/tools/query-session.py "<error message>" --verbose
+
+# See past decisions about <TECH>
+sk query "<TECH>" --decisions
+
+# After fixing a bug — record it
+sk learn --mistake "Title" "Root cause and fix" \
+  --tags "<KEY_TAG_1>,<KEY_TAG_2>" --wing <WING> --room <ROOM>
+# fallback: python3 ~/.copilot/tools/learn.py --mistake ...
+
+# After implementing a feature
+sk learn --feature "Title" "What was built" \
+  --tags "<KEY_TAG_1>"
+```
+
+## Wing / Room Mappings
+
+Knowledge is organized hierarchically. Use these when recording entries:
+
+| Wing | Rooms | What belongs here |
+|------|-------|-------------------|
+| `<WING_1>` | `<ROOM_1_A>`, `<ROOM_1_B>` | <WING_1_DESCRIPTION> |
+| `<WING_2>` | `<ROOM_2_A>`, `<ROOM_2_B>` | <WING_2_DESCRIPTION> |
+| `<WING_3>` | `<ROOM_3_A>`, `<ROOM_3_B>` | <WING_3_DESCRIPTION> |
+
+## Interpreting Results
+
+- **`[mistake]`** — what went wrong; read carefully to avoid repeating
+- **`[pattern]`** — proven solutions for <PROJECT_NAME>; apply directly
+- **`[decision]`** — past architectural choices; check if still valid
+- **`[tool]`** — configurations specific to <FRAMEWORK>
+- **Confidence < 0.5** — verify before using
+
+<example>
+**Task:** Fix <KEY_ACTIVITY_1> bug in <KEY_MODULE_1>
+
+```bash
+sk briefing "fix <KEY_ACTIVITY_1> in <KEY_MODULE_1>"
+# → shows 1 past mistake about <DOMAIN_ISSUE>, 1 pattern for <DOMAIN_SOLUTION>
+
+sk query "<ERROR_TYPE>" --verbose
+# → finds the root cause from a previous session
+
+# After fixing:
+sk learn --mistake "<KEY_MODULE_1> <ERROR_TYPE>" \
+  "Root cause: <CAUSE>. Fix: <FIX_DESCRIPTION>" \
+  --tags "<KEY_TAG_1>,<KEY_TAG_2>" --wing <WING_1> --room <ROOM_1_A>
+```
+</example>
+```
+
+---
+
+## How to customize this template
+
+| Placeholder | What to put there |
+|-------------|-------------------|
+| `<PROJECT_NAME>` | Actual project name |
+| `<LANGUAGE>` | e.g. TypeScript, Kotlin, Python |
+| `<FRAMEWORK>` | e.g. Next.js, Spring Boot, Django |
+| `<DOMAIN>` | Short domain description (e.g. "e-commerce", "mobile health") |
+| `<KEY_ACTIVITY_1/2/3>` | Common developer activities in this project |
+| `<KEY_MODULE_1/2>` | Most-touched modules/directories |
+| `<KEY_TAG_1/2>` | Tags derived from the module/tech stack |
+| `<WING_N>` | Top-level architecture layer |
+| `<ROOM_N_X>` | Sub-module within the wing |
+| `<WING_N_DESCRIPTION>` | One-line description of what goes in that wing |
+| `<DOMAIN_ISSUE/SOLUTION>` | Domain-specific example for the `<example>` block |
+| `<ERROR_TYPE>` | Realistic error type for the project |
+| `<CAUSE>/<FIX_DESCRIPTION>` | Example root cause / fix language |
+
+Remove the outer markdown fence before saving. The file must start with `---` (YAML frontmatter).

--- a/.github/skills/session-knowledge/SKILL.md
+++ b/.github/skills/session-knowledge/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: session-knowledge
+description: >-
+  Use when starting a complex task, hitting an error, or making a design decision — search
+  past Copilot/Claude session knowledge. Run briefing.py for relevant mistakes, patterns,
+  decisions. Use query-session.py to search errors, tools, architecture choices.
+  Supports semantic search with embeddings.
+---
+
+# Session Knowledge
+
+You have access to a knowledge base built from past Copilot and Claude sessions.
+Use it to avoid repeating mistakes, reuse proven patterns, and recall past decisions.
+
+All tools are available as `sk <command>` (the preferred short form). If `sk` is not yet on PATH, use `python3 ~/.copilot/tools/<script>.py` on macOS/Linux, or `python "$env:USERPROFILE\.copilot\tools\<script>.py"` in Windows PowerShell.
+
+## When to Use
+
+- **Starting a complex task** → run `briefing.py` to check for relevant past experience
+- **Hitting an error** → search for the error message, someone may have solved it before
+- **Making a design decision** → check `--decisions` for past architectural choices
+- **Unsure about a tool/config** → search for the tool name
+
+**Skip** when the task is trivial (renaming a variable, formatting code, etc.)
+
+## Context Budget
+
+Always start with the lightest fetch, then escalate only when a hit is relevant:
+
+| Task complexity | Recommended command | Approx tokens |
+|----------------|---------------------|---------------|
+| Trivial / session start | `briefing.py --wakeup` | ~170 |
+| Moderate (bug fix, small feature) | `briefing.py "specific task description" --compact` | ~500 |
+| General orientation (not task-specific) | `briefing.py --auto --compact` | ~500 |
+| Complex / unfamiliar area | `briefing.py "task" --full` | ~3K |
+| Drill into one entry | `query-session.py --detail <id>` | varies |
+
+**Do not load `--full` when `--compact` shows no relevant hits.** A large briefing that
+surfaces nothing useful costs tokens without benefit.
+
+**`--auto` extracts keywords from git diff** — good for session orientation, but off-topic
+for targeted task recall. Prefer `briefing.py "your actual task" --compact` for any specific task.
+
+**`--compact` truncates to ~180 chars per entry.** Always follow up with `--detail <id>`
+on any entry whose title looks relevant — the actual fix/solution is usually in the truncated part.
+
+## Core Commands
+
+### 1. Briefing (recommended first step)
+
+```bash
+sk briefing "your task description"    # Compact ~500 tokens
+sk briefing "your task" --full         # Full detail ~3K tokens
+sk briefing --auto                     # Auto-detect from git/plan
+sk briefing --wakeup                   # Ultra-compact ~170 tokens for session start
+sk briefing --titles-only              # Index only ~10 tok/entry — progressive disclosure
+sk briefing --titles-only "topic"      # Filtered titles
+sk briefing "task" --wing ui --room settings  # Filter by wing/room
+sk briefing "task" --min-confidence 0.7       # High-quality entries only
+# fallback: macOS/Linux `python3 ~/.copilot/tools/briefing.py <args>`;
+# Windows PowerShell `python "$env:USERPROFILE\.copilot\tools\briefing.py" <args>`
+```
+
+Output includes: relevant mistakes to avoid, patterns to follow, related past work.
+**Read entry IDs in the output** — use them to drill down.
+
+### 1b. Sub-agent Context Injection
+
+When dispatching tentacle agents, prefer the bundle-first structured recall path:
+
+```bash
+sk tentacle swarm <name> --briefing
+# fallback: macOS/Linux `python3 ~/.copilot/tools/tentacle.py swarm <name> --briefing`;
+# Windows PowerShell `python "$env:USERPROFILE\.copilot\tools\tentacle.py" swarm <name> --briefing`
+```
+
+This materializes `.octogent/tentacles/<name>/bundle/` by default, keeps the dispatch prompt
+lean, and writes bounded `[KNOWLEDGE EVIDENCE]` to `briefing.md` plus machine-readable
+`recall-pack.json` by running task-scoped `briefing.py --task <id> --json` first, then
+`briefing.py "<query>" --pack --limit 3` only when task recall is empty.
+`--task --json` exposes `tagged_entries[]` / `related_entries[]`; `--pack` keeps
+`entries.<category>[]`. Drilldown may append `query-session.py --related <entry_id>`
+only when the first evidence bullet has related entries.
+
+For manual compatibility and ad hoc non-tentacle prompts, inject context directly:
+
+```bash
+sk briefing "task description" --for-subagent
+# fallbacks follow the same macOS/Linux `python3 ...` and Windows PowerShell `python "$env:USERPROFILE\..."` pattern above
+```
+
+This outputs a compact `[KNOWLEDGE CONTEXT]` block (~200 tokens) designed to be
+embedded directly into prompts. Example manual workflow:
+
+1. Run `sk briefing "fix Docker networking" --for-subagent` → get context block
+2. Prepend the context block to the sub-agent's prompt
+3. Sub-agent now knows past mistakes/patterns without querying KB directly
+
+### 2. Search
+
+```bash
+sk query "search terms"              # Compact results
+sk query "docker error" --verbose    # Full content
+sk query "deployment error" --semantic            # Compact semantic output
+sk query "deployment error" --semantic --verbose  # Shows feedback bias only when non-zero
+sk query "spring" --source copilot   # Filter by agent
+sk query "gradle" --type research    # Filter by doc type
+# fallback: macOS/Linux `python3 ~/.copilot/tools/query-session.py <args>`;
+# Windows PowerShell `python "$env:USERPROFILE\.copilot\tools\query-session.py" <args>`
+```
+
+### 3. Drill Down (use entry IDs from search/briefing results)
+
+```bash
+sk query --detail <id>     # Full content of one entry
+sk query --context <id>    # Entry + same-session entries
+sk query --related <id>    # Entry + graph connections
+# fallback: macOS/Linux `python3 ~/.copilot/tools/query-session.py <flag> <id>`;
+# Windows PowerShell `python "$env:USERPROFILE\.copilot\tools\query-session.py" <flag> <id>`
+```
+
+`sk query --detail <id>` writes stateless `detail_open` telemetry:
+- found entry → `hit_count=1`, `selected_entry_ids=[id]`
+- missing entry → `hit_count=0`, `selected_entry_ids=[]`
+
+### 4. Browse by Category
+
+```bash
+sk query --mistakes    # Past errors and how they were fixed
+sk query --patterns    # Reusable best practices
+sk query --decisions   # Architecture/design choices
+sk query --tools       # Tool configs and usage notes
+```
+
+### 4b. Recall Telemetry Stats
+
+```bash
+sk index health --recall
+sk index health --recall --json
+# fallback: python3 ~/.copilot/tools/knowledge-health.py --recall [--json]
+```
+
+- `recall_events` is lean telemetry (counts/IDs/output size only), not verbose output logging.
+- Default `sk query "query"` telemetry aggregates the full emitted surface
+  (primary search + `sessions_fts` + knowledge-entry blocks).
+- `--recall` outputs recall-only stats (text or JSON). No browse UI / contextual summary / provider rerank scope here.
+
+### 5. Knowledge Graph
+
+```bash
+sk query --graph "topic"   # Visual: entries + connections
+```
+
+Shows how knowledge entries relate to each other:
+- **RESOLVED_BY** — a mistake linked to the pattern/tool that fixed it
+- **TAG_OVERLAP** — entries sharing similar tags (related domain)
+- **SAME_SESSION** — entries discovered together in one session
+- **SAME_TOPIC** — same topic tracked across multiple sessions
+
+### 6. Record Knowledge
+
+```bash
+# 7 observation types
+sk learn --mistake "Title"   "What went wrong and fix"         --tags "tag1,tag2"
+sk learn --pattern "Title"   "What works well / best practice" --tags "tag1"
+sk learn --decision "Title"  "Architecture decision rationale" --tags "tag1"
+sk learn --tool "Title"      "Tool/config that was useful"     --tags "tag1"
+sk learn --feature "Title"   "New feature implementation"      --tags "tag1"
+sk learn --refactor "Title"  "Code improvement description"    --tags "tag1"
+sk learn --discovery "Title" "Codebase finding or insight"     --tags "tag1"
+
+# Structured facts (discrete, verifiable statements)
+sk learn --pattern "Title" "Description" \
+  --fact "max retries is 3" --fact "timeout is 30s"
+
+# Palace categorization (wing/room)
+sk learn --mistake "Title" "Description" --wing ui --room settings
+
+# Knowledge graph relations
+sk learn --relate "ScreenA" "navigates_to" "ScreenB"
+sk learn --relate "ComponentX" "uses" "ThemeToken"
+
+# Bulk import / view
+sk learn --from-file notes.md    # Bulk import from markdown
+sk learn --list                   # List recent entries
+sk learn --stats                  # Knowledge base statistics
+# fallback: macOS/Linux `python3 ~/.copilot/tools/learn.py <args>`;
+# Windows PowerShell `python "$env:USERPROFILE\.copilot\tools\learn.py" <args>`
+```
+
+### 7. Auto-Update Tools
+
+```bash
+sk update              # Auto-update (24h cooldown)
+sk update --force       # Force update now
+sk update --status      # Show version info
+sk update --doctor      # Health check
+# fallback: python3 ~/.copilot/tools/auto-update-tools.py <args>
+```
+
+### 8. Optional Sync Runtime (local-first)
+
+Use these only when sync replication is needed. Local `knowledge.db` remains primary.
+
+```bash
+# Single connection string in ~/.copilot/tools/sync-config.json
+sk sync config --setup https://gateway.example.com
+sk sync config --setup-env SYNC_GATEWAY_URL
+sk sync config --status
+sk sync config --status --json
+sk sync config --get
+sk sync config --clear
+
+# Local-first runtime + diagnostics
+sk sync run --once
+sk sync run --daemon
+sk sync run --interval 30
+sk sync run --push-only
+sk sync run --pull-only
+sk sync status --json
+sk sync status --watch-status --json
+sk sync status --health-check --json
+sk sync status --audit --json
+sk update --restart-watch
+sk update --watch-status
+sk update --health-check
+sk update --audit-runtime
+# fallback: python3 ~/.copilot/tools/sync-config.py / sync-daemon.py / sync-status.py / auto-update-tools.py
+```
+
+If no `connection_string` is configured, daemon sync remains local-only/idle.
+Daemon runtime is hardened for backlog catch-up: adaptive per-cycle limits, multi-page pull in one cycle, and post-pull targeted refresh of `knowledge_fts` / `ke_fts`.
+`sk sync config --setup` expects an HTTP(S) gateway URL (not a raw Postgres/libSQL DSN).
+`sync-gateway.py` is a **reference/mock** contract surface in this repo (not production authority).
+Default provider rollout recommendation: Neon (backing Postgres) + Railway (thin gateway host), while preserving the same HTTP gateway contract.
+
+### 9. Trend Scout operations (scheduled, not hook-driven)
+
+```bash
+sk scout run --search-only
+sk scout run --dry-run --limit 1 --force
+sk scout run --limit 1 --force
+# fallback: python3 ~/.copilot/tools/trend-scout.py <args>
+```
+
+- Trend Scout creates **or updates** marker-linked issues.
+- Veto and grace behavior come from `trend-scout-config.json` (script defaults may differ from repo-configured values).
+- Keep Trend Scout out of interactive hooks (`preToolUse`/`postToolUse`) to avoid session spam.
+
+## Interpreting Results
+
+- **`[mistake]`** entries = things that went wrong → read carefully to avoid repeating
+- **`[pattern]`** entries = proven solutions → consider applying directly
+- **`[decision]`** entries = past choices with rationale → check if still valid
+- **`[tool]`** entries = configurations, commands → copy-paste ready
+- **`[feature]`** entries = feature implementation details → reference for similar work
+- **`[refactor]`** entries = code improvements → reuse approach
+- **`[discovery]`** entries = codebase insights → context for decisions
+- **Confidence score** (0.3–1.0) = how reliable the entry is. Below 0.5 = verify before using.
+- **Entry ID `#1234`** = use with `--detail 1234` to see full content
+
+## Workflow Example
+
+```
+1. sk briefing "fix Docker compose networking"
+   → shows 2 past mistakes about Docker DNS, 1 pattern about compose networks
+
+2. sk query --detail 2045
+   → reads the full mistake: was using wrong network driver
+
+3. Apply the fix using the pattern from the briefing
+
+4. sk learn --pattern "Docker DNS Fix" "Use bridge network with explicit DNS" \
+     --fact "compose DNS uses service names" --wing infrastructure --room docker
+```
+
+<example>
+User: "I need to add retry logic to the payment service. Where should I start?"
+
+1. Run briefing before touching anything:
+   ```
+   sk briefing "add retry logic payment service" --auto --compact
+   ```
+   → Output surfaces a past mistake: "Exponential backoff not applied to idempotent endpoints"
+   and a pattern: "Use tenacity library with max_attempts=3, wait=wait_exponential(min=1, max=10)"
+
+2. Drill into the pattern entry shown in results:
+   ```
+   sk query --detail 1842
+   ```
+   → Full entry: exact tenacity config that worked in the order service
+
+3. Implement retry logic using the pattern, avoiding the known mistake.
+
+4. Record what was learned:
+   ```
+   sk learn --pattern "Payment retry with tenacity" \
+     "Use tenacity with max_attempts=3, wait_exponential(min=1, max=10) on POST /charge" \
+     --fact "idempotency key required on retry" --wing backend --room payments
+   ```
+</example>
+
+<example>
+User: "Getting 'SSL: CERTIFICATE_VERIFY_FAILED' on CI — has this come up before?"
+
+1. Search for the error message:
+   ```
+   sk query "SSL CERTIFICATE_VERIFY_FAILED"
+   ```
+   → Finds a past mistake entry explaining that the corporate proxy strips certs and the fix
+   was to set `REQUESTS_CA_BUNDLE` to the internal CA bundle path.
+
+2. Apply the fix directly from the KB entry — no need to debug from scratch.
+
+3. If it was a new variant, record it:
+   ```
+   sk learn --mistake "SSL verify failed behind proxy" \
+     "Corporate proxy strips SSL — set REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt" \
+     --tags "ssl,ci,proxy" --wing devops --room ci
+   ```
+</example>
+
+## Search Quality Rules
+
+**Use specific, task-relevant keywords.** Vague searches waste tokens and miss knowledge:
+
+```bash
+# ❌ BAD — too vague
+sk query "fix" --compact
+sk query "error" --compact
+
+# ✅ GOOD — specific to the actual problem
+sk query "WASAPI loopback buffer underflow" --compact
+sk query "tokio runtime thread panicked" --compact
+sk query "ratatui crossterm Windows resize" --compact
+```
+
+**`--compact` is step 1 only.** It outputs titles (~20 tokens each). You MUST follow up with
+`--detail <id>` on any hit whose title looks relevant to your task:
+
+```bash
+# Step 1
+sk query "docker compose networking" --compact
+# Step 2 — drill into relevant hits
+sk query --detail 1842
+```
+
+❌ NEVER stop after `--compact` without `--detail <id>` on relevant-looking hits.
+❌ NEVER search with generic words like "fix", "error", "issue" — use specific tech/module terms.
+✅ If first search returns < 3 hits, expand with 1–2 related keyword variants.
+
+## Semantic Search (if embeddings configured)
+
+```bash
+sk query "deployment error" --semantic
+# fallback: python3 ~/.copilot/tools/query-session.py "deployment error" --semantic
+```
+
+Works with meaning, not just keywords. Requires API key setup via `embed.py --setup`.

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ This tool **indexes all session data** into SQLite FTS5, **auto-extracts knowled
 git clone https://github.com/magicpro97/copilot-session-knowledge.git ~/.copilot/tools
 
 # 2. Build knowledge base
-python3 ~/.copilot/tools/sk.py index build && python3 ~/.copilot/tools/sk.py index extract
+sk index build && sk index extract
+# fallback: python3 ~/.copilot/tools/sk.py index build && python3 ~/.copilot/tools/sk.py index extract
 
 # 3. Get a briefing
-python3 ~/.copilot/tools/sk.py briefing "your task description"
-# (fallback: python3 ~/.copilot/tools/briefing.py "your task description")
+sk briefing "your task description"
+# fallback: python3 ~/.copilot/tools/briefing.py "your task description"
 ```
 After `install.py --test` (full install), the `sk` launcher is added to your user PATH. Already-running Windows terminals may need `$env:Path = "$env:USERPROFILE\.copilot\bin;$env:Path"` or a restart before `sk` resolves; until then use `python "$env:USERPROFILE\.copilot\tools\sk.py"`.
 That's it. Your AI agent now has memory across sessions.
@@ -67,7 +68,7 @@ python3 ~/.copilot/tools/build-session-index.py
 python3 ~/.copilot/tools/extract-knowledge.py
 python3 ~/.copilot/tools/migrate.py
 python3 ~/.copilot/tools/install.py --test
-# → sk launcher auto-provisioned on PATH
+# → sk launcher auto-provisioned on PATH; use `sk` from here on
 
 # macOS: install LaunchAgents (auto-start watcher + daily auto-update)
 python3 ~/.copilot/tools/launchd/install-launchd.py
@@ -137,14 +138,16 @@ qs --session-raw <session-id>        # Dump raw events for a session
 ### Index Health
 
 ```bash
-python3 ~/.copilot/tools/index-status.py          # Row counts, FTS integrity, offset coverage
+sk index status          # Row counts, FTS integrity, offset coverage
+# fallback: python3 ~/.copilot/tools/index-status.py
 ```
 
 ### Recall Telemetry (Phase 5)
 
 ```bash
-python3 ~/.copilot/tools/knowledge-health.py --recall         # Recall-only telemetry dashboard
-python3 ~/.copilot/tools/knowledge-health.py --recall --json  # Recall-only JSON stats
+sk index health --recall         # Recall-only telemetry dashboard
+sk index health --recall --json  # Recall-only JSON stats
+# fallback: python3 ~/.copilot/tools/knowledge-health.py --recall [--json]
 ```
 
 - Telemetry is intentionally lean (`recall_events`): counts/IDs/size only, no verbose output bodies.
@@ -170,40 +173,42 @@ Multi-agent parallel execution via scoped work units. The runtime-bundle workflo
 
 ```bash
 # 1. Create a tentacle with scope + briefing + skills
-python3 ~/.copilot/tools/tentacle.py create api-export \
+sk tentacle create api-export \
   --scope "src/api/*.py" --desc "Export API endpoints" --briefing \
   --skill karpathy-guidelines --skill code-reviewer
+# fallback: python3 ~/.copilot/tools/tentacle.py create api-export ...
 
 # 2. Add atomic todo items (one per agent delegation unit)
-python3 ~/.copilot/tools/tentacle.py todo api-export add "Generate OpenAPI schema"
+sk tentacle todo api-export add "Generate OpenAPI schema"
 
 # 3. (Optional) Prepare isolated git worktree
-python3 ~/.copilot/tools/tentacle.py worktree api-export prepare
-python3 ~/.copilot/tools/tentacle.py worktree api-export status
+sk tentacle worktree api-export prepare
+sk tentacle worktree api-export status
 
 # 4. (Optional) Pre-materialize isolated context bundle
 #    Writes briefing.md, instructions.md, skills.md, session-metadata.md,
 #    recall-pack.json (machine-readable JSON recall), and manifest.json to bundle/
-python3 ~/.copilot/tools/tentacle.py bundle api-export
+sk tentacle bundle api-export
 
 # 5. Dispatch — bundle is default; prompt stays lean and surfaces bundle_path
-python3 ~/.copilot/tools/tentacle.py swarm api-export \
+sk tentacle swarm api-export \
   --agent-type general-purpose --model claude-sonnet-4.6 --briefing      # single prompt
-python3 ~/.copilot/tools/tentacle.py swarm api-export --output parallel --briefing  # one dispatch per todo
-python3 ~/.copilot/tools/tentacle.py swarm api-export --output json --briefing      # structured JSON + bundle_path
-python3 ~/.copilot/tools/tentacle.py swarm api-export --worktree         # include worktree path reference
-python3 ~/.copilot/tools/tentacle.py dispatch api-export --worktree      # single-agent alias with worktree
-python3 ~/.copilot/tools/tentacle.py swarm api-export --no-bundle        # rare tiny-prompt opt-out
+sk tentacle swarm api-export --output parallel --briefing  # one dispatch per todo
+sk tentacle swarm api-export --output json --briefing      # structured JSON + bundle_path
+sk tentacle swarm api-export --worktree         # include worktree path reference
+sk tentacle dispatch api-export --worktree      # single-agent alias with worktree
+sk tentacle swarm api-export --no-bundle        # rare tiny-prompt opt-out
 
 # 6. Monitor runtime (read-only operator view)
-python3 ~/.copilot/tools/tentacle.py status           # Dashboard: all tentacles + states
+sk tentacle status           # Dashboard: all tentacles + states
 
 # 7. After agents finish: run verification commands, record results, and close (orchestrator only)
-python3 ~/.copilot/tools/tentacle.py verify api-export "python3 test_fixes.py" --label "tests"
-python3 ~/.copilot/tools/tentacle.py handoff api-export "Done. Learned X" --learn
-python3 ~/.copilot/tools/tentacle.py complete api-export  # Marks done, unblocks git commit
-python3 ~/.copilot/tools/tentacle.py complete api-export --auto-verify "python3 test_fixes.py"
-python3 ~/.copilot/tools/tentacle.py worktree api-export cleanup
+sk tentacle verify api-export "python3 test_fixes.py" --label "tests"
+sk tentacle handoff api-export "Done. Learned X" --learn
+sk tentacle complete api-export  # Marks done, unblocks git commit
+sk tentacle complete api-export --auto-verify "python3 test_fixes.py"
+sk tentacle worktree api-export cleanup
+# fallback for all: python3 ~/.copilot/tools/tentacle.py <subcommand> <args>
 ```
 
 > `--output parallel` maximises parallelism (one agent per todo). `swarm` and `dispatch`
@@ -222,29 +227,31 @@ orchestrator should commit after review + verification. Enforcement is local-onl
 > **Cross-repo isolation:** marker entries carry `git_root`, so repo A's active tentacle does not
 > block commits in repo B. Old entries without `git_root` conservatively block as before.
 
-> **Stuck marker:** markers expire after 4 hours. Manual clear: `python3 ~/.copilot/tools/tentacle.py complete <name>`
+> **Stuck marker:** markers expire after 4 hours. Manual clear: `sk tentacle complete <name>`
 > (or remove `~/.copilot/markers/dispatched-subagent-active` directly).
 
 ### Tentacle Next Step
 
 ```bash
 # Show the grounded next step for a named tentacle (read-only)
-python3 ~/.copilot/tools/tentacle.py next-step api-export         # First pending todo + checkpoint context
-python3 ~/.copilot/tools/tentacle.py next-step api-export --all   # All pending todos
-python3 ~/.copilot/tools/tentacle.py next-step api-export --briefing        # + live knowledge briefing
-python3 ~/.copilot/tools/tentacle.py next-step api-export --no-checkpoint   # Skip checkpoint context
-python3 ~/.copilot/tools/tentacle.py next-step api-export --format json     # JSON output
+sk tentacle next-step api-export         # First pending todo + checkpoint context
+sk tentacle next-step api-export --all   # All pending todos
+sk tentacle next-step api-export --briefing        # + live knowledge briefing
+sk tentacle next-step api-export --no-checkpoint   # Skip checkpoint context
+sk tentacle next-step api-export --format json     # JSON output
+# fallback: python3 ~/.copilot/tools/tentacle.py next-step api-export <args>
 ```
 
 ### Project Context
 
 ```bash
 # Generate deterministic project-context.md (repo structure, profile, hooks, test expectations)
-python3 ~/.copilot/tools/project-context.py                # Write to session files/ dir
-python3 ~/.copilot/tools/project-context.py --stdout       # Print to stdout only
-python3 ~/.copilot/tools/project-context.py --output PATH  # Write to explicit path
-python3 ~/.copilot/tools/project-context.py --profile python  # Force a preset profile
-python3 ~/.copilot/tools/project-context.py --list-profiles   # Show available profiles
+sk context project                # Write to session files/ dir
+sk context project --stdout       # Print to stdout only
+sk context project --output PATH  # Write to explicit path
+sk context project --profile python  # Force a preset profile
+sk context project --list-profiles   # Show available profiles
+# fallback: python3 ~/.copilot/tools/project-context.py <args>
 ```
 
 No AI generation, no network access. The artifact is derived purely from repo/profile facts and is deterministic for the same repo state.
@@ -253,15 +260,16 @@ No AI generation, no network access. The artifact is derived purely from repo/pr
 
 ```bash
 # Save
-python3 ~/.copilot/tools/checkpoint-save.py --title "Auth done" --overview "JWT added"
+sk checkpoint save --title "Auth done" --overview "JWT added"
 # Read back (read-only)
-python3 ~/.copilot/tools/checkpoint-restore.py --list
-python3 ~/.copilot/tools/checkpoint-restore.py --show latest
-python3 ~/.copilot/tools/checkpoint-restore.py --export latest --format json
+sk checkpoint restore --list
+sk checkpoint restore --show latest
+sk checkpoint restore --export latest --format json
 # Compare
-python3 ~/.copilot/tools/checkpoint-diff.py --from 1 --to latest
-python3 ~/.copilot/tools/checkpoint-diff.py --summary
-python3 ~/.copilot/tools/checkpoint-diff.py --from 1 --to latest --pager   # external pager (safe allowlist)
+sk checkpoint diff --from 1 --to latest
+sk checkpoint diff --summary
+sk checkpoint diff --from 1 --to latest --pager   # external pager (safe allowlist)
+# fallback: python3 ~/.copilot/tools/checkpoint-save.py / checkpoint-restore.py / checkpoint-diff.py <args>
 ```
 
 ### Web UI (browse.py)
@@ -301,11 +309,12 @@ Classic Python-rendered routes (F1–F15 including `/`, `/sessions`, `/graph`, `
 Build, share, and deploy custom workflow profiles:
 
 ```bash
-python3 ~/.copilot/tools/profile-builder.py --name myteam \
+sk profile build --name myteam \
   --hooks dangerous-blocker.py commit-gate.py --phases CLARIFY BUILD TEST COMMIT
-python3 ~/.copilot/tools/profile-export.py --profile myteam --output myteam.json
-python3 ~/.copilot/tools/profile-import.py --file myteam.json
-python3 ~/.copilot/tools/setup-project.py --profile myteam   # deploy
+sk profile export --profile myteam --output myteam.json
+sk profile import --file myteam.json
+sk setup --profile myteam   # deploy
+# fallback: python3 ~/.copilot/tools/profile-builder.py / profile-export.py / profile-import.py / setup-project.py <args>
 ```
 
 📖 **Full command reference:** [docs/USAGE.md](docs/USAGE.md)
@@ -315,21 +324,24 @@ python3 ~/.copilot/tools/setup-project.py --profile myteam   # deploy
 Sync is **local-first and optional**: local `knowledge.db` remains the primary read/query source; remote sync is transport/storage only.
 
 - **Config** (`~/.copilot/tools/sync-config.json`, single `connection_string`):
-  - `python3 ~/.copilot/tools/sync-config.py --setup https://gateway.example.com`
-  - `python3 ~/.copilot/tools/sync-config.py --setup-env SYNC_GATEWAY_URL`
+  - `sk sync config --setup https://gateway.example.com`
+  - `sk sync config --setup-env SYNC_GATEWAY_URL`
   - Setup accepts an HTTP(S) gateway URL (not a raw Postgres/libSQL DSN).
-  - `python3 ~/.copilot/tools/sync-config.py --status --json`
-  - `python3 ~/.copilot/tools/sync-config.py --get`
-  - `python3 ~/.copilot/tools/sync-config.py --clear`
+  - `sk sync config --status --json`
+  - `sk sync config --get`
+  - `sk sync config --clear`
+  - fallback: `python3 ~/.copilot/tools/sync-config.py <args>`
 - **Runtime**:
-  - `python3 ~/.copilot/tools/sync-daemon.py --once|--daemon|--interval 30|--push-only|--pull-only`
+  - `sk sync run --once|--daemon|--interval 30|--push-only|--pull-only`
   - Backlog-aware adaptive per-cycle sync limits are applied automatically (`sync_txns` volume + relation-heavy queue boost).
   - Pull consumes multiple pages per cycle (`MAX_PULL_PAGES_PER_CYCLE`) and refreshes local retrieval surfaces (`knowledge_fts`, `ke_fts`) for touched rows after canonical apply.
   - If no `connection_string` is configured, daemon stays local-only (no hard failure).
+  - fallback: `python3 ~/.copilot/tools/sync-daemon.py <args>`
 - **Diagnostics**:
-  - `python3 ~/.copilot/tools/sync-status.py --watch-status|--health-check|--audit [--json]`
+  - `sk sync status --watch-status|--health-check|--audit [--json]`
   - Browse `/healthz` advertises `sync_status_endpoint: "/api/sync/status"`.
   - Browse `/api/sync/status` is read-only local queue/failure/config/cursor status.
+  - fallback: `python3 ~/.copilot/tools/sync-status.py <args>`
 - **Gateway in this repo**: `sync-gateway.py` is **reference/mock only** (not production authority), exposing `/sync/push`, `/sync/pull`, `/healthz`.
 - **Default provider rollout recommendation**: keep the same HTTP gateway contract, with Neon (backing Postgres) + Railway (thin gateway host) as the default rollout path. This is a recommendation, not a vendor lock.
 
@@ -411,26 +423,26 @@ python3 ~/.copilot/tools/install.py --lock-hooks          # Lock hooks (tamper p
 python3 ~/.copilot/tools/install.py --install-git-hooks   # Install pre-commit/pre-push into current repo
 
 # Project setup with a workflow profile
-python3 ~/.copilot/tools/setup-project.py --profile python      # Python hook bundle + WORKFLOW.md
+sk setup --profile python                # Python hook bundle + WORKFLOW.md
 python3 ~/.copilot/tools/install-project-hooks.py --profile mobile  # Mobile hooks standalone
 
 # Custom profile lifecycle
-python3 ~/.copilot/tools/profile-builder.py --name myteam --hooks dangerous-blocker.py --phases BUILD TEST COMMIT
-python3 ~/.copilot/tools/profile-export.py --profile myteam --output myteam.json
-python3 ~/.copilot/tools/profile-import.py --file myteam.json
+sk profile build --name myteam --hooks dangerous-blocker.py --phases BUILD TEST COMMIT
+sk profile export --profile myteam --output myteam.json
+sk profile import --file myteam.json
 ```
 
 **Session-start hooks** run through the unified `hook_runner.py` architecture (1 Python process per event, fail-open, HMAC-signed markers, audit logging) and automatically refresh the codebase map (`codebase-map.py`) at the start of each session — no manual step required.
 
 **Session lifecycle hooks** run through `hook_runner.py`: `sessionEnd` performs marker cleanup + sync flush signal, and `agentStop`/`subagentStop` perform best-effort dispatched-subagent marker cleanup using stop payload hints.
 Hooks never auto-save checkpoints.
-To save a checkpoint yourself, run `python3 ~/.copilot/tools/checkpoint-save.py`.
+To save a checkpoint yourself, run `sk checkpoint save`.
 
 ### Context Load Management
 
 Excessive context load in Copilot sessions comes primarily from **duplicate skills** and **overly broad instruction surfaces** — not from the unified hook runner (which is a single process per event and is efficient). To keep load manageable:
 
-- **Minimal-context-first**: start with `briefing.py --compact` (~500 tokens) before escalating to `--full`. Instruction files with `applyTo: '**/*'` inject into every context — scope them narrowly (e.g., `**/*.ts`) when they apply only to specific file types.
+- **Minimal-context-first**: start with `sk briefing --compact` (~500 tokens) before escalating to `--full`. Instruction files with `applyTo: '**/*'` inject into every context — scope them narrowly (e.g., `**/*.ts`) when they apply only to specific file types.
 - **Progressive escalation**: retrieve only what the current step needs. Full session history and semantic search are available but should be requested on demand, not injected by default.
 - **Propagation discipline**: when a skill or instruction is promoted to global scope (`~/.copilot/skills/`, `~/.github/instructions/`), remove the project-local copy to prevent duplication. Audit by manually comparing `~/.copilot/skills/` against `.github/skills/` in each project and removing any skill that exists at both levels. (`hooks/lint-skills.py --all` validates schema — it does not detect cross-scope duplicates.)
 
@@ -466,23 +478,24 @@ sk tentacle goal verify-loop [--escalate]
 `trend-scout.py` discovers relevant GitHub repositories via the **GitHub Search API** using a **multi-lane discovery** architecture and creates or updates structured issues in the target repo for review. Each lane is an independent search channel with its own keyword set, topic filters, language constraint, and `min_stars` threshold — allowing the pipeline to surface both language-specific repos and language-agnostic adjacent projects in parallel.
 
 ```bash
-python3 ~/.copilot/tools/trend-scout.py                 # Full pipeline
-python3 ~/.copilot/tools/trend-scout.py --dry-run       # Preview without creating issues
-python3 ~/.copilot/tools/trend-scout.py --search-only   # Discovery + shortlist, no issues
-python3 ~/.copilot/tools/trend-scout.py --explain       # Emit a discovery explainability artifact
-python3 ~/.copilot/tools/trend-scout.py --limit 3       # Cap issues created this run
-python3 ~/.copilot/tools/trend-scout.py --repo owner/repo  # Override target repo
-python3 ~/.copilot/tools/trend-scout.py --config path.json # Custom config file
-python3 ~/.copilot/tools/trend-scout.py --token TOKEN   # Explicit GitHub token (overrides GITHUB_TOKEN env)
-python3 ~/.copilot/tools/trend-scout.py --force         # Bypass grace window; force a new run
+sk scout run                         # Full pipeline
+sk scout run --dry-run               # Preview without creating issues
+sk scout run --search-only           # Discovery + shortlist, no issues
+sk scout run --explain               # Emit a discovery explainability artifact
+sk scout run --limit 3               # Cap issues created this run
+sk scout run --repo owner/repo       # Override target repo
+sk scout run --config path.json      # Custom config file
+sk scout run --token TOKEN           # Explicit GitHub token (overrides GITHUB_TOKEN env)
+sk scout run --force                 # Bypass grace window; force a new run
+# fallback: python3 ~/.copilot/tools/trend-scout.py <args>
 ```
 
 Requires a `GITHUB_TOKEN` env var (or `--token TOKEN`). `--limit` caps new creates only; marker-matched open issues are updated in place. Supports multi-lane discovery (`lanes[]` in config), gold-set watchlists (`trend-scout-goldset.json`), optional GitHub Models analysis (`analysis.enabled=true`), veto gates, and a configurable grace window. Edit `trend-scout-config.json` to tune all settings.
 
 **GitHub Actions workflow:** `.github/workflows/trend-scout.yml` runs daily at 07:00 UTC (`contents: read`, `issues: write`, `models: read`). Manual `workflow_dispatch` supports `dry_run`, `search_only`, `repo`, `limit`, `force`, `explain` inputs; `explain=true` uploads the discovery JSON as an artifact. **Hook noise control:** Trend Scout is **not** wired to `preToolUse`/`postToolUse` — keep cron/workflow driven. 📖 **Details:** [docs/USAGE.md#trend-scout](docs/USAGE.md#trend-scout)
 ## Retrospective
-`retro.py` computes a composite operator score (0–100) across knowledge, skills, hooks, and git signals; run `python3 ~/.copilot/tools/retro.py`, `python3 ~/.copilot/tools/retro.py --mode repo`, `python3 ~/.copilot/tools/retro.py --json`, `python3 ~/.copilot/tools/retro.py --score`, or `python3 ~/.copilot/tools/retro.py --subreport behavior` (behavior section, local mode only).
-Local mode (`--mode local`) includes knowledge, skills, hooks, and git, but may report `score_confidence=low` with distortion flags like `hook_deny_dry_noise` or `skills_unverified`; repo mode (`--mode repo`) is git-only, cleaner, and CI-safe for trend tracking. The JSON payload includes additive top-level fields: `scout` (read-only Trend Scout coverage health) and `toward_100` (ranked per-section gap diagnostics with metric-derived barriers explaining what pulls each score below 100). Both fields are informational only and do **not** affect `retro_score`, `weights`, or existing subscores; surfaces that do not recognise them degrade gracefully. Browse surfaces: `/v2/insights` (Retrospective card with scout coverage panel), `http://localhost:<port>/retro?token=<token>`, and `/api/retro/summary?mode=repo`. Trigger `retro.yml` via `workflow_dispatch` for a read-only markdown artifact/job summary with score, confidence, distortions, accuracy notes, and recommended actions. For commit-keyed comparison, run `python3 ~/.copilot/tools/benchmark.py record`, `python3 ~/.copilot/tools/benchmark.py list --limit 5`, or `python3 ~/.copilot/tools/benchmark.py compare --commits <older> <newer>`; compare output includes `retro_gap` and `health_gap` gap-to-target fields (100 minus score) so measurable progress is explicit; snapshots live in `benchmark_snapshots` (default DB: `~/.copilot/session-state/knowledge.db`, override with `--db PATH`) and the manual-only `.github/workflows/benchmark.yml` workflow uploads the DB + JSON artifact without writing back to the branch. 📖 **Operator details:** [docs/OPERATOR-PLAYBOOK.md#retrospective](docs/OPERATOR-PLAYBOOK.md#retrospective)
+`sk retro` computes a composite operator score (0–100) across knowledge, skills, hooks, and git signals; run `sk retro`, `sk retro --mode repo`, `sk retro --json`, `sk retro --score`, or `sk retro --subreport behavior` (behavior section, local mode only).
+Local mode (`--mode local`) includes knowledge, skills, hooks, and git, but may report `score_confidence=low` with distortion flags like `hook_deny_dry_noise` or `skills_unverified`; repo mode (`--mode repo`) is git-only, cleaner, and CI-safe for trend tracking. The JSON payload includes additive top-level fields: `scout` (read-only Trend Scout coverage health) and `toward_100` (ranked per-section gap diagnostics with metric-derived barriers explaining what pulls each score below 100). Both fields are informational only and do **not** affect `retro_score`, `weights`, or existing subscores; surfaces that do not recognise them degrade gracefully. Browse surfaces: `/v2/insights` (Retrospective card with scout coverage panel), `http://localhost:<port>/retro?token=<token>`, and `/api/retro/summary?mode=repo`. Trigger `retro.yml` via `workflow_dispatch` for a read-only markdown artifact/job summary with score, confidence, distortions, accuracy notes, and recommended actions. For commit-keyed comparison, run `sk benchmark record`, `sk benchmark list --limit 5`, or `sk benchmark compare --commits <older> <newer>`; compare output includes `retro_gap` and `health_gap` gap-to-target fields (100 minus score) so measurable progress is explicit; snapshots live in `benchmark_snapshots` (default DB: `~/.copilot/session-state/knowledge.db`, override with `--db PATH`) and the manual-only `.github/workflows/benchmark.yml` workflow uploads the DB + JSON artifact without writing back to the branch. 📖 **Operator details:** [docs/OPERATOR-PLAYBOOK.md#retrospective](docs/OPERATOR-PLAYBOOK.md#retrospective)
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ qs --session-raw <session-id>        # Dump raw events for a session
 
 ```bash
 sk index status          # Row counts, FTS integrity, offset coverage
-# fallback: python3 ~/.copilot/tools/index-status.py
 ```
 
 ### Recall Telemetry (Phase 5)
@@ -147,7 +146,6 @@ sk index status          # Row counts, FTS integrity, offset coverage
 ```bash
 sk index health --recall         # Recall-only telemetry dashboard
 sk index health --recall --json  # Recall-only JSON stats
-# fallback: python3 ~/.copilot/tools/knowledge-health.py --recall [--json]
 ```
 
 - Telemetry is intentionally lean (`recall_events`): counts/IDs/size only, no verbose output bodies.
@@ -251,7 +249,6 @@ sk context project --stdout       # Print to stdout only
 sk context project --output PATH  # Write to explicit path
 sk context project --profile python  # Force a preset profile
 sk context project --list-profiles   # Show available profiles
-# fallback: python3 ~/.copilot/tools/project-context.py <args>
 ```
 
 No AI generation, no network access. The artifact is derived purely from repo/profile facts and is deterministic for the same repo state.
@@ -393,7 +390,6 @@ sk update --force          # Force update now
 sk update --doctor         # Health check
 sk update --restart-watch  # Restart watcher
 sk update --watch-status   # Watcher status
-# fallback: python3 ~/.copilot/tools/auto-update-tools.py [flags]
 ```
 
 Smart pipeline analyzes `git diff` to run only what changed. Post-merge hook auto-triggers on `git pull`.

--- a/docs/migration/v1.2-to-v1.3.md
+++ b/docs/migration/v1.2-to-v1.3.md
@@ -1,0 +1,123 @@
+# Migration Guide: v1.2 → v1.3
+
+## Summary
+
+v1.3 promotes `sk` as the **single entry point** for all tools. You no longer need to remember
+individual script paths like `python3 ~/.copilot/tools/briefing.py`. All commands are now
+accessible via `sk <subcommand>`.
+
+**No Python scripts have been removed.** Legacy paths remain fully functional as fallbacks.
+
+---
+
+## What Changed
+
+| Before (v1.2) | After (v1.3) |
+|--------------|-------------|
+| `python3 ~/.copilot/tools/briefing.py <args>` | `sk briefing <args>` |
+| `python3 ~/.copilot/tools/query-session.py <args>` | `sk query <args>` |
+| `python3 ~/.copilot/tools/learn.py <args>` | `sk learn <args>` |
+| `python3 ~/.copilot/tools/tentacle.py <args>` | `sk tentacle <args>` |
+| `python3 ~/.copilot/tools/watch-sessions.py <args>` | `sk watch <args>` |
+| `python3 ~/.copilot/tools/auto-update-tools.py <args>` | `sk update <args>` |
+| `python3 ~/.copilot/tools/build-session-index.py` | `sk index build` |
+| `python3 ~/.copilot/tools/extract-knowledge.py` | `sk index extract` |
+| `python3 ~/.copilot/tools/migrate.py` | `sk index migrate` |
+| `python3 ~/.copilot/tools/index-status.py` | `sk index status` |
+| `python3 ~/.copilot/tools/knowledge-health.py --recall` | `sk index health --recall` |
+| `python3 ~/.copilot/tools/embed.py --setup` | `sk index embed --setup` |
+| `python3 ~/.copilot/tools/sync-config.py <args>` | `sk sync config <args>` |
+| `python3 ~/.copilot/tools/sync-daemon.py <args>` | `sk sync run <args>` |
+| `python3 ~/.copilot/tools/sync-status.py <args>` | `sk sync status <args>` |
+| `python3 ~/.copilot/tools/trend-scout.py <args>` | `sk scout run <args>` |
+| `python3 ~/.copilot/tools/checkpoint-save.py <args>` | `sk checkpoint save <args>` |
+| `python3 ~/.copilot/tools/checkpoint-restore.py <args>` | `sk checkpoint restore <args>` |
+| `python3 ~/.copilot/tools/checkpoint-diff.py <args>` | `sk checkpoint diff <args>` |
+| `python3 ~/.copilot/tools/project-context.py <args>` | `sk context project <args>` |
+| `python3 ~/.copilot/tools/profile-builder.py <args>` | `sk profile build <args>` |
+| `python3 ~/.copilot/tools/profile-export.py <args>` | `sk profile export <args>` |
+| `python3 ~/.copilot/tools/profile-import.py <args>` | `sk profile import <args>` |
+| `python3 ~/.copilot/tools/setup-project.py <args>` | `sk setup <args>` |
+| `python3 ~/.copilot/tools/retro.py <args>` | `sk retro <args>` |
+
+---
+
+## Setup `sk` on PATH
+
+If `sk` is not yet on your PATH, run the installer:
+
+```bash
+python3 ~/.copilot/tools/install.py --test
+# → sk launcher auto-provisioned at ~/.copilot/bin/sk
+```
+
+Verify it works:
+
+```bash
+sk --help
+sk briefing --wakeup
+```
+
+**Windows PowerShell** — until PATH is updated:
+```powershell
+$env:Path = "$env:USERPROFILE\.copilot\bin;$env:Path"
+# Or use the fallback path directly:
+python "$env:USERPROFILE\.copilot\tools\sk.py" briefing --wakeup
+```
+
+---
+
+## Why `sk`?
+
+- **Single command to remember** — no more script-path lookup
+- **Consistent interface** — `sk <cmd> --help` for every subcommand
+- **Binary acceleration** — Rust binary at `~/.copilot/bin/sk` is 3–5× faster for hot paths
+- **Grouped namespaces** — `sk index build|extract|migrate|status|health|embed|tag`, `sk sync run|config|status`, `sk checkpoint save|restore|diff`, etc.
+
+---
+
+## Legacy Python Paths (DEPRECATED)
+
+> **Still fully functional.** These paths will remain on disk. Use them when `sk` is not yet
+> on PATH or in non-interactive environments where the binary is unavailable.
+
+```bash
+# Knowledge
+python3 ~/.copilot/tools/briefing.py "task description" --compact
+python3 ~/.copilot/tools/query-session.py "search terms"
+python3 ~/.copilot/tools/learn.py --mistake "Title" "Description" --tags "tag1"
+
+# Indexing
+python3 ~/.copilot/tools/build-session-index.py
+python3 ~/.copilot/tools/extract-knowledge.py
+python3 ~/.copilot/tools/migrate.py
+python3 ~/.copilot/tools/index-status.py
+python3 ~/.copilot/tools/knowledge-health.py --recall
+
+# Orchestration
+python3 ~/.copilot/tools/tentacle.py create <name> --scope "<paths>" --desc "<desc>"
+python3 ~/.copilot/tools/tentacle.py swarm <name> --agent-type general-purpose --model claude-sonnet-4.6
+python3 ~/.copilot/tools/tentacle.py handoff <name> "summary" --status DONE --changed-file <path> --learn
+python3 ~/.copilot/tools/tentacle.py complete <name>
+
+# Sync
+python3 ~/.copilot/tools/sync-config.py --setup https://gateway.example.com
+python3 ~/.copilot/tools/sync-daemon.py --once
+python3 ~/.copilot/tools/sync-status.py --health-check --json
+
+# Watch
+python3 ~/.copilot/tools/watch-sessions.py
+
+# Trend Scout
+python3 ~/.copilot/tools/trend-scout.py --search-only
+
+# Checkpoint
+python3 ~/.copilot/tools/checkpoint-save.py --title "Title" --overview "Overview"
+python3 ~/.copilot/tools/checkpoint-restore.py --list
+python3 ~/.copilot/tools/checkpoint-diff.py --summary
+
+# Auto-update
+python3 ~/.copilot/tools/auto-update-tools.py --force
+```
+
+**Windows PowerShell** — replace `python3 ~/.copilot/tools/` with `python "$env:USERPROFILE\.copilot\tools\"`.


### PR DESCRIPTION
## Summary
Replaces all `python3 ~/.copilot/tools/*.py` references in docs with `sk <subcommand>`.

## Changes
- `.github/skills/session-knowledge/SKILL.md` — sk-first commands, DEPRECATED appendix preserved
- `.github/skills/session-knowledge-creator/SKILL.md` — sk-first template
- `README.md` — Quick Start and all CLI sections use sk first
- `docs/migration/v1.2-to-v1.3.md` — new migration guide with legacy path mapping

## Verification
No Python changes → no test suite run required. All documented sk subcommands verified to exist in sk.py dispatch.

Closes #578