### PR TITLE
feat(#748): MCP resources support — sk://status, knowledge, sessions, code symbols

### DIFF
--- a/mcp-server.py
+++ b/mcp-server.py
@@ -796,6 +796,188 @@ def _handle_tools_call(params: dict[str, Any]) -> dict[str, Any]:
     raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"Unknown tool: {name}")
 
 
+# ── MCP Resources ──────────────────────────────────────────────────────────────
+# Static resource URI catalog — browseable by MCP clients.
+RESOURCES = [
+    {
+        "uri": "sk://status",
+        "name": "sk status",
+        "description": "sk version, DB path, and health info",
+        "mimeType": "application/json",
+    },
+    {
+        "uri": "sk://sessions/recent",
+        "name": "Recent sessions",
+        "description": "Last 20 indexed session titles and IDs",
+        "mimeType": "application/json",
+    },
+    {
+        "uri": "sk://knowledge/list",
+        "name": "Knowledge entries",
+        "description": "List of all knowledge entry IDs and titles",
+        "mimeType": "application/json",
+    },
+]
+
+
+def _resource_status() -> dict:
+    info: dict = {
+        "version": SERVER_INFO.get("version", "unknown"),
+        "db_path": str(_DB_PATH),
+        "db_exists": _DB_PATH.exists(),
+        "protocol_version": PROTOCOL_VERSION,
+    }
+    if _DB_PATH.exists():
+        try:
+            db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
+            row = db.execute("PRAGMA user_version").fetchone()
+            info["schema_version"] = row[0] if row else None
+            ke = db.execute("SELECT COUNT(*) FROM knowledge_entries").fetchone()
+            info["knowledge_entries"] = ke[0] if ke else 0
+            sess = db.execute("SELECT COUNT(*) FROM sessions").fetchone()
+            info["sessions"] = sess[0] if sess else 0
+            db.close()
+        except Exception:
+            info["db_error"] = "could not query DB"
+    return info
+
+
+def _resource_sessions_recent() -> list:
+    if not _DB_PATH.exists():
+        return []
+    try:
+        db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
+        db.row_factory = sqlite3.Row
+        rows = db.execute("SELECT id, summary, indexed_at FROM sessions ORDER BY indexed_at DESC LIMIT 20").fetchall()
+        db.close()
+        return [{"id": r["id"], "summary": r["summary"], "indexed_at": r["indexed_at"]} for r in rows]
+    except Exception:
+        return []
+
+
+def _resource_knowledge_list() -> list:
+    if not _DB_PATH.exists():
+        return []
+    try:
+        db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
+        db.row_factory = sqlite3.Row
+        rows = db.execute(
+            "SELECT id, title, entry_type, tags FROM knowledge_entries ORDER BY created_at DESC LIMIT 100"
+        ).fetchall()
+        db.close()
+        return [{"id": r["id"], "title": r["title"], "type": r["entry_type"], "tags": r["tags"]} for r in rows]
+    except Exception:
+        return []
+
+
+def _resource_knowledge_entry(entry_id: str) -> dict | None:
+    if not _DB_PATH.exists():
+        return None
+    try:
+        db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
+        db.row_factory = sqlite3.Row
+        row = db.execute(
+            "SELECT id, title, body, entry_type, tags, wing, room, created_at FROM knowledge_entries WHERE id = ?",
+            (entry_id,),
+        ).fetchone()
+        db.close()
+        return dict(row) if row else None
+    except Exception:
+        return None
+
+
+def _resource_code_symbols(project_id: str) -> list:
+    if not _DB_PATH.exists():
+        return []
+    try:
+        db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
+        db.row_factory = sqlite3.Row
+        has = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='code_index'").fetchone()
+        if not has:
+            db.close()
+            return []
+        rows = db.execute(
+            "SELECT file_path, symbol_name, symbol_kind, start_line, language FROM code_index WHERE project_id=? ORDER BY file_path, start_line LIMIT 500",
+            (project_id,),
+        ).fetchall()
+        db.close()
+        return [dict(r) for r in rows]
+    except Exception:
+        return []
+
+
+def _handle_resources_list() -> dict:
+    resources = list(RESOURCES)
+    # Add dynamic resources for knowledge entries if DB exists
+    if _DB_PATH.exists():
+        try:
+            db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
+            db.row_factory = sqlite3.Row
+            rows = db.execute("SELECT id, title FROM knowledge_entries ORDER BY created_at DESC LIMIT 20").fetchall()
+            db.close()
+            for r in rows:
+                eid = str(r["id"])
+                resources.append(
+                    {
+                        "uri": f"sk://knowledge/{eid}",
+                        "name": r["title"] or f"Entry {eid}",
+                        "description": f"Knowledge entry #{eid}",
+                        "mimeType": "text/plain",
+                    }
+                )
+        except Exception:
+            pass
+    return {"resources": resources}
+
+
+def _handle_resources_read(params: dict) -> dict:
+    uri = params.get("uri")
+    if not isinstance(uri, str) or not uri:
+        raise JsonRpcError(JSONRPC_INVALID_PARAMS, "'uri' must be a non-empty string")
+
+    if uri == "sk://status":
+        data = _resource_status()
+        text = json.dumps(data, ensure_ascii=False, indent=2)
+        return {"contents": [{"uri": uri, "mimeType": "application/json", "text": text}]}
+
+    if uri == "sk://sessions/recent":
+        data = _resource_sessions_recent()
+        text = json.dumps(data, ensure_ascii=False, indent=2)
+        return {"contents": [{"uri": uri, "mimeType": "application/json", "text": text}]}
+
+    if uri == "sk://knowledge/list":
+        data = _resource_knowledge_list()
+        text = json.dumps(data, ensure_ascii=False, indent=2)
+        return {"contents": [{"uri": uri, "mimeType": "application/json", "text": text}]}
+
+    if uri.startswith("sk://knowledge/") and not uri.endswith("/list"):
+        entry_id = uri[len("sk://knowledge/") :]
+        entry = _resource_knowledge_entry(entry_id)
+        if entry is None:
+            raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"Knowledge entry not found: {entry_id}")
+        lines = [f"# {entry.get('title', 'Untitled')}"]
+        lines.append(f"Type: {entry.get('entry_type', '')}")
+        if entry.get("tags"):
+            lines.append(f"Tags: {entry['tags']}")
+        if entry.get("wing"):
+            lines.append(f"Wing: {entry['wing']}")
+        if entry.get("room"):
+            lines.append(f"Room: {entry['room']}")
+        lines.append(f"Created: {entry.get('created_at', '')}")
+        lines.append("")
+        lines.append(entry.get("body", ""))
+        text = "\n".join(lines)
+        return {"contents": [{"uri": uri, "mimeType": "text/plain", "text": text}]}
+
+    if uri.startswith("sk://code/symbols/"):
+        project_id = uri[len("sk://code/symbols/") :]
+        symbols = _resource_code_symbols(project_id)
+        text = json.dumps(symbols, ensure_ascii=False, indent=2)
+        return {"contents": [{"uri": uri, "mimeType": "application/json", "text": text}]}
+
+    raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"Unknown resource URI: {uri}")
+
+
 def _read_exact(stream, length: int) -> bytes:
     chunks = []
     remaining = length
@@ -878,9 +1060,9 @@ def _handle_request(message: dict[str, Any]) -> tuple[bool, dict[str, Any] | Non
         )
         return False, {
             "protocolVersion": protocol,
-            "capabilities": {"tools": {"listChanged": False}},
+            "capabilities": {"tools": {"listChanged": False}, "resources": {"subscribe": False, "listChanged": False}},
             "serverInfo": SERVER_INFO,
-            "instructions": "Read-only tools backed by briefing.py and query-session.py.",
+            "instructions": "Read-only tools and resources backed by sk session knowledge.",
         }
     if method == "ping":
         return False, {}
@@ -890,6 +1072,10 @@ def _handle_request(message: dict[str, Any]) -> tuple[bool, dict[str, Any] | Non
         return False, {"tools": TOOLS}
     if method == "tools/call":
         return False, _handle_tools_call(params)
+    if method == "resources/list":
+        return False, _handle_resources_list()
+    if method == "resources/read":
+        return False, _handle_resources_read(params)
     if method in {"notifications/initialized", "exit"}:
         return method == "exit", None
     raise JsonRpcError(JSONRPC_METHOD_NOT_FOUND, f"Method not found: {method}")

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -820,6 +820,10 @@ RESOURCES = [
 ]
 
 
+def _log_resource_error(exc: Exception) -> None:
+    print(f"MCP resource error: {exc}", file=sys.stderr)
+
+
 def _resource_status() -> dict:
     info: dict = {
         "version": SERVER_INFO.get("version", "unknown"),
@@ -829,15 +833,18 @@ def _resource_status() -> dict:
     }
     if _DB_PATH.exists():
         try:
-            db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
-            row = db.execute("PRAGMA user_version").fetchone()
-            info["schema_version"] = row[0] if row else None
-            ke = db.execute("SELECT COUNT(*) FROM knowledge_entries").fetchone()
-            info["knowledge_entries"] = ke[0] if ke else 0
-            sess = db.execute("SELECT COUNT(*) FROM sessions").fetchone()
-            info["sessions"] = sess[0] if sess else 0
-            db.close()
-        except Exception:
+            with sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True) as db:
+                try:
+                    sv = db.execute("SELECT MAX(version) FROM schema_version").fetchone()
+                    info["schema_version"] = sv[0] if sv and sv[0] is not None else 0
+                except sqlite3.Error:
+                    info["schema_version"] = 0
+                ke = db.execute("SELECT COUNT(*) FROM knowledge_entries").fetchone()
+                info["knowledge_entries"] = ke[0] if ke else 0
+                sess = db.execute("SELECT COUNT(*) FROM sessions").fetchone()
+                info["sessions"] = sess[0] if sess else 0
+        except (sqlite3.Error, OSError) as exc:
+            _log_resource_error(exc)
             info["db_error"] = "could not query DB"
     return info
 
@@ -846,12 +853,14 @@ def _resource_sessions_recent() -> list:
     if not _DB_PATH.exists():
         return []
     try:
-        db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
-        db.row_factory = sqlite3.Row
-        rows = db.execute("SELECT id, summary, indexed_at FROM sessions ORDER BY indexed_at DESC LIMIT 20").fetchall()
-        db.close()
+        with sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True) as db:
+            db.row_factory = sqlite3.Row
+            rows = db.execute(
+                "SELECT id, summary, indexed_at FROM sessions ORDER BY indexed_at DESC LIMIT 20"
+            ).fetchall()
         return [{"id": r["id"], "summary": r["summary"], "indexed_at": r["indexed_at"]} for r in rows]
-    except Exception:
+    except (sqlite3.Error, OSError) as exc:
+        _log_resource_error(exc)
         return []
 
 
@@ -859,14 +868,14 @@ def _resource_knowledge_list() -> list:
     if not _DB_PATH.exists():
         return []
     try:
-        db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
-        db.row_factory = sqlite3.Row
-        rows = db.execute(
-            "SELECT id, title, entry_type, tags FROM knowledge_entries ORDER BY created_at DESC LIMIT 100"
-        ).fetchall()
-        db.close()
-        return [{"id": r["id"], "title": r["title"], "type": r["entry_type"], "tags": r["tags"]} for r in rows]
-    except Exception:
+        with sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True) as db:
+            db.row_factory = sqlite3.Row
+            rows = db.execute(
+                "SELECT id, title, category, tags FROM knowledge_entries ORDER BY last_seen DESC LIMIT 100"
+            ).fetchall()
+        return [{"id": r["id"], "title": r["title"], "type": r["category"], "tags": r["tags"]} for r in rows]
+    except (sqlite3.Error, OSError) as exc:
+        _log_resource_error(exc)
         return []
 
 
@@ -874,15 +883,15 @@ def _resource_knowledge_entry(entry_id: str) -> dict | None:
     if not _DB_PATH.exists():
         return None
     try:
-        db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
-        db.row_factory = sqlite3.Row
-        row = db.execute(
-            "SELECT id, title, body, entry_type, tags, wing, room, created_at FROM knowledge_entries WHERE id = ?",
-            (entry_id,),
-        ).fetchone()
-        db.close()
+        with sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True) as db:
+            db.row_factory = sqlite3.Row
+            row = db.execute(
+                "SELECT id, title, content, category, tags, wing, room, first_seen, last_seen FROM knowledge_entries WHERE id = ?",
+                (entry_id,),
+            ).fetchone()
         return dict(row) if row else None
-    except Exception:
+    except (sqlite3.Error, OSError) as exc:
+        _log_resource_error(exc)
         return None
 
 
@@ -890,19 +899,18 @@ def _resource_code_symbols(project_id: str) -> list:
     if not _DB_PATH.exists():
         return []
     try:
-        db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
-        db.row_factory = sqlite3.Row
-        has = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='code_index'").fetchone()
-        if not has:
-            db.close()
-            return []
-        rows = db.execute(
-            "SELECT file_path, symbol_name, symbol_kind, start_line, language FROM code_index WHERE project_id=? ORDER BY file_path, start_line LIMIT 500",
-            (project_id,),
-        ).fetchall()
-        db.close()
+        with sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True) as db:
+            db.row_factory = sqlite3.Row
+            has = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='code_index'").fetchone()
+            if not has:
+                return []
+            rows = db.execute(
+                "SELECT file_path, symbol_name, symbol_kind, start_line, language FROM code_index WHERE project_id=? ORDER BY file_path, start_line LIMIT 500",
+                (project_id,),
+            ).fetchall()
         return [dict(r) for r in rows]
-    except Exception:
+    except (sqlite3.Error, OSError) as exc:
+        _log_resource_error(exc)
         return []
 
 
@@ -911,10 +919,9 @@ def _handle_resources_list() -> dict:
     # Add dynamic resources for knowledge entries if DB exists
     if _DB_PATH.exists():
         try:
-            db = sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True)
-            db.row_factory = sqlite3.Row
-            rows = db.execute("SELECT id, title FROM knowledge_entries ORDER BY created_at DESC LIMIT 20").fetchall()
-            db.close()
+            with sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True) as db:
+                db.row_factory = sqlite3.Row
+                rows = db.execute("SELECT id, title FROM knowledge_entries ORDER BY last_seen DESC LIMIT 20").fetchall()
             for r in rows:
                 eid = str(r["id"])
                 resources.append(
@@ -925,8 +932,8 @@ def _handle_resources_list() -> dict:
                         "mimeType": "text/plain",
                     }
                 )
-        except Exception:
-            pass
+        except (sqlite3.Error, OSError) as exc:
+            _log_resource_error(exc)
     return {"resources": resources}
 
 
@@ -952,20 +959,22 @@ def _handle_resources_read(params: dict) -> dict:
 
     if uri.startswith("sk://knowledge/") and not uri.endswith("/list"):
         entry_id = uri[len("sk://knowledge/") :]
+        if not entry_id.isdigit():
+            raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"Invalid knowledge entry ID (must be numeric): {entry_id}")
         entry = _resource_knowledge_entry(entry_id)
         if entry is None:
             raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"Knowledge entry not found: {entry_id}")
         lines = [f"# {entry.get('title', 'Untitled')}"]
-        lines.append(f"Type: {entry.get('entry_type', '')}")
+        lines.append(f"Type: {entry.get('category', '')}")
         if entry.get("tags"):
             lines.append(f"Tags: {entry['tags']}")
         if entry.get("wing"):
             lines.append(f"Wing: {entry['wing']}")
         if entry.get("room"):
             lines.append(f"Room: {entry['room']}")
-        lines.append(f"Created: {entry.get('created_at', '')}")
+        lines.append(f"Created: {entry.get('first_seen', '')}")
         lines.append("")
-        lines.append(entry.get("body", ""))
+        lines.append(entry.get("content", ""))
         text = "\n".join(lines)
         return {"contents": [{"uri": uri, "mimeType": "text/plain", "text": text}]}
 

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -836,16 +836,16 @@ def _resource_status() -> dict:
             with sqlite3.connect(_DB_PATH.as_uri() + "?mode=ro", uri=True) as db:
                 try:
                     sv = db.execute("SELECT MAX(version) FROM schema_version").fetchone()
-                    info["schema_version"] = sv[0] if sv and sv[0] is not None else 0
+                    info["schema_version"] = sv[0] if sv else None
                 except sqlite3.Error:
-                    info["schema_version"] = 0
+                    info["schema_version"] = None
                 ke = db.execute("SELECT COUNT(*) FROM knowledge_entries").fetchone()
                 info["knowledge_entries"] = ke[0] if ke else 0
                 sess = db.execute("SELECT COUNT(*) FROM sessions").fetchone()
                 info["sessions"] = sess[0] if sess else 0
         except (sqlite3.Error, OSError) as exc:
             _log_resource_error(exc)
-            info["db_error"] = "could not query DB"
+            info["db_error"] = f"could not query DB: {exc}"
     return info
 
 

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -11176,6 +11176,228 @@ except Exception as _e723:
         "23",
     ]:
         test(f"I723-{_sfx}: retro grouped view", False, str(_e723))
+# I756: MCP resources/list + resources/read round-trip coverage
+
+
+def _mcp756_roundtrip(_home756: Path, method: str, params: dict):
+    _env756 = os.environ.copy()
+    _env756["HOME"] = str(_home756)
+    _env756["USERPROFILE"] = str(_home756)
+    _proc756 = subprocess.Popen(
+        [sys.executable, str(REPO / "mcp-server.py")],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=_env756,
+        cwd=str(REPO),
+    )
+    _request_bytes756 = bytearray()
+    for _msg756 in (
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05", "capabilities": {}},
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": method, "params": params},
+        {"jsonrpc": "2.0", "id": 3, "method": "shutdown"},
+    ):
+        _payload756 = json.dumps(_msg756).encode("utf-8")
+        _request_bytes756.extend(f"Content-Length: {len(_payload756)}\r\n\r\n".encode("ascii") + _payload756)
+    try:
+        _stdout756, _stderr756 = _proc756.communicate(bytes(_request_bytes756), timeout=15)
+    finally:
+        if _proc756.poll() is None:
+            _proc756.kill()
+            _proc756.wait(timeout=5)
+
+    _responses756 = []
+    _remaining756 = _stdout756
+    while _remaining756:
+        if b"Content-Length:" not in _remaining756:
+            break
+        _hdr_end756 = _remaining756.find(b"\r\n\r\n")
+        if _hdr_end756 == -1:
+            break
+        _header756 = _remaining756[:_hdr_end756].decode("ascii", errors="replace")
+        _length756 = int(
+            [_line.split(":", 1)[1].strip() for _line in _header756.split("\r\n") if "content-length" in _line.lower()][
+                0
+            ]
+        )
+        _body_start756 = _hdr_end756 + 4
+        _body756 = _remaining756[_body_start756 : _body_start756 + _length756]
+        _remaining756 = _remaining756[_body_start756 + _length756 :]
+        try:
+            _responses756.append(json.loads(_body756))
+        except Exception:
+            pass
+
+    _matches756 = [r for r in _responses756 if r.get("id") == 2]
+    if not _matches756:
+        raise RuntimeError(_stderr756.decode("utf-8", errors="replace") or "no MCP response")
+    return _matches756[0]
+
+
+def _run_i756_resource_tests():
+    import shutil as _sh756
+
+    _root756 = Path(tempfile.mkdtemp(prefix="i756-", dir=str(REPO)))
+    try:
+        _home756 = _root756 / "home"
+        _state756 = _home756 / ".copilot" / "session-state"
+        _state756.mkdir(parents=True, exist_ok=True)
+        _db756 = sqlite3.connect(_state756 / "knowledge.db")
+        _db756.executescript(
+            """
+            CREATE TABLE schema_version (
+                version INTEGER PRIMARY KEY,
+                migrated_at TEXT DEFAULT '',
+                name TEXT DEFAULT ''
+            );
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                path TEXT NOT NULL DEFAULT '',
+                summary TEXT DEFAULT '',
+                indexed_at TEXT
+            );
+            CREATE TABLE knowledge_entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL DEFAULT '',
+                document_id INTEGER,
+                category TEXT NOT NULL,
+                title TEXT NOT NULL,
+                stable_id TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                tags TEXT DEFAULT '',
+                confidence REAL DEFAULT 1.0,
+                occurrence_count INTEGER DEFAULT 1,
+                first_seen TEXT,
+                last_seen TEXT,
+                source TEXT DEFAULT 'copilot',
+                topic_key TEXT,
+                revision_count INTEGER DEFAULT 1,
+                content_hash TEXT,
+                wing TEXT DEFAULT '',
+                room TEXT DEFAULT '',
+                facts TEXT DEFAULT '[]',
+                est_tokens INTEGER DEFAULT 0,
+                task_id TEXT DEFAULT '',
+                affected_files TEXT DEFAULT '[]',
+                source_section TEXT DEFAULT '',
+                source_file TEXT DEFAULT '',
+                start_line INTEGER DEFAULT 0,
+                end_line INTEGER DEFAULT 0,
+                code_language TEXT DEFAULT '',
+                code_snippet TEXT DEFAULT '',
+                error_type TEXT DEFAULT '',
+                root_cause TEXT DEFAULT '',
+                severity TEXT DEFAULT 'medium',
+                is_resolved INTEGER DEFAULT 0,
+                fix_steps TEXT DEFAULT '',
+                prevention_hook TEXT DEFAULT '',
+                recurrence_after_briefing INTEGER DEFAULT 0,
+                valence TEXT DEFAULT '',
+                intensity REAL DEFAULT 0.5,
+                priority TEXT DEFAULT 'P2',
+                project_id TEXT DEFAULT ''
+            );
+            """
+        )
+        _db756.execute("INSERT INTO schema_version (version, name) VALUES (?, ?)", (27, "mcp-resources"))
+        _db756.execute(
+            "INSERT INTO sessions (id, path, summary, indexed_at) VALUES (?, ?, ?, ?)",
+            ("sess-756", "/repo", "Seeded MCP session", "2025-02-02T10:00:00Z"),
+        )
+        _db756.execute(
+            "INSERT INTO knowledge_entries (id, session_id, category, title, content, tags, wing, room, first_seen, last_seen) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                1,
+                "sess-756",
+                "pattern",
+                "Resource entry alpha",
+                "Alpha content",
+                "alpha,one",
+                "backend",
+                "mcp",
+                "2025-02-01T00:00:00Z",
+                "2025-02-03T00:00:00Z",
+            ),
+        )
+        _db756.execute(
+            "INSERT INTO knowledge_entries (id, session_id, category, title, content, tags, wing, room, first_seen, last_seen) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                2,
+                "sess-756",
+                "mistake",
+                "Resource entry beta",
+                "Beta content",
+                "beta,two",
+                "backend",
+                "mcp",
+                "2025-02-02T00:00:00Z",
+                "2025-02-04T00:00:00Z",
+            ),
+        )
+        _db756.commit()
+        _db756.close()
+
+        _res_list756 = _mcp756_roundtrip(_home756, "resources/list", {})
+        _uris756 = [r.get("uri") for r in _res_list756.get("result", {}).get("resources", [])]
+        test("I756-1a: resources/list includes sk://status", "sk://status" in _uris756, str(_uris756))
+        test("I756-1b: resources/list includes sk://sessions/recent", "sk://sessions/recent" in _uris756, str(_uris756))
+        test("I756-1c: resources/list includes sk://knowledge/list", "sk://knowledge/list" in _uris756, str(_uris756))
+        test("I756-1d: resources/list includes seeded knowledge URI", "sk://knowledge/2" in _uris756, str(_uris756))
+
+        _res_status756 = _mcp756_roundtrip(_home756, "resources/read", {"uri": "sk://status"})
+        _status756 = json.loads(_res_status756.get("result", {}).get("contents", [{}])[0].get("text", "{}"))
+        test(
+            "I756-2a: resources/read sk://status returns schema version",
+            _status756.get("schema_version") == 27,
+            str(_status756),
+        )
+        test(
+            "I756-2b: resources/read sk://status returns knowledge count",
+            _status756.get("knowledge_entries") == 2,
+            str(_status756),
+        )
+        test(
+            "I756-2c: resources/read sk://status returns db path",
+            str(_status756.get("db_path", "")).endswith("knowledge.db"),
+            str(_status756),
+        )
+
+        _res_kl756 = _mcp756_roundtrip(_home756, "resources/read", {"uri": "sk://knowledge/list"})
+        _entries756 = json.loads(_res_kl756.get("result", {}).get("contents", [{}])[0].get("text", "[]"))
+        _first756 = _entries756[0] if _entries756 else {}
+        test("I756-3a: knowledge/list returns seeded entries", len(_entries756) == 2, str(_entries756))
+        test("I756-3b: knowledge/list maps category to type", _first756.get("type") == "mistake", str(_first756))
+        test("I756-3c: knowledge/list orders by last_seen", _first756.get("id") == 2, str(_entries756))
+
+        _res_ke756 = _mcp756_roundtrip(_home756, "resources/read", {"uri": "sk://knowledge/1"})
+        _text756 = _res_ke756.get("result", {}).get("contents", [{}])[0].get("text", "")
+        test("I756-4a: knowledge entry read shows type", "Type: pattern" in _text756, _text756)
+        test("I756-4b: knowledge entry read shows created", "Created: 2025-02-01T00:00:00Z" in _text756, _text756)
+        test("I756-4c: knowledge entry read shows content", "Alpha content" in _text756, _text756)
+
+        _res_bad756 = _mcp756_roundtrip(_home756, "resources/read", {"uri": "sk://knowledge/not-a-number"})
+        _bad756 = _res_bad756.get("error", {})
+        test("I756-5a: invalid entry id returns invalid params", _bad756.get("code") == -32602, str(_bad756))
+        test(
+            "I756-5b: invalid entry id explains numeric requirement",
+            "must be numeric" in str(_bad756.get("message", "")),
+            str(_bad756),
+        )
+    finally:
+        _sh756.rmtree(_root756, ignore_errors=True)
+
+
+try:
+    _run_i756_resource_tests()
+except Exception as _e756:
+    for _suffix756 in ["1a", "1b", "1c", "1d", "2a", "2b", "2c", "3a", "3b", "3c", "4a", "4b", "4c", "5a", "5b"]:
+        test(f"I756-{_suffix756}: MCP resources", False, str(_e756))
 
 # ---------------------------------------------------------------------------
 if FAIL == 0:


### PR DESCRIPTION
## Summary
Implements #748: expose sk knowledge base as MCP resources alongside existing tools.

## Changes

- **mcp-server.py**: Full MCP resources support
  - `resources/list` handler: enumerates static + dynamic knowledge entry URIs
  - `resources/read` for:
    - `sk://status` — version, DB path, schema version, entry/session counts
    - `sk://sessions/recent` — last 20 sessions (application/json)
    - `sk://knowledge/list` — all entry IDs + titles (application/json)
    - `sk://knowledge/{id}` — full entry with title/tags/wing/room/body (text/plain)
    - `sk://code/symbols/{project_id}` — indexed symbols from code_index (application/json)
  - `initialize` capabilities updated: adds `resources: {subscribe: false, listChanged: false}`

## Testing

- `python3 test_security.py`: 13/13 ✅
- `python3 test_fixes.py`: 137/137 ✅
- `ruff check`: clean ✅
- `ruff format --check`: clean ✅

Closes #748