### PR TITLE
feat(automation): confidence-gated auto-PR of learnings (#612)

### DIFF
--- a/learn.py
+++ b/learn.py
@@ -2169,6 +2169,300 @@ def _insert_supersedes_relation(source_id: int, target_id: int, session_id: str 
         db.close()
 
 
+# ---- Auto-PR helpers (Issue #612) -----------------------------------------
+
+
+def _autopr_parse_toml(path: Path) -> dict:
+    """Parse a minimal flat TOML file. Falls back to line-by-line on Python <3.11."""
+    try:
+        import tomllib  # Python 3.11+
+
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except ImportError:
+        pass
+    result: dict = {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key, val = key.strip(), val.strip()
+        if (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
+            result[key] = val[1:-1]
+        elif val.lower() == "true":
+            result[key] = True
+        elif val.lower() == "false":
+            result[key] = False
+        elif val.startswith("[") and val.endswith("]"):
+            result[key] = [s.strip().strip("\"'") for s in val[1:-1].split(",") if s.strip()]
+        else:
+            try:
+                result[key] = float(val)
+            except ValueError:
+                result[key] = val
+    return result
+
+
+def _autopr_load_config(threshold_override: float | None = None) -> dict:
+    """Load ~/.copilot/sk-autopr.toml with sensible defaults."""
+    cfg: dict = {
+        "repo_root": str(TOOLS_DIR),
+        "target_path": "docs/learnings",
+        "base_branch": "main",
+        "confidence_threshold": 0.85,
+        "categories": ["decision", "pattern"],
+        "dry_run": False,
+    }
+    config_path = Path.home() / ".copilot" / "sk-autopr.toml"
+    if config_path.is_file():
+        try:
+            cfg.update(_autopr_parse_toml(config_path))
+        except Exception:
+            pass
+    if threshold_override is not None:
+        cfg["confidence_threshold"] = threshold_override
+    if isinstance(cfg.get("categories"), str):
+        cfg["categories"] = [c.strip() for c in str(cfg["categories"]).split(",")]
+    return cfg
+
+
+# Mirrors the pattern set from sk-rust/src/redact.rs (Issue #612 HARD REQUIREMENT).
+_AUTOPR_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"(?s)-----BEGIN [A-Z ]+PRIVATE KEY-----.*?-----END [A-Z ]+PRIVATE KEY-----"), "pem_private_key"),
+    (re.compile(r"eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}"), "jwt"),
+    (re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"), "github_token"),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "aws_key"),
+    (
+        re.compile(r"""(?i)(?:password|passwd|secret|token|api[_\-]?key)\s*[=:]\s*['"]?([^\s'",;]{6,})['"]?"""),
+        "credential_kv",
+    ),
+]
+
+
+def _autopr_redactor_gate(text: str) -> tuple[bool, str]:
+    """Check text for secrets. Returns (passed, reason). passed=False means blocked."""
+    findings = [kind for pat, kind in _AUTOPR_SECRET_PATTERNS if pat.search(text)]
+    if findings:
+        return False, f"redactor found secret pattern(s): {', '.join(findings)}"
+    return True, ""
+
+
+def _autopr_render_markdown(
+    stable_id: str,
+    title: str,
+    content: str,
+    facts: list,
+    wing: str,
+    room: str,
+    confidence: float,
+    tags: str,
+    session_id: str | None,
+    category: str,
+) -> str:
+    """Render the canonical markdown template for a learning entry."""
+    tags_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
+    tags_yaml = "[" + ", ".join(tags_list) + "]"
+    facts_section = "\n".join(f"- {f}" for f in facts) if facts else "_none_"
+    sid = session_id or "unknown"
+    return (
+        f"---\nstable_id: {stable_id}\nwing: {wing or 'general'}\n"
+        f"room: {room or 'general'}\nconfidence: {confidence:.2f}\n"
+        f"tags: {tags_yaml}\ncategory: {category}\n---\n"
+        f"# {title}\n\n{content}\n\n## Facts\n{facts_section}\n\n## Source\nSession: {sid}\n"
+    )
+
+
+def _autopr_default_confidence(category: str) -> float:
+    """Mirror default confidence lookup from _write_learn_entry."""
+    return {"decision": 0.8, "tool": 0.5, "refactor": 0.6, "discovery": 0.6}.get(category, 0.7)
+
+
+def _autopr_run_git(cmd: list[str], repo_root: str) -> tuple[int, str, str]:
+    """Run a git command in repo_root. Returns (returncode, stdout, stderr)."""
+    result = subprocess.run(["git"] + cmd, cwd=repo_root, capture_output=True, text=True)
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def _autopr_branch_exists(branch: str, repo_root: str) -> bool:
+    """Return True if the local git branch already exists."""
+    rc, out, _ = _autopr_run_git(["branch", "--list", branch], repo_root)
+    return rc == 0 and branch in out
+
+
+def _autopr_pr_url(branch: str, repo_root: str) -> str | None:
+    """Return existing open PR URL for the branch, or None if not found."""
+    try:
+        res = subprocess.run(
+            ["gh", "pr", "list", "--head", branch, "--json", "url", "--jq", ".[0].url"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if res.returncode == 0:
+            url = res.stdout.strip()
+            return url if url and url.startswith("http") else None
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _autopr_write_file(file_path: Path, md_content: str) -> None:
+    """Atomically write markdown to file_path, creating parent dirs as needed."""
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = file_path.with_suffix(".tmp")
+    tmp.write_text(md_content, encoding="utf-8")
+    os.replace(tmp, file_path)
+
+
+def _autopr_git_branch_and_commit(
+    stable_id: str,
+    branch: str,
+    file_path: Path,
+    title: str,
+    repo_root: str,
+    md_content: str,
+    amend: bool,
+) -> tuple[bool, str]:
+    """Switch to/create branch, write file, stage and commit. Returns (ok, error_msg)."""
+    if amend:
+        rc, _, err = _autopr_run_git(["switch", branch], repo_root)
+    else:
+        rc, _, err = _autopr_run_git(["switch", "-c", branch], repo_root)
+    if rc != 0:
+        return False, f"git switch failed: {err}"
+    _autopr_write_file(file_path, md_content)
+    rel_path = str(file_path.relative_to(Path(repo_root)))
+    _autopr_run_git(["add", rel_path], repo_root)
+    commit_msg = f"docs(learnings): add {title[:80]}"
+    commit_cmd = ["commit", "--amend", "--no-edit"] if amend else ["commit", "-m", commit_msg]
+    rc, _, err = _autopr_run_git(commit_cmd, repo_root)
+    if rc != 0:
+        return False, f"git commit failed: {err}"
+    return True, ""
+
+
+def _autopr_build_pr_cmd(branch: str, base_branch: str, title: str, pr_body: str) -> list[str]:
+    """Build the gh pr create command list."""
+    return [
+        "gh",
+        "pr",
+        "create",
+        "--draft",
+        "--head",
+        branch,
+        "--base",
+        base_branch,
+        "--title",
+        title[:120],
+        "--body",
+        pr_body,
+    ]
+
+
+def _autopr_try_gh(cmd: list[str], repo_root: str) -> tuple[bool, str]:
+    """Run gh pr create. Returns (ok, url_or_error_message)."""
+    try:
+        res = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True, timeout=30)
+        if res.returncode == 0:
+            return True, res.stdout.strip()
+        return False, res.stderr.strip()
+    except FileNotFoundError:
+        return False, "gh not found"
+    except subprocess.TimeoutExpired:
+        return False, "gh timed out"
+
+
+def _autopr_execute(
+    branch: str,
+    file_path: Path,
+    title: str,
+    repo_root: str,
+    md_content: str,
+    pr_cmd: list[str],
+    stable_id: str,
+) -> None:
+    """Perform git ops and PR creation for the non-dry-run path."""
+    existing_url = _autopr_pr_url(branch, repo_root)
+    if existing_url:
+        print(f"  auto-pr: PR already open: {existing_url}")
+        return
+    amend = _autopr_branch_exists(branch, repo_root)
+    ok, err = _autopr_git_branch_and_commit(stable_id, branch, file_path, title, repo_root, md_content, amend)
+    if not ok:
+        print(f"  auto-pr: git error — {err}", file=sys.stderr)
+        return
+    ok, result = _autopr_try_gh(pr_cmd, repo_root)
+    if ok:
+        print(f"  auto-pr: PR created: {result}")
+    elif "not found" in result:
+        print(f"  auto-pr: gh not available. Run manually:\n    {' '.join(pr_cmd)}")
+    else:
+        print(f"  auto-pr: gh error — {result}", file=sys.stderr)
+
+
+def _maybe_autopr(
+    *,
+    category: str,
+    title: str,
+    content: str,
+    confidence: float,
+    wing: str,
+    room: str,
+    tags: str,
+    facts: list,
+    session_id: str | None,
+    threshold_override: float | None = None,
+    dry_run: bool = False,
+) -> None:
+    """Orchestrate auto-PR after a successful sk learn insert (Issue #612).
+
+    Gate order: token present → config check → confidence threshold → category
+    allowed → redactor → git branch → commit → gh pr create --draft.
+    """
+    token_present = bool(os.environ.get("SK_AUTOPR_TOKEN"))
+    if not token_present and not dry_run:
+        dry_run = True  # No token → same as dry-run per spec
+    cfg = _autopr_load_config(threshold_override)
+    if cfg.get("dry_run"):
+        dry_run = True
+    threshold = float(cfg["confidence_threshold"])
+    allowed = [c.lower() for c in (cfg.get("categories") or [])]
+    if confidence < threshold:
+        print(f"  auto-pr: skipped (confidence {confidence:.2f} < threshold {threshold:.2f})", file=sys.stderr)
+        return
+    if category.lower() not in allowed:
+        print(f"  auto-pr: skipped (category '{category}' not in {allowed})", file=sys.stderr)
+        return
+    passed, reason = _autopr_redactor_gate(content + " " + title)
+    if not passed:
+        print(f"  auto-pr: REFUSED — {reason}", file=sys.stderr)
+        return
+    stable_id = _knowledge_stable_id(session_id or "", category, title)
+    wing_part = wing or "general"
+    room_part = room or "general"
+    repo_root = str(cfg["repo_root"])
+    file_path = Path(repo_root) / str(cfg["target_path"]) / wing_part / room_part / f"{stable_id}.md"
+    branch = f"sk-learning/{stable_id}"
+    md_content = _autopr_render_markdown(
+        stable_id, title, content, facts, wing, room, confidence, tags, session_id, category
+    )
+    pr_body = (
+        f"## Learning: {title}\n\n**Category:** {category}  \n**Confidence:** {confidence:.2f}  \n"
+        f"**Wing/Room:** {wing_part}/{room_part}\n\n{content}\n\nCloses #612 (auto-pr learning)"
+    )
+    pr_cmd = _autopr_build_pr_cmd(branch, str(cfg["base_branch"]), f"docs(learnings): {title[:80]}", pr_body)
+    if dry_run:
+        print(f"  auto-pr [dry-run]: branch={branch}")
+        print(f"  auto-pr [dry-run]: file={file_path}")
+        print(f"  auto-pr [dry-run]: {' '.join(pr_cmd)}")
+        return
+    _autopr_execute(branch, file_path, title, repo_root, md_content, pr_cmd, stable_id)
+
+
+# ---- End Auto-PR helpers ---------------------------------------------------
+
+
 def main():
     args = sys.argv[1:]
 
@@ -2577,6 +2871,7 @@ def main():
             "--supersedes",
             "--cerebrum-output",
             "--cerebrum-sections",
+            "--confidence-threshold",
         ):
             _next = args[i + 1] if i + 1 < len(args) else None
             skip_next = bool(_next and not _next.startswith("--"))
@@ -2598,6 +2893,16 @@ def main():
     skip_scan = "--skip-scan" in args
     json_mode = "--json" in args
     update_cerebrum = "--update-cerebrum" in args
+
+    # Auto-PR flags (Issue #612)
+    auto_pr = "--auto-pr" in args
+    auto_pr_threshold: float | None = None
+    if "--confidence-threshold" in args:
+        _ct_idx = args.index("--confidence-threshold")
+        try:
+            auto_pr_threshold = float(args[_ct_idx + 1]) if _ct_idx + 1 < len(args) else None
+        except (ValueError, IndexError):
+            auto_pr_threshold = None
 
     cerebrum_output = "CEREBRUM.md"
     if "--cerebrum-output" in args:
@@ -2732,6 +3037,22 @@ def main():
 
     if supersedes_id is not None and entry_id >= 0:
         _insert_supersedes_relation(entry_id, supersedes_id, session_id)
+
+    # Auto-PR post-write hook (Issue #612)
+    if auto_pr and entry_id >= 0:
+        eff_conf = confidence if confidence is not None else _autopr_default_confidence(category)
+        _maybe_autopr(
+            category=category,
+            title=title,
+            content=content,
+            confidence=eff_conf,
+            wing=wing,
+            room=room,
+            tags=tags,
+            facts=facts,
+            session_id=session_id,
+            threshold_override=auto_pr_threshold,
+        )
 
     if json_mode:
         # Machine-readable output: emit structured JSON with write result

--- a/tests/test_autopr.py
+++ b/tests/test_autopr.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+"""Tests for --auto-pr / Issue #612: confidence-gated auto-PR of learnings.
+
+These tests exercise the auto-PR helper functions directly without touching the
+real git repo or gh CLI. All git / gh calls are replaced with subprocess-level
+mocking via monkeypatching or dry-run mode.
+"""
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+if os.name == "nt":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+# ---------------------------------------------------------------------------
+# Import helpers from learn.py
+# ---------------------------------------------------------------------------
+_TOOLS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(_TOOLS_DIR))
+
+import learn as _learn  # noqa: E402  (must come after sys.path insert)
+
+
+class TestAutoPRConfig(unittest.TestCase):
+    """_autopr_load_config / _autopr_parse_toml"""
+
+    def test_defaults_when_no_config_file(self) -> None:
+        with patch.object(Path, "is_file", return_value=False):
+            cfg = _learn._autopr_load_config()
+        self.assertAlmostEqual(cfg["confidence_threshold"], 0.85)
+        self.assertIn("decision", cfg["categories"])
+        self.assertIn("pattern", cfg["categories"])
+        self.assertFalse(cfg["dry_run"])
+
+    def test_threshold_override(self) -> None:
+        with patch.object(Path, "is_file", return_value=False):
+            cfg = _learn._autopr_load_config(threshold_override=0.6)
+        self.assertAlmostEqual(cfg["confidence_threshold"], 0.6)
+
+    def test_parse_toml_basic(self) -> None:
+        toml = 'confidence_threshold = 0.75\ncategories = ["decision"]\ndry_run = true\n'
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write(toml)
+            tmp = Path(f.name)
+        try:
+            result = _learn._autopr_parse_toml(tmp)
+            self.assertAlmostEqual(result["confidence_threshold"], 0.75)
+            self.assertEqual(result["categories"], ["decision"])
+            self.assertTrue(result["dry_run"])
+        finally:
+            tmp.unlink(missing_ok=True)
+
+
+class TestAutoPRRedactorGate(unittest.TestCase):
+    """_autopr_redactor_gate: secret patterns block PR creation."""
+
+    def test_clean_content_passes(self) -> None:
+        passed, reason = _learn._autopr_redactor_gate("This is a safe learning about caching patterns.")
+        self.assertTrue(passed)
+        self.assertEqual(reason, "")
+
+    def test_bearer_token_blocked(self) -> None:
+        # credential_kv pattern: token=<value> (mirrors Rust redact.rs credential_kv rule)
+        passed, reason = _learn._autopr_redactor_gate("token=sk-XXXX1234567890abcdef for auth.")
+        self.assertFalse(passed)
+        self.assertIn("credential_kv", reason)
+
+    def test_github_token_blocked(self) -> None:
+        token = "ghp_" + "A" * 36
+        passed, reason = _learn._autopr_redactor_gate(f"My token: {token}")
+        self.assertFalse(passed)
+        self.assertIn("github_token", reason)
+
+    def test_aws_key_blocked(self) -> None:
+        passed, reason = _learn._autopr_redactor_gate("AKIAIOSFODNN7EXAMPLE is an AWS key")
+        self.assertFalse(passed)
+        self.assertIn("aws_key", reason)
+
+    def test_jwt_blocked(self) -> None:
+        jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf"
+        passed, reason = _learn._autopr_redactor_gate(jwt)
+        self.assertFalse(passed)
+        self.assertIn("jwt", reason)
+
+
+class TestAutoPRRenderMarkdown(unittest.TestCase):
+    """_autopr_render_markdown: template correctness."""
+
+    def test_template_fields_present(self) -> None:
+        md = _learn._autopr_render_markdown(
+            stable_id="abc123",
+            title="My Pattern",
+            content="Use caching.",
+            facts=["fact one", "fact two"],
+            wing="backend",
+            room="cache",
+            confidence=0.9,
+            tags="caching,redis",
+            session_id="sess-42",
+            category="pattern",
+        )
+        self.assertIn("stable_id: abc123", md)
+        self.assertIn("wing: backend", md)
+        self.assertIn("room: cache", md)
+        self.assertIn("confidence: 0.90", md)
+        self.assertIn("# My Pattern", md)
+        self.assertIn("Use caching.", md)
+        self.assertIn("- fact one", md)
+        self.assertIn("- fact two", md)
+        self.assertIn("Session: sess-42", md)
+        self.assertIn("caching", md)
+
+    def test_no_facts_shows_none(self) -> None:
+        md = _learn._autopr_render_markdown(
+            stable_id="x",
+            title="T",
+            content="C",
+            facts=[],
+            wing="",
+            room="",
+            confidence=0.8,
+            tags="",
+            session_id=None,
+            category="decision",
+        )
+        self.assertIn("_none_", md)
+
+    def test_yaml_frontmatter_format(self) -> None:
+        md = _learn._autopr_render_markdown(
+            stable_id="s1",
+            title="T1",
+            content="C1",
+            facts=[],
+            wing="w",
+            room="r",
+            confidence=0.75,
+            tags="t1,t2",
+            session_id="sid",
+            category="decision",
+        )
+        self.assertTrue(md.startswith("---\n"))
+        self.assertIn("\n---\n", md)
+
+
+class TestMaybeAutoPRDryRun(unittest.TestCase):
+    """_maybe_autopr: dry-run mode prints plan without writing files."""
+
+    def _call_dry(self, category: str = "pattern", confidence: float = 0.9, threshold: float = 0.85) -> list[str]:
+        """Call _maybe_autopr in dry-run mode and return captured stderr lines."""
+        import io
+
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"SK_AUTOPR_TOKEN": "test-token"}, clear=False):
+            with patch.object(
+                _learn,
+                "_autopr_load_config",
+                return_value={
+                    "repo_root": "/tmp/fake-repo",
+                    "target_path": "docs/learnings",
+                    "base_branch": "main",
+                    "confidence_threshold": threshold,
+                    "categories": ["decision", "pattern"],
+                    "dry_run": True,
+                },
+            ):
+                with patch("sys.stdout", new=buf):
+                    _learn._maybe_autopr(
+                        category=category,
+                        title="My Title",
+                        content="Safe content here.",
+                        confidence=confidence,
+                        wing="backend",
+                        room="cache",
+                        tags="caching",
+                        facts=["fact1"],
+                        session_id="sess-1",
+                        threshold_override=None,
+                        dry_run=True,
+                    )
+        return buf.getvalue().splitlines()
+
+    def test_dry_run_prints_branch(self) -> None:
+        lines = self._call_dry()
+        joined = "\n".join(lines)
+        self.assertIn("dry-run", joined)
+        self.assertIn("branch=", joined)
+        self.assertIn("sk-learning/", joined)
+
+    def test_dry_run_prints_gh_command(self) -> None:
+        lines = self._call_dry()
+        joined = "\n".join(lines)
+        self.assertIn("gh pr create", joined)
+        self.assertIn("--draft", joined)
+
+    def test_dry_run_no_files_written(self) -> None:
+        with patch("builtins.open", side_effect=AssertionError("should not open files")):
+            with patch.dict(os.environ, {"SK_AUTOPR_TOKEN": "test-token"}, clear=False):
+                with patch.object(
+                    _learn,
+                    "_autopr_load_config",
+                    return_value={
+                        "repo_root": "/tmp/fake",
+                        "target_path": "docs/learnings",
+                        "base_branch": "main",
+                        "confidence_threshold": 0.85,
+                        "categories": ["pattern"],
+                        "dry_run": True,
+                    },
+                ):
+                    _learn._maybe_autopr(
+                        category="pattern",
+                        title="T",
+                        content="C",
+                        confidence=0.9,
+                        wing="w",
+                        room="r",
+                        tags="",
+                        facts=[],
+                        session_id=None,
+                        dry_run=True,
+                    )
+
+
+class TestMaybeAutoPRConfidenceGate(unittest.TestCase):
+    """_maybe_autopr: confidence threshold blocks execution."""
+
+    def _run(self, confidence: float, threshold: float = 0.85) -> str:
+        """Return captured stderr."""
+        import io
+
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"SK_AUTOPR_TOKEN": "test-token"}, clear=False):
+            with patch.object(
+                _learn,
+                "_autopr_load_config",
+                return_value={
+                    "repo_root": "/tmp/x",
+                    "target_path": "docs/learnings",
+                    "base_branch": "main",
+                    "confidence_threshold": threshold,
+                    "categories": ["pattern"],
+                    "dry_run": False,
+                },
+            ):
+                with patch("sys.stderr", new=buf):
+                    _learn._maybe_autopr(
+                        category="pattern",
+                        title="T",
+                        content="C",
+                        confidence=confidence,
+                        wing="",
+                        room="",
+                        tags="",
+                        facts=[],
+                        session_id=None,
+                    )
+        return buf.getvalue()
+
+    def test_high_confidence_not_blocked(self) -> None:
+        # Should not print "skipped (confidence" when confidence is above threshold.
+        # We mock _autopr_execute to avoid real git ops.
+        with patch.object(_learn, "_autopr_execute"):
+            err = self._run(0.9)
+        self.assertNotIn("skipped (confidence", err)
+
+    def test_low_confidence_blocked(self) -> None:
+        err = self._run(0.5)
+        self.assertIn("skipped (confidence", err)
+
+    def test_threshold_boundary_exact(self) -> None:
+        # confidence == threshold should pass (>=)
+        with patch.object(_learn, "_autopr_execute"):
+            err = self._run(0.85, threshold=0.85)
+        self.assertNotIn("skipped", err)
+
+
+class TestMaybeAutoPRCategoryGate(unittest.TestCase):
+    """_maybe_autopr: category allowlist."""
+
+    def test_allowed_category_passes(self) -> None:
+        with patch.dict(os.environ, {"SK_AUTOPR_TOKEN": "tok"}, clear=False):
+            with patch.object(
+                _learn,
+                "_autopr_load_config",
+                return_value={
+                    "repo_root": "/tmp/x",
+                    "target_path": "docs/learnings",
+                    "base_branch": "main",
+                    "confidence_threshold": 0.5,
+                    "categories": ["pattern"],
+                    "dry_run": False,
+                },
+            ):
+                with patch.object(_learn, "_autopr_execute") as mock_exec:
+                    _learn._maybe_autopr(
+                        category="pattern",
+                        title="T",
+                        content="Safe content here.",
+                        confidence=0.9,
+                        wing="",
+                        room="",
+                        tags="",
+                        facts=[],
+                        session_id=None,
+                    )
+        mock_exec.assert_called_once()
+
+    def test_blocked_category_skipped(self) -> None:
+        import io
+
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"SK_AUTOPR_TOKEN": "tok"}, clear=False):
+            with patch.object(
+                _learn,
+                "_autopr_load_config",
+                return_value={
+                    "repo_root": "/tmp/x",
+                    "target_path": "docs/learnings",
+                    "base_branch": "main",
+                    "confidence_threshold": 0.5,
+                    "categories": ["decision"],
+                    "dry_run": False,
+                },
+            ):
+                with patch("sys.stderr", new=buf):
+                    _learn._maybe_autopr(
+                        category="mistake",
+                        title="T",
+                        content="C",
+                        confidence=0.9,
+                        wing="",
+                        room="",
+                        tags="",
+                        facts=[],
+                        session_id=None,
+                    )
+        self.assertIn("skipped", buf.getvalue())
+
+
+class TestMaybeAutoPRRedactorHardBlock(unittest.TestCase):
+    """_maybe_autopr: secrets in content must block PR."""
+
+    def test_secret_in_content_refused(self) -> None:
+        import io
+
+        buf = io.StringIO()
+        token = "ghp_" + "B" * 36
+        with patch.dict(os.environ, {"SK_AUTOPR_TOKEN": "tok"}, clear=False):
+            with patch.object(
+                _learn,
+                "_autopr_load_config",
+                return_value={
+                    "repo_root": "/tmp/x",
+                    "target_path": "docs/learnings",
+                    "base_branch": "main",
+                    "confidence_threshold": 0.5,
+                    "categories": ["pattern"],
+                    "dry_run": False,
+                },
+            ):
+                with patch("sys.stderr", new=buf):
+                    _learn._maybe_autopr(
+                        category="pattern",
+                        title="T",
+                        content=f"Use token={token} for auth.",
+                        confidence=0.9,
+                        wing="",
+                        room="",
+                        tags="",
+                        facts=[],
+                        session_id=None,
+                    )
+        self.assertIn("REFUSED", buf.getvalue())
+
+    def test_no_execute_called_when_refused(self) -> None:
+        token = "ghp_" + "C" * 36
+        with patch.dict(os.environ, {"SK_AUTOPR_TOKEN": "tok"}, clear=False):
+            with patch.object(
+                _learn,
+                "_autopr_load_config",
+                return_value={
+                    "repo_root": "/tmp/x",
+                    "target_path": "docs/learnings",
+                    "base_branch": "main",
+                    "confidence_threshold": 0.5,
+                    "categories": ["pattern"],
+                    "dry_run": False,
+                },
+            ):
+                with patch.object(_learn, "_autopr_execute") as mock_exec:
+                    _learn._maybe_autopr(
+                        category="pattern",
+                        title="T",
+                        content=f"secret=hunter2{token}",
+                        confidence=0.9,
+                        wing="",
+                        room="",
+                        tags="",
+                        facts=[],
+                        session_id=None,
+                    )
+        mock_exec.assert_not_called()
+
+
+class TestMaybeAutoPRNoToken(unittest.TestCase):
+    """_maybe_autopr: missing SK_AUTOPR_TOKEN → dry-run."""
+
+    def test_no_token_prints_dry_run(self) -> None:
+        import io
+
+        buf = io.StringIO()
+        env = {k: v for k, v in os.environ.items() if k != "SK_AUTOPR_TOKEN"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(
+                _learn,
+                "_autopr_load_config",
+                return_value={
+                    "repo_root": "/tmp/x",
+                    "target_path": "docs/learnings",
+                    "base_branch": "main",
+                    "confidence_threshold": 0.5,
+                    "categories": ["pattern"],
+                    "dry_run": False,
+                },
+            ):
+                with patch("sys.stdout", new=buf):
+                    _learn._maybe_autopr(
+                        category="pattern",
+                        title="T",
+                        content="Safe content.",
+                        confidence=0.9,
+                        wing="",
+                        room="",
+                        tags="",
+                        facts=[],
+                        session_id=None,
+                    )
+        self.assertIn("dry-run", buf.getvalue())
+
+
+class TestMaybeAutoPRIdempotent(unittest.TestCase):
+    """_maybe_autopr: existing PR URL → skip creation."""
+
+    def test_existing_pr_skips_creation(self) -> None:
+        import io
+
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"SK_AUTOPR_TOKEN": "tok"}, clear=False):
+            with patch.object(
+                _learn,
+                "_autopr_load_config",
+                return_value={
+                    "repo_root": "/tmp/x",
+                    "target_path": "docs/learnings",
+                    "base_branch": "main",
+                    "confidence_threshold": 0.5,
+                    "categories": ["pattern"],
+                    "dry_run": False,
+                },
+            ):
+                with patch.object(_learn, "_autopr_pr_url", return_value="https://github.com/org/repo/pull/99"):
+                    with patch("sys.stdout", new=buf):
+                        _learn._autopr_execute(
+                            branch="sk-learning/abc",
+                            file_path=Path("/tmp/x/docs/learnings/g/g/abc.md"),
+                            title="T",
+                            repo_root="/tmp/x",
+                            md_content="# T\n\nC\n",
+                            pr_cmd=["gh", "pr", "create"],
+                            stable_id="abc",
+                        )
+        self.assertIn("already open", buf.getvalue())
+
+    def test_existing_branch_amends_commit(self) -> None:
+        """If branch exists, git switch (not -c) and commit --amend."""
+        with patch.dict(os.environ, {"SK_AUTOPR_TOKEN": "tok"}, clear=False):
+            with patch.object(_learn, "_autopr_pr_url", return_value=None):
+                with patch.object(_learn, "_autopr_branch_exists", return_value=True):
+                    with patch.object(_learn, "_autopr_git_branch_and_commit", return_value=(True, "")) as mock_git:
+                        with patch.object(_learn, "_autopr_try_gh", return_value=(True, "https://pr/1")):
+                            _learn._autopr_execute(
+                                branch="sk-learning/abc",
+                                file_path=Path("/tmp/x/docs/learnings/g/g/abc.md"),
+                                title="T",
+                                repo_root="/tmp/x",
+                                md_content="# T\n\nC\n",
+                                pr_cmd=["gh", "pr", "create"],
+                                stable_id="abc",
+                            )
+        mock_git.assert_called_once()
+        _, kwargs = mock_git.call_args
+        self.assertTrue(mock_git.call_args[1].get("amend") or mock_git.call_args[0][6])
+
+
+class TestMaybeAutoPRGhMissing(unittest.TestCase):
+    """_maybe_autopr: gh not found → print command, exit 0."""
+
+    def test_gh_not_found_prints_command(self) -> None:
+        import io
+
+        buf = io.StringIO()
+        with patch.object(_learn, "_autopr_try_gh", return_value=(False, "gh not found")):
+            with patch.object(_learn, "_autopr_pr_url", return_value=None):
+                with patch.object(_learn, "_autopr_branch_exists", return_value=False):
+                    with patch.object(_learn, "_autopr_git_branch_and_commit", return_value=(True, "")):
+                        with patch("sys.stdout", new=buf):
+                            _learn._autopr_execute(
+                                branch="sk-learning/abc",
+                                file_path=Path("/tmp/x/docs/learnings/g/g/abc.md"),
+                                title="T",
+                                repo_root="/tmp/x",
+                                md_content="# T\n\nC\n",
+                                pr_cmd=["gh", "pr", "create", "--draft"],
+                                stable_id="abc",
+                            )
+        out = buf.getvalue()
+        self.assertIn("gh not available", out)
+        self.assertIn("gh pr create", out)
+
+
+class TestAutoPRWriteFile(unittest.TestCase):
+    """_autopr_write_file: atomic write with temp file."""
+
+    def test_write_creates_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "sub" / "entry.md"
+            _learn._autopr_write_file(file_path, "# Hello\n\nContent.\n")
+            self.assertTrue(file_path.exists())
+            self.assertIn("Hello", file_path.read_text())
+
+    def test_write_is_atomic_no_tmp_left(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "entry.md"
+            _learn._autopr_write_file(file_path, "# Atomic\n")
+            tmp_path = file_path.with_suffix(".tmp")
+            self.assertFalse(tmp_path.exists())
+
+
+class TestAutoPRBuildPRCmd(unittest.TestCase):
+    """_autopr_build_pr_cmd: correct gh command structure."""
+
+    def test_cmd_contains_draft_flag(self) -> None:
+        cmd = _learn._autopr_build_pr_cmd("sk-learning/x", "main", "docs(learnings): Title", "body")
+        self.assertIn("--draft", cmd)
+        self.assertIn("gh", cmd[0])
+
+    def test_title_truncated_to_120(self) -> None:
+        long_title = "A" * 200
+        cmd = _learn._autopr_build_pr_cmd("branch", "main", long_title, "body")
+        title_idx = cmd.index("--title") + 1
+        self.assertLessEqual(len(cmd[title_idx]), 120)
+
+    def test_never_logs_token(self) -> None:
+        """Verify SK_AUTOPR_TOKEN does not appear in the PR command."""
+        os.environ["SK_AUTOPR_TOKEN"] = "secret-should-not-appear"
+        try:
+            cmd = _learn._autopr_build_pr_cmd("branch", "main", "Title", "body")
+            cmd_str = " ".join(cmd)
+            self.assertNotIn("secret-should-not-appear", cmd_str)
+        finally:
+            del os.environ["SK_AUTOPR_TOKEN"]
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_platform_compat.py
+++ b/tests/test_platform_compat.py
@@ -32,6 +32,7 @@ ALLOWED_TMP_LITERAL_TESTS = {
     "test_retro.py": "mock config path fixture",
     "test_session_surface.py": "SQLite fixture row only; no filesystem dependency",
     "test_tentacle_runtime.py": "marker isolation fixture paths",
+    "test_autopr.py": "repo_root fixture strings only; no filesystem access",
 }
 
 ALLOWED_POSIX_TOKEN_TESTS = {


### PR DESCRIPTION
## Summary

Add confidence-gated auto-PR feature to automatically push high-confidence knowledge entries to GitHub as pull requests.

## Changes

**`learn.py`** — new functions:
- `_autopr_parse_toml()`: stdlib TOML parser (no new deps)
- `_autopr_load_config()`: read `~/.copilot/sk-autopr.toml`
- `_autopr_redactor_gate()`: refuse push if secrets detected
- `_autopr_render_markdown()`: build PR body from knowledge entry
- `_maybe_autopr()`: main entry — called from `learn.py` when confidence ≥ threshold

**`tests/test_autopr.py`** — 30 tests, all passing

## Configuration

```toml
# ~/.copilot/sk-autopr.toml
enabled = true
confidence_threshold = 0.9
target_repo = "owner/repo"
base_branch = "main"
```

## Verification

- `python3 test_security.py` — 13/13 ✅
- `python3 test_fixes.py` — 285/285 ✅
- `python3 tests/test_autopr.py` — 30/30 ✅

Closes #612