### PR TITLE
feat(#787): sk trace — tool-call span observability from JSONL

### DIFF
--- a/install.py
+++ b/install.py
@@ -246,6 +246,7 @@ TOOL_FILES = [
     "repo-map.py",
     "coverage.py",
     "entity-extract.py",
+    "trace.py",
 ]
 
 SUPPORT_FILES = [

--- a/migrate.py
+++ b/migrate.py
@@ -1822,6 +1822,23 @@ if __name__ == "__main__":
                 "CREATE INDEX IF NOT EXISTS idx_ke_last_accessed ON knowledge_entries(last_accessed_at)",
             ],
         ),
+        (
+            39,
+            "tool_spans",
+            [
+                """CREATE TABLE IF NOT EXISTS tool_spans (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    turn_index INTEGER,
+                    duration_ms REAL,
+                    status TEXT DEFAULT 'unknown',
+                    created_at REAL DEFAULT (unixepoch('now'))
+                )""",
+                "CREATE INDEX IF NOT EXISTS idx_tool_spans_session ON tool_spans (session_id)",
+                "CREATE INDEX IF NOT EXISTS idx_tool_spans_tool ON tool_spans (tool_name)",
+            ],
+        ),
     ]
     applied = 0
     for ver, name, stmts in MIGRATIONS:

--- a/sk.py
+++ b/sk.py
@@ -170,6 +170,7 @@ _DIRECT: dict[str, CommandMeta] = {
     ),
     "repo-map": CommandMeta("repo-map.py", "PageRank-ranked symbol map for AI context injection", ("index", "map")),
     "coverage": CommandMeta("coverage.py", "Per-file knowledge coverage heatmap showing blind spots", ("index", "map")),
+    "trace": CommandMeta("trace.py", "Parse Copilot JSONL tool-call spans into SQLite", ("index", "observability")),
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}


### PR DESCRIPTION
Implements #787. New trace.py script parses Copilot JSONL and indexes tool-call spans. Closes #787