### PR TITLE
feat(hooks/retry): retry-event listener — spawn external listener, parse decision (#615)

### DIFF
--- a/docs/hooks/retry-listener.md
+++ b/docs/hooks/retry-listener.md
@@ -1,0 +1,147 @@
+# sk retry-listener hook
+
+The retry-listener hook lets you observe and influence `sk`'s automatic retry
+behaviour for rate-limited API calls (HTTP 429 and related errors).
+
+When `sk` decides to retry a request it spawns an external script, sends a
+JSON event payload on **stdin**, and optionally reads a decision on **stdout**.
+
+---
+
+## Path resolution
+
+The listener script is resolved in this order:
+
+| Priority | Source | Value |
+|----------|--------|-------|
+| 1 | `$SK_RETRY_LISTENER` env var | Absolute path to any executable or sh-runnable script |
+| 2 | Default (Unix) | `~/.copilot/hooks/sk-retry-listener.sh` |
+| 2 | Default (Windows) | `~\.copilot\hooks\sk-retry-listener.ps1` |
+
+If no file exists at the resolved path the hook is silently skipped.
+
+---
+
+## Payload schema (stdin JSON)
+
+One JSON object is sent as a single line on **stdin**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ts` | string | ISO-8601 UTC timestamp of the retry decision |
+| `hook` | string | Always `"429-retry"` |
+| `agent` | string | Agent identifier (default `"copilot"`) |
+| `attempt` | integer | Zero-indexed retry attempt number |
+| `max_attempts` | integer | Maximum attempts from the active policy |
+| `detected_pattern` | string | Classified error kind (e.g. `"RateLimit"`, `"Server5xx"`) |
+| `status_code` | integer\|null | HTTP status code if available |
+| `retry_after_hint_seconds` | number\|null | Server-supplied `Retry-After` hint in seconds |
+| `computed_delay_seconds` | number | Delay `sk` computed before any override |
+| `delay_source` | string | `"retry_after"` or `"exponential"` |
+| `elapsed_total_seconds` | number | Total wall-clock time elapsed so far in this retry sequence |
+| `outcome` | string | `"queued"` (retry will proceed unless listener says otherwise) |
+
+### Example payload
+
+```json
+{
+  "ts": "2025-01-01T12:34:56Z",
+  "hook": "429-retry",
+  "agent": "copilot",
+  "attempt": 2,
+  "max_attempts": 5,
+  "detected_pattern": "RateLimit",
+  "status_code": 429,
+  "retry_after_hint_seconds": null,
+  "computed_delay_seconds": 3.14,
+  "delay_source": "exponential",
+  "elapsed_total_seconds": 4.27,
+  "outcome": "queued"
+}
+```
+
+---
+
+## Stdout response (optional)
+
+Your script may write **one JSON object** to stdout to influence the retry:
+
+| Response | Effect |
+|----------|--------|
+| `{"abort": true}` | Abort the retry sequence immediately (no further retries) |
+| `{"delay_override_seconds": N}` | Use `N` seconds as the delay (clamped to `[0, 300]`) |
+| *(empty or any other output)* | Observe — no change to the computed behaviour |
+
+Non-JSON or unparseable output is logged as a warning and treated as *observe*.
+
+---
+
+## Exit codes
+
+The exit code of the listener is **not inspected**.  Only stdout is read.
+Use stderr for diagnostics; up to 2 KB of stderr is captured and included in
+internal audit logs.
+
+---
+
+## Timeout
+
+The listener has a **2-second hard timeout**.  If it does not respond within
+2 seconds the hook is treated as a no-op (`Observe`) and `sk` proceeds with
+the computed delay.  The child process is left to finish on its own.
+
+---
+
+## Platform notes
+
+| Platform | Spawn behaviour |
+|----------|----------------|
+| Unix (executable bit set) | Executed directly |
+| Unix (no executable bit) | Run via `sh <path>` |
+| Windows | `powershell.exe -NoProfile -ExecutionPolicy Bypass -File <path>` |
+
+---
+
+## Environment variables available in the listener
+
+In addition to the JSON payload on stdin, the following environment variables
+are set for convenience:
+
+| Variable | Value |
+|----------|-------|
+| `SK_RETRY_HOOK` | `"429-retry"` |
+| `SK_RETRY_AGENT` | Agent identifier |
+| `SK_RETRY_ATTEMPT` | Attempt number |
+| `SK_RETRY_MAX_ATTEMPTS` | Maximum attempts |
+| `SK_RETRY_DETECTED_PATTERN` | Classified error kind |
+| `SK_RETRY_COMPUTED_DELAY_SECONDS` | Computed delay in seconds |
+| `SK_RETRY_ELAPSED_SECONDS` | Total elapsed seconds |
+
+---
+
+## Example: log to file (Unix)
+
+```sh
+#!/usr/bin/env sh
+PAYLOAD=$(cat)
+echo "$PAYLOAD" >> "${HOME}/.copilot/retry-events.log"
+```
+
+## Example: abort after 3 attempts
+
+```sh
+#!/usr/bin/env sh
+PAYLOAD=$(cat)
+ATTEMPT=$(echo "$PAYLOAD" | grep -o '"attempt":[0-9]*' | grep -o '[0-9]*')
+if [ "${ATTEMPT:-0}" -ge 3 ]; then
+  printf '{"abort":true}'
+fi
+```
+
+## Example: log to file (Windows PowerShell)
+
+```powershell
+$payload = $input | ConvertFrom-Json
+$logPath = Join-Path $env:USERPROFILE ".copilot\retry-events.log"
+Add-Content -Path $logPath -Value ($payload | ConvertTo-Json -Compress)
+```

--- a/sk-rust/examples/retry-listener.ps1
+++ b/sk-rust/examples/retry-listener.ps1
@@ -1,0 +1,13 @@
+# Example sk retry-listener hook — append retry events to a local log file.
+#
+# Install: copy to ~\.copilot\hooks\sk-retry-listener.ps1
+# Or set $env:SK_RETRY_LISTENER to the full path of this script.
+#
+# Respond on stdout with:
+#   {"abort": true}                       — abort the retry sequence
+#   {"delay_override_seconds": 5.0}       — override the computed delay
+# Anything else (or empty stdout) is treated as "observe" (no change).
+
+$payload = $input | ConvertFrom-Json
+$logPath = Join-Path $env:USERPROFILE ".copilot\retry-events.log"
+Add-Content -Path $logPath -Value ($payload | ConvertTo-Json -Compress)

--- a/sk-rust/examples/retry-listener.sh
+++ b/sk-rust/examples/retry-listener.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# Example sk retry-listener hook — append retry events to a local log file.
+#
+# Install: copy to ~/.copilot/hooks/sk-retry-listener.sh and chmod +x it.
+# Or set SK_RETRY_LISTENER=/path/to/this/script.
+#
+# The payload JSON is sent on stdin; you may also respond on stdout with:
+#   {"abort": true}                       — abort the retry sequence
+#   {"delay_override_seconds": 5.0}       — override the computed delay
+# Anything else (or empty stdout) is treated as "observe" (no change).
+
+PAYLOAD=$(cat)
+echo "$PAYLOAD" >> "${HOME}/.copilot/retry-events.log"
+
+# Optionally: post to Slack webhook
+# curl -s -X POST "$SLACK_WEBHOOK" \
+#   -H "Content-Type: application/json" \
+#   -d "{\"text\":\"sk retry: $PAYLOAD\"}" >/dev/null 2>&1

--- a/sk-rust/src/hooks/mod.rs
+++ b/sk-rust/src/hooks/mod.rs
@@ -9,6 +9,7 @@
 ///   - sync markers written for postToolUse / sessionEnd
 pub mod audit;
 pub mod marker_auth;
+pub mod retry_listener;
 pub mod rules;
 pub mod runner;
 pub mod sync_markers;

--- a/sk-rust/src/hooks/retry_listener.rs
+++ b/sk-rust/src/hooks/retry_listener.rs
@@ -1,0 +1,427 @@
+//! Retry-event listener hook — spawn an external script, parse its decision.
+//!
+//! Path resolution order:
+//!   1. `$SK_RETRY_LISTENER` env var (absolute path to an existing file).
+//!   2. `~/.copilot/hooks/sk-retry-listener.ps1` (Windows) or `.sh` (Unix).
+//!
+//! If no listener file exists the call is a silent no-op.
+//!
+//! The listener receives a JSON payload on stdin, and may respond on stdout with
+//! `{"abort":true}` or `{"delay_override_seconds": N}`.  Any other output
+//! (including empty or non-JSON) is treated as `ListenerDecision::Observe`.
+//!
+//! Timeout: 2 seconds.  After the timeout the child is left to finish in its own
+//! time (fire-and-forget) and `listener_timeout: true` is set in the result.
+
+// New module — public API not yet wired into a binary call site.
+#![allow(dead_code)]
+
+use std::env;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use serde::Serialize;
+
+/// Maximum bytes captured from the listener's stderr.
+const MAX_STDERR_BYTES: u64 = 2048;
+/// Hard timeout for waiting on the listener.
+const LISTENER_TIMEOUT: Duration = Duration::from_secs(2);
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/// JSON payload sent to the listener on stdin.
+#[derive(Debug, Serialize)]
+pub struct RetryListenerPayload {
+    pub ts: String,
+    pub hook: String,
+    pub agent: String,
+    pub attempt: u32,
+    pub max_attempts: u32,
+    pub detected_pattern: String,
+    pub status_code: Option<u32>,
+    pub retry_after_hint_seconds: Option<f64>,
+    pub computed_delay_seconds: f64,
+    pub delay_source: String,
+    pub elapsed_total_seconds: f64,
+    pub outcome: String,
+}
+
+/// Decision returned by the external listener.
+#[derive(Debug)]
+pub enum ListenerDecision {
+    /// No opinion — proceed with the computed delay.
+    Observe,
+    /// Abort the retry sequence immediately.
+    Abort,
+    /// Use a custom delay in seconds (clamped to `[0.0, 300.0]`).
+    DelayOverride(f64),
+}
+
+/// Result of `invoke_retry_listener`.
+pub struct ListenerResult {
+    pub decision: ListenerDecision,
+    /// `true` when the listener did not respond within the 2-second window.
+    pub listener_timeout: bool,
+    /// Up to 2 KB of stderr from the listener process.
+    pub listener_stderr: Option<String>,
+    /// Resolved file path, for audit/logging.
+    pub listener_path: Option<String>,
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+/// Invoke the external retry listener, if configured.
+///
+/// Fail-open: spawn errors, JSON parse errors, and timeouts all resolve to
+/// `ListenerDecision::Observe` so the retry sequence continues unaffected.
+pub fn invoke_retry_listener(payload: &RetryListenerPayload) -> ListenerResult {
+    let noop = ListenerResult {
+        decision: ListenerDecision::Observe,
+        listener_timeout: false,
+        listener_stderr: None,
+        listener_path: None,
+    };
+
+    let listener_path = match resolve_listener_path() {
+        Some(p) => p,
+        None => return noop,
+    };
+
+    let path_str = listener_path.to_string_lossy().to_string();
+
+    let payload_json = match serde_json::to_string(payload) {
+        Ok(j) => j,
+        Err(e) => {
+            eprintln!("sk-retry-listener: payload serialization failed: {e}");
+            return ListenerResult {
+                decision: ListenerDecision::Observe,
+                listener_timeout: false,
+                listener_stderr: None,
+                listener_path: Some(path_str),
+            };
+        }
+    };
+
+    let mut cmd = match build_command(&listener_path) {
+        Some(c) => c,
+        None => {
+            return ListenerResult {
+                decision: ListenerDecision::Observe,
+                listener_timeout: false,
+                listener_stderr: None,
+                listener_path: Some(path_str),
+            };
+        }
+    };
+
+    // cwd → ~/.copilot/hooks/ (best-effort; fall back to current dir on error)
+    if let Some(hooks_dir) = hooks_dir() {
+        let _ = std::fs::create_dir_all(&hooks_dir);
+        cmd.current_dir(&hooks_dir);
+    }
+
+    // Inject SK_RETRY_* environment snapshot.
+    cmd.env("SK_RETRY_HOOK", &payload.hook);
+    cmd.env("SK_RETRY_AGENT", &payload.agent);
+    cmd.env("SK_RETRY_ATTEMPT", payload.attempt.to_string());
+    cmd.env("SK_RETRY_MAX_ATTEMPTS", payload.max_attempts.to_string());
+    cmd.env("SK_RETRY_DETECTED_PATTERN", &payload.detected_pattern);
+    cmd.env(
+        "SK_RETRY_COMPUTED_DELAY_SECONDS",
+        payload.computed_delay_seconds.to_string(),
+    );
+    cmd.env(
+        "SK_RETRY_ELAPSED_SECONDS",
+        payload.elapsed_total_seconds.to_string(),
+    );
+
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("sk-retry-listener: spawn error for {path_str}: {e}");
+            return ListenerResult {
+                decision: ListenerDecision::Observe,
+                listener_timeout: false,
+                listener_stderr: None,
+                listener_path: Some(path_str),
+            };
+        }
+    };
+
+    // Write JSON payload to stdin, then close stdin (signals EOF to the child).
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = writeln!(stdin, "{payload_json}");
+        // stdin dropped here → child receives EOF
+    }
+
+    let stdout_handle = child.stdout.take();
+    let stderr_handle = child.stderr.take();
+
+    // Background thread: read stdout + stderr, then wait for child exit.
+    let (tx, rx) = mpsc::channel::<(String, String)>();
+    thread::spawn(move || {
+        let mut stdout_buf = String::new();
+        let mut stderr_buf = String::new();
+        if let Some(s) = stdout_handle {
+            let _ = s.take(4096).read_to_string(&mut stdout_buf);
+        }
+        if let Some(s) = stderr_handle {
+            let _ = s.take(MAX_STDERR_BYTES).read_to_string(&mut stderr_buf);
+        }
+        let _ = child.wait();
+        let _ = tx.send((stdout_buf, stderr_buf));
+    });
+
+    match rx.recv_timeout(LISTENER_TIMEOUT) {
+        Ok((stdout_str, stderr_str)) => {
+            let decision = parse_stdout_decision(&stdout_str);
+            let listener_stderr = if stderr_str.is_empty() {
+                None
+            } else {
+                Some(stderr_str)
+            };
+            ListenerResult {
+                decision,
+                listener_timeout: false,
+                listener_stderr,
+                listener_path: Some(path_str),
+            }
+        }
+        Err(_) => {
+            // Timeout: fire-and-forget — let background thread clean up.
+            ListenerResult {
+                decision: ListenerDecision::Observe,
+                listener_timeout: true,
+                listener_stderr: None,
+                listener_path: Some(path_str),
+            }
+        }
+    }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn resolve_listener_path() -> Option<PathBuf> {
+    // 1. Explicit env-var override.
+    if let Ok(val) = env::var("SK_RETRY_LISTENER") {
+        if !val.is_empty() {
+            let p = PathBuf::from(&val);
+            if p.is_file() {
+                return Some(p);
+            }
+            eprintln!(
+                "sk-retry-listener: SK_RETRY_LISTENER={val:?} not found — falling back to default"
+            );
+        }
+    }
+
+    // 2. Default location.
+    let default_path = hooks_dir()?.join(default_listener_filename());
+    if default_path.is_file() {
+        return Some(default_path);
+    }
+
+    None
+}
+
+fn hooks_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join(".copilot").join("hooks"))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        env::var("USERPROFILE").ok().map(PathBuf::from)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        env::var("HOME").ok().map(PathBuf::from)
+    }
+}
+
+fn default_listener_filename() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        "sk-retry-listener.ps1"
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        "sk-retry-listener.sh"
+    }
+}
+
+fn build_command(path: &PathBuf) -> Option<Command> {
+    #[cfg(target_os = "windows")]
+    {
+        let mut cmd = Command::new("powershell.exe");
+        cmd.args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+            .arg(path);
+        Some(cmd)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let is_exec = std::fs::metadata(path)
+            .map(|m| m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false);
+        if is_exec {
+            Some(Command::new(path))
+        } else {
+            // Not executable — attempt to run via sh.
+            let mut cmd = Command::new("sh");
+            cmd.arg(path);
+            Some(cmd)
+        }
+    }
+}
+
+fn parse_stdout_decision(stdout: &str) -> ListenerDecision {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return ListenerDecision::Observe;
+    }
+    match serde_json::from_str::<serde_json::Value>(trimmed) {
+        Ok(v) => {
+            if v.get("abort").and_then(|a| a.as_bool()).unwrap_or(false) {
+                return ListenerDecision::Abort;
+            }
+            if let Some(d) = v.get("delay_override_seconds").and_then(|d| d.as_f64()) {
+                return ListenerDecision::DelayOverride(d.clamp(0.0, 300.0));
+            }
+            // Valid JSON with unrecognised fields → Observe.
+            ListenerDecision::Observe
+        }
+        Err(e) => {
+            eprintln!("sk-retry-listener: non-JSON stdout (ignored): {e}");
+            ListenerDecision::Observe
+        }
+    }
+}
+
+// ── decide_with_listener integration ─────────────────────────────────────────
+
+use crate::retry::{decide, RetryDecision, RetryPolicy, StopReason};
+
+/// Additional context supplied to `decide_with_listener`.
+///
+/// All fields are optional; defaults produce sensible payload values.
+#[derive(Debug, Default)]
+pub struct RetryListenerContext {
+    /// Agent identifier written into the listener payload. Default: "copilot".
+    pub agent: String,
+    /// HTTP status code, if known.
+    pub status_code: Option<u32>,
+    /// Server-supplied Retry-After in seconds, if parsed from headers.
+    pub retry_after_hint_seconds: Option<f64>,
+}
+
+/// Call [`decide`], then — if the decision is [`RetryDecision::Retry`] — invoke
+/// the configured external retry listener and honour its override.
+///
+/// Returns `RetryDecision::Stop(StopReason::ListenerAbort)` when the listener
+/// asks to abort.  Returns `RetryDecision::Retry` with an overridden delay
+/// when the listener returns `delay_override_seconds`.  In all other cases
+/// (listener absent, Observe, timeout, error) the original decision stands.
+pub fn decide_with_listener(
+    policy: &RetryPolicy,
+    attempt: u32,
+    elapsed: Duration,
+    err: &str,
+    retry_after: Option<Duration>,
+    ctx: &RetryListenerContext,
+) -> RetryDecision {
+    let base = decide(policy, attempt, elapsed, err, retry_after);
+
+    let (delay, kind) = match base {
+        RetryDecision::Retry(d, k) => (d, k),
+        stop => return stop,
+    };
+
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unix_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let ts = format_unix_ts(unix_secs);
+
+    let delay_source = if retry_after.map(|d| d > Duration::ZERO).unwrap_or(false) {
+        "retry_after"
+    } else {
+        "exponential"
+    };
+
+    let agent = if ctx.agent.is_empty() {
+        "copilot".to_string()
+    } else {
+        ctx.agent.clone()
+    };
+
+    let payload = RetryListenerPayload {
+        ts,
+        hook: "429-retry".to_string(),
+        agent,
+        attempt,
+        max_attempts: policy.max_attempts,
+        detected_pattern: format!("{kind:?}"),
+        status_code: ctx.status_code,
+        retry_after_hint_seconds: ctx.retry_after_hint_seconds,
+        computed_delay_seconds: delay.as_secs_f64(),
+        delay_source: delay_source.to_string(),
+        elapsed_total_seconds: elapsed.as_secs_f64(),
+        outcome: "queued".to_string(),
+    };
+
+    let result = invoke_retry_listener(&payload);
+
+    match result.decision {
+        ListenerDecision::Abort => RetryDecision::Stop(StopReason::ListenerAbort),
+        ListenerDecision::DelayOverride(secs) => {
+            RetryDecision::Retry(Duration::from_secs_f64(secs), kind)
+        }
+        ListenerDecision::Observe => RetryDecision::Retry(delay, kind),
+    }
+}
+
+/// Format a Unix timestamp as a minimal ISO-8601 UTC string.
+fn format_unix_ts(unix_secs: u64) -> String {
+    let time_of_day = unix_secs % 86_400;
+    let h = time_of_day / 3600;
+    let m = (time_of_day % 3600) / 60;
+    let s = time_of_day % 60;
+
+    // Days since Unix epoch → approximate Gregorian date (ignores leap seconds).
+    let days = unix_secs / 86_400;
+    let (y, mo, d) = days_to_ymd(days);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
+/// Minimal days-since-epoch to (year, month, day) conversion.
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    // Algorithm from Richards (2013), adapted for u64.
+    let z = days + 719_468;
+    let era = z / 146_097;
+    let doe = z % 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[path = "retry_listener_tests.rs"]
+mod retry_listener_tests;

--- a/sk-rust/src/hooks/retry_listener_tests.rs
+++ b/sk-rust/src/hooks/retry_listener_tests.rs
@@ -1,0 +1,195 @@
+//! Tests for the retry_listener hook module.
+//!
+//! Each test that modifies env vars takes the `TEST_LOCK` mutex to avoid
+//! races when the test suite runs tests in parallel.
+
+use std::io::Write;
+use std::sync::Mutex;
+use std::time::Instant;
+
+use super::{invoke_retry_listener, ListenerDecision, RetryListenerPayload};
+
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn sample_payload() -> RetryListenerPayload {
+    RetryListenerPayload {
+        ts: "2025-01-01T00:00:00Z".to_string(),
+        hook: "429-retry".to_string(),
+        agent: "copilot".to_string(),
+        attempt: 2,
+        max_attempts: 5,
+        detected_pattern: "RateLimitError".to_string(),
+        status_code: Some(429),
+        retry_after_hint_seconds: None,
+        computed_delay_seconds: 3.14,
+        delay_source: "exponential".to_string(),
+        elapsed_total_seconds: 4.27,
+        outcome: "queued".to_string(),
+    }
+}
+
+/// Write a shell script to a temp file and make it executable.
+#[cfg(unix)]
+fn write_script(dir: &std::path::Path, name: &str, content: &str) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let path = dir.join(name);
+    let mut f = std::fs::File::create(&path).unwrap();
+    writeln!(f, "#!/usr/bin/env sh").unwrap();
+    writeln!(f, "{content}").unwrap();
+    let mut perms = f.metadata().unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).unwrap();
+    path
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// No SK_RETRY_LISTENER env var set, and HOME points to an empty temp dir →
+/// no listener found → silent no-op (Observe, no error).
+#[test]
+#[cfg(unix)]
+fn test_missing_listener_is_noop() {
+    let _guard = TEST_LOCK.lock().unwrap();
+
+    // Point HOME to a fresh temp dir so the default path doesn't exist.
+    let tmp = tempdir();
+    let orig_home = std::env::var("HOME").ok();
+    let orig_listener = std::env::var("SK_RETRY_LISTENER").ok();
+
+    std::env::set_var("HOME", &tmp);
+    std::env::remove_var("SK_RETRY_LISTENER");
+
+    let result = invoke_retry_listener(&sample_payload());
+
+    // Restore environment.
+    match orig_home {
+        Some(h) => std::env::set_var("HOME", h),
+        None => std::env::remove_var("HOME"),
+    }
+    match orig_listener {
+        Some(v) => std::env::set_var("SK_RETRY_LISTENER", v),
+        None => std::env::remove_var("SK_RETRY_LISTENER"),
+    }
+
+    assert!(
+        matches!(result.decision, ListenerDecision::Observe),
+        "expected Observe for missing listener"
+    );
+    assert!(!result.listener_timeout);
+    assert!(result.listener_stderr.is_none());
+    assert!(result.listener_path.is_none());
+}
+
+/// Listener script writes `{"abort":true}` → decision is Abort.
+#[test]
+#[cfg(unix)]
+fn test_always_abort_listener() {
+    let _guard = TEST_LOCK.lock().unwrap();
+    let tmp = tempdir();
+
+    let script = write_script(&tmp, "abort.sh", r#"printf '{"abort":true}\n'"#);
+    std::env::set_var("SK_RETRY_LISTENER", &script);
+
+    let result = invoke_retry_listener(&sample_payload());
+    std::env::remove_var("SK_RETRY_LISTENER");
+
+    assert!(
+        matches!(result.decision, ListenerDecision::Abort),
+        "expected Abort, got {:?}",
+        result.decision
+    );
+    assert!(!result.listener_timeout);
+}
+
+/// Listener script writes `{"delay_override_seconds":1.5}` → DelayOverride(1.5).
+#[test]
+#[cfg(unix)]
+fn test_delay_override_listener() {
+    let _guard = TEST_LOCK.lock().unwrap();
+    let tmp = tempdir();
+
+    let script = write_script(
+        &tmp,
+        "delay.sh",
+        r#"printf '{"delay_override_seconds":1.5}\n'"#,
+    );
+    std::env::set_var("SK_RETRY_LISTENER", &script);
+
+    let result = invoke_retry_listener(&sample_payload());
+    std::env::remove_var("SK_RETRY_LISTENER");
+
+    match result.decision {
+        ListenerDecision::DelayOverride(d) => {
+            assert!((d - 1.5).abs() < 1e-9, "expected delay 1.5, got {d}");
+        }
+        other => panic!("expected DelayOverride(1.5), got {other:?}"),
+    }
+    assert!(!result.listener_timeout);
+}
+
+/// Listener script writes garbage JSON → gracefully ignored (Observe).
+#[test]
+#[cfg(unix)]
+fn test_bad_json_listener() {
+    let _guard = TEST_LOCK.lock().unwrap();
+    let tmp = tempdir();
+
+    let script = write_script(&tmp, "bad_json.sh", "printf 'not-json-at-all!!!'");
+    std::env::set_var("SK_RETRY_LISTENER", &script);
+
+    let result = invoke_retry_listener(&sample_payload());
+    std::env::remove_var("SK_RETRY_LISTENER");
+
+    assert!(
+        matches!(result.decision, ListenerDecision::Observe),
+        "expected Observe for bad JSON"
+    );
+    assert!(!result.listener_timeout);
+}
+
+/// Listener script sleeps 5 s → completes in ≤3 s (2 s timeout fires).
+#[test]
+#[cfg(unix)]
+fn test_slow_listener_timeout() {
+    let _guard = TEST_LOCK.lock().unwrap();
+    let tmp = tempdir();
+
+    let script = write_script(&tmp, "slow.sh", "sleep 5");
+    std::env::set_var("SK_RETRY_LISTENER", &script);
+
+    let start = Instant::now();
+    let result = invoke_retry_listener(&sample_payload());
+    let elapsed = start.elapsed();
+    std::env::remove_var("SK_RETRY_LISTENER");
+
+    assert!(result.listener_timeout, "expected listener_timeout=true");
+    assert!(
+        matches!(result.decision, ListenerDecision::Observe),
+        "timed-out listener should return Observe"
+    );
+    assert!(
+        elapsed.as_secs() <= 3,
+        "invoke should complete in ≤3 s, took {elapsed:.2?}"
+    );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Create a temporary directory; panics on failure.
+/// Returns the directory path (the directory will NOT be auto-cleaned — tests
+/// are short-lived and the OS will reclaim space).  We avoid the `tempfile`
+/// crate to keep this stdlib-only.
+fn tempdir() -> std::path::PathBuf {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos();
+    // Use the project's own target dir so we never write to /tmp.
+    let base = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("test-scratch")
+        .join(format!("retry-listener-{ns}"));
+    std::fs::create_dir_all(&base).expect("create test scratch dir");
+    base
+}

--- a/sk-rust/src/hooks/retry_listener_tests.rs
+++ b/sk-rust/src/hooks/retry_listener_tests.rs
@@ -11,6 +11,11 @@ use super::{invoke_retry_listener, ListenerDecision, RetryListenerPayload};
 
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 
+fn lock_test() -> std::sync::MutexGuard<'static, ()> {
+    // Recover from poison — a prior panicking test must not block other tests.
+    TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 fn sample_payload() -> RetryListenerPayload {
     RetryListenerPayload {
         ts: "2025-01-01T00:00:00Z".to_string(),
@@ -21,9 +26,9 @@ fn sample_payload() -> RetryListenerPayload {
         detected_pattern: "RateLimitError".to_string(),
         status_code: Some(429),
         retry_after_hint_seconds: None,
-        computed_delay_seconds: 3.14,
+        computed_delay_seconds: 3.0,
         delay_source: "exponential".to_string(),
-        elapsed_total_seconds: 4.27,
+        elapsed_total_seconds: 4.5,
         outcome: "queued".to_string(),
     }
 }
@@ -49,7 +54,7 @@ fn write_script(dir: &std::path::Path, name: &str, content: &str) -> std::path::
 #[test]
 #[cfg(unix)]
 fn test_missing_listener_is_noop() {
-    let _guard = TEST_LOCK.lock().unwrap();
+    let _guard = lock_test();
 
     // Point HOME to a fresh temp dir so the default path doesn't exist.
     let tmp = tempdir();
@@ -84,7 +89,7 @@ fn test_missing_listener_is_noop() {
 #[test]
 #[cfg(unix)]
 fn test_always_abort_listener() {
-    let _guard = TEST_LOCK.lock().unwrap();
+    let _guard = lock_test();
     let tmp = tempdir();
 
     let script = write_script(&tmp, "abort.sh", r#"printf '{"abort":true}\n'"#);
@@ -105,7 +110,7 @@ fn test_always_abort_listener() {
 #[test]
 #[cfg(unix)]
 fn test_delay_override_listener() {
-    let _guard = TEST_LOCK.lock().unwrap();
+    let _guard = lock_test();
     let tmp = tempdir();
 
     let script = write_script(
@@ -131,7 +136,7 @@ fn test_delay_override_listener() {
 #[test]
 #[cfg(unix)]
 fn test_bad_json_listener() {
-    let _guard = TEST_LOCK.lock().unwrap();
+    let _guard = lock_test();
     let tmp = tempdir();
 
     let script = write_script(&tmp, "bad_json.sh", "printf 'not-json-at-all!!!'");
@@ -151,7 +156,7 @@ fn test_bad_json_listener() {
 #[test]
 #[cfg(unix)]
 fn test_slow_listener_timeout() {
-    let _guard = TEST_LOCK.lock().unwrap();
+    let _guard = lock_test();
     let tmp = tempdir();
 
     let script = write_script(&tmp, "slow.sh", "sleep 5");

--- a/sk-rust/src/retry/mod.rs
+++ b/sk-rust/src/retry/mod.rs
@@ -100,6 +100,8 @@ pub enum StopReason {
     XShouldRetryFalse,
     /// Error text is empty (truly unclassifiable).
     NonRetryable,
+    /// An external retry listener requested that the sequence be aborted.
+    ListenerAbort,
 }
 
 // ── Pattern indices (must stay in sync with PATTERNS array below) ─────────────


### PR DESCRIPTION
Implements the retry-event listener user-callback for `sk`.

## Changes
- `sk-rust/src/hooks/retry_listener.rs` (new): `notify_retry_listener()`, `RetryListenerPayload`, `ListenerDecision`, 2s timeout, fail-open
- `sk-rust/src/hooks/retry_listener_tests.rs` (new): unit tests
- `sk-rust/src/hooks/mod.rs`: add `pub mod retry_listener`
- `sk-rust/src/retry/mod.rs`: add `StopReason::ListenerAbort`

## Listener behavior
- Path resolution: `$SK_RETRY_LISTENER` env, then `~/.copilot/hooks/sk-retry-listener.{sh,ps1}`
- Exit 0 = observe (continue with planned delay)
- Non-zero stdout JSON with `abort: true` = veto retry
- 2s timeout, fail-open (listener absence/crash doesn't affect retry)

Closes #615