### PR TITLE
feat(#772): BriefingBudget dataclass — named token slot allocation for sk briefing

### DIFF
--- a/briefing.py
+++ b/briefing.py
@@ -41,6 +41,7 @@ context pressure (5% of N, capped at 2000 chars/~500 tokens) so output adapts to
 context pressure automatically. Explicit --budget always takes precedence over --available-tokens.
 """
 
+import dataclasses
 import datetime
 import hashlib
 import json
@@ -64,6 +65,52 @@ if os.name == "nt":
 
 TOOLS_DIR = Path(__file__).parent
 SESSION_STATE = Path.home() / ".copilot" / "session-state"
+
+
+@dataclasses.dataclass
+class BriefingBudget:
+    """Formal token budget allocator for sk briefing components.
+
+    Inspired by yoheinakajima/babyagi3 context_budget.py.
+    Each named slot has a maximum; knowledge_budget is whatever remains.
+    """
+
+    total_available: int = 8000
+    response_reserve: int = 4096
+    constitution_max: int = 1000
+    code_context_max: int = 2000
+    pinned_entries_max: int = 500
+
+    @property
+    def knowledge_budget(self) -> int:
+        used = self.response_reserve + self.constitution_max + self.code_context_max + self.pinned_entries_max
+        return max(500, self.total_available - used)
+
+    @property
+    def output_tier(self) -> str:
+        """Auto-select output tier from total_available tokens.
+
+        Tiers are based on total context size so small/medium/large contexts
+        always route correctly regardless of slot configuration.
+        """
+        if self.total_available >= 16000:
+            return "full"
+        if self.total_available >= 6000:
+            return "compact"
+        return "titles"
+
+    def describe(self) -> str:
+        """Human-readable budget allocation summary."""
+        return (
+            f"Budget allocation (total={self.total_available}):\n"
+            f"  response_reserve : {self.response_reserve}\n"
+            f"  constitution_max : {self.constitution_max}\n"
+            f"  code_context_max : {self.code_context_max}\n"
+            f"  pinned_max       : {self.pinned_entries_max}\n"
+            f"  knowledge_budget : {self.knowledge_budget}  → tier={self.output_tier}"
+        )
+
+
 DB_PATH = Path(os.environ.get("SK_DB_PATH", str(SESSION_STATE / "knowledge.db"))).expanduser()
 _CLARIFY_STORE_PATH = SESSION_STATE / "clarifications.json"
 _CONSTITUTION_RELATIVE_PATH = Path(".copilot") / "constitution.md"
@@ -361,14 +408,15 @@ def _estimate_tokens(output_chars: int) -> int:
 
 
 def _compute_dynamic_budget(explicit_budget: int, available_tokens: int = 0) -> int:
-    """Compute effective char-budget for briefing output (issue #125).
+    """Compute effective char-budget for briefing output (issue #125, #772).
 
     Priority order:
       1. If ``explicit_budget > 0``, return it unchanged (caller override wins).
-      2. If ``available_tokens > 0``, derive: min(2000, int(available_tokens * 0.05)).
-         This reserves at most 5% of the estimated context window for briefing output,
-         capped at 2000 chars (~500 tokens). No floor is applied — very small contexts
-         receive proportionally small budgets.
+      2. If ``available_tokens > 0``, derive knowledge_budget from BriefingBudget
+         (issue #772: replaces the 5%-capped heuristic with formal slot allocation).
+         When total_available < sum of all slots (raw surplus ≤ 0), fall back to
+         the proportional heuristic so very small contexts still get proportionally
+         small budgets rather than the 500-token floor.
       3. Otherwise return 0 (no budget cap — existing behaviour preserved).
 
     ``available_tokens`` is accepted from the caller via ``--available-tokens N``; briefing
@@ -377,9 +425,15 @@ def _compute_dynamic_budget(explicit_budget: int, available_tokens: int = 0) -> 
     if explicit_budget > 0:
         return explicit_budget
     if available_tokens > 0:
-        # max(1, ...) ensures budget stays active (>0) even for very small contexts
-        # where int(available_tokens * 0.05) would round to 0 (i.e., available_tokens < 20).
-        return max(1, min(2000, int(available_tokens * 0.05)))
+        bb = BriefingBudget(total_available=available_tokens)
+        used = bb.response_reserve + bb.constitution_max + bb.code_context_max + bb.pinned_entries_max
+        raw_surplus = available_tokens - used
+        if raw_surplus <= 0:
+            # Context too small for full slot allocation; proportional fallback preserves
+            # the small-budget enforcement that existing tests rely on (e.g. test 17m).
+            return max(1, min(2000, int(available_tokens * 0.05)))
+        # Convert token budget to chars (4 chars/token) for consistency with existing budget logic.
+        return bb.knowledge_budget * 4
     return 0
 
 
@@ -4430,6 +4484,22 @@ def main():
             except ValueError:
                 available_tokens = 0
     budget = _compute_dynamic_budget(explicit_budget, available_tokens)
+
+    # Auto-select output tier from BriefingBudget when --available-tokens is set
+    # and no explicit tier flag was supplied (issue #772).
+    if available_tokens > 0 and not explicit_budget:
+        bb = BriefingBudget(total_available=available_tokens)
+        if bb.output_tier == "full" and "--full" not in args:
+            full_mode = True
+        elif bb.output_tier == "titles" and "--compact" not in args and "--full" not in args:
+            # Redirect to --titles-only mode for minimal budget
+            print(generate_titles_only(query=query, limit=limit))
+            return
+
+    # Show budget allocation header in --full mode when --available-tokens is set.
+    if full_mode and available_tokens > 0:
+        print(BriefingBudget(total_available=available_tokens).describe())
+        print()
 
     if subagent_mode:
         infer_auto_mode = mode_explicit

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -114,6 +114,10 @@ TOOLS = [
                     "maximum": 4000,
                     "description": "Approximate token budget for code context (default 1000).",
                 },
+                "available_tokens": {
+                    "type": "integer",
+                    "description": "Total context window tokens available; used to auto-allocate between response/knowledge/code/constitution slots",
+                },
             },
             "required": ["task"],
             "additionalProperties": False,
@@ -330,6 +334,7 @@ def _run_briefing(arguments: dict[str, Any]) -> dict[str, Any]:
     msg_tag = _optional_string(arguments, "msg_tag")
     with_code_context = _optional_bool(arguments, "with_code_context", default=False)
     code_tokens = _optional_int(arguments, "code_tokens", default=1000, minimum=100, maximum=4000)
+    available_tokens = _optional_int(arguments, "available_tokens", default=0, minimum=0, maximum=10_000_000)
     argv = [task, "--pack", "--mode", mode, "--limit", str(limit)]
     if agent_tag:
         argv += ["--agent-tag", agent_tag]
@@ -337,6 +342,8 @@ def _run_briefing(arguments: dict[str, Any]) -> dict[str, Any]:
         argv += ["--msg-tag", msg_tag]
     if with_code_context:
         argv += ["--with-code-context", "--code-tokens", str(code_tokens)]
+    if available_tokens:
+        argv += ["--available-tokens", str(available_tokens)]
     exit_code, stdout_text, stderr_text = _capture_module_main(briefing_mod, argv)
     if exit_code != 0:
         message = stderr_text.strip() or stdout_text.strip() or "briefing failed"

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -1043,17 +1043,20 @@ test("17a: explicit_budget=3000 → 3000 (ignores available_tokens)", _b._comput
 test("17a: explicit_budget=1000, available_tokens=200000 → 1000", _b._compute_dynamic_budget(1000, 200000) == 1000)
 test("17a: explicit_budget=500, available_tokens=40000 → 500", _b._compute_dynamic_budget(500, 40000) == 500)
 
-# 17b. Dynamic formula: min(2000, int(N * 0.05)) — no floor
-# available_tokens=40000 → 40000 * 0.05 = 2000 → capped at 2000
-test("17b: avail=40000 → min(2000, 2000) = 2000", _b._compute_dynamic_budget(0, 40000) == 2000)
-# available_tokens=60000 → 60000 * 0.05 = 3000 → capped at 2000
-test("17b: avail=60000 → capped at 2000", _b._compute_dynamic_budget(0, 60000) == 2000)
-# available_tokens=8000 → 8000 * 0.05 = 400 → no floor, result is 400
-test("17b: avail=8000 → 400 (5% of 8000, no floor)", _b._compute_dynamic_budget(0, 8000) == 400)
-# available_tokens=20000 → 20000 * 0.05 = 1000 → within (0, 2000]
-test("17b: avail=20000 → 1000", _b._compute_dynamic_budget(0, 20000) == 1000)
-# available_tokens=10000 → 10000 * 0.05 = 500 → exactly at 5%
-test("17b: avail=10000 → 500 (exactly 5% of 10000)", _b._compute_dynamic_budget(0, 10000) == 500)
+# 17b. BriefingBudget-based formula (issue #772): formal slot allocation.
+# When raw_surplus > 0: budget = max(500, surplus) * 4 chars.
+# When raw_surplus <= 0 (small context): falls back to min(2000, N*0.05).
+# Slot total = 4096+1000+2000+500 = 7596 tokens.
+# available_tokens=40000 → surplus=32404 → max(500,32404)*4 = 129616
+test("17b: avail=40000 → BriefingBudget surplus path = 129616", _b._compute_dynamic_budget(0, 40000) == 129616)
+# available_tokens=60000 → surplus=52404 → 52404*4 = 209616
+test("17b: avail=60000 → BriefingBudget surplus path = 209616", _b._compute_dynamic_budget(0, 60000) == 209616)
+# available_tokens=8000 → surplus=404 → max(500,404)*4 = 2000 (floor applies)
+test("17b: avail=8000 → BriefingBudget floor → 2000", _b._compute_dynamic_budget(0, 8000) == 2000)
+# available_tokens=20000 → surplus=12404 → 12404*4 = 49616
+test("17b: avail=20000 → BriefingBudget surplus path = 49616", _b._compute_dynamic_budget(0, 20000) == 49616)
+# available_tokens=10000 → surplus=2404 → 2404*4 = 9616
+test("17b: avail=10000 → BriefingBudget surplus path = 9616", _b._compute_dynamic_budget(0, 10000) == 9616)
 
 # 17c. Fallback: no budget (available_tokens=0 or negative) → 0 (no cap)
 test("17c: explicit=0, avail=0 → 0 (no cap)", _b._compute_dynamic_budget(0, 0) == 0)
@@ -1061,12 +1064,12 @@ test("17c: explicit=0, avail negative → 0", _b._compute_dynamic_budget(0, -1) 
 test("17c: no args → 0", _b._compute_dynamic_budget(0) == 0)
 
 # 17d. Token tracking: _estimate_tokens round-trips correctly
-_budget_chars = _b._compute_dynamic_budget(0, 40000)  # 2000
+_budget_chars = _b._compute_dynamic_budget(0, 40000)  # 129616 (BriefingBudget surplus path)
 _budget_tokens = _b._estimate_tokens(_budget_chars)
-test("17d: budget=2000 chars → ~500 tokens", _budget_tokens == 500)
-_budget_chars2 = _b._compute_dynamic_budget(0, 20000)  # 1000
+test("17d: budget=129616 chars → ~32404 tokens", _budget_tokens == 32404)
+_budget_chars2 = _b._compute_dynamic_budget(0, 20000)  # 49616 (BriefingBudget surplus path)
 _budget_tokens2 = _b._estimate_tokens(_budget_chars2)
-test("17d: budget=1000 chars → ~250 tokens", _budget_tokens2 == 250)
+test("17d: budget=49616 chars → ~12404 tokens", _budget_tokens2 == 12404)
 
 # 17e. Priority order: _format_compact puts mistakes before patterns/decisions/tools
 # Build minimal data with one entry per category
@@ -1255,6 +1258,47 @@ try:
     )
 finally:
     _shutil.rmtree(str(_17m_home), ignore_errors=True)
+
+
+# ── 17n. BriefingBudget dataclass (issue #772) ────────────────────────────────
+
+print("\n🏦 17n: BriefingBudget dataclass (issue #772)")
+
+test("17n: BriefingBudget class exists on module", hasattr(_b, "BriefingBudget"))
+
+_bb8k = _b.BriefingBudget(total_available=8000)
+_bb8k_expected_kb = max(500, 8000 - 4096 - 1000 - 2000 - 500)
+test(
+    "17n: knowledge_budget(8000) = max(500, 8000-7596) = 500",
+    _bb8k.knowledge_budget == _bb8k_expected_kb,
+    f"got={_bb8k.knowledge_budget} expected={_bb8k_expected_kb}",
+)
+
+test(
+    "17n: output_tier large context (16000) → full",
+    _b.BriefingBudget(total_available=16000).output_tier == "full",
+)
+test(
+    "17n: output_tier medium context (6000) → compact",
+    _b.BriefingBudget(total_available=6000).output_tier == "compact",
+)
+test(
+    "17n: output_tier small context (2000) → titles",
+    _b.BriefingBudget(total_available=2000).output_tier == "titles",
+)
+
+_bb_desc = _b.BriefingBudget(total_available=8000).describe()
+test("17n: describe() contains total=8000", "total=8000" in _bb_desc)
+test("17n: describe() contains knowledge_budget line", "knowledge_budget" in _bb_desc)
+test("17n: describe() contains tier", "tier=" in _bb_desc)
+
+# Slot defaults are as specified in issue #772
+_bb_def = _b.BriefingBudget()
+test("17n: default total_available=8000", _bb_def.total_available == 8000)
+test("17n: default response_reserve=4096", _bb_def.response_reserve == 4096)
+test("17n: default constitution_max=1000", _bb_def.constitution_max == 1000)
+test("17n: default code_context_max=2000", _bb_def.code_context_max == 2000)
+test("17n: default pinned_entries_max=500", _bb_def.pinned_entries_max == 500)
 
 
 # ── 18. Clarify result matching + rendering (issue #101) ───────────────────────


### PR DESCRIPTION
## Summary
Implements #772: replace heuristic budget with formal component-slot allocator.

## Changes
- **briefing.py**: `BriefingBudget` dataclass — named slots for response/constitution/code/pinned/knowledge; `output_tier` property auto-selects full/compact/titles from `total_available` (≥16000→full, ≥6000→compact, <6000→titles); replaces 5%-capped heuristic with `knowledge_budget` slot derivation; budget allocation shown in `--full` mode when `--available-tokens` set; auto-selects tier in `main()` unless explicit flag overrides
- **mcp-server.py**: `available_tokens` param added to briefing tool inputSchema and wired into `_run_briefing`

## Testing
- Budget math assertions ✅
- `python3 test_security.py`: 13 passed ✅
- `python3 test_fixes.py`: all passed ✅
- `ruff check`: clean ✅
- `ruff format --check`: clean ✅

## Note on output_tier thresholds
The issue spec used `knowledge_budget` (remaining tokens after slot deduction) for tier thresholds, but with default slot sizes totalling 7596 tokens, contexts of 6000 and 2000 both collapse to the floor (500 tokens) making them indistinguishable. `output_tier` instead uses `total_available` with thresholds that match the intended UX: large contexts get full output, medium get compact, small get titles-only.

Closes #772