### PR TITLE
feat(#771): FTS5 trigram tokenizer for code-search — partial-symbol fuzzy matching

### DIFF
--- a/code-index.py
+++ b/code-index.py
@@ -134,6 +134,11 @@ def _check_tables(db: sqlite3.Connection) -> None:
         sys.exit(1)
 
 
+def _has_trigram_table(db: sqlite3.Connection) -> bool:
+    row = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='code_fts_trigram'").fetchone()
+    return row is not None
+
+
 def _ensure_project(db: sqlite3.Connection, root: Path) -> str:
     """Register project in project_registry if table exists, return project_id."""
     has_registry = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='project_registry'").fetchone()
@@ -249,6 +254,11 @@ def _index_file(
         "DELETE FROM code_fts WHERE rowid IN (SELECT id FROM code_index WHERE file_path=? AND project_id=?)",
         [fp_str, project_id],
     )
+    if _has_trigram_table(db):
+        db.execute(
+            "DELETE FROM code_fts_trigram WHERE rowid IN (SELECT id FROM code_index WHERE file_path=? AND project_id=?)",
+            [fp_str, project_id],
+        )
     db.execute(
         "DELETE FROM code_index WHERE file_path=? AND project_id=?",
         [fp_str, project_id],
@@ -271,6 +281,13 @@ def _index_file(
         " FROM code_index WHERE file_path=? AND project_id=?",
         [fp_str, project_id],
     )
+    if _has_trigram_table(db):
+        db.execute(
+            "INSERT INTO code_fts_trigram(rowid, symbol_name, content_snippet, file_path, language, project_id)"
+            " SELECT id, symbol_name, content_snippet, file_path, language, project_id"
+            " FROM code_index WHERE file_path=? AND project_id=?",
+            [fp_str, project_id],
+        )
 
     return len(symbols)
 

--- a/code-search.py
+++ b/code-search.py
@@ -544,6 +544,50 @@ def search_fts(
     return [dict(r) for r in rows]
 
 
+def search_fts_trigram(
+    conn: sqlite3.Connection,
+    query: str,
+    language: str,
+    project_id: str,
+    limit: int,
+) -> list[dict]:
+    """Search using FTS5 trigram tokenizer — enables partial-symbol and error-string matching."""
+    if len(query.strip()) < 3:
+        return []
+    has_table = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='code_fts_trigram'").fetchone()
+    if not has_table:
+        return []
+
+    conditions: list[str] = []
+    params: list = []
+    if language:
+        conditions.append("ci.language = ?")
+        params.append(language)
+    if project_id:
+        conditions.append("ci.project_id = ?")
+        params.append(project_id)
+
+    where_prefix = ("WHERE " + " AND ".join(conditions) + " AND ") if conditions else "WHERE "
+    # Trigram ignores most FTS operators but strip quotes to avoid parse errors
+    safe_query = query.replace('"', "")
+
+    try:
+        rows = conn.execute(
+            f"""SELECT ci.file_path, ci.project_id, ci.language,
+                       ci.start_line, ci.end_line, ci.symbol_name,
+                       ci.symbol_kind, ci.content_snippet,
+                       bm25(code_fts_trigram) AS rank_score
+                FROM code_fts_trigram AS fts
+                JOIN code_index AS ci ON ci.id = fts.rowid
+                {where_prefix}code_fts_trigram MATCH ?
+                ORDER BY rank_score LIMIT ?""",
+            [*params, safe_query, limit],
+        ).fetchall()
+        return [dict(r) for r in rows]
+    except sqlite3.OperationalError:
+        return []
+
+
 def search(
     query: str,
     lang: str = "",
@@ -551,6 +595,7 @@ def search(
     limit: int = 10,
     context_lines: int = 3,
     rank_mode: str = "hybrid",
+    fuzzy: bool = False,
 ) -> list[dict]:
     """Primary search entry point: tries FTS first, then ripgrep fallback."""
     if not DB_PATH.exists():
@@ -561,11 +606,24 @@ def search(
         has_table = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='code_index'").fetchone()
         if not has_table:
             return []
-        results = search_fts(conn, query, lang, project_id, limit, rank_mode)
+
+        results: list[dict] = []
+        if fuzzy:
+            results = search_fts_trigram(conn, query, lang, project_id, limit)
+
+        porter_results = search_fts(conn, query, lang, project_id, limit, rank_mode)
+
+        # Merge with deduplication — trigram results first for fuzzy mode
+        seen = {(r["file_path"], r["symbol_name"]) for r in results}
+        for r in porter_results:
+            key = (r["file_path"], r["symbol_name"])
+            if key not in seen:
+                results.append(r)
+                seen.add(key)
     finally:
         conn.close()
 
-    return results
+    return results[:limit]
 
 
 # ---------------------------------------------------------------------------
@@ -633,6 +691,11 @@ def main() -> None:
         default="hybrid",
         help="BM25 column weight mode: symbol (name-boosted), content (body-boosted), hybrid (default)",
     )
+    parser.add_argument(
+        "--fuzzy",
+        action="store_true",
+        help="Use trigram FTS5 index for partial-symbol and error-string matching (requires 3+ char query)",
+    )
 
     args = parser.parse_args()
 
@@ -653,6 +716,7 @@ def main() -> None:
         limit=args.limit,
         context_lines=args.context,
         rank_mode=args.rank,
+        fuzzy=args.fuzzy,
     )
 
     if args.as_json:

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -258,6 +258,10 @@ TOOLS = [
                 "language": {"type": "string", "description": "Filter by language (python, rust, typescript, etc.)"},
                 "project_id": {"type": "string", "description": "Restrict to a specific project"},
                 "limit": {"type": "integer", "minimum": 1, "maximum": 50, "description": "Max results (default 10)"},
+                "fuzzy": {
+                    "type": "boolean",
+                    "description": "Use trigram index for partial-symbol and error-string matching",
+                },
             },
             "required": ["query"],
             "additionalProperties": False,
@@ -707,6 +711,7 @@ def _run_code_search(arguments: dict) -> dict:
     language = _optional_string(arguments, "language", max_length=50)
     project_id = _optional_string(arguments, "project_id", max_length=200)
     limit = _optional_int(arguments, "limit", default=10, minimum=1, maximum=50)
+    fuzzy = bool(arguments.get("fuzzy", False))
 
     if not _DB_PATH.exists():
         body = {
@@ -747,8 +752,30 @@ def _run_code_search(arguments: dict) -> dict:
         fts_safe = re.sub(r'["*]|\b(?:OR|AND|NOT|NEAR)\b', " ", query_text, flags=re.IGNORECASE).strip()
         if not fts_safe:
             fts_safe = query_text.replace('"', "")
+
+        rows: list = []
+
+        # Trigram search when --fuzzy requested and table exists
+        if fuzzy and len(query_text.strip()) >= 3:
+            has_trigram = db.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='code_fts_trigram'"
+            ).fetchone()
+            if has_trigram:
+                try:
+                    safe_trigram = query_text.replace('"', "")
+                    rows = db.execute(
+                        f"""SELECT ci.file_path, ci.project_id, ci.language,
+                               ci.start_line, ci.end_line, ci.symbol_name, ci.symbol_kind, ci.content_snippet
+                        FROM code_fts_trigram fts JOIN code_index ci ON fts.rowid = ci.id
+                        {where_sql}code_fts_trigram MATCH ? ORDER BY rank LIMIT ?""",
+                        [*params, safe_trigram, limit],
+                    ).fetchall()
+                except sqlite3.OperationalError:
+                    rows = []
+
+        # Porter FTS search (always run; merged with trigram results)
         try:
-            rows = db.execute(
+            porter_rows = db.execute(
                 f"""SELECT ci.file_path, ci.project_id, ci.language,
                        ci.start_line, ci.end_line, ci.symbol_name, ci.symbol_kind, ci.content_snippet
                 FROM code_fts fts JOIN code_index ci ON fts.rowid = ci.id
@@ -757,7 +784,7 @@ def _run_code_search(arguments: dict) -> dict:
             ).fetchall()
         except sqlite3.OperationalError:
             like = f"%{query_text.lower()}%"
-            rows = db.execute(
+            porter_rows = db.execute(
                 f"""SELECT file_path, project_id, language,
                        start_line, end_line, symbol_name, symbol_kind, content_snippet
                 FROM code_index ci
@@ -766,6 +793,15 @@ def _run_code_search(arguments: dict) -> dict:
                 ORDER BY file_path LIMIT ?""",
                 [*params, like, like, limit],
             ).fetchall()
+
+        # Merge with deduplication (trigram rows first)
+        seen: set[tuple] = {(r["file_path"], r["symbol_name"]) for r in rows}
+        for r in porter_rows:
+            key = (r["file_path"], r["symbol_name"])
+            if key not in seen:
+                rows.append(r)
+                seen.add(key)
+        rows = rows[:limit]
     finally:
         db.close()
 

--- a/migrate.py
+++ b/migrate.py
@@ -1774,6 +1774,27 @@ if __name__ == "__main__":
                 )""",
             ],
         ),
+        # v36: issue #771 — FTS5 trigram tokenizer for partial-symbol and error-string search.
+        # code_fts_trigram uses content= for low-overhead storage; 3 triggers keep it in sync.
+        (
+            36,
+            "code_fts_trigram_index",
+            [
+                """CREATE VIRTUAL TABLE IF NOT EXISTS code_fts_trigram USING fts5(
+                    symbol_name,
+                    content_snippet,
+                    file_path UNINDEXED,
+                    language UNINDEXED,
+                    project_id UNINDEXED,
+                    tokenize='trigram',
+                    content='code_index',
+                    content_rowid='id'
+                )""",
+                "CREATE TRIGGER IF NOT EXISTS code_fts_trigram_ai AFTER INSERT ON code_index BEGIN INSERT INTO code_fts_trigram(rowid, symbol_name, content_snippet, file_path, language, project_id) VALUES (new.id, new.symbol_name, new.content_snippet, new.file_path, new.language, new.project_id); END",
+                "CREATE TRIGGER IF NOT EXISTS code_fts_trigram_ad AFTER DELETE ON code_index BEGIN INSERT INTO code_fts_trigram(code_fts_trigram, rowid, symbol_name, content_snippet, file_path, language, project_id) VALUES ('delete', old.id, old.symbol_name, old.content_snippet, old.file_path, old.language, old.project_id); END",
+                "CREATE TRIGGER IF NOT EXISTS code_fts_trigram_au AFTER UPDATE ON code_index BEGIN INSERT INTO code_fts_trigram(code_fts_trigram, rowid, symbol_name, content_snippet, file_path, language, project_id) VALUES ('delete', old.id, old.symbol_name, old.content_snippet, old.file_path, old.language, old.project_id); INSERT INTO code_fts_trigram(rowid, symbol_name, content_snippet, file_path, language, project_id) VALUES (new.id, new.symbol_name, new.content_snippet, new.file_path, new.language, new.project_id); END",
+            ],
+        ),
     ]
     applied = 0
     for ver, name, stmts in MIGRATIONS:


### PR DESCRIPTION
## Summary
Implements #771: trigram FTS5 index for partial-identifier and error-string search.

## Changes
- **migrate.py**: `code_fts_trigram` virtual table (v36) + 3 maintenance triggers (AI/AD/AU)
- **code-index.py**: Populates trigram table alongside porter FTS when indexing; clears on file re-index
- **code-search.py**: `--fuzzy` flag; `search_fts_trigram()`; dual-search with deduplication
- **mcp-server.py**: `fuzzy` param in `code_search` tool; inline trigram+porter merge

## Testing
- `python3 test_security.py`: 13 passed ✅
- `python3 test_fixes.py`: all passed ✅
- `ruff check`: clean ✅
- `ruff format --check`: clean ✅

Closes #771