### PR TITLE
refactor(retry): extract shared sk::retry library — policy + classifier + jittered backoff (#616)

### DIFF
--- a/sk-rust/src/browse/broker/telegram.rs
+++ b/sk-rust/src/browse/broker/telegram.rs
@@ -498,13 +498,17 @@ impl super::Broker for TelegramBroker {
                     // Pre-increment to match original 1-indexed formula:
                     // attempt=1 -> 1*2^1=2s, attempt=2 -> 4s, ..., attempt=6+ -> 60s.
                     consecutive_errors += 1;
-                    let streak_start =
-                        *error_streak_start.get_or_insert_with(Instant::now);
+                    let streak_start = *error_streak_start.get_or_insert_with(Instant::now);
                     let elapsed = streak_start.elapsed();
                     let err_str = e.to_string();
 
-                    match decide(&POLL_RETRY_POLICY, consecutive_errors, elapsed, &err_str, None)
-                    {
+                    match decide(
+                        &POLL_RETRY_POLICY,
+                        consecutive_errors,
+                        elapsed,
+                        &err_str,
+                        None,
+                    ) {
                         RetryDecision::Retry(wait, _kind) => {
                             let wait_secs = wait.as_secs();
                             warn!(

--- a/sk-rust/src/browse/broker/telegram.rs
+++ b/sk-rust/src/browse/broker/telegram.rs
@@ -26,6 +26,7 @@ use serde_json::{json, Value};
 use tracing::{debug, error, info, warn};
 
 use super::{chunk_text, BrokerConfig, BrokerError, CancellationToken};
+use crate::retry::{decide, RetryDecision, RetryPolicy};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -36,6 +37,22 @@ const DEFAULT_TG_BASE: &str = "https://api.telegram.org/bot";
 const SEARCH_LIMIT: usize = 5;
 const RECENT_LIMIT: usize = 10;
 const MAX_BACKOFF_SECS: u64 = 60;
+
+/// Retry policy for the `getUpdates` long-poll loop.
+///
+/// Matches the original bit-shift formula:
+///   `(1u64 << consecutive_errors.min(63)).min(MAX_BACKOFF_SECS)` in seconds,
+/// using `base=1s, multiplier=2.0, cap=60s, no-jitter`.
+/// With `attempt = consecutive_errors` (pre-incremented, 1-indexed):
+///   attempt=1 -> 2s, attempt=2 -> 4s, ..., attempt=6+ -> 60s.
+const POLL_RETRY_POLICY: RetryPolicy = RetryPolicy {
+    base: Duration::from_secs(1),
+    cap: Duration::from_secs(MAX_BACKOFF_SECS),
+    multiplier: 2.0,
+    jitter: (1.0, 1.0), // no jitter -- deterministic, matches original formula
+    max_attempts: u32::MAX,
+    budget: None, // broker runs indefinitely until cancelled
+};
 
 const HELP_TEXT: &str = "\
 *Hindsight Browse — available commands*
@@ -441,6 +458,8 @@ impl super::Broker for TelegramBroker {
 
         let mut offset: i64 = 0;
         let mut consecutive_errors: u32 = 0;
+        // Tracks when an error streak began; used to compute elapsed for budget checks.
+        let mut error_streak_start: Option<Instant> = None;
 
         loop {
             // Check for cancellation before polling.
@@ -460,6 +479,7 @@ impl super::Broker for TelegramBroker {
             match poll_result {
                 Ok(updates) => {
                     consecutive_errors = 0;
+                    error_streak_start = None;
                     for update in &updates {
                         offset = offset.max(update.update_id + 1);
 
@@ -475,18 +495,39 @@ impl super::Broker for TelegramBroker {
                     return Ok(());
                 }
                 Err(e) => {
+                    // Pre-increment to match original 1-indexed formula:
+                    // attempt=1 -> 1*2^1=2s, attempt=2 -> 4s, ..., attempt=6+ -> 60s.
                     consecutive_errors += 1;
-                    let wait_secs = (1u64 << consecutive_errors.min(63)).min(MAX_BACKOFF_SECS);
-                    warn!(
-                        error = %e,
-                        consecutive_errors,
-                        wait_secs,
-                        "getUpdates error; retrying with backoff"
-                    );
-                    tokio::select! {
-                        _ = tokio::time::sleep(Duration::from_secs(wait_secs)) => {}
-                        _ = token.cancelled() => {
-                            info!("Telegram broker shutting down (cancellation during backoff)");
+                    let streak_start =
+                        *error_streak_start.get_or_insert_with(Instant::now);
+                    let elapsed = streak_start.elapsed();
+                    let err_str = e.to_string();
+
+                    match decide(&POLL_RETRY_POLICY, consecutive_errors, elapsed, &err_str, None)
+                    {
+                        RetryDecision::Retry(wait, _kind) => {
+                            let wait_secs = wait.as_secs();
+                            warn!(
+                                error = %e,
+                                consecutive_errors,
+                                wait_secs,
+                                "getUpdates error; retrying with backoff"
+                            );
+                            tokio::select! {
+                                _ = tokio::time::sleep(wait) => {}
+                                _ = token.cancelled() => {
+                                    info!("Telegram broker shutting down (cancellation during backoff)");
+                                    return Ok(());
+                                }
+                            }
+                        }
+                        RetryDecision::Stop(reason) => {
+                            // Only reached for auth/quota errors (max_attempts=u32::MAX, budget=None).
+                            warn!(
+                                error = %e,
+                                ?reason,
+                                "getUpdates: stopping retry loop (non-retryable error)"
+                            );
                             return Ok(());
                         }
                     }

--- a/sk-rust/src/embeddings/http.rs
+++ b/sk-rust/src/embeddings/http.rs
@@ -13,9 +13,10 @@
 //!
 //! Available only when the `native-embed` Cargo feature is enabled.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::embeddings::config::{get_api_key, ProviderConfig};
+use crate::retry::{decide, RetryDecision, RetryPolicy, StopReason};
 
 // ── Error types ──────────────────────────────────────────────────────────
 
@@ -94,6 +95,16 @@ pub fn call_embedding_api_with_client(
 
     let mut last_err = String::new();
 
+    let policy = RetryPolicy {
+        base: Duration::from_secs(2),
+        cap: Duration::from_secs(30),
+        multiplier: 2.0,
+        jitter: (0.5, 1.0),
+        max_attempts: max_retries,
+        budget: None,
+    };
+    let started = Instant::now();
+
     for attempt in 0..max_retries {
         let mut body = serde_json::json!({
             "input": texts,
@@ -115,12 +126,23 @@ pub fn call_embedding_api_with_client(
             Err(e) => {
                 let msg = e.to_string();
                 last_err = format!("Network error: {msg}");
-                let wait = ((1u64 << attempt) + 1).min(30);
-                eprintln!(
-                    "    🌐 {last_err} — retry {}/{max_retries} in {wait}s",
-                    attempt + 1
-                );
-                std::thread::sleep(Duration::from_secs(wait));
+                match decide(&policy, attempt, started.elapsed(), &last_err, None) {
+                    RetryDecision::Retry(wait, _kind) => {
+                        eprintln!(
+                            "    🌐 {last_err} — retry {}/{max_retries} in {}s",
+                            attempt + 1,
+                            wait.as_secs()
+                        );
+                        std::thread::sleep(wait);
+                    }
+                    RetryDecision::Stop(StopReason::AuthFailure) => {
+                        return Err(EmbedApiError::Auth(last_err));
+                    }
+                    RetryDecision::Stop(StopReason::QuotaExhausted) => {
+                        return Err(EmbedApiError::RateLimit(last_err));
+                    }
+                    RetryDecision::Stop(_) => break,
+                }
             }
 
             Ok(resp) => {
@@ -172,25 +194,29 @@ pub fn call_embedding_api_with_client(
                         "🔍 Model not found (404): Check model name in config. {}",
                         &body_txt[..body_txt.len().min(100)]
                     )));
-                } else if status == 429 {
-                    let wait = ((1u64 << attempt) + 1).min(30);
-                    last_err = "Rate limited (429)".to_string();
-                    eprintln!(
-                        "    ⏳ {last_err} — retry {}/{max_retries} in {wait}s",
-                        attempt + 1
-                    );
-                    std::thread::sleep(Duration::from_secs(wait));
                 } else {
                     let code = status.as_u16();
                     let body_txt = resp.text().unwrap_or_default();
                     last_err =
                         format!("API error {code}: {}", &body_txt[..body_txt.len().min(200)]);
-                    let wait = ((1u64 << attempt) + 1).min(30);
-                    eprintln!(
-                        "    ❌ {last_err} — retry {}/{max_retries} in {wait}s",
-                        attempt + 1
-                    );
-                    std::thread::sleep(Duration::from_secs(wait));
+                    match decide(&policy, attempt, started.elapsed(), &last_err, None) {
+                        RetryDecision::Retry(wait, _kind) => {
+                            eprintln!(
+                                "    {} {last_err} — retry {}/{max_retries} in {}s",
+                                if code == 429 { "⏳" } else { "❌" },
+                                attempt + 1,
+                                wait.as_secs()
+                            );
+                            std::thread::sleep(wait);
+                        }
+                        RetryDecision::Stop(StopReason::AuthFailure) => {
+                            return Err(EmbedApiError::Auth(last_err));
+                        }
+                        RetryDecision::Stop(StopReason::QuotaExhausted) => {
+                            return Err(EmbedApiError::RateLimit(last_err));
+                        }
+                        RetryDecision::Stop(_) => break,
+                    }
                 }
             }
         }

--- a/sk-rust/src/hooks/sync_markers.rs
+++ b/sk-rust/src/hooks/sync_markers.rs
@@ -2,16 +2,31 @@
 ///
 /// Writes atomic JSON marker files so that watch-sessions / sync-daemon can
 /// react to tool-use events without polling:
-///   - `postToolUse` → `~/.copilot/markers/sync-nudge.json`
-///   - `sessionEnd`  → `~/.copilot/markers/sync-flush.json`
+///   - `postToolUse` -> `~/.copilot/markers/sync-nudge.json`
+///   - `sessionEnd`  -> `~/.copilot/markers/sync-flush.json`
 ///
 /// All writes are best-effort: failure is silently ignored.
 use crate::config::resolve_home_dir;
+use crate::retry::{next_delay, RetryPolicy};
 use std::fs;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use chrono::Utc;
 use serde_json::Value;
+
+/// Retry policy for the atomic rename in [`try_record_sync_signal`].
+///
+/// Flat 30 ms delay for all 3 attempts -- matches the original fixed sleep.
+/// `multiplier=1.0` and `jitter=(1.0,1.0)` produce exactly `base` every time.
+const RENAME_RETRY_POLICY: RetryPolicy = RetryPolicy {
+    base: Duration::from_millis(30),
+    cap: Duration::from_millis(90),
+    multiplier: 1.0,
+    jitter: (1.0, 1.0), // no jitter -- deterministic
+    max_attempts: 3,
+    budget: None,
+};
 
 fn markers_dir() -> PathBuf {
     resolve_home_dir()
@@ -64,14 +79,14 @@ fn try_record_sync_signal(event: &str, data: &Value) -> std::io::Result<()> {
     let tmp = target.with_extension("json.tmp");
     fs::write(&tmp, serde_json::to_string(&payload).unwrap_or_default())?;
     let mut last_err = None;
-    for attempt in 0..3u8 {
+    for attempt in 0..3u32 {
         match fs::rename(&tmp, &target) {
             Ok(()) => return Ok(()),
             Err(e) => {
                 last_err = Some(e);
                 if attempt < 2 {
                     // Brief back-off before retry (Windows sharing violations are transient).
-                    std::thread::sleep(std::time::Duration::from_millis(30));
+                    std::thread::sleep(next_delay(&RENAME_RETRY_POLICY, attempt, None));
                 }
             }
         }

--- a/sk-rust/src/lib.rs
+++ b/sk-rust/src/lib.rs
@@ -1,6 +1,10 @@
 //! Library surface for `sk` — currently only exposes browse modules for
 //! integration testing and future crate-level reuse.
 
+// Shared retry library: policy, classification, delay, and decision.
+// Zero new dependencies -- uses only `regex` (already a dep) and a stdlib PRNG.
+pub mod retry;
+
 // `browse::algo` (pure algorithms) is always compiled in; feature-gated
 // submodules inside `browse/mod.rs` guard the server-specific code.
 pub mod browse;

--- a/sk-rust/src/main.rs
+++ b/sk-rust/src/main.rs
@@ -8,6 +8,7 @@ mod hooks;
 mod index;
 mod providers;
 mod redact;
+mod retry;
 mod sync;
 
 use std::process::ExitCode;

--- a/sk-rust/src/retry/mod.rs
+++ b/sk-rust/src/retry/mod.rs
@@ -1,0 +1,346 @@
+//! Crate-wide shared retry library.
+//!
+//! Provides a unified [`RetryPolicy`], error classification, delay calculation,
+//! and retry decision logic for use across all native retry call sites:
+//! the Telegram broker, file-rename loop in sync_markers, and the embedding
+//! HTTP client.
+//!
+//! # Security
+//! [`classify_error`] inspects only the *structure* of the error text (regex
+//! pattern matching).  It never returns raw error text — only a [`RetryKind`]
+//! enum variant — so credentials embedded in error messages cannot leak.
+//!
+//! # Zero new dependencies
+//! Uses only `regex` (already a workspace dep) and a stdlib SplitMix64 PRNG
+//! for jitter.  No `fastrand` or any other new crate is introduced.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use regex::RegexSet;
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/// Retry policy parameters.
+///
+/// All durations use [`Duration`] (monotonic).  The budget check uses elapsed
+/// wall-time supplied by the caller via [`decide`] — callers must use
+/// [`std::time::Instant`], never `SystemTime`, for elapsed computation.
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    /// Base delay for the first retry.  Default: 1 s.
+    pub base: Duration,
+    /// Maximum delay (exponential cap).  Default: 60 s.
+    pub cap: Duration,
+    /// Exponential back-off multiplier.  Default: 1.6.
+    pub multiplier: f64,
+    /// Jitter range `(lo_factor, hi_factor)`.  Default: `(0.5, 1.0)`.
+    ///
+    /// When `lo >= hi`, jitter is disabled and the exact computed delay is used.
+    pub jitter: (f64, f64),
+    /// Maximum number of retry attempts before stopping.  Default: 5.
+    pub max_attempts: u32,
+    /// Optional wall-clock budget.  `None` means no budget limit.  Default: `Some(5 min)`.
+    pub budget: Option<Duration>,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        RetryPolicy {
+            base: Duration::from_secs(1),
+            cap: Duration::from_secs(60),
+            multiplier: 1.6,
+            jitter: (0.5, 1.0),
+            max_attempts: 5,
+            budget: Some(Duration::from_secs(300)),
+        }
+    }
+}
+
+/// Classification of why a retry is occurring.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetryKind {
+    /// HTTP 429 / "rate limit exceeded".
+    RateLimit,
+    /// HTTP 5xx server error.
+    Server5xx,
+    /// Explicit throttling signal.
+    Throttle,
+    /// Backend overloaded / over capacity.
+    Overloaded,
+    /// API quota exhausted (distinct from per-request rate limiting).
+    Quota,
+    /// Authentication / authorization failure.
+    Auth,
+    /// Non-empty error that matches no specific pattern; retrying may help.
+    Unknown,
+}
+
+/// Decision returned by [`decide`].
+#[derive(Debug)]
+pub enum RetryDecision {
+    /// Caller should sleep `Duration` then retry; error was classified as `RetryKind`.
+    Retry(Duration, RetryKind),
+    /// Caller should stop retrying.
+    Stop(StopReason),
+}
+
+/// Reason a retry sequence is terminated.
+#[derive(Debug, PartialEq, Eq)]
+pub enum StopReason {
+    /// Reached `policy.max_attempts`.
+    MaxAttempts,
+    /// Elapsed time exceeded `policy.budget`.
+    Budget,
+    /// Error is an authentication failure; retrying will not help.
+    AuthFailure,
+    /// API quota exhausted; retrying will not help immediately.
+    QuotaExhausted,
+    /// Upstream sent `x-should-retry: false`.
+    XShouldRetryFalse,
+    /// Error text is empty (truly unclassifiable).
+    NonRetryable,
+}
+
+// ── Pattern indices (must stay in sync with PATTERNS array below) ─────────────
+
+const IDX_AUTH: usize = 0;
+const IDX_QUOTA: usize = 1;
+const IDX_RATE_LIMIT: usize = 2;
+const IDX_THROTTLE: usize = 3;
+const IDX_OVERLOADED: usize = 4;
+const IDX_SERVER5XX: usize = 5;
+const IDX_NO_RETRY: usize = 6;
+
+/// Lazily-compiled pattern set.  Compiled exactly once per process.
+static PATTERNS: OnceLock<RegexSet> = OnceLock::new();
+
+fn patterns() -> &'static RegexSet {
+    PATTERNS.get_or_init(|| {
+        RegexSet::new([
+            // 0: Auth — do not retry
+            r"(?i)\b(401|403|unauthori[sz]ed|forbidden|invalid[._]api[._]key|api[._]key[._]invalid|authentication[._]failed)\b",
+            // 1: Quota — do not retry
+            r"(?i)\b(insufficient[._]quota|quota[._]exceeded|billing[._]hard[._]limit)\b",
+            // 2: RateLimit — retry
+            r"(?i)\b(429|rate[._-]?limit|too[\s._-]many[\s._-]requests|ratelimited|rate_limit_exceeded)\b",
+            // 3: Throttle — retry
+            r"(?i)\bthrottl",
+            // 4: Overloaded — retry
+            r"(?i)\b(overload\w*|over[._]capacity|server[._]overload)\b",
+            // 5: Server5xx — retry
+            r"(?i)\b(5[0-9]{2}|internal[._]server[._]error|bad[._]gateway|service[._]unavailable|gateway[._]timeout)\b",
+            // 6: x-should-retry: false — explicit no-retry signal
+            r"(?i)x-should-retry\s*:\s*false",
+        ])
+        .expect("retry: invalid regex pattern -- compile-time bug")
+    })
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Classify an error string into a [`RetryKind`].
+///
+/// Returns `None` only when `text` is empty (unclassifiable).  Returns
+/// `Some(RetryKind::Unknown)` for non-empty text that matches no pattern.
+///
+/// # Security
+/// Only the enum variant is returned.  The raw `text` is never stored,
+/// returned, or logged, so credentials in error messages cannot leak.
+pub fn classify_error(text: &str) -> Option<RetryKind> {
+    if text.is_empty() {
+        return None;
+    }
+    let ms = patterns().matches(text);
+    // Priority: Auth > Quota > RateLimit > Throttle > Overloaded > Server5xx > Unknown
+    if ms.matched(IDX_AUTH) {
+        return Some(RetryKind::Auth);
+    }
+    if ms.matched(IDX_QUOTA) {
+        return Some(RetryKind::Quota);
+    }
+    if ms.matched(IDX_RATE_LIMIT) {
+        return Some(RetryKind::RateLimit);
+    }
+    if ms.matched(IDX_THROTTLE) {
+        return Some(RetryKind::Throttle);
+    }
+    if ms.matched(IDX_OVERLOADED) {
+        return Some(RetryKind::Overloaded);
+    }
+    if ms.matched(IDX_SERVER5XX) {
+        return Some(RetryKind::Server5xx);
+    }
+    Some(RetryKind::Unknown)
+}
+
+/// Compute the next retry delay.
+///
+/// # Precedence
+/// 1. `retry_after` — server-supplied hint (clamped to `policy.cap`).
+/// 2. Exponential back-off: `base * multiplier^attempt`, clamped to `cap`.
+/// 3. Jitter: if `policy.jitter.0 < policy.jitter.1`, a random factor in
+///    `[lo, hi)` is applied; otherwise the exact computed delay is returned.
+///
+/// # Overflow guard
+/// When `attempt > 64`, returns `policy.cap` immediately without computing
+/// the exponentiation (avoids `powi` overflow on absurdly large attempts).
+pub fn next_delay(policy: &RetryPolicy, attempt: u32, retry_after: Option<Duration>) -> Duration {
+    // Server-supplied Retry-After wins.
+    if let Some(ra) = retry_after {
+        if ra > Duration::ZERO {
+            return ra.min(policy.cap);
+        }
+    }
+
+    // Compute exponential back-off, guarded against overflow.
+    let base_delay = compute_backoff(policy, attempt);
+
+    // Apply jitter.
+    apply_jitter(base_delay, policy)
+}
+
+/// Decide whether to retry or stop.
+///
+/// Checks (in order):
+/// 1. `attempt >= policy.max_attempts` → [`StopReason::MaxAttempts`]
+/// 2. `elapsed >= policy.budget` (when budget is `Some`) → [`StopReason::Budget`]
+/// 3. `x-should-retry: false` in `err` → [`StopReason::XShouldRetryFalse`]
+/// 4. [`classify_error`] returns `None` → [`StopReason::NonRetryable`]
+/// 5. [`RetryKind::Auth`] → [`StopReason::AuthFailure`]
+/// 6. [`RetryKind::Quota`] → [`StopReason::QuotaExhausted`]
+/// 7. All other kinds → [`RetryDecision::Retry`] with delay from [`next_delay`]
+pub fn decide(
+    policy: &RetryPolicy,
+    attempt: u32,
+    elapsed: Duration,
+    err: &str,
+    retry_after: Option<Duration>,
+) -> RetryDecision {
+    // 1. Max attempts guard.
+    if attempt >= policy.max_attempts {
+        return RetryDecision::Stop(StopReason::MaxAttempts);
+    }
+
+    // 2. Budget guard (budget=None means unlimited).
+    if let Some(budget) = policy.budget {
+        if elapsed >= budget {
+            return RetryDecision::Stop(StopReason::Budget);
+        }
+    }
+
+    // 3. x-should-retry: false — upstream explicitly forbids retry.
+    if !err.is_empty() && patterns().matches(err).matched(IDX_NO_RETRY) {
+        return RetryDecision::Stop(StopReason::XShouldRetryFalse);
+    }
+
+    // 4–6. Classify error.
+    match classify_error(err) {
+        None => RetryDecision::Stop(StopReason::NonRetryable),
+        Some(RetryKind::Auth) => RetryDecision::Stop(StopReason::AuthFailure),
+        Some(RetryKind::Quota) => RetryDecision::Stop(StopReason::QuotaExhausted),
+        Some(kind) => {
+            let delay = next_delay(policy, attempt, retry_after);
+            RetryDecision::Retry(delay, kind)
+        }
+    }
+}
+
+// ── Internals ─────────────────────────────────────────────────────────────────
+
+/// Compute exponential back-off delay, clamped to `policy.cap`.
+///
+/// Overflow guard: returns `cap` immediately for `attempt > 64`.
+fn compute_backoff(policy: &RetryPolicy, attempt: u32) -> Duration {
+    if attempt > 64 {
+        return policy.cap;
+    }
+    let m = policy.multiplier;
+    if !m.is_finite() || m <= 0.0 {
+        return policy.cap;
+    }
+    let delay_f = policy.base.as_secs_f64() * m.powi(attempt as i32);
+    if !delay_f.is_finite() || delay_f >= policy.cap.as_secs_f64() {
+        return policy.cap;
+    }
+    Duration::from_secs_f64(delay_f.max(0.0)).min(policy.cap)
+}
+
+/// Apply jitter to `base_delay` using the `policy.jitter` range.
+///
+/// When `lo >= hi` (or either is non-finite), returns `base_delay` unchanged
+/// (no-jitter / deterministic mode).
+fn apply_jitter(base_delay: Duration, policy: &RetryPolicy) -> Duration {
+    let (lo, hi) = policy.jitter;
+    if !lo.is_finite() || !hi.is_finite() || lo >= hi {
+        return base_delay;
+    }
+    let factor = jitter_in_range(lo, hi);
+    let jittered = base_delay.as_secs_f64() * factor;
+    Duration::from_secs_f64(jittered.max(0.0)).min(policy.cap)
+}
+
+/// Return a random `f64` in `[lo, hi)` using the thread-local SplitMix64 PRNG.
+fn jitter_in_range(lo: f64, hi: f64) -> f64 {
+    // Map a 53-bit integer uniformly to [0.0, 1.0).
+    let r = next_u64_tl();
+    let t = (r >> 11) as f64 / (1u64 << 53) as f64;
+    lo + t * (hi - lo)
+}
+
+// ── SplitMix64 thread-local PRNG ─────────────────────────────────────────────
+//
+// A minimal, zero-allocation, no-unsafe SplitMix64 PRNG.  Each thread gets
+// a distinct seed derived from wall-clock nanoseconds XOR'd with the stack
+// frame address (proxy for thread identity).  No external crate needed.
+
+std::thread_local! {
+    static PRNG_STATE: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static PRNG_SEEDED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+fn next_u64_tl() -> u64 {
+    PRNG_STATE.with(|cell| {
+        if !PRNG_SEEDED.with(|b| b.get()) {
+            let seed = prng_initial_seed();
+            cell.set(seed);
+            PRNG_SEEDED.with(|b| b.set(true));
+        }
+        let next = cell.get().wrapping_add(0x9e37_79b9_7f4a_7c15);
+        cell.set(next);
+        splitmix64_mix(next)
+    })
+}
+
+#[inline(always)]
+fn splitmix64_mix(mut z: u64) -> u64 {
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}
+
+fn prng_initial_seed() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let time_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64)
+        .unwrap_or(0xdead_beef_cafe_babe);
+    let addr = stack_addr();
+    time_ns ^ addr
+}
+
+#[inline(never)]
+fn stack_addr() -> u64 {
+    let x: u8 = 0;
+    &x as *const u8 as u64
+}
+
+/// Seed the thread-local PRNG to a known value (test use only).
+#[cfg(test)]
+pub fn seed_prng(seed: u64) {
+    PRNG_STATE.with(|c| c.set(seed));
+    PRNG_SEEDED.with(|b| b.set(true));
+}
+
+#[cfg(test)]
+mod tests;

--- a/sk-rust/src/retry/tests.rs
+++ b/sk-rust/src/retry/tests.rs
@@ -1,0 +1,423 @@
+//! Table-driven tests for the shared `retry` module.
+//!
+//! Covers:
+//! - Each `RetryKind` via `classify_error`
+//! - Each `StopReason` via `decide`
+//! - Jitter bounds and no-jitter mode
+//! - Overflow guard in `next_delay` / `compute_backoff`
+//! - `retry_after` precedence
+//! - Telegram broker backoff golden sequence
+
+use std::time::Duration;
+
+use super::{
+    classify_error, decide, next_delay, seed_prng, RetryDecision, RetryKind, RetryPolicy,
+    StopReason,
+};
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+/// A no-jitter policy convenient for deterministic tests.
+fn no_jitter(base_secs: u64, cap_secs: u64, multiplier: f64, max_attempts: u32) -> RetryPolicy {
+    RetryPolicy {
+        base: Duration::from_secs(base_secs),
+        cap: Duration::from_secs(cap_secs),
+        multiplier,
+        jitter: (1.0, 1.0), // lo == hi → no jitter
+        max_attempts,
+        budget: None,
+    }
+}
+
+// ── classify_error ────────────────────────────────────────────────────────────
+
+#[test]
+fn classify_empty_returns_none() {
+    assert!(classify_error("").is_none());
+}
+
+#[test]
+fn classify_429_rate_limit() {
+    assert_eq!(
+        classify_error("429 Too Many Requests"),
+        Some(RetryKind::RateLimit)
+    );
+}
+
+#[test]
+fn classify_rate_limit_keyword() {
+    assert_eq!(
+        classify_error("rate_limit_exceeded"),
+        Some(RetryKind::RateLimit)
+    );
+}
+
+#[test]
+fn classify_too_many_requests_phrase() {
+    assert_eq!(
+        classify_error("error: too many requests, slow down"),
+        Some(RetryKind::RateLimit)
+    );
+}
+
+#[test]
+fn classify_500_server_error() {
+    assert_eq!(
+        classify_error("500 Internal Server Error"),
+        Some(RetryKind::Server5xx)
+    );
+}
+
+#[test]
+fn classify_503_service_unavailable() {
+    assert_eq!(
+        classify_error("503 Service Unavailable"),
+        Some(RetryKind::Server5xx)
+    );
+}
+
+#[test]
+fn classify_throttled() {
+    assert_eq!(
+        classify_error("Request throttled by upstream"),
+        Some(RetryKind::Throttle)
+    );
+}
+
+#[test]
+fn classify_overloaded() {
+    assert_eq!(
+        classify_error("Server overloaded, try again later"),
+        Some(RetryKind::Overloaded)
+    );
+}
+
+#[test]
+fn classify_over_capacity() {
+    assert_eq!(
+        classify_error("over_capacity: cluster at 100%"),
+        Some(RetryKind::Overloaded)
+    );
+}
+
+#[test]
+fn classify_quota_exhausted() {
+    assert_eq!(classify_error("insufficient_quota"), Some(RetryKind::Quota));
+}
+
+#[test]
+fn classify_quota_exceeded_variant() {
+    assert_eq!(
+        classify_error("quota_exceeded: monthly limit reached"),
+        Some(RetryKind::Quota)
+    );
+}
+
+#[test]
+fn classify_401_auth() {
+    assert_eq!(classify_error("401 Unauthorized"), Some(RetryKind::Auth));
+}
+
+#[test]
+fn classify_403_forbidden() {
+    assert_eq!(classify_error("403 Forbidden"), Some(RetryKind::Auth));
+}
+
+#[test]
+fn classify_invalid_api_key() {
+    assert_eq!(
+        classify_error("invalid_api_key: check your credentials"),
+        Some(RetryKind::Auth)
+    );
+}
+
+#[test]
+fn classify_unknown_for_network_error() {
+    // Network errors (connection reset, timeout, etc.) should be Unknown (retryable).
+    assert_eq!(
+        classify_error("transport error: connection reset by peer"),
+        Some(RetryKind::Unknown)
+    );
+}
+
+#[test]
+fn classify_unknown_for_arbitrary_text() {
+    assert_eq!(
+        classify_error("something went wrong"),
+        Some(RetryKind::Unknown)
+    );
+}
+
+// ── next_delay ────────────────────────────────────────────────────────────────
+
+#[test]
+fn next_delay_attempt0_no_jitter() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    assert_eq!(next_delay(&p, 0, None), Duration::from_secs(1));
+}
+
+#[test]
+fn next_delay_attempt1_no_jitter() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    assert_eq!(next_delay(&p, 1, None), Duration::from_secs(2));
+}
+
+#[test]
+fn next_delay_attempt2_no_jitter() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    assert_eq!(next_delay(&p, 2, None), Duration::from_secs(4));
+}
+
+#[test]
+fn next_delay_clamped_to_cap() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    // 2^10 = 1024 > 60 → should be capped
+    assert_eq!(next_delay(&p, 10, None), Duration::from_secs(60));
+}
+
+#[test]
+fn next_delay_overflow_guard_attempt_over_64() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    assert_eq!(next_delay(&p, 65, None), Duration::from_secs(60));
+    assert_eq!(next_delay(&p, u32::MAX, None), Duration::from_secs(60));
+}
+
+#[test]
+fn next_delay_retry_after_wins() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    assert_eq!(
+        next_delay(&p, 0, Some(Duration::from_secs(10))),
+        Duration::from_secs(10)
+    );
+}
+
+#[test]
+fn next_delay_retry_after_clamped_to_cap() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    // retry_after=90 > cap=60 → clamped to 60
+    assert_eq!(
+        next_delay(&p, 0, Some(Duration::from_secs(90))),
+        Duration::from_secs(60)
+    );
+}
+
+#[test]
+fn next_delay_retry_after_zero_ignored() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    // retry_after=0 → fall through to exponential back-off
+    assert_eq!(
+        next_delay(&p, 0, Some(Duration::ZERO)),
+        Duration::from_secs(1)
+    );
+}
+
+#[test]
+fn next_delay_no_jitter_lo_equals_hi() {
+    // jitter (1.0, 1.0): lo == hi → no jitter, exact value returned
+    let p = no_jitter(4, 60, 1.0, 5);
+    assert_eq!(next_delay(&p, 0, None), Duration::from_secs(4));
+    assert_eq!(next_delay(&p, 3, None), Duration::from_secs(4));
+}
+
+#[test]
+fn next_delay_with_jitter_within_bounds() {
+    seed_prng(0xdead_beef_1234_5678);
+    let p = RetryPolicy {
+        base: Duration::from_secs(10),
+        cap: Duration::from_secs(60),
+        multiplier: 1.0,
+        jitter: (0.5, 1.0),
+        max_attempts: 5,
+        budget: None,
+    };
+    for _ in 0..50 {
+        let d = next_delay(&p, 0, None);
+        assert!(
+            d >= Duration::from_secs(5) && d <= Duration::from_secs(10),
+            "jitter out of [5s, 10s]: {d:?}"
+        );
+    }
+}
+
+#[test]
+fn next_delay_invalid_multiplier_caps_to_cap() {
+    let p = RetryPolicy {
+        base: Duration::from_secs(1),
+        cap: Duration::from_secs(60),
+        multiplier: f64::NAN,
+        jitter: (1.0, 1.0),
+        max_attempts: 5,
+        budget: None,
+    };
+    assert_eq!(next_delay(&p, 0, None), Duration::from_secs(60));
+}
+
+#[test]
+fn next_delay_multiplier_one_flat_backoff() {
+    // multiplier=1.0 → all attempts use base delay (like sync_markers policy)
+    let p = RetryPolicy {
+        base: Duration::from_millis(30),
+        cap: Duration::from_millis(90),
+        multiplier: 1.0,
+        jitter: (1.0, 1.0),
+        max_attempts: 3,
+        budget: None,
+    };
+    assert_eq!(next_delay(&p, 0, None), Duration::from_millis(30));
+    assert_eq!(next_delay(&p, 1, None), Duration::from_millis(30));
+    assert_eq!(next_delay(&p, 2, None), Duration::from_millis(30));
+}
+
+// ── decide ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn decide_stop_max_attempts() {
+    let p = no_jitter(1, 60, 2.0, 3);
+    match decide(&p, 3, Duration::ZERO, "network error", None) {
+        RetryDecision::Stop(StopReason::MaxAttempts) => {}
+        other => panic!("expected MaxAttempts, got {other:?}"),
+    }
+}
+
+#[test]
+fn decide_stop_budget_exceeded() {
+    let p = RetryPolicy {
+        budget: Some(Duration::from_secs(5)),
+        ..no_jitter(1, 60, 2.0, 10)
+    };
+    match decide(&p, 0, Duration::from_secs(10), "network error", None) {
+        RetryDecision::Stop(StopReason::Budget) => {}
+        other => panic!("expected Budget, got {other:?}"),
+    }
+}
+
+#[test]
+fn decide_stop_auth_failure() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    match decide(&p, 0, Duration::ZERO, "401 Unauthorized", None) {
+        RetryDecision::Stop(StopReason::AuthFailure) => {}
+        other => panic!("expected AuthFailure, got {other:?}"),
+    }
+}
+
+#[test]
+fn decide_stop_quota_exhausted() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    match decide(&p, 0, Duration::ZERO, "insufficient_quota", None) {
+        RetryDecision::Stop(StopReason::QuotaExhausted) => {}
+        other => panic!("expected QuotaExhausted, got {other:?}"),
+    }
+}
+
+#[test]
+fn decide_stop_x_should_retry_false() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    match decide(&p, 0, Duration::ZERO, "x-should-retry: false", None) {
+        RetryDecision::Stop(StopReason::XShouldRetryFalse) => {}
+        other => panic!("expected XShouldRetryFalse, got {other:?}"),
+    }
+}
+
+#[test]
+fn decide_stop_nonretryable_on_empty_error() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    match decide(&p, 0, Duration::ZERO, "", None) {
+        RetryDecision::Stop(StopReason::NonRetryable) => {}
+        other => panic!("expected NonRetryable, got {other:?}"),
+    }
+}
+
+#[test]
+fn decide_retry_rate_limit() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    match decide(&p, 0, Duration::ZERO, "429 rate_limit_exceeded", None) {
+        RetryDecision::Retry(_, RetryKind::RateLimit) => {}
+        other => panic!("expected Retry(RateLimit), got {other:?}"),
+    }
+}
+
+#[test]
+fn decide_retry_server5xx() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    match decide(&p, 1, Duration::ZERO, "500 internal server error", None) {
+        RetryDecision::Retry(d, RetryKind::Server5xx) => {
+            assert_eq!(d, Duration::from_secs(2));
+        }
+        other => panic!("expected Retry(Server5xx), got {other:?}"),
+    }
+}
+
+#[test]
+fn decide_retry_unknown_network_error() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    match decide(&p, 0, Duration::ZERO, "connection reset by peer", None) {
+        RetryDecision::Retry(d, RetryKind::Unknown) => {
+            assert_eq!(d, Duration::from_secs(1));
+        }
+        other => panic!("expected Retry(Unknown), got {other:?}"),
+    }
+}
+
+#[test]
+fn decide_no_budget_does_not_stop_on_elapsed() {
+    // budget=None → elapsed check skipped, should retry
+    let p = RetryPolicy {
+        budget: None,
+        ..no_jitter(1, 60, 2.0, u32::MAX)
+    };
+    match decide(&p, 0, Duration::from_secs(99999), "network error", None) {
+        RetryDecision::Retry(_, _) => {}
+        other => panic!("expected Retry, got {other:?}"),
+    }
+}
+
+#[test]
+fn decide_retry_after_passed_through() {
+    let p = no_jitter(1, 60, 2.0, 5);
+    match decide(
+        &p,
+        0,
+        Duration::ZERO,
+        "429 rate limit",
+        Some(Duration::from_secs(7)),
+    ) {
+        RetryDecision::Retry(d, RetryKind::RateLimit) => {
+            assert_eq!(d, Duration::from_secs(7));
+        }
+        other => panic!("expected Retry with 7s delay, got {other:?}"),
+    }
+}
+
+// ── Telegram broker golden backoff sequence ───────────────────────────────────
+//
+// Original formula: `(1u64 << consecutive_errors.min(63)).min(MAX_BACKOFF_SECS)`
+// with consecutive_errors = 1, 2, 3, 4, 5, 6, ...
+//
+// Equivalent policy: base=1s, multiplier=2.0, cap=60s, no jitter,
+// attempt = consecutive_errors (1-indexed after increment).
+//
+// Expected sequence: 2, 4, 8, 16, 32, 60, 60, ...
+
+#[test]
+fn telegram_backoff_golden_sequence() {
+    let policy = RetryPolicy {
+        base: Duration::from_secs(1),
+        cap: Duration::from_secs(60),
+        multiplier: 2.0,
+        jitter: (1.0, 1.0), // no jitter — deterministic
+        max_attempts: u32::MAX,
+        budget: None,
+    };
+
+    let expected = [2u64, 4, 8, 16, 32, 60, 60, 60, 60, 60];
+    for (i, &exp_secs) in expected.iter().enumerate() {
+        // consecutive_errors is 1-indexed (pre-incremented before decide() call)
+        let attempt = (i + 1) as u32;
+        let d = next_delay(&policy, attempt, None);
+        assert_eq!(
+            d,
+            Duration::from_secs(exp_secs),
+            "attempt {attempt}: expected {exp_secs}s, got {d:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Extract crate-wide shared retry library at `sk-rust/src/retry/` used across hooks, embeddings, and browse. Zero new dependencies — uses only `regex` (already present) and a stdlib PRNG (SplitMix64).

## Library API

```rust
// Policy configuration
let policy = RetryPolicy { base: Duration::from_secs(1), cap: Duration::from_secs(30), .. };

// Make a retry decision  
match decide(attempt, elapsed, retry_after, status_code, error_text, &policy) {
    RetryDecision::Retry(delay, kind) => sleep(delay),
    RetryDecision::Stop(reason) => return Err(reason),
}
```

## Components

- **`RetryPolicy`**: base, cap, multiplier, jitter, max_attempts, budget
- **`classify_error()`**: single `OnceLock<RegexSet>` (7 patterns), returns `Option<RetryKind>` (no credential leakage)
- **`next_delay()`**: overflow-safe (attempt>64→cap), retry_after precedence, SplitMix64 jitter
- **`decide()`**: ordered checks: max_attempts → budget → x-should-retry:false → classify

## Migrations (call sites updated)

| File | Before | After |
|------|--------|-------|
| `telegram.rs` | `1u64 << consecutive_errors` | `decide()` with `POLL_RETRY_POLICY` |
| `sync_markers.rs` | 3-try rename loop | `next_delay()` with flat 30ms policy |
| `embeddings/http.rs` | `((1u64<<attempt)+1).min(30)` | `decide()` with `RetryPolicy{base:2s,cap:30s}` |

## Tests

- `src/retry/tests.rs`: 40 table-driven tests
- `cargo test --lib`: **204/204 pass**

Closes #616