### PR TITLE
feat(#834): sk retro --capture — auto-persist retro as knowledge entry

### DIFF
--- a/retro.py
+++ b/retro.py
@@ -13,16 +13,18 @@ Usage:
     python3 retro.py --mode repo             # Repo-only mode (git signals only, no local DBs)
     python3 retro.py --days N                # Lookback window in days (default 30)
     python3 retro.py --stale N               # Staleness threshold in days for knowledge (default 30)
+    python3 retro.py --capture               # Auto-persist retro report as a knowledge entry via learn.py
 
 Modes:
     local (default) — reads knowledge.db, skill-metrics.db, audit.jsonl, git history
     repo            — reads only git history; safe for CI and environments without local DBs
 
 Read-only guarantees:
-    - No writes to any database
+    - No writes to any database (unless --capture is passed)
     - No issue creation, PR creation, or git commits
     - No hook binding or indexing side effects
     - State cache (.retro-state.json) is written locally but never committed
+    - --capture invokes learn.py to persist the report as a knowledge entry
 """
 
 import importlib.util
@@ -1458,9 +1460,10 @@ def main() -> None:
         if args["capture"]:
             import datetime as _dt834
 
-            title = f"Session retro {_dt834.datetime.now().strftime('%Y-%m-%d')}"
-            tags = "retro,session-retrospective"
-            subprocess.run(
+            _today = _dt834.datetime.now().strftime("%Y-%m-%d")
+            title = f"Session retro {_today}"
+            tags = f"retro,session-retrospective,date:{_today}"
+            _cap = subprocess.run(
                 [
                     sys.executable,
                     str(Path(__file__).parent / "learn.py"),
@@ -1471,8 +1474,13 @@ def main() -> None:
                     tags,
                 ],
                 check=False,
+                capture_output=True,
+                timeout=30,
             )
-            print(f"[retro] Saved as knowledge entry: {title}")
+            if _cap.returncode == 0:
+                print(f"[retro] Saved as knowledge entry: {title}")
+            else:
+                print(f"[retro] Failed to save knowledge entry (exit {_cap.returncode})", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/retro.py
+++ b/retro.py
@@ -1333,6 +1333,7 @@ def _parse_args(argv: list) -> dict:
         "by_wing": False,
         "by_tag": None,
         "by_room": None,
+        "capture": False,
     }
     i = 0
     while i < len(argv):
@@ -1378,6 +1379,8 @@ def _parse_args(argv: list) -> dict:
             if i + 1 < len(argv):
                 i += 1
                 args["by_room"] = argv[i]
+        elif a == "--capture":
+            args["capture"] = True
         i += 1
     return args
 
@@ -1452,6 +1455,24 @@ def main() -> None:
             except Exception:
                 pass
         print(report)
+        if args["capture"]:
+            import datetime as _dt834
+
+            title = f"Session retro {_dt834.datetime.now().strftime('%Y-%m-%d')}"
+            tags = "retro,session-retrospective"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).parent / "learn.py"),
+                    "--discovery",
+                    title,
+                    report,
+                    "--tags",
+                    tags,
+                ],
+                check=False,
+            )
+            print(f"[retro] Saved as knowledge entry: {title}")
 
 
 if __name__ == "__main__":

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -12272,6 +12272,119 @@ except Exception as _e819:
         test(f"I819-{_lbl819}: knowledge entry version history", False, str(_e819))
 
 # ---------------------------------------------------------------------------
+# I834: retro --capture flag
+# ---------------------------------------------------------------------------
+try:
+    import importlib.util as _ilu834
+
+    _retro834_path = REPO / "retro.py"
+    _spec834 = _ilu834.spec_from_file_location("retro834", str(_retro834_path))
+    _retro834 = _ilu834.module_from_spec(_spec834)
+    _spec834.loader.exec_module(_retro834)
+
+    # I834-1: _parse_args accepts --capture flag
+    _args834 = _retro834._parse_args(["--capture"])
+    test("I834-1: _parse_args accepts --capture flag", _args834.get("capture") is True, str(_args834))
+
+    # I834-2: --capture is False by default
+    _args834_def = _retro834._parse_args([])
+    test("I834-2: capture defaults to False", _args834_def.get("capture") is False, str(_args834_def))
+
+    # I834-3: --capture combined with other flags parses correctly
+    _args834_combo = _retro834._parse_args(["--mode", "repo", "--capture", "--days", "7"])
+    test(
+        "I834-3: --capture combines with --mode and --days",
+        _args834_combo.get("capture") is True
+        and _args834_combo.get("mode") == "repo"
+        and _args834_combo.get("days") == 7,
+        str(_args834_combo),
+    )
+
+    # I834-4: main() with --capture calls learn.py subprocess (mock subprocess.run)
+    import subprocess as _sp834
+    import unittest.mock as _mock834
+
+    _calls834: list = []
+
+    def _mock_run834(*_a, **_kw):
+        _calls834.append((_a, _kw))
+
+        class _R:
+            returncode = 0
+
+        return _R()
+
+    _orig_run834 = _sp834.run
+    _sp834.run = _mock_run834
+    _retro834_orig_sp = _retro834.subprocess
+    _retro834.subprocess = _sp834
+
+    import io as _io834
+    from contextlib import redirect_stdout as _rs834
+
+    _buf834 = _io834.StringIO()
+    try:
+        with _rs834(_buf834):
+            _retro834.main.__globals__["sys"].argv = ["retro.py", "--capture", "--mode", "repo"]
+        # Parse args outside redirect so test() output is visible
+        _args834_main = _retro834._parse_args(["--capture", "--mode", "repo"])
+        test("I834-4a: main args capture=True", _args834_main["capture"] is True)
+    finally:
+        _sp834.run = _orig_run834
+
+    # I834-5: learn.py is invoked with --discovery and retro,session-retrospective tags
+    _calls834b: list = []
+
+    def _mock_run834b(*_a, **_kw):
+        _calls834b.append((_a, _kw))
+
+        class _R:
+            returncode = 0
+
+        return _R()
+
+    _sp834.run = _mock_run834b
+
+    import sys as _sys834
+
+    _buf834b = _io834.StringIO()
+    try:
+        with _rs834(_buf834b):
+            # Simulate the capture block as written in retro.py main()
+            import datetime as _dt834
+
+            _title834 = f"Session retro {_dt834.datetime.now().strftime('%Y-%m-%d')}"
+            _tags834 = "retro,session-retrospective"
+            _report834 = "## Retro\nscore: 80"
+            _sp834.run(
+                [
+                    _sys834.executable,
+                    str(_retro834_path.parent / "learn.py"),
+                    "--discovery",
+                    _title834,
+                    _report834,
+                    "--tags",
+                    _tags834,
+                ],
+                check=False,
+            )
+            print(f"[retro] Saved as knowledge entry: {_title834}")
+        _out834b = _buf834b.getvalue()
+        test("I834-5a: learn.py subprocess called with --discovery", len(_calls834b) == 1, str(len(_calls834b)))
+        if _calls834b:
+            _cmd834 = _calls834b[0][0][0]
+            test("I834-5b: subprocess cmd contains --discovery", "--discovery" in _cmd834, str(_cmd834))
+            test("I834-5c: subprocess cmd contains retro tag", "retro,session-retrospective" in _cmd834, str(_cmd834))
+            test("I834-5d: subprocess cmd contains learn.py", any("learn.py" in str(c) for c in _cmd834), str(_cmd834))
+        test("I834-5e: [retro] confirmation printed", "[retro] Saved as knowledge entry:" in _out834b, repr(_out834b))
+    finally:
+        _sp834.run = _orig_run834
+
+except Exception as _e834:
+    for _lbl834 in ["1", "2", "3", "4a", "5a", "5b", "5c", "5d", "5e"]:
+        test(f"I834-{_lbl834}: retro --capture", False, str(_e834))
+
+# ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")
 else:

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -12276,6 +12276,10 @@ except Exception as _e819:
 # ---------------------------------------------------------------------------
 try:
     import importlib.util as _ilu834
+    import io as _io834
+    import subprocess as _sp834
+    from contextlib import redirect_stderr as _re834
+    from contextlib import redirect_stdout as _rs834
 
     _retro834_path = REPO / "retro.py"
     _spec834 = _ilu834.spec_from_file_location("retro834", str(_retro834_path))
@@ -12300,88 +12304,66 @@ try:
         str(_args834_combo),
     )
 
-    # I834-4: main() with --capture calls learn.py subprocess (mock subprocess.run)
-    import subprocess as _sp834
-    import unittest.mock as _mock834
-
+    # I834-4: main() with --capture actually invokes subprocess.run with learn.py
     _calls834: list = []
+    _orig_run834 = _sp834.run
 
     def _mock_run834(*_a, **_kw):
         _calls834.append((_a, _kw))
 
         class _R:
             returncode = 0
+            stdout = b""
+            stderr = b""
 
         return _R()
 
-    _orig_run834 = _sp834.run
-    _sp834.run = _mock_run834
-    _retro834_orig_sp = _retro834.subprocess
-    _retro834.subprocess = _sp834
-
-    import io as _io834
-    from contextlib import redirect_stdout as _rs834
-
+    # Patch subprocess.run in the retro module's namespace
+    _retro834.subprocess.run = _mock_run834
+    _retro834_sys = _retro834.main.__globals__["sys"]
+    _orig_argv834 = _retro834_sys.argv
+    _retro834_sys.argv = ["retro.py", "--capture", "--mode", "repo"]
     _buf834 = _io834.StringIO()
+    _ebuf834 = _io834.StringIO()
     try:
-        with _rs834(_buf834):
-            _retro834.main.__globals__["sys"].argv = ["retro.py", "--capture", "--mode", "repo"]
-        # Parse args outside redirect so test() output is visible
-        _args834_main = _retro834._parse_args(["--capture", "--mode", "repo"])
-        test("I834-4a: main args capture=True", _args834_main["capture"] is True)
+        with _rs834(_buf834), _re834(_ebuf834):
+            _retro834.main()
+    except SystemExit:
+        pass
     finally:
-        _sp834.run = _orig_run834
+        _retro834_sys.argv = _orig_argv834
+        _retro834.subprocess.run = _orig_run834
 
-    # I834-5: learn.py is invoked with --discovery and retro,session-retrospective tags
-    _calls834b: list = []
+    _out834 = _buf834.getvalue()
+    # Find the learn.py call among all subprocess.run calls
+    _learn_calls834 = [c for c in _calls834 if any("learn.py" in str(x) for x in (c[0][0] if c[0] else []))]
+    test("I834-4a: main() invoked learn.py subprocess", len(_learn_calls834) >= 1, f"calls={len(_learn_calls834)}")
+    if _learn_calls834:
+        _cmd834 = _learn_calls834[0][0][0]
+        test("I834-4b: subprocess cmd contains --discovery", "--discovery" in _cmd834, str(_cmd834))
+        test(
+            "I834-4c: subprocess cmd contains retro tags",
+            any("retro,session-retrospective" in str(c) for c in _cmd834),
+            str(_cmd834),
+        )
+        test(
+            "I834-4d: subprocess cmd contains date tag",
+            any("date:" in str(c) for c in _cmd834),
+            str(_cmd834),
+        )
+    else:
+        for _l in ["4b", "4c", "4d"]:
+            test(f"I834-{_l}: skipped (no learn.py call found)", False, "learn.py not called")
 
-    def _mock_run834b(*_a, **_kw):
-        _calls834b.append((_a, _kw))
+    # I834-5: success message only prints on returncode==0
+    test("I834-5: [retro] success message printed", "[retro] Saved as knowledge entry:" in _out834, repr(_out834[:200]))
 
-        class _R:
-            returncode = 0
-
-        return _R()
-
-    _sp834.run = _mock_run834b
-
-    import sys as _sys834
-
-    _buf834b = _io834.StringIO()
-    try:
-        with _rs834(_buf834b):
-            # Simulate the capture block as written in retro.py main()
-            import datetime as _dt834
-
-            _title834 = f"Session retro {_dt834.datetime.now().strftime('%Y-%m-%d')}"
-            _tags834 = "retro,session-retrospective"
-            _report834 = "## Retro\nscore: 80"
-            _sp834.run(
-                [
-                    _sys834.executable,
-                    str(_retro834_path.parent / "learn.py"),
-                    "--discovery",
-                    _title834,
-                    _report834,
-                    "--tags",
-                    _tags834,
-                ],
-                check=False,
-            )
-            print(f"[retro] Saved as knowledge entry: {_title834}")
-        _out834b = _buf834b.getvalue()
-        test("I834-5a: learn.py subprocess called with --discovery", len(_calls834b) == 1, str(len(_calls834b)))
-        if _calls834b:
-            _cmd834 = _calls834b[0][0][0]
-            test("I834-5b: subprocess cmd contains --discovery", "--discovery" in _cmd834, str(_cmd834))
-            test("I834-5c: subprocess cmd contains retro tag", "retro,session-retrospective" in _cmd834, str(_cmd834))
-            test("I834-5d: subprocess cmd contains learn.py", any("learn.py" in str(c) for c in _cmd834), str(_cmd834))
-        test("I834-5e: [retro] confirmation printed", "[retro] Saved as knowledge entry:" in _out834b, repr(_out834b))
-    finally:
-        _sp834.run = _orig_run834
+    # I834-6: --help/docstring mentions --capture
+    _doc834 = _retro834.__doc__ or ""
+    test("I834-6: docstring mentions --capture", "--capture" in _doc834, _doc834[:200])
 
 except Exception as _e834:
-    for _lbl834 in ["1", "2", "3", "4a", "5a", "5b", "5c", "5d", "5e"]:
+    for _lbl834 in ["1", "2", "3", "4a", "4b", "4c", "4d", "5", "6"]:
         test(f"I834-{_lbl834}: retro --capture", False, str(_e834))
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retro.py
+++ b/tests/test_retro.py
@@ -144,15 +144,25 @@ def test_no_subprocess_commits():
 
 
 def test_no_learn_calls():
-    """retro.py must not invoke learn.py, learn() functions, or indexing."""
+    """retro.py must not invoke learn.py outside --capture, and never call indexing."""
     retro = load_retro()
     import inspect
+    import re
 
     src = inspect.getsource(retro)
+    # learn.py is allowed inside the --capture guard block and in docstrings.
+    # Strip both before checking for banned references.
+    _capture_re = re.compile(
+        r'if args\["capture"\]:.*?(?=\n    if |\n\nif __name__|$)', re.DOTALL
+    )
+    src_no_capture = _capture_re.sub("", src)
+    # Also strip triple-quoted docstrings (both ''' and """)
+    _doc_re = re.compile(r'""".*?"""|\'\'\'.*?\'\'\'', re.DOTALL)
+    src_clean = _doc_re.sub("", src_no_capture)
     banned = ["learn.py", "build-session-index", "extract-knowledge", "watch-sessions"]
-    found = [b for b in banned if b in src]
+    found = [b for b in banned if b in src_clean]
     test(
-        "retro.py has no indexing/learning side-effects",
+        "retro.py has no indexing/learning side-effects outside --capture",
         len(found) == 0,
         f"found: {found}" if found else "",
     )


### PR DESCRIPTION
Implements #834. --capture flag saves retro output as [discovery] knowledge entry tagged retro,session-retrospective. Closes #834