### PR TITLE
feat(#816): agent-to-agent knowledge fanout — broadcast marker for parallel agents

### DIFF
--- a/briefing.py
+++ b/briefing.py
@@ -5132,6 +5132,7 @@ def main():
 
     subagent_mode = "--for-subagent" in args
     no_danger = "--no-danger" in args
+    broadcast_check = "--broadcast-check" in args
 
     # --with-code-context: append relevant code spans from code_index (issue #747)
     with_code_context = "--with-code-context" in args
@@ -5408,6 +5409,19 @@ def main():
             _no_repeat_session_id,
             already_served | set(output_meta.get("selected_entry_ids", [])),
         )
+
+    if broadcast_check:
+        since = time.time() - 3600  # last 1 hour
+        broadcast_path = Path.home() / ".copilot" / "markers" / "knowledge-broadcast.jsonl"
+        new_count = 0
+        if broadcast_path.exists():
+            try:
+                with broadcast_path.open(encoding="utf-8") as f:
+                    new_count = sum(1 for line in f if line.strip() and json.loads(line).get("ts", 0) >= since)
+            except Exception:
+                pass
+        if new_count > 0:
+            print(f"⚡ {new_count} new entries from parallel agents (last 1h) — run: sk knowledge broadcast")
 
     print(output)
 

--- a/install.py
+++ b/install.py
@@ -247,6 +247,7 @@ TOOL_FILES = [
     "coverage.py",
     "entity-extract.py",
     "trace.py",
+    "knowledge-broadcast.py",
 ]
 
 SUPPORT_FILES = [

--- a/knowledge-broadcast.py
+++ b/knowledge-broadcast.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""sk knowledge broadcast — tail broadcast log for new entries from parallel agents."""
+
+import os
+import sys
+
+if os.name == "nt":
+    sys.stdout.reconfigure(encoding="utf-8")
+
+import json
+import time
+from pathlib import Path
+
+BROADCAST_PATH = Path.home() / ".copilot" / "markers" / "knowledge-broadcast.jsonl"
+
+
+def _read_since(since: float, limit: int) -> list[dict]:
+    if not BROADCAST_PATH.exists():
+        return []
+    entries = []
+    try:
+        with BROADCAST_PATH.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                    if rec.get("ts", 0) >= since:
+                        entries.append(rec)
+                except json.JSONDecodeError:
+                    pass
+    except OSError:
+        pass
+    return entries[-limit:]
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="sk knowledge broadcast — check for new entries from parallel agents")
+    parser.add_argument(
+        "--since",
+        type=float,
+        default=time.time() - 3600,
+        help="Epoch timestamp; show entries since this time (default: last 1h)",
+    )
+    parser.add_argument("--limit", type=int, default=20, help="Max entries to show")
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    args = parser.parse_args()
+
+    entries = _read_since(args.since, args.limit)
+
+    if args.json:
+        print(json.dumps(entries, indent=2))
+        return
+
+    if not entries:
+        print("No new knowledge entries since specified time.")
+        return
+
+    print(f"⚡ {len(entries)} new knowledge entries:")
+    for e in entries:
+        ts_str = time.strftime("%H:%M", time.localtime(e.get("ts", 0)))
+        print(f"  [{ts_str}] [{e.get('category', '?')}] #{e.get('entry_id', '?')} — {e.get('title', '?')[:60]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/learn.py
+++ b/learn.py
@@ -211,6 +211,28 @@ def _replay_queued_payload(payload: dict) -> tuple[int, int]:
     return entry_id, cerebrum_rc
 
 
+def _broadcast_new_entry(entry_id: int, category: str, title: str, session_id: str) -> None:
+    """Append lightweight notification to broadcast log for parallel agents."""
+    import json
+    import time
+
+    markers_dir = Path.home() / ".copilot" / "markers"
+    markers_dir.mkdir(parents=True, exist_ok=True)
+    broadcast_path = markers_dir / "knowledge-broadcast.jsonl"
+    record = {
+        "ts": time.time(),
+        "entry_id": entry_id,
+        "category": category,
+        "title": title[:100],
+        "session_id": session_id or "",
+    }
+    try:
+        with broadcast_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        pass  # fail-open
+
+
 def _write_learn_entry(
     entry_kwargs: dict,
     *,
@@ -1655,6 +1677,7 @@ def add_entry(
 
     db.commit()
     db.close()
+    _broadcast_new_entry(entry_id, category, title, session_id)
     return entry_id
 
 

--- a/sk.py
+++ b/sk.py
@@ -265,6 +265,7 @@ _GROUPS: dict[str, dict[str, str]] = {
         "unpin": "knowledge-health.py",
         "pins": "knowledge-health.py",
         "bulk-tag": "knowledge-health.py",
+        "broadcast": "knowledge-broadcast.py",
     },
     "entity": {
         "extract": "entity-extract.py",


### PR DESCRIPTION
## Summary

Implements #816: agent-to-agent knowledge fanout via broadcast marker.

## Changes

- **learn.py**: Added `_broadcast_new_entry()` that appends a lightweight JSONL record to `~/.copilot/markers/knowledge-broadcast.jsonl` after every successful knowledge INSERT. Fail-open — `OSError` is silently ignored.
- **knowledge-broadcast.py** (new): CLI to tail the broadcast log. Supports `--since <epoch>`, `--limit`, and `--json` output. Invoked via `sk knowledge broadcast`.
- **briefing.py**: Added `--broadcast-check` flag — prepends `⚡ N new entries from parallel agents (last 1h)` before normal briefing output when new entries are detected.
- **install.py**: Added `knowledge-broadcast.py` to `TOOL_FILES`.
- **sk.py**: Added `"broadcast": "knowledge-broadcast.py"` to the `knowledge` sub-command group.

## Verification

- `python3 test_security.py`: **13 passed, 0 failed** ✅
- `python3 test_fixes.py`: **all tests passed** ✅
- `ruff check` + `ruff format --check`: **all clean** ✅
- `python3 -c "import ast; ..."`: **syntax OK** ✅

Closes #816