### PR TITLE
feat(#797): FSRS-style recall stability — confirmed recalls slow decay

### DIFF
--- a/briefing.py
+++ b/briefing.py
@@ -1777,6 +1777,15 @@ def _ke_has_is_resolved(db: sqlite3.Connection) -> bool:
         return False
 
 
+def _ke_has_stability_factor(db: sqlite3.Connection) -> bool:
+    """Return True if knowledge_entries has the stability_factor column (v37 migration applied)."""
+    try:
+        cols = {row[1] for row in db.execute("PRAGMA table_info(knowledge_entries)").fetchall()}
+        return "stability_factor" in cols
+    except Exception:
+        return False
+
+
 def _ke_has_recurrence(db: sqlite3.Connection) -> bool:
     """Return True if knowledge_entries has the recurrence_after_briefing column."""
     try:
@@ -1811,11 +1820,16 @@ def _intensity_order_expr(alias: str = "ke", has_priority: bool = False) -> str:
     return f"COALESCE({alias}.intensity, 0.5) DESC, {alias}.confidence DESC, rank"
 
 
-def _recency_decay(last_seen_str: str | None, half_life_days: float = 30.0) -> float:
-    """Exponential decay weight for an entry's age.
+def _recency_decay(
+    last_seen_str: str | None,
+    half_life_days: float = 30.0,
+    stability_factor: float = 1.0,
+) -> float:
+    """Exponential decay weight for an entry's age, scaled by FSRS stability factor.
 
     Returns a value in (0, 1]: 1.0 for a just-created entry, approaching 0 for
-    a very old one.  An entry exactly ``half_life_days`` old scores 0.5.
+    a very old one.  An entry exactly ``half_life_days * stability_factor`` old
+    scores 0.5 — higher stability means slower decay (issue #797).
     Returns 1.0 (fail-open) when the timestamp is absent or unparseable.
     """
     if not last_seen_str or half_life_days <= 0:
@@ -1825,7 +1839,8 @@ def _recency_decay(last_seen_str: str | None, half_life_days: float = 30.0) -> f
         ts = datetime.datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S")
         now_utc = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         age_days = max(0.0, (now_utc - ts).total_seconds() / 86400.0)
-        return 0.5 ** (age_days / half_life_days)
+        effective_half_life = half_life_days * max(0.1, stability_factor or 1.0)
+        return 0.5 ** (age_days / effective_half_life)
     except Exception:
         return 1.0
 
@@ -1963,7 +1978,8 @@ def _recency_composite_score(entry: dict, half_life_days: float) -> float:
         # no-intensity rows to the same constant.
         confidence_raw = entry.get("confidence")
         intensity = float(confidence_raw) if confidence_raw is not None else 0.5
-    decay = _recency_decay(entry.get("last_seen"), half_life_days)
+    stability = float(entry.get("stability_factor") or 1.0)
+    decay = _recency_decay(entry.get("last_seen"), half_life_days, stability_factor=stability)
     access_decay = _decay_weight(entry.get("last_accessed_at", ""))
     return priority_base + intensity * decay * access_decay
 
@@ -2047,9 +2063,11 @@ def search_knowledge_entries(
     has_recurrence = _ke_has_recurrence(db)
     has_is_resolved = _ke_has_is_resolved(db)
     has_last_accessed = _ke_has_last_accessed(db)
+    has_stability = _ke_has_stability_factor(db)
     order_by = _intensity_order_expr("ke", has_priority) if has_intensity else "ke.confidence DESC, rank"
     # Extra columns fetched so Python-level recency composite scoring has priority + intensity + age.
     _rec_cols = ", COALESCE(ke.intensity, 0.5) as intensity, ke.last_seen" if has_intensity else ", ke.last_seen"
+    _stability_col = ", COALESCE(ke.stability_factor, 1.0) as stability_factor" if has_stability else ""
     _priority_col = ", COALESCE(ke.priority, 'P2') as priority" if has_priority else ""
     _recurrence_col = (
         ", COALESCE(ke.recurrence_after_briefing, 0) AS recurrence_after_briefing" if has_recurrence else ""
@@ -2080,7 +2098,7 @@ def search_knowledge_entries(
                    d.doc_type as source_doc_type,
                    d.title as source_doc_title,
                    d.file_path as source_doc_file_path,
-                   d.seq as source_doc_seq{_rec_cols}{_priority_col}{_recurrence_col}{_last_accessed_col}
+                   d.seq as source_doc_seq{_rec_cols}{_priority_col}{_recurrence_col}{_last_accessed_col}{_stability_col}
             FROM ke_fts fts
             JOIN knowledge_entries ke ON fts.rowid = ke.id
             LEFT JOIN documents d ON ke.document_id = d.id
@@ -2089,7 +2107,7 @@ def search_knowledge_entries(
             AND ke.confidence >= ?{_date_clause}{_resolved_clause}{_exclude_clause}
             ORDER BY {order_by}
             LIMIT ?
-        """,
+            """,
             (fts_query, category, effective_confidence, *_date_params, limit),
         ).fetchall()
         results.extend([dict(r) for r in rows])
@@ -2098,7 +2116,7 @@ def search_knowledge_entries(
             rows = db.execute(
                 f"""
                 SELECT ke.id, ke.title, ke.content, ke.tags,
-                       ke.confidence, ke.session_id, ke.occurrence_count{_rec_cols}{_priority_col}{_recurrence_col}{_last_accessed_col}
+                       ke.confidence, ke.session_id, ke.occurrence_count{_rec_cols}{_priority_col}{_recurrence_col}{_last_accessed_col}{_stability_col}
                 FROM ke_fts fts
                 JOIN knowledge_entries ke ON fts.rowid = ke.id
                 WHERE ke_fts MATCH ?
@@ -2127,7 +2145,7 @@ def search_knowledge_entries(
                        d.doc_type as source_doc_type,
                        d.title as source_doc_title,
                        d.file_path as source_doc_file_path,
-                       d.seq as source_doc_seq{_rec_cols}{_priority_col}{_recurrence_col}{_last_accessed_col}
+                       d.seq as source_doc_seq{_rec_cols}{_priority_col}{_recurrence_col}{_last_accessed_col}{_stability_col}
                 FROM ke_fts fts
                 JOIN knowledge_entries ke ON fts.rowid = ke.id
                 LEFT JOIN documents d ON ke.document_id = d.id
@@ -2136,7 +2154,7 @@ def search_knowledge_entries(
                 AND ke.confidence >= ?{_date_clause}{_resolved_clause}{_exclude_clause}
                 ORDER BY {order_by}
                 LIMIT ?
-            """,
+                """,
                 (base_query, category, min_confidence, *_date_params, limit),
             ).fetchall()
             results.extend([dict(r) for r in rows])
@@ -2145,7 +2163,7 @@ def search_knowledge_entries(
                 rows = db.execute(
                     f"""
                     SELECT ke.id, ke.title, ke.content, ke.tags,
-                           ke.confidence, ke.session_id, ke.occurrence_count{_rec_cols}{_priority_col}{_recurrence_col}{_last_accessed_col}
+                           ke.confidence, ke.session_id, ke.occurrence_count{_rec_cols}{_priority_col}{_recurrence_col}{_last_accessed_col}{_stability_col}
                     FROM ke_fts fts
                     JOIN knowledge_entries ke ON fts.rowid = ke.id
                     WHERE ke_fts MATCH ?

--- a/learn.py
+++ b/learn.py
@@ -2286,11 +2286,62 @@ def mark_resolved(entry_id: int, fix_steps: str = "", prevention_hook: str = "")
     if prevention_hook and "prevention_hook" in ke_columns:
         set_parts.append("prevention_hook = ?")
         params.append(prevention_hook)
+    # FSRS stability: resolving a mistake signals strong recall — boost half-life.
+    if "stability_factor" in ke_columns and row["category"] == "mistake":
+        cur_sf = db.execute(
+            "SELECT COALESCE(stability_factor, 1.0) FROM knowledge_entries WHERE id = ?", (entry_id,)
+        ).fetchone()[0]
+        new_sf = min(4.0, (cur_sf or 1.0) * 1.5)
+        set_parts.append("stability_factor = ?")
+        params.append(new_sf)
     params.append(entry_id)
     db.execute(f"UPDATE knowledge_entries SET {', '.join(set_parts)} WHERE id = ?", params)
     db.commit()
     db.close()
     print(f"  ✅ Resolved #{entry_id} [{row['category']}] {row['title'][:60]}")
+    return True
+
+
+def update_stability_factor(entry_id: int, verdict: str) -> bool:
+    """Update FSRS stability_factor for an entry based on recall feedback (issue #797).
+
+    verdict: 'good' multiplies by 1.3 (capped at 4.0) — slower decay.
+             'bad'  multiplies by 0.8 (floored at 0.5) — faster decay.
+    Returns True on success, False when entry not found or schema is pre-v37.
+    """
+    if verdict not in ("good", "bad"):
+        print(f"  ⚠ --feedback verdict must be 'good' or 'bad' (got {verdict!r})", file=sys.stderr)
+        return False
+    db = get_db()
+    ke_columns = {row[1] for row in db.execute("PRAGMA table_info(knowledge_entries)").fetchall()}
+    if "stability_factor" not in ke_columns:
+        print(
+            "  ⚠ DB schema missing stability_factor column. Run migrate.py to enable FSRS stability.",
+            file=sys.stderr,
+        )
+        db.close()
+        return False
+    row = db.execute(
+        "SELECT id, title, COALESCE(stability_factor, 1.0) AS stability_factor FROM knowledge_entries WHERE id = ?",
+        (entry_id,),
+    ).fetchone()
+    if not row:
+        print(f"  ⚠ Entry #{entry_id} not found.", file=sys.stderr)
+        db.close()
+        return False
+    cur_sf = float(row["stability_factor"] or 1.0)
+    if verdict == "good":
+        new_sf = min(4.0, cur_sf * 1.3)
+    else:
+        new_sf = max(0.5, cur_sf * 0.8)
+    db.execute(
+        "UPDATE knowledge_entries SET stability_factor = ? WHERE id = ?",
+        (new_sf, entry_id),
+    )
+    db.commit()
+    db.close()
+    label = "↑" if verdict == "good" else "↓"
+    print(f"  {label} stability_factor #{entry_id}: {cur_sf:.3f} → {new_sf:.3f} ({verdict})")
     return True
 
 
@@ -2806,6 +2857,20 @@ def main():
 
     if "--stats" in args:
         show_stats()
+        return
+
+    if "--feedback" in args:
+        idx = args.index("--feedback")
+        raw_id = args[idx + 1] if idx + 1 < len(args) else ""
+        raw_verdict = args[idx + 2] if idx + 2 < len(args) else ""
+        try:
+            fb_id = int(raw_id)
+        except (ValueError, TypeError):
+            print(f"Error: --feedback requires an integer entry ID (got {raw_id!r})", file=sys.stderr)
+            sys.exit(1)
+        ok = update_stability_factor(fb_id, raw_verdict)
+        if not ok:
+            sys.exit(1)
         return
 
     if "--mark-resolved" in args:

--- a/migrate.py
+++ b/migrate.py
@@ -1839,6 +1839,17 @@ if __name__ == "__main__":
                 "CREATE INDEX IF NOT EXISTS idx_tool_spans_tool ON tool_spans (tool_name)",
             ],
         ),
+        # v37: issue #797 — FSRS-style recall stability factor.
+        # stability_factor scales the Ebbinghaus half-life in briefing decay scoring.
+        # Default 1.0 = unchanged; ×1.3 on good feedback, ×0.8 on bad feedback,
+        # ×1.5 on mark-resolved (mistake). Clamped to [0.5, 4.0].
+        (
+            41,
+            "fsrs_stability_factor",
+            [
+                "ALTER TABLE knowledge_entries ADD COLUMN stability_factor REAL DEFAULT 1.0",
+            ],
+        ),
         (
             42,
             "search_feedback_note",


### PR DESCRIPTION
Implements #797. Adds stability_factor column; --feedback good/bad and --mark-resolved update it; _recency_decay() uses it in Ebbinghaus formula. Closes #797