### PR TITLE
feat(hooks): add loop detection rule (#663)

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -45,6 +45,7 @@ hooks/
 | `syntax-gate` | preToolUse | Blocks `edit`/`create` payloads that introduce Python syntax errors — applies the proposed change in memory and runs `py_compile`; fail-open on non-`.py` paths and missing files. Catches errors before they land on disk. |
 | `read-before-edit` | preToolUse + postToolUse | Tracks viewed files (postToolUse on `view`), warns on `edit`/`create` of files not yet read in session (fail-open). |
 | `read-tracker` | preToolUse | Warns on repeated `view` reads of the same file in a session, using shared per-session state populated by `token-tracker`; configurable ignores via `READ_TRACKER_IGNORE_SUFFIXES`; never blocks. |
+| `loop-detector` | preToolUse | Detects consecutive identical tool calls using SHA-256 signatures of sorted `{tool, args}` (metadata keys stripped). Soft warning at 3 repeats (`LOOP_SOFT_THRESHOLD`), hard deny at 5 (`LOOP_HARD_THRESHOLD`). Thread-safe state, fail-open on errors. |
 | `block-edit-dist` | preToolUse | Blocks `edit`/`create` targeting `browse-ui/dist/`. These are build artifacts — run `cd browse-ui && pnpm build` instead. |
 | `pnpm-lockfile-guard` | preToolUse | Blocks staging `browse-ui/package.json` changes without a matching `pnpm-lock.yaml` update. Prevents lockfile drift. |
 | `block-unsafe-html` | preToolUse | Blocks `dangerouslySetInnerHTML` usage in `.ts`/`.tsx` files without `DOMPurify.sanitize()` or the `<Highlight>` component. |

--- a/hooks/rules/__init__.py
+++ b/hooks/rules/__init__.py
@@ -32,6 +32,7 @@ def get_rules_for_event(event):
     from .integrity import IntegrityRule
     from .learn_gate import EnforceLearnRule
     from .learn_reminder import LearnReminderRule
+    from .loop_detector import LoopDetectorRule
     from .new_file_advisory import NewFileAdvisoryRule
     from .nextjs_typecheck import NextjsTypecheckRule
     from .pnpm_lockfile_guard import PnpmLockfileGuardRule
@@ -70,6 +71,7 @@ def get_rules_for_event(event):
         NewFileAdvisoryRule(),
         ReadBeforeEditRule(),
         ReadTrackerRule(),  # Issue #85: warn on repeat reads (preToolUse)
+        LoopDetectorRule(),  # Issue #663: detect repeated identical tool calls
         # postToolUse (all run, output is informational)
         TrackEditsRule(),
         LearnReminderRule(),

--- a/hooks/rules/loop_detector.py
+++ b/hooks/rules/loop_detector.py
@@ -1,0 +1,125 @@
+"""Loop detection hook rule — Issue #663.
+
+Detects when the agent calls the same tool with identical arguments
+repeatedly in a session.  Inspired by Cline's loop-detection.ts.
+
+Detection strategy
+------------------
+* Fires on ``preToolUse`` for **all** tools.
+* Computes a SHA-256 signature of ``json.dumps(sorted({tool_name, args}))``
+  with transient metadata keys stripped.
+* Tracks consecutive identical-signature calls via session state.
+
+Thresholds
+----------
+* **Soft** (default 3): ``info()`` warning — non-blocking, fires ONCE per streak.
+* **Hard** (default 5): ``deny()`` — blocks the tool call.
+
+Configuration
+-------------
+* ``LOOP_SOFT_THRESHOLD`` env var: override soft threshold (default 3).
+* ``LOOP_HARD_THRESHOLD`` env var: override hard threshold (default 5).
+
+Fail-open: any exception returns None (never blocks tool use).
+"""
+
+import hashlib
+import json
+import os
+
+from . import Rule
+from .common import deny, info, update_session_state
+
+_DEFAULT_SOFT = 3
+_DEFAULT_HARD = 5
+
+# Metadata keys stripped before hashing — transient per-invocation fields.
+_STRIP_KEYS = frozenset(
+    {
+        "_session_id",
+        "_timestamp",
+        "_request_id",
+        "_trace_id",
+        "sessionId",
+        "timestamp",
+    }
+)
+
+
+def _get_threshold(env_var: str, default: int) -> int:
+    """Read an integer threshold from an env var, falling back to *default*."""
+    raw = os.environ.get(env_var, "")
+    if raw.strip().isdigit():
+        return int(raw.strip())
+    return default
+
+
+def _compute_signature(tool_name: str, tool_args: dict) -> str:
+    """Return SHA-256 hex digest of the canonical (tool_name, cleaned args)."""
+    cleaned = {k: v for k, v in tool_args.items() if k not in _STRIP_KEYS}
+    payload = json.dumps({"tool": tool_name, "args": cleaned}, sort_keys=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class LoopDetectorRule(Rule):
+    """Detect and block repeated identical tool calls."""
+
+    name = "loop-detector"
+    events = ["preToolUse"]
+    tools = []  # All tools
+
+    def evaluate(self, event, data):
+        try:
+            return self._run(data)
+        except Exception:
+            return None  # Fail-open
+
+    def _run(self, data: dict):
+        tool_name = data.get("toolName", "") or ""
+        tool_args = data.get("toolInput") or data.get("toolArgs") or {}
+        if not isinstance(tool_args, dict):
+            tool_args = {}
+
+        sig = _compute_signature(tool_name, tool_args)
+        soft = _get_threshold("LOOP_SOFT_THRESHOLD", _DEFAULT_SOFT)
+        hard = _get_threshold("LOOP_HARD_THRESHOLD", _DEFAULT_HARD)
+
+        # Mutable closure result — populated inside the updater.
+        result = {"action": None}
+
+        def updater(state):
+            ld = state.setdefault(
+                "loop_detector",
+                {
+                    "last_sig": "",
+                    "streak": 0,
+                    "soft_warned": False,
+                },
+            )
+
+            if sig == ld.get("last_sig", ""):
+                ld["streak"] = ld.get("streak", 0) + 1
+            else:
+                # Signature changed — reset streak.
+                ld["last_sig"] = sig
+                ld["streak"] = 1
+                ld["soft_warned"] = False
+
+            streak = ld["streak"]
+
+            if streak >= hard:
+                result["action"] = deny(
+                    f"Loop detected: tool '{tool_name}' called {streak} times "
+                    f"with identical arguments (hard threshold {hard}). "
+                    f"Try a different approach."
+                )
+            elif streak >= soft and not ld.get("soft_warned", False):
+                ld["soft_warned"] = True
+                result["action"] = info(
+                    f"  ⚠ Possible loop: tool '{tool_name}' called {streak} "
+                    f"times with identical arguments. Consider varying your "
+                    f"approach before the hard limit ({hard})."
+                )
+
+        update_session_state(updater, data)
+        return result["action"]


### PR DESCRIPTION
New LoopDetectorRule detects consecutive identical tool calls using SHA-256 signatures. Soft warning at 3 repeats, hard deny at 5. Configurable via env vars. Thread-safe state, fail-open. Tests: 13/13 security, 272/272 fixes. Closes #663