### PR TITLE
fix(hooks): output structured JSON for context injection (#661)

### DIFF
--- a/hooks/hook_runner.py
+++ b/hooks/hook_runner.py
@@ -221,11 +221,21 @@ def main():
                 if verbose:
                     _audit_log(event, tool_name, rule.name, "allow", msg[:100] if msg else "")
         else:
-            # postToolUse/sessionStart/sessionEnd/agentStop/subagentStop/errorOccurred: informational
-            msg = result.get("message", "")
-            if msg:
-                print(msg)
-            _audit_log(event, tool_name, rule.name, "info", msg[:100] if msg else "")
+            # postToolUse/sessionStart/sessionEnd/agentStop/subagentStop/errorOccurred
+            # Structured JSON keys the Copilot CLI SDK expects on stdout:
+            _STRUCTURED_KEYS = ("additionalContext", "sessionSummary", "modifiedPrompt")
+            has_structured = any(k in result for k in _STRUCTURED_KEYS)
+            if has_structured:
+                # Emit structured JSON so the SDK can inject context into the LLM
+                print(json.dumps(result))
+                detail = next((result[k][:100] for k in _STRUCTURED_KEYS if k in result), "")
+                _audit_log(event, tool_name, rule.name, "context", detail)
+            else:
+                # Backward-compatible: plain text info() results display as-is
+                msg = result.get("message", "")
+                if msg:
+                    print(msg)
+                _audit_log(event, tool_name, rule.name, "info", msg[:100] if msg else "")
 
     if event in {"postToolUse", "sessionEnd"}:
         _record_sync_signal(event, data)

--- a/hooks/rules/briefing.py
+++ b/hooks/rules/briefing.py
@@ -12,6 +12,7 @@ from .common import (
     TOOLS_DIR,
     _is_pid_running,
     bash_writes_source_files,
+    context,
     deny,
     get_session_marker_suffix,
     info,
@@ -381,7 +382,7 @@ class AutoBriefingRule(Rule):
         sign_marker(MARKER, "briefing-done")
         session_marker = MARKERS_DIR / f"briefing-done-{session_id}"
         sign_marker(session_marker, f"briefing-done-{session_id}")
-        return info("\n".join(lines))
+        return context("\n".join(lines))
 
 
 class EnforceBriefingRule(Rule):

--- a/hooks/rules/common.py
+++ b/hooks/rules/common.py
@@ -210,8 +210,36 @@ def deny(reason):
 
 
 def info(message):
-    """Create an informational message result."""
+    """Create an informational message result (plain text display)."""
     return {"message": message}
+
+
+def context(message):
+    """Create a structured additionalContext result for LLM injection.
+
+    The Copilot CLI SDK reads this JSON field from hook stdout and injects
+    its value into the model's system context, making it visible to the LLM.
+    Use for sessionStart payloads like MEMORY.md, briefing output, etc.
+    """
+    return {"additionalContext": message}
+
+
+def session_summary(message):
+    """Create a structured sessionSummary result for sessionEnd.
+
+    The Copilot CLI SDK reads this JSON field at session end and uses it
+    as the session summary for the model.
+    """
+    return {"sessionSummary": message}
+
+
+def modified_prompt(prompt):
+    """Create a structured modifiedPrompt result.
+
+    The Copilot CLI SDK reads this JSON field and replaces the user's
+    prompt with the modified version before sending to the model.
+    """
+    return {"modifiedPrompt": prompt}
 
 
 # ── Shared per-session state helpers (used by token_tracker and read_tracker) ──

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -4541,11 +4541,11 @@ try:
         _rb25.BRIEFING_SCRIPT = _dummy_briefing25f
 
         _result25f = _rule25f.evaluate("sessionStart", {})
-        _msg25f = _result25f.get("message", "") if isinstance(_result25f, dict) else ""
+        _msg25f = (_result25f.get("additionalContext") or _result25f.get("message", "")) if isinstance(_result25f, dict) else ""
 
         test(
             "25f: AutoBriefingRule returns info() dict",
-            isinstance(_result25f, dict) and "message" in _result25f,
+            isinstance(_result25f, dict) and ("message" in _result25f or "additionalContext" in _result25f),
             f"got: {_result25f!r}",
         )
         test(
@@ -5589,7 +5589,7 @@ try:
         finally:
             _rb27g.subprocess.run = _orig_sp_run27g
 
-    _msg27g = _result27g.get("message", "") if isinstance(_result27g, dict) else ""
+    _msg27g = (_result27g.get("additionalContext") or _result27g.get("message", "")) if isinstance(_result27g, dict) else ""
     test(
         "27g: AutoBriefingRule timeout preserves partial skill-index output",
         "\U0001f4e6 Skills" in _msg27g,


### PR DESCRIPTION
Fix hook_runner.py to output structured JSON (additionalContext, sessionSummary, modifiedPrompt) instead of plain text. Adds context(), session_summary(), modified_prompt() helpers to common.py. AutoBriefingRule now uses context() for MEMORY.md LLM injection. Tests: 13/13 security, 272/272 fixes. Closes #661