### PR TITLE
fix(install): auto-inject statusLine config (#654)

### DIFF
--- a/install.py
+++ b/install.py
@@ -11,6 +11,7 @@ Usage:
     python install.py --deploy-hooks         # Deploy hooks.json to ~/.copilot/hooks/
     python install.py --deploy-instructions  # Deploy global instructions to ~/.github/
     python install.py --inject-global        # Add session-knowledge to global copilot-instructions
+    python install.py --deploy-statusline    # Inject statusLine config into ~/.copilot/settings.json
     python install.py --install-git-hooks    # Install pre-commit/pre-push into current repo's .git/hooks/
     python install.py --lock-hooks           # Lock hooks with OS immutable flags (tamper protection)
     python install.py --unlock-hooks         # Unlock hooks for updates
@@ -2121,6 +2122,59 @@ def inject_global():
     print(f"  {INFO} Injected pointer block — full policy lives in session-knowledge.instructions.md")
 
 
+def inject_statusline_config():
+    """Auto-inject statusLine config into ~/.copilot/settings.json.
+
+    Builds a platform-specific command string and merges the statusLine
+    block into settings.json.  Skips injection when the key already exists.
+    """
+    settings_path = COPILOT_DIR / "settings.json"
+    print("\nStatusLine Config Injection")
+    print(f"  Target: {_tilde(settings_path)}")
+
+    # --- build platform-specific command ---
+    statusline_script = TOOLS_DIR / "statusline.py"
+    if not statusline_script.is_file():
+        print(f"  {FAIL} statusline.py not found at {_tilde(statusline_script)}")
+        return
+
+    if os.name == "nt":
+        # Windows: use 'python' prefix + absolute path with forward slashes
+        abs_path = str(statusline_script).replace("\\", "/")
+        command = f"python {abs_path}"
+    else:
+        # macOS / Linux: use 'python3' + tilde-based path
+        command = "python3 ~/.copilot/tools/statusline.py"
+
+    statusline_block = {
+        "type": "command",
+        "command": command,
+        "padding": 1,
+    }
+
+    # --- read existing settings or start fresh ---
+    settings: dict = {}
+    if settings_path.is_file():
+        try:
+            raw = settings_path.read_text(encoding="utf-8")
+            settings = json.loads(raw)
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"  {WARN} Could not parse {_tilde(settings_path)}: {exc}")
+            print(f"  {INFO} Skipping statusLine injection to avoid data loss")
+            return
+
+    # --- skip if already configured ---
+    if "statusLine" in settings:
+        print(f"  {INFO} statusLine already configured — skipping")
+        return
+
+    # --- merge and write ---
+    settings["statusLine"] = statusline_block
+    COPILOT_DIR.mkdir(parents=True, exist_ok=True)
+    _atomic_write_text(settings_path, json.dumps(settings, indent=2, ensure_ascii=False) + "\n")
+    print(f"  {OK} Injected statusLine config (command: {command})")
+
+
 # ===================================================================
 # 3. Self-Test
 # ===================================================================
@@ -2433,6 +2487,7 @@ def install():
     print("\n  Installing sk launcher...")
     install_sk_launcher()
     deploy_global_skills()
+    inject_statusline_config()
     _record_managed_paths(managed_paths)
     _show_usage_hints()
 
@@ -3123,6 +3178,10 @@ def main():
 
     if "--inject-global" in args:
         inject_global()
+        return
+
+    if "--deploy-statusline" in args:
+        inject_statusline_config()
         return
 
     if "--test" in args:


### PR DESCRIPTION
install.py now auto-injects statusLine config into settings.json during install. Handles Windows (python + absolute path) and macOS/Linux (python3 + tilde path). Skips if already configured. Adds --deploy-statusline CLI flag. Tests: 13/13 security, 272/272 fixes. Closes #654