### PR TITLE
feat(#799): mistake recurrence detection — auto-escalate to P0

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -54,6 +54,7 @@ hooks/
 | `verification-gate` | preToolUse + postToolUse | Tracks dirty Python / `browse-ui` TS/JS surfaces, records successful verification commands, and blocks closeout-style actions (`task_complete`, `gh issue close/comment`, tentacle `handoff --status DONE`, tentacle `complete`) until the required fresh evidence exists. |
 | `file-size-advisory` | preToolUse | Warns when an `edit`/`create` payload would leave a Python file over 400 lines. Advisory-only and fail-open: emits information but never denies the tool call. |
 | `new-file-advisory` | preToolUse | Warns when a `create` payload targets a new root Python script. Advisory-only and fail-open: cites Rule 11 and asks agents to justify the new file, reuse an existing home when possible, and update tests/lint coverage. |
+| `post-commit-briefing` | postToolUse | Emits a scoped mini-briefing when `git commit` completes in `bash`. Queries `knowledge_entries` for entries referencing committed files, then returns relevant past mistakes and patterns as `additionalContext`. Fail-open and silent when no entries match. |
 | `track-edits` | postToolUse | Detects file changes via `git status` (language-agnostic) |
 | `learn-reminder` | postToolUse | Reminds to record learnings after task_complete; writes `learn-done` for `learn.py` and `sk learn`; also surfaces [docs/SYNC-MATRIX.md](SYNC-MATRIX.md) plus a skill-creator standards follow-up when lessons should update reusable skills |
 | `test-reminder` | postToolUse | Reminds to run tests after 3+ Python file edits |

--- a/learn.py
+++ b/learn.py
@@ -545,6 +545,54 @@ _ROOM_RULES = [
 ]
 
 
+def _detect_recurrence(db: sqlite3.Connection, entry_id: int, category: str) -> bool:
+    """Return True if this entry was already served in the current session (recurrence)."""
+    if category != "mistake":
+        return False
+    try:
+        rows = db.execute(
+            "SELECT selected_entry_ids FROM recall_events "
+            "WHERE created_at > unixepoch('now', '-8 hours') "
+            "ORDER BY created_at DESC LIMIT 20"
+        ).fetchall()
+        for row in rows:
+            if row[0]:
+                try:
+                    ids = json.loads(row[0])
+                    if entry_id in ids or str(entry_id) in ids:
+                        return True
+                except (json.JSONDecodeError, TypeError):
+                    pass
+    except Exception:
+        pass
+    return False
+
+
+def _handle_recurrence(db: sqlite3.Connection, entry_id: int) -> None:
+    """Escalate entry to P0 and tag as recurring if recurrence_count >= 2."""
+    db.execute(
+        "UPDATE knowledge_entries SET recurrence_count = recurrence_count + 1 WHERE id = ?",
+        (entry_id,),
+    )
+    row = db.execute(
+        "SELECT recurrence_count, tags, priority FROM knowledge_entries WHERE id = ?",
+        (entry_id,),
+    ).fetchone()
+    if not row:
+        return
+    count, tags, priority = row
+    if count >= 2:
+        new_tags = tags or ""
+        if "recurring" not in new_tags:
+            new_tags = (new_tags + ",recurring").strip(",")
+        db.execute(
+            "UPDATE knowledge_entries SET priority = 'P0', tags = ? WHERE id = ?",
+            (new_tags, entry_id),
+        )
+        print(f"⚠️  Recurrence detected (count={count})! Entry #{entry_id} escalated to P0 with tag 'recurring'.")
+    db.commit()
+
+
 def _detect_wing(tags: str, title: str, content: str) -> str:
     """Auto-detect wing from tags/title/content."""
     tag_set = {t.strip().lower() for t in tags.split(",") if t.strip()}
@@ -1200,6 +1248,7 @@ def add_entry(
     has_epistemic_humility_columns = all(c in ke_columns for c in ("certainty", "caveats"))
     has_deleted_at_column = "deleted_at" in ke_columns
     has_recurrence_column = "recurrence_after_briefing" in ke_columns
+    has_recurrence_count_column = "recurrence_count" in ke_columns
     has_briefing_deliveries = (
         db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='briefing_deliveries'").fetchone()
         is not None
@@ -1594,6 +1643,24 @@ def add_entry(
                 "UPDATE knowledge_entries SET certainty = ?, caveats = ? WHERE id = ?",
                 (certainty or "", caveats or "", entry_id),
             )
+        # Recurrence detection (#799): for new mistake entries, check if a similar
+        # existing entry was recently served via recall_events. Escalate it to P0 if so.
+        if has_recurrence_count_column and category == "mistake":
+            _sim_sql2 = "SELECT id, title, content FROM knowledge_entries WHERE category = ? AND id != ?"
+            if has_deleted_at_column:
+                _sim_sql2 += " AND deleted_at IS NULL"
+            _sim_sql2 += " ORDER BY id DESC LIMIT 50"
+            _sim_rows2 = db.execute(_sim_sql2, (category, entry_id)).fetchall()
+            _new_tokens2 = {t for t in re.findall(r"[a-z0-9]+", (title + " " + content).lower()) if t}
+            for _sim_row2 in _sim_rows2:
+                _row_text2 = (_sim_row2[1] or "") + " " + (_sim_row2[2] or "")
+                _row_tokens2 = {t for t in re.findall(r"[a-z0-9]+", _row_text2.lower()) if t}
+                if not _new_tokens2 or not _row_tokens2:
+                    continue
+                _sim_score2 = len(_new_tokens2 & _row_tokens2) / len(_new_tokens2 | _row_tokens2)
+                if _sim_score2 >= 0.6 and _detect_recurrence(db, _sim_row2[0], category):
+                    _handle_recurrence(db, _sim_row2[0])
+                    break
         if has_stable_id_column:
             inserted_stable_id = db.execute(
                 "SELECT COALESCE(stable_id, '') FROM knowledge_entries WHERE id = ?",

--- a/migrate.py
+++ b/migrate.py
@@ -1839,6 +1839,16 @@ if __name__ == "__main__":
                 "CREATE INDEX IF NOT EXISTS idx_tool_spans_tool ON tool_spans (tool_name)",
             ],
         ),
+        # v37: issue #799 — mistake recurrence detection.
+        # recurrence_count tracks how many times a mistake entry was re-learned after
+        # a similar entry was recently served via recall_events (8-hour window).
+        (
+            40,
+            "add_recurrence_count",
+            [
+                "ALTER TABLE knowledge_entries ADD COLUMN recurrence_count INTEGER DEFAULT 0",
+            ],
+        ),
         # v37: issue #797 — FSRS-style recall stability factor.
         # stability_factor scales the Ebbinghaus half-life in briefing decay scoring.
         # Default 1.0 = unchanged; ×1.3 on good feedback, ×0.8 on bad feedback,


### PR DESCRIPTION
Implements #799. Detects when a briefing-served mistake is re-learned. Auto-escalates to P0 + 'recurring' tag. Closes #799