### PR TITLE
feat(#774): sk_compact_session MCP tool — capture mid-session structured checkpoint

### DIFF
--- a/mcp-server.py
+++ b/mcp-server.py
@@ -285,6 +285,25 @@ TOOLS = [
             "additionalProperties": False,
         },
     },
+    {
+        "name": "sk_compact_session",
+        "description": "Capture a mid-session structured checkpoint from conversation history into knowledge.db. Returns summary of what was stored.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "Conversation summary to compact (required)",
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": "Session ID to associate with (optional, auto-detected if omitted)",
+                },
+            },
+            "required": ["summary"],
+            "additionalProperties": False,
+        },
+    },
 ]
 
 
@@ -876,6 +895,31 @@ def _run_rate_entry(arguments: dict[str, Any]) -> dict[str, Any]:
     return {"content": [{"type": "text", "text": json.dumps(body, ensure_ascii=False)}], "structuredContent": body}
 
 
+def _run_compact_session(arguments: dict) -> dict:
+    """Delegate to session-compact.py with a caller-provided summary."""
+    summary = _require_string(arguments, "summary", max_length=32_000)
+    session_id = _optional_string(arguments, "session_id", max_length=200)
+
+    cmd = [sys.executable, str(TOOLS_DIR / "session-compact.py"), "--summary", summary, "--json"]
+    if session_id:
+        cmd += ["--session-id", session_id]
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        body = {"status": "error", "output": "Timed out after 30s"}
+        return {"content": [{"type": "text", "text": json.dumps(body)}], "structuredContent": body}
+    except Exception as exc:
+        body = {"status": "error", "output": str(exc)}
+        return {"content": [{"type": "text", "text": json.dumps(body)}], "structuredContent": body}
+
+    if proc.returncode == 0:
+        body = {"status": "ok", "output": proc.stdout.strip()}
+    else:
+        body = {"status": "error", "output": (proc.stderr.strip() or proc.stdout.strip())}
+    return {"content": [{"type": "text", "text": json.dumps(body, ensure_ascii=False)}], "structuredContent": body}
+
+
 def _handle_tools_call(params: dict[str, Any]) -> dict[str, Any]:
     name = params.get("name")
     if not isinstance(name, str) or not name:
@@ -901,6 +945,8 @@ def _handle_tools_call(params: dict[str, Any]) -> dict[str, Any]:
         return _run_code_search(arguments)
     if name == "rate_entry":
         return _run_rate_entry(arguments)
+    if name == "sk_compact_session":
+        return _run_compact_session(arguments)
     raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"Unknown tool: {name}")
 
 

--- a/session-compact.py
+++ b/session-compact.py
@@ -342,6 +342,12 @@ def main() -> None:
         dest="cross_session",
         help="Cluster last N session summaries using TF-IDF (default N=20)",
     )
+    parser.add_argument(
+        "--summary", dest="summary", default=None, help="Use provided text as checkpoint content directly (MCP path)"
+    )
+    parser.add_argument(
+        "--session-id", dest="session_id_flag", default=None, help="Session ID (alternative to positional arg)"
+    )
     args = parser.parse_args()
 
     db_path = _db_path()
@@ -379,10 +385,44 @@ def main() -> None:
         conn.close()
         return
 
-    session_id = args.session_id or _most_recent_session(conn)
+    session_id = args.session_id_flag or args.session_id or _most_recent_session(conn)
     if not session_id:
         print("No sessions found.", file=sys.stderr)
         sys.exit(1)
+
+    # MCP path: caller provides the summary text directly — store it without DB entry lookup
+    if args.summary:
+        content = args.summary.strip()
+        if not content:
+            print("--summary must not be empty.", file=sys.stderr)
+            sys.exit(1)
+        existing = _existing_checkpoint(conn, session_id)
+        est_tokens = len(content) // 4
+        if args.dry_run:
+            print(f"DRY RUN — would store provided summary for session {session_id[:30]}...")
+            print(f"Checkpoint: {len(content)} chars (~{est_tokens} tokens)")
+            conn.close()
+            return
+        entry_id = _store_checkpoint(conn, session_id, content, existing["id"] if existing else None)
+        if args.as_json:
+            print(
+                json.dumps(
+                    {
+                        "session_id": session_id,
+                        "entry_id": entry_id,
+                        "entries_compacted": 0,
+                        "checkpoint_chars": len(content),
+                        "est_tokens": est_tokens,
+                        "updated": existing is not None,
+                    }
+                )
+            )
+        else:
+            action = "Updated" if existing else "Created"
+            print(f"✅ {action} checkpoint #{entry_id} for session {session_id[:30]}...")
+            print(f"   Stored provided summary → {len(content)} chars (~{est_tokens} tokens)")
+        conn.close()
+        return
 
     entries = _get_entries(conn, session_id)
     if not entries:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -103,8 +103,8 @@ class TestToolsList(unittest.TestCase):
         self.tools = {t["name"]: t for t in mcp.TOOLS}
 
     def test_exactly_two_tools(self):
-        # Updated: wave 8 added learn, status, session_list; code_search added later; rate_entry added (#820); now 8 tools total
-        self.assertEqual(len(mcp.TOOLS), 8)
+        # Updated: wave 8 added learn, status, session_list; code_search added later; rate_entry added (#820); now 9 tools total
+        self.assertEqual(len(mcp.TOOLS), 9)
 
     def test_briefing_tool_present(self):
         self.assertIn("briefing", self.tools)
@@ -1098,8 +1098,8 @@ class TestQueryMemoryTool(unittest.TestCase):
         self.assertTrue(self.tools["code_search"]["description"])
 
     def test_exactly_three_tools(self):
-        # Updated: wave 8 added learn, status, session_list; code_search added later; rate_entry added (#820); now 8 tools total
-        self.assertEqual(len(mcp.TOOLS), 8)
+        # Updated: wave 8 added learn, status, session_list; code_search added later; rate_entry added (#820); now 9 tools total
+        self.assertEqual(len(mcp.TOOLS), 9)
 
     def test_rate_entry_tool_present(self):
         self.assertIn("rate_entry", self.tools)


### PR DESCRIPTION
Implements #774. Adds `sk_compact_session` to the MCP server.

## Changes
- **mcp-server.py**: New `sk_compact_session` tool in `TOOLS` list, `_run_compact_session()` handler, wired into `_handle_tools_call()`
- **session-compact.py**: Added `--summary` and `--session-id` flags to support MCP-driven direct-text checkpoints (bypasses DB entry lookup when summary is provided inline)

## Tool schema
`sk_compact_session(summary: str, session_id?: str)` — caller provides a conversation summary; the tool stores it as a `session_checkpoint` entry via `session-compact.py --summary`.

Closes #774