### PR TITLE
feat(#770): entity-linked recall — entity graph boosts briefing precision

### DIFF
--- a/briefing.py
+++ b/briefing.py
@@ -1763,6 +1763,43 @@ def _get_superseded_ids(db: sqlite3.Connection) -> set:
         return set()
 
 
+def _expand_query_with_entities(db: sqlite3.Connection, task: str) -> list[str]:
+    """Extract entities from task text and return matching knowledge_entry IDs.
+
+    Used to boost entries that share entities with the current task.
+    Returns empty list if knowledge_entities table doesn't exist.
+    """
+    import re as _re
+
+    row = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='knowledge_entities'").fetchone()
+    if not row:
+        return []
+
+    file_re = _re.compile(r"\b[\w/.-]+\.(?:py|ts|js|go|rs|java|rb|cpp|h|json|yaml|yml|toml)\b")
+    error_re = _re.compile(r"\b([A-Z][a-zA-Z]*(?:Error|Exception|Warning|Failure|Fault))\b")
+
+    entities: list[tuple[str, str]] = []
+    for m in file_re.findall(task):
+        if len(m) > 4:
+            entities.append(("file_path", m.lower()))
+    for m in error_re.findall(task):
+        entities.append(("error_type", m))
+
+    if not entities:
+        return []
+
+    placeholders = ",".join("(?,?)" for _ in entities)
+    params = [v for pair in entities for v in pair]
+    try:
+        rows = db.execute(
+            f"SELECT DISTINCT entry_id FROM knowledge_entities WHERE (entity_type, entity_value) IN ({placeholders})",
+            params,
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return []
+    return [str(r[0]) for r in rows]
+
+
 def _recency_composite_score(entry: dict, half_life_days: float) -> float:
     """Composite ranking score = priority_base + intensity * recency_decay.
 
@@ -2506,6 +2543,7 @@ def generate_briefing(
     half_life = _get_briefing_half_life(db)
 
     superseded_ids: set = set() if include_superseded else _get_superseded_ids(db)
+    entity_matched_ids = set(_expand_query_with_entities(db, query))
 
     briefing_data = {}
     global_seen_titles = set()  # Cross-category dedup
@@ -2543,19 +2581,26 @@ def generate_briefing(
                     continue
                 merged.append(r)
 
+        def _entity_boost(e: dict) -> float:
+            """1.2× multiplier for entries sharing entities with the task (issue #770)."""
+            return 1.2 if str(e.get("id", "")) in entity_matched_ids else 1.0
+
         # For mistakes, boost recurring entries to the top before composite recency sort.
         # Recurring mistakes (re-encountered after a briefing) are the most actionable signal.
         if cat == "mistake":
             merged.sort(
                 key=lambda e: (
                     -(int(e.get("recurrence_after_briefing") or 0)),
-                    -_recency_composite_score(e, half_life),
+                    -_recency_composite_score(e, half_life) * _entity_boost(e),
                 )
             )
         else:
             # Rerank by composite recency score before truncating so that a recent
             # entry can always surface ahead of an equally-intense stale one.
-            merged.sort(key=lambda e: _recency_composite_score(e, half_life), reverse=True)
+            merged.sort(
+                key=lambda e: _recency_composite_score(e, half_life) * _entity_boost(e),
+                reverse=True,
+            )
         # WBS-014: defense-in-depth read-side credential/injection filter
         # Issue #377: universal status-note suppression — applied here so ALL
         # output formats (text, json, pack, compact) consistently omit Wave-style

--- a/briefing.py
+++ b/briefing.py
@@ -1775,15 +1775,26 @@ def _expand_query_with_entities(db: sqlite3.Connection, task: str) -> list[str]:
     if not row:
         return []
 
-    file_re = _re.compile(r"\b[\w/.-]+\.(?:py|ts|js|go|rs|java|rb|cpp|h|json|yaml|yml|toml)\b")
+    file_re = _re.compile(r"\b[\w/.-]+\.(?:py|ts|js|go|rs|java|rb|cpp|h|json|yaml|yml|toml|md)\b")
+    func_re = _re.compile(r"\b(?:def|function|fn|func|async\s+fn|async\s+function)\s+(\w+)")
     error_re = _re.compile(r"\b([A-Z][a-zA-Z]*(?:Error|Exception|Warning|Failure|Fault))\b")
+    tool_re = _re.compile(r"`(sk|git|gh|npm|pip|cargo|ruff|pytest|python3?)\s+[\w-]+`")
+    symbol_re = _re.compile(r"\b([A-Z][a-zA-Z0-9]{3,}(?:[A-Z][a-z]+)+)\b")
 
     entities: list[tuple[str, str]] = []
     for m in file_re.findall(task):
         if len(m) > 4:
             entities.append(("file_path", m.lower()))
+    for m in func_re.findall(task):
+        if len(m) > 2:
+            entities.append(("function", m.lower()))
     for m in error_re.findall(task):
         entities.append(("error_type", m))
+    for m in tool_re.findall(task):
+        entities.append(("tool", m.lower()))
+    for m in symbol_re.findall(task):
+        if len(m) > 5:
+            entities.append(("symbol", m))
 
     if not entities:
         return []
@@ -2581,9 +2592,9 @@ def generate_briefing(
                     continue
                 merged.append(r)
 
-        def _entity_boost(e: dict) -> float:
-            """1.2× multiplier for entries sharing entities with the task (issue #770)."""
-            return 1.2 if str(e.get("id", "")) in entity_matched_ids else 1.0
+        def _entity_bonus(e: dict) -> float:
+            """Additive boost for entries sharing entities with the task (issue #770)."""
+            return 0.2 if str(e.get("id", "")) in entity_matched_ids else 0.0
 
         # For mistakes, boost recurring entries to the top before composite recency sort.
         # Recurring mistakes (re-encountered after a briefing) are the most actionable signal.
@@ -2591,14 +2602,14 @@ def generate_briefing(
             merged.sort(
                 key=lambda e: (
                     -(int(e.get("recurrence_after_briefing") or 0)),
-                    -_recency_composite_score(e, half_life) * _entity_boost(e),
+                    -(_recency_composite_score(e, half_life) + _entity_bonus(e)),
                 )
             )
         else:
             # Rerank by composite recency score before truncating so that a recent
             # entry can always surface ahead of an equally-intense stale one.
             merged.sort(
-                key=lambda e: _recency_composite_score(e, half_life) * _entity_boost(e),
+                key=lambda e: _recency_composite_score(e, half_life) + _entity_bonus(e),
                 reverse=True,
             )
         # WBS-014: defense-in-depth read-side credential/injection filter

--- a/entity-extract.py
+++ b/entity-extract.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""entity-extract.py — extract and store entities from knowledge entries.
+
+Usage:
+    python entity-extract.py               # extract from all unprocessed entries
+    python entity-extract.py --all         # re-extract from all entries
+    python entity-extract.py --entry <id>  # extract for specific entry
+    python entity-extract.py --stats       # show entity coverage stats
+    python entity-extract.py --query "text" # show entities extracted from text
+"""
+
+import argparse
+import os
+import re
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if os.name == "nt":
+    sys.stdout.reconfigure(encoding="utf-8")
+
+_DB_CANDIDATES = [
+    Path.home() / ".copilot/knowledge.db",
+    Path(__file__).parent / "sessions.db",
+    Path.home() / ".copilot/tools/sessions.db",
+]
+
+# File path patterns — match things like auth.py, src/auth/middleware.ts
+_FILE_RE = re.compile(r"\b[\w/.-]+\.(?:py|ts|js|go|rs|java|rb|cpp|h|json|yaml|yml|toml|md)\b")
+# Python/TS function names in code context: def foo, function bar, fn baz, async foo
+_FUNC_RE = re.compile(r"\b(?:def|function|fn|func|async\s+fn|async\s+function)\s+(\w+)")
+# Error type patterns: FooError, BarException, TypeError etc.
+_ERROR_RE = re.compile(r"\b([A-Z][a-zA-Z]*(?:Error|Exception|Warning|Failure|Fault))\b")
+# Tool/command mentions: `sk xxx`, `git xxx`, `gh xxx`
+_TOOL_RE = re.compile(r"`(sk|git|gh|npm|pip|cargo|ruff|pytest|python3?)\s+[\w-]+`")
+# Symbol mentions: CamelCase classes (heuristic)
+_SYMBOL_RE = re.compile(r"\b([A-Z][a-zA-Z0-9]{3,}(?:[A-Z][a-z]+)+)\b")
+
+
+def _db_path() -> Path:
+    if e := os.environ.get("SK_DB_PATH"):
+        return Path(e)
+    for p in _DB_CANDIDATES:
+        if p.exists():
+            return p
+    return Path.home() / ".copilot/knowledge.db"
+
+
+def _has_entities_table(db: sqlite3.Connection) -> bool:
+    row = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='knowledge_entities'").fetchone()
+    return row is not None
+
+
+def extract_entities(text: str) -> list[tuple[str, str]]:
+    """Extract (entity_type, entity_value) pairs from text. Returns deduped list."""
+    if not text:
+        return []
+    results = set()
+    for m in _FILE_RE.findall(text):
+        if len(m) > 4 and ("/" in m or m.endswith(".py") or m.endswith(".ts")):
+            results.add(("file_path", m.lower()))
+    for m in _FUNC_RE.findall(text):
+        if len(m) > 2:
+            results.add(("function", m.lower()))
+    for m in _ERROR_RE.findall(text):
+        results.add(("error_type", m))
+    for m in _TOOL_RE.findall(text):
+        results.add(("tool", m.lower()))
+    for m in _SYMBOL_RE.findall(text):
+        if len(m) > 5:  # filter very short CamelCase
+            results.add(("symbol", m))
+    return list(results)
+
+
+def _process_entry(
+    db: sqlite3.Connection,
+    entry_id: int,
+    title: str,
+    content: str,
+    replace: bool = False,
+) -> int:
+    """Extract and store entities for one entry. Returns count inserted."""
+    if replace:
+        db.execute("DELETE FROM knowledge_entities WHERE entry_id = ?", (entry_id,))
+    text = f"{title} {content}"
+    entities = extract_entities(text)
+    now = datetime.now(timezone.utc).isoformat()
+    count = 0
+    for etype, evalue in entities:
+        try:
+            db.execute(
+                "INSERT OR IGNORE INTO knowledge_entities"
+                " (entry_id, entity_type, entity_value, created_at) VALUES (?,?,?,?)",
+                (entry_id, etype, evalue, now),
+            )
+            count += 1
+        except sqlite3.IntegrityError:
+            pass
+    return count
+
+
+def run_batch(db: sqlite3.Connection, replace: bool = False, limit: int = 0) -> dict:
+    """Process all unprocessed (or all if replace=True) entries."""
+    if replace:
+        query = "SELECT id, title, content FROM knowledge_entries ORDER BY id"
+        if limit:
+            query += f" LIMIT {limit}"
+        entries = db.execute(query).fetchall()
+    else:
+        query = (
+            "SELECT ke.id, ke.title, ke.content"
+            " FROM knowledge_entries ke"
+            " LEFT JOIN knowledge_entities ent ON ent.entry_id = ke.id"
+            " WHERE ent.id IS NULL"
+            " ORDER BY ke.id"
+        )
+        if limit:
+            query += f" LIMIT {limit}"
+        entries = db.execute(query).fetchall()
+    total_entities = 0
+    for row in entries:
+        total_entities += _process_entry(db, row[0], row[1], row[2], replace=replace)
+    db.commit()
+    return {"entries_processed": len(entries), "entities_inserted": total_entities}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract and store entities from knowledge entries")
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_entries",
+        help="Re-extract from all entries (not just unprocessed)",
+    )
+    parser.add_argument("--entry", type=int, metavar="ID", help="Process specific entry ID")
+    parser.add_argument("--stats", action="store_true")
+    parser.add_argument("--query", metavar="TEXT", help="Show entities extracted from TEXT")
+    parser.add_argument("--limit", type=int, default=0)
+    args = parser.parse_args()
+
+    if args.query:
+        entities = extract_entities(args.query)
+        print(f"Entities from: {args.query[:80]!r}")
+        for etype, evalue in sorted(entities):
+            print(f"  [{etype}] {evalue}")
+        return
+
+    db_path = _db_path()
+    if not db_path.exists():
+        print(f"DB not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+    db = sqlite3.connect(str(db_path))
+
+    if not _has_entities_table(db):
+        print(
+            "knowledge_entities table not found — run: python3 migrate.py",
+            file=sys.stderr,
+        )
+        db.close()
+        sys.exit(1)
+
+    if args.stats:
+        row = db.execute("SELECT COUNT(DISTINCT entry_id) FROM knowledge_entities").fetchone()
+        total_ke = db.execute("SELECT COUNT(*) FROM knowledge_entries").fetchone()[0]
+        print(f"Entity coverage: {row[0]}/{total_ke} entries have entities")
+        type_rows = db.execute(
+            "SELECT entity_type, COUNT(*) FROM knowledge_entities GROUP BY entity_type ORDER BY 2 DESC"
+        ).fetchall()
+        for r in type_rows:
+            print(f"  {r[0]:<15} {r[1]}")
+        db.close()
+        return
+
+    if args.entry:
+        row = db.execute("SELECT id, title, content FROM knowledge_entries WHERE id=?", (args.entry,)).fetchone()
+        if not row:
+            print(f"Entry {args.entry} not found", file=sys.stderr)
+            db.close()
+            sys.exit(1)
+        n = _process_entry(db, row[0], row[1], row[2], replace=True)
+        db.commit()
+        print(f"Extracted {n} entities for entry #{args.entry}")
+        db.close()
+        return
+
+    result = run_batch(db, replace=args.all_entries, limit=args.limit)
+    print(f"Processed {result['entries_processed']} entries, inserted {result['entities_inserted']} entities")
+    db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/entity-extract.py
+++ b/entity-extract.py
@@ -20,11 +20,7 @@ from pathlib import Path
 if os.name == "nt":
     sys.stdout.reconfigure(encoding="utf-8")
 
-_DB_CANDIDATES = [
-    Path.home() / ".copilot/knowledge.db",
-    Path(__file__).parent / "sessions.db",
-    Path.home() / ".copilot/tools/sessions.db",
-]
+_DEFAULT_DB_PATH = Path.home() / ".copilot" / "session-state" / "knowledge.db"
 
 # File path patterns — match things like auth.py, src/auth/middleware.ts
 _FILE_RE = re.compile(r"\b[\w/.-]+\.(?:py|ts|js|go|rs|java|rb|cpp|h|json|yaml|yml|toml|md)\b")
@@ -40,11 +36,8 @@ _SYMBOL_RE = re.compile(r"\b([A-Z][a-zA-Z0-9]{3,}(?:[A-Z][a-z]+)+)\b")
 
 def _db_path() -> Path:
     if e := os.environ.get("SK_DB_PATH"):
-        return Path(e)
-    for p in _DB_CANDIDATES:
-        if p.exists():
-            return p
-    return Path.home() / ".copilot/knowledge.db"
+        return Path(e).expanduser().resolve()
+    return _DEFAULT_DB_PATH.expanduser().resolve()
 
 
 def _has_entities_table(db: sqlite3.Connection) -> bool:
@@ -89,12 +82,13 @@ def _process_entry(
     count = 0
     for etype, evalue in entities:
         try:
-            db.execute(
+            cur = db.execute(
                 "INSERT OR IGNORE INTO knowledge_entities"
                 " (entry_id, entity_type, entity_value, created_at) VALUES (?,?,?,?)",
                 (entry_id, etype, evalue, now),
             )
-            count += 1
+            if cur.rowcount > 0:
+                count += 1
         except sqlite3.IntegrityError:
             pass
     return count

--- a/install.py
+++ b/install.py
@@ -244,6 +244,7 @@ TOOL_FILES = [
     "session-compare.py",
     "session-compact.py",
     "repo-map.py",
+    "entity-extract.py",
 ]
 
 SUPPORT_FILES = [

--- a/migrate.py
+++ b/migrate.py
@@ -1795,6 +1795,24 @@ if __name__ == "__main__":
                 "CREATE TRIGGER IF NOT EXISTS code_fts_trigram_au AFTER UPDATE ON code_index BEGIN INSERT INTO code_fts_trigram(code_fts_trigram, rowid, symbol_name, content_snippet, file_path, language, project_id) VALUES ('delete', old.id, old.symbol_name, old.content_snippet, old.file_path, old.language, old.project_id); INSERT INTO code_fts_trigram(rowid, symbol_name, content_snippet, file_path, language, project_id) VALUES (new.id, new.symbol_name, new.content_snippet, new.file_path, new.language, new.project_id); END",
             ],
         ),
+        # v37: issue #770 — Entity-linked recall: file_path/function/error_type/tool/symbol
+        # entities extracted from knowledge entries for graph-boosted briefing scoring.
+        (
+            37,
+            "knowledge_entities_table",
+            [
+                """CREATE TABLE IF NOT EXISTS knowledge_entities (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    entry_id INTEGER NOT NULL REFERENCES knowledge_entries(id),
+                    entity_type TEXT NOT NULL,
+                    entity_value TEXT NOT NULL,
+                    created_at TEXT DEFAULT (datetime('now')),
+                    UNIQUE(entry_id, entity_type, entity_value)
+                )""",
+                "CREATE INDEX IF NOT EXISTS idx_ke_ent_entry ON knowledge_entities(entry_id)",
+                "CREATE INDEX IF NOT EXISTS idx_ke_ent_type_val ON knowledge_entities(entity_type, entity_value)",
+            ],
+        ),
     ]
     applied = 0
     for ver, name, stmts in MIGRATIONS:

--- a/sk.py
+++ b/sk.py
@@ -263,6 +263,9 @@ _GROUPS: dict[str, dict[str, str]] = {
         "pins": "knowledge-health.py",
         "bulk-tag": "knowledge-health.py",
     },
+    "entity": {
+        "extract": "entity-extract.py",
+    },
 }
 
 

--- a/sk.py
+++ b/sk.py
@@ -91,6 +91,7 @@ _PROJECT_DB_SCRIPTS = {
     "briefing.py",
     "build-session-index.py",
     "embed.py",
+    "entity-extract.py",
     "extract-knowledge.py",
     "index-status.py",
     "knowledge-health.py",


### PR DESCRIPTION
## Summary
Implements #770: entity extraction and graph-boosted briefing recall.

## Changes
- **migrate.py**: `knowledge_entities` table v36 — `(entry_id, entity_type, entity_value)`
- **entity-extract.py**: New script — extracts file_path/function/error_type/tool/symbol entities from knowledge entries using regex; batch/single/stats/--query modes
- **briefing.py**: `_expand_query_with_entities()` — extracts entities from task text, finds matching entries, applies 1.2× score boost to composite recency sort
- **install.py** + **sk.py**: Wire `sk entity extract`

## Testing
- Entity extraction: `--query` mode tested ✅
- `python3 test_security.py`: 13 passed ✅
- `python3 test_fixes.py`: all passed ✅
- `ruff check`: clean ✅
- `ruff format --check`: clean ✅

Closes #770