### PR TITLE
feat(#747): sk briefing --with-code-context — inject code spans pre-task

### DIFF
--- a/briefing.py
+++ b/briefing.py
@@ -4020,6 +4020,72 @@ def generate_never_recalled(fmt: str = "text") -> str:
             pass
 
 
+def _query_code_context(db_path: Path, query: str, token_budget: int = 1000) -> list[dict]:
+    """Query code_fts for relevant snippets. Returns [] if table missing or error."""
+    try:
+        db = sqlite3.connect(str(db_path))
+        has = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='code_index'").fetchone()
+        if not has:
+            db.close()
+            return []
+        char_budget = token_budget * 4
+        results = []
+        safe_q = re.sub(r'["*]|\b(?:OR|AND|NOT|NEAR)\b', " ", query, flags=re.IGNORECASE).strip()
+        if safe_q:
+            try:
+                rows = db.execute(
+                    """SELECT ci.file_path, ci.language, ci.start_line, ci.symbol_name,
+                              ci.content_snippet
+                       FROM code_fts fts JOIN code_index ci ON fts.rowid = ci.id
+                       WHERE code_fts MATCH ? ORDER BY rank LIMIT 10""",
+                    [f'"{safe_q}"'],
+                ).fetchall()
+            except sqlite3.OperationalError:
+                rows = db.execute(
+                    """SELECT file_path, language, start_line, symbol_name, content_snippet
+                       FROM code_index
+                       WHERE LOWER(content_snippet) LIKE ? OR LOWER(symbol_name) LIKE ?
+                       LIMIT 10""",
+                    [f"%{query.lower()}%", f"%{query.lower()}%"],
+                ).fetchall()
+            used = 0
+            for r in rows:
+                snippet = r[4] if isinstance(r, tuple) else r["content_snippet"]
+                if used + len(snippet) > char_budget:
+                    break
+                results.append(
+                    {
+                        "file_path": r[0],
+                        "language": r[1],
+                        "start_line": r[2],
+                        "symbol_name": r[3],
+                        "content": snippet,
+                    }
+                )
+                used += len(snippet)
+        db.close()
+        return results
+    except Exception:
+        return []
+
+
+def _format_code_context(snippets: list[dict]) -> str:
+    """Format code snippets as fenced markdown blocks."""
+    if not snippets:
+        return ""
+    lines = ["\n## Relevant Code Context"]
+    for s in snippets:
+        lang = s.get("language", "")
+        fname = s.get("file_path", "")
+        lineno = s.get("start_line", 0)
+        sym = s.get("symbol_name", "")
+        lines.append(f"\n### {fname}:{lineno} — {sym} ({lang})")
+        lines.append(f"```{lang}")
+        lines.append(s.get("content", "").rstrip())
+        lines.append("```")
+    return "\n".join(lines)
+
+
 def main():
     args = sys.argv[1:]
 
@@ -4283,6 +4349,17 @@ def main():
 
     subagent_mode = "--for-subagent" in args
 
+    # --with-code-context: append relevant code spans from code_index (issue #747)
+    with_code_context = "--with-code-context" in args
+    code_tokens = 1000
+    if "--code-tokens" in args:
+        idx = args.index("--code-tokens")
+        if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+            try:
+                code_tokens = max(100, min(4000, int(args[idx + 1])))
+            except ValueError:
+                code_tokens = 1000
+
     # --pinned [N]: always include top-N P0 entries regardless of query (issue #708)
     pinned_n = 0
     if "--pinned" in args:
@@ -4314,6 +4391,7 @@ def main():
                 "--msg-tag",
                 "--since",
                 "--days",
+                "--code-tokens",
             ) and i + 1 < len(args):
                 consumed_value_indices.add(i + 1)
         query_parts = [
@@ -4451,6 +4529,12 @@ def main():
                 "output_chars": len(output),
             },
         )
+
+    if with_code_context and query and fmt not in ("json", "pack"):
+        snippets = _query_code_context(DB_PATH, query, token_budget=code_tokens)
+        code_section = _format_code_context(snippets)
+        if code_section:
+            output = output + code_section
 
     print(output)
 

--- a/briefing.py
+++ b/briefing.py
@@ -4530,11 +4530,43 @@ def main():
             },
         )
 
-    if with_code_context and query and fmt not in ("json", "pack"):
+    if with_code_context and query and fmt != "json":
         snippets = _query_code_context(DB_PATH, query, token_budget=code_tokens)
-        code_section = _format_code_context(snippets)
-        if code_section:
-            output = output + code_section
+        if snippets:
+            if fmt == "pack":
+                try:
+                    pack_payload = json.loads(output)
+                except json.JSONDecodeError:
+                    pack_payload = None
+                if isinstance(pack_payload, dict):
+                    selected_snippets = []
+                    for snippet in snippets:
+                        candidate_snippets = selected_snippets + [snippet]
+                        candidate_output = json.dumps(
+                            {**pack_payload, "code_context": candidate_snippets},
+                            indent=2,
+                            ensure_ascii=False,
+                        )
+                        if budget and len(candidate_output) > budget:
+                            break
+                        selected_snippets = candidate_snippets
+                    if selected_snippets:
+                        output = json.dumps(
+                            {**pack_payload, "code_context": selected_snippets},
+                            indent=2,
+                            ensure_ascii=False,
+                        )
+            else:
+                code_section = _format_code_context(snippets)
+                if code_section:
+                    if budget:
+                        remaining = max(0, budget - len(output))
+                        if remaining <= 100:
+                            code_section = ""
+                        elif len(code_section) > remaining:
+                            code_section = code_section[:remaining].rsplit("\n", 1)[0]
+                    if code_section:
+                        output = output + code_section
 
     print(output)
 

--- a/briefing.py
+++ b/briefing.py
@@ -4530,6 +4530,7 @@ def main():
             },
         )
 
+    # TODO(issue #754): add focused coverage for pack/code-context budget interactions.
     if with_code_context and query and fmt != "json":
         snippets = _query_code_context(DB_PATH, query, token_budget=code_tokens)
         if snippets:

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -106,7 +106,7 @@ TOOLS = [
                 },
                 "with_code_context": {
                     "type": "boolean",
-                    "description": "Include relevant code spans from indexed codebase (requires sk code-index first).",
+                    "description": "Include relevant code spans from the indexed codebase (via `sk code-search`).",
                 },
                 "code_tokens": {
                     "type": "integer",
@@ -291,6 +291,17 @@ def _optional_int(arguments: dict[str, Any], key: str, *, default: int, minimum:
     return value
 
 
+def _optional_bool(arguments: dict[str, Any], key: str, *, default: bool) -> bool:
+    value = arguments.get(key, default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "false"}:
+            return lowered == "true"
+    raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"'{key}' must be a boolean")
+
+
 def _capture_module_main(module, argv: list[str]) -> tuple[int, str, str]:
     stdout_buf = io.StringIO()
     stderr_buf = io.StringIO()
@@ -321,7 +332,7 @@ def _run_briefing(arguments: dict[str, Any]) -> dict[str, Any]:
     limit = _optional_int(arguments, "limit", default=3, minimum=1, maximum=20)
     agent_tag = _optional_string(arguments, "agent_tag")
     msg_tag = _optional_string(arguments, "msg_tag")
-    with_code_context = arguments.get("with_code_context", False)
+    with_code_context = _optional_bool(arguments, "with_code_context", default=False)
     code_tokens = _optional_int(arguments, "code_tokens", default=1000, minimum=100, maximum=4000)
     argv = [task, "--pack", "--mode", mode, "--limit", str(limit)]
     if agent_tag:

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -104,6 +104,16 @@ TOOLS = [
                     "type": "string",
                     "description": "Filter entries by message tag (e.g. 'msg:review'). Issue #399.",
                 },
+                "with_code_context": {
+                    "type": "boolean",
+                    "description": "Include relevant code spans from indexed codebase (requires sk code-index first).",
+                },
+                "code_tokens": {
+                    "type": "integer",
+                    "minimum": 100,
+                    "maximum": 4000,
+                    "description": "Approximate token budget for code context (default 1000).",
+                },
             },
             "required": ["task"],
             "additionalProperties": False,
@@ -311,11 +321,15 @@ def _run_briefing(arguments: dict[str, Any]) -> dict[str, Any]:
     limit = _optional_int(arguments, "limit", default=3, minimum=1, maximum=20)
     agent_tag = _optional_string(arguments, "agent_tag")
     msg_tag = _optional_string(arguments, "msg_tag")
+    with_code_context = arguments.get("with_code_context", False)
+    code_tokens = _optional_int(arguments, "code_tokens", default=1000, minimum=100, maximum=4000)
     argv = [task, "--pack", "--mode", mode, "--limit", str(limit)]
     if agent_tag:
         argv += ["--agent-tag", agent_tag]
     if msg_tag:
         argv += ["--msg-tag", msg_tag]
+    if with_code_context:
+        argv += ["--with-code-context", "--code-tokens", str(code_tokens)]
     exit_code, stdout_text, stderr_text = _capture_module_main(briefing_mod, argv)
     if exit_code != 0:
         message = stderr_text.strip() or stdout_text.strip() or "briefing failed"

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -293,13 +293,9 @@ def _optional_int(arguments: dict[str, Any], key: str, *, default: int, minimum:
 
 def _optional_bool(arguments: dict[str, Any], key: str, *, default: bool) -> bool:
     value = arguments.get(key, default)
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"true", "false"}:
-            return lowered == "true"
-    raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"'{key}' must be a boolean")
+    if not isinstance(value, bool):
+        raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"'{key}' must be a boolean")
+    return value
 
 
 def _capture_module_main(module, argv: list[str]) -> tuple[int, str, str]:

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -13,6 +13,7 @@ import json
 import os
 import plistlib
 import re
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -2818,6 +2819,314 @@ with tempfile.TemporaryDirectory(prefix="mcp-server-test-") as _mcp_tmp:
                 except subprocess.TimeoutExpired:
                     _mcp_proc.kill()
                     _mcp_proc.wait(timeout=5)
+
+def test_i754_briefing_with_code_context_emits_snippets():
+    base_dir = REPO / "_test_i754_briefing_code_context"
+    shutil.rmtree(base_dir, ignore_errors=True)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        home = _seed_briefing_test_home(base_dir)
+        db_path = home / ".copilot" / "session-state" / "knowledge.db"
+        db = sqlite3.connect(str(db_path))
+        db.executescript(
+            """
+            CREATE TABLE code_index (
+                id INTEGER PRIMARY KEY,
+                file_path TEXT,
+                language TEXT,
+                start_line INTEGER,
+                symbol_name TEXT,
+                content_snippet TEXT
+            );
+            CREATE VIRTUAL TABLE code_fts USING fts5(content_snippet, symbol_name);
+            """
+        )
+        snippet = "def validate_jwt(token):\n    return token.startswith('jwt:')\n"
+        row_id = db.execute(
+            "INSERT INTO code_index(file_path, language, start_line, symbol_name, content_snippet) VALUES (?, ?, ?, ?, ?)",
+            ("src/auth.py", "python", 10, "validate_jwt", snippet),
+        ).lastrowid
+        db.execute(
+            "INSERT INTO code_fts(rowid, content_snippet, symbol_name) VALUES (?, ?, ?)",
+            (row_id, snippet, "validate_jwt"),
+        )
+        db.commit()
+        db.close()
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        proc = _run_utf8_text(
+            [
+                sys.executable,
+                str(REPO / "briefing.py"),
+                "validate_jwt",
+                "--pack",
+                "--with-code-context",
+                "--code-tokens",
+                "120",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        payload = json.loads(proc.stdout or "{}")
+        code_context = payload.get("code_context", [])
+        test("I754-1a: briefing with code context exits 0", proc.returncode == 0, proc.stderr.strip())
+        test("I754-1b: briefing pack output includes code_context", len(code_context) == 1, json.dumps(payload)[:200])
+        if code_context:
+            test(
+                "I754-1c: code context includes indexed snippet",
+                code_context[0].get("symbol_name") == "validate_jwt" and "jwt:" in code_context[0].get("content", ""),
+                json.dumps(code_context[0], ensure_ascii=False),
+            )
+    except Exception as exc:
+        for suffix in ("1a", "1b", "1c"):
+            test(f"I754-{suffix}: briefing code context", False, str(exc))
+    finally:
+        shutil.rmtree(base_dir, ignore_errors=True)
+
+
+def test_i754_briefing_with_code_context_noop_without_index():
+    base_dir = REPO / "_test_i754_briefing_no_index"
+    shutil.rmtree(base_dir, ignore_errors=True)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        home = _seed_briefing_test_home(base_dir)
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        proc = _run_utf8_text(
+            [sys.executable, str(REPO / "briefing.py"), "validate_jwt", "--pack", "--with-code-context"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        payload = json.loads(proc.stdout or "{}")
+        test("I754-2a: briefing without code index exits 0", proc.returncode == 0, proc.stderr.strip())
+        test(
+            "I754-2b: briefing without code index leaves pack unchanged",
+            "code_context" not in payload,
+            json.dumps(payload, ensure_ascii=False)[:200],
+        )
+    except Exception as exc:
+        for suffix in ("2a", "2b"):
+            test(f"I754-{suffix}: briefing without index", False, str(exc))
+    finally:
+        shutil.rmtree(base_dir, ignore_errors=True)
+
+
+def test_i754_briefing_code_context_budget_respected():
+    base_dir = REPO / "_test_i754_briefing_budget"
+    shutil.rmtree(base_dir, ignore_errors=True)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        home = _seed_briefing_test_home(base_dir)
+        db_path = home / ".copilot" / "session-state" / "knowledge.db"
+        db = sqlite3.connect(str(db_path))
+        db.executescript(
+            """
+            CREATE TABLE code_index (
+                id INTEGER PRIMARY KEY,
+                file_path TEXT,
+                language TEXT,
+                start_line INTEGER,
+                symbol_name TEXT,
+                content_snippet TEXT
+            );
+            CREATE VIRTUAL TABLE code_fts USING fts5(content_snippet, symbol_name);
+            """
+        )
+        snippets = [
+            ("src/auth.py", "validate_jwt", "def validate_jwt(token):\n" + "    return token == 'jwt'\n" * 12),
+            ("src/session.py", "refresh_jwt", "def refresh_jwt(token):\n" + "    return token + '-refresh'\n" * 12),
+        ]
+        for file_path, symbol_name, content in snippets:
+            row_id = db.execute(
+                "INSERT INTO code_index(file_path, language, start_line, symbol_name, content_snippet) VALUES (?, ?, ?, ?, ?)",
+                (file_path, "python", 10, symbol_name, content),
+            ).lastrowid
+            db.execute(
+                "INSERT INTO code_fts(rowid, content_snippet, symbol_name) VALUES (?, ?, ?)",
+                (row_id, content, symbol_name),
+            )
+        db.commit()
+        db.close()
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        proc = _run_utf8_text(
+            [
+                sys.executable,
+                str(REPO / "briefing.py"),
+                "jwt",
+                "--pack",
+                "--limit",
+                "1",
+                "--budget",
+                "700",
+                "--with-code-context",
+                "--code-tokens",
+                "100",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        payload = json.loads(proc.stdout or "{}")
+        code_context = payload.get("code_context", [])
+        code_chars = sum(len(item.get("content", "")) for item in code_context)
+        test("I754-3a: briefing budgeted code context exits 0", proc.returncode == 0, proc.stderr.strip())
+        test("I754-3b: code context stays within code_tokens budget", code_chars <= 400, str(code_chars))
+        test("I754-3c: code context stays within briefing budget", len(proc.stdout) <= 700, str(len(proc.stdout)))
+    except Exception as exc:
+        for suffix in ("3a", "3b", "3c"):
+            test(f"I754-{suffix}: briefing budget", False, str(exc))
+    finally:
+        shutil.rmtree(base_dir, ignore_errors=True)
+
+
+def test_i754_mcp_briefing_code_context_validation_and_serving():
+    base_dir = REPO / "_test_i754_mcp_briefing"
+    shutil.rmtree(base_dir, ignore_errors=True)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    proc = None
+    try:
+        home = _seed_briefing_test_home(base_dir)
+        db_path = home / ".copilot" / "session-state" / "knowledge.db"
+        db = sqlite3.connect(str(db_path))
+        db.executescript(
+            """
+            CREATE TABLE code_index (
+                id INTEGER PRIMARY KEY,
+                file_path TEXT,
+                language TEXT,
+                start_line INTEGER,
+                symbol_name TEXT,
+                content_snippet TEXT
+            );
+            CREATE VIRTUAL TABLE code_fts USING fts5(content_snippet, symbol_name);
+            """
+        )
+        snippet = "def validate_jwt(token):\n    return token.startswith('jwt:')\n"
+        row_id = db.execute(
+            "INSERT INTO code_index(file_path, language, start_line, symbol_name, content_snippet) VALUES (?, ?, ?, ?, ?)",
+            ("src/auth.py", "python", 10, "validate_jwt", snippet),
+        ).lastrowid
+        db.execute(
+            "INSERT INTO code_fts(rowid, content_snippet, symbol_name) VALUES (?, ?, ?)",
+            (row_id, snippet, "validate_jwt"),
+        )
+        db.commit()
+        db.close()
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        proc = subprocess.Popen(
+            [sys.executable, str(REPO / "mcp-server.py")],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+
+        _mcp_write(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 101,
+                "method": "initialize",
+                "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test"}},
+            },
+        )
+        _mcp_read(proc)
+        _mcp_write(proc, {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+
+        _mcp_write(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 102,
+                "method": "tools/call",
+                "params": {
+                    "name": "briefing",
+                    "arguments": {"task": "validate_jwt", "with_code_context": True, "code_tokens": 120},
+                },
+            },
+        )
+        with_context = _mcp_read(proc)
+        structured = with_context.get("result", {}).get("structuredContent", {})
+        test(
+            "I754-4a: MCP briefing serves code context",
+            len(structured.get("code_context", [])) == 1,
+            json.dumps(with_context, ensure_ascii=False)[:200],
+        )
+
+        _mcp_write(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 103,
+                "method": "tools/call",
+                "params": {
+                    "name": "briefing",
+                    "arguments": {"task": "validate_jwt", "with_code_context": "false", "code_tokens": 120},
+                },
+            },
+        )
+        with_false = _mcp_read(proc)
+        false_structured = with_false.get("result", {}).get("structuredContent", {})
+        test(
+            "I754-4b: MCP briefing coerces string false",
+            "code_context" not in false_structured,
+            json.dumps(with_false, ensure_ascii=False)[:200],
+        )
+
+        _mcp_write(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 104,
+                "method": "tools/call",
+                "params": {
+                    "name": "briefing",
+                    "arguments": {"task": "validate_jwt", "with_code_context": "bogus"},
+                },
+            },
+        )
+        invalid_bool = _mcp_read(proc)
+        test(
+            "I754-4c: MCP briefing rejects invalid boolean strings",
+            invalid_bool.get("error", {}).get("code") == -32602,
+            json.dumps(invalid_bool, ensure_ascii=False),
+        )
+
+        _mcp_write(proc, {"jsonrpc": "2.0", "id": 105, "method": "shutdown", "params": {}})
+        _mcp_read(proc)
+        _mcp_write(proc, {"jsonrpc": "2.0", "method": "exit", "params": {}})
+        proc.wait(timeout=5)
+        proc = None
+    except Exception as exc:
+        for suffix in ("4a", "4b", "4c"):
+            test(f"I754-{suffix}: MCP briefing code context", False, str(exc))
+    finally:
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        shutil.rmtree(base_dir, ignore_errors=True)
+
+
+test_i754_briefing_with_code_context_emits_snippets()
+test_i754_briefing_with_code_context_noop_without_index()
+test_i754_briefing_code_context_budget_respected()
+test_i754_mcp_briefing_code_context_validation_and_serving()
+
 
 # ─── Priority Classification (#121) ─────────────────────────────────────
 

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -2820,6 +2820,7 @@ with tempfile.TemporaryDirectory(prefix="mcp-server-test-") as _mcp_tmp:
                     _mcp_proc.kill()
                     _mcp_proc.wait(timeout=5)
 
+
 def test_i754_briefing_with_code_context_emits_snippets():
     base_dir = REPO / "_test_i754_briefing_code_context"
     shutil.rmtree(base_dir, ignore_errors=True)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -320,6 +320,35 @@ class TestHandleToolsCall(unittest.TestCase):
             )
         self.assertEqual(ctx.exception.code, mcp.JSONRPC_INVALID_PARAMS)
 
+    def test_briefing_with_code_context_non_bool_raises(self):
+        with self.assertRaises(mcp.JsonRpcError) as ctx:
+            mcp._handle_tools_call(
+                {
+                    "name": "briefing",
+                    "arguments": {"task": "hello", "with_code_context": "false"},
+                }
+            )
+        self.assertEqual(ctx.exception.code, mcp.JSONRPC_INVALID_PARAMS)
+
+    def test_briefing_with_code_context_passes_flags(self):
+        captured_argv = []
+
+        def fake_capture(_module, argv):
+            captured_argv.extend(argv)
+            return 0, json.dumps({"entries": {"patterns": []}}), ""
+
+        with patch.object(mcp, "_capture_module_main", side_effect=fake_capture):
+            mcp._handle_tools_call(
+                {
+                    "name": "briefing",
+                    "arguments": {"task": "hello", "with_code_context": True, "code_tokens": 1200},
+                }
+            )
+
+        self.assertIn("--with-code-context", captured_argv)
+        self.assertIn("--code-tokens", captured_argv)
+        self.assertIn("1200", captured_argv)
+
     def test_briefing_valid_returns_content_block(self):
         fake_output = json.dumps({"entries": {"mistakes": []}})
         with patch.object(mcp, "_capture_module_main", return_value=(0, fake_output, "")):


### PR DESCRIPTION
## Summary
Implements #747: unified briefing with both session knowledge and code context.

## Changes
- **briefing.py**: `--with-code-context`, `--code-tokens N` flags
  - Queries code_fts FTS5 (graceful no-op if code_index missing)
  - Appends Relevant Code Context section with fenced code blocks  
  - Token budget respected (approx 4 chars/token)
- **mcp-server.py**: `briefing` tool gets optional `with_code_context`/`code_tokens` params

## Testing
- `python3 test_security.py`: 13/13 ✅
- `python3 test_fixes.py`: 137/137 ✅
- `ruff check`: clean ✅

Closes #747