### PR TITLE
feat(#836): Aider & Windsurf session adapters

### DIFF
--- a/aider-adapter.py
+++ b/aider-adapter.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+aider-adapter.py — Parse Aider chat history into knowledge.db format
+
+Reads .aider.chat.history.md and extracts AI responses as knowledge entries
+(mistakes, patterns, decisions) into the sk knowledge database.
+
+Usage:
+    python aider-adapter.py                          # Import default history
+    python aider-adapter.py --dry-run                # Parse but don't write
+    python aider-adapter.py --from ~/.aider.chat.history.md
+    python aider-adapter.py --since 2024-01-01
+    python aider-adapter.py --limit 10
+    python aider-adapter.py --json
+
+Pure Python stdlib. No pip deps.
+"""
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+if os.name == "nt":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+DB_PATH = Path(
+    os.environ.get(
+        "SK_DB_PATH", str(Path.home() / ".copilot" / "session-state" / "knowledge.db")
+    )
+).expanduser()
+
+DEFAULT_HISTORY = Path.home() / ".aider.chat.history.md"
+
+MISTAKE_WORDS = {"mistake", "error", "fixed", "bug", "wrong", "incorrect"}
+PATTERN_WORDS = {"pattern", "learned", "best practice", "approach", "recommend"}
+DECISION_WORDS = {"decision", "architecture", "design", "decided", "chosen", "approach"}
+
+
+def classify_response(text: str) -> str:
+    """Classify an AI response into a category based on keywords."""
+    lower = text.lower()
+    if any(w in lower for w in MISTAKE_WORDS):
+        return "mistake"
+    if any(w in lower for w in PATTERN_WORDS):
+        return "pattern"
+    if any(w in lower for w in DECISION_WORDS):
+        return "decision"
+    return "note"
+
+
+def make_title(text: str) -> str:
+    """Extract first sentence, trimmed to 80 chars."""
+    # Get first sentence
+    m = re.match(r"([^.!?\n]+[.!?\n]?)", text.strip())
+    if m:
+        title = m.group(1).strip()
+    else:
+        title = text.strip().split("\n")[0].strip()
+    return title[:80]
+
+
+def parse_aider_history(path: Path, since: date | None = None) -> list[dict]:
+    """Parse .aider.chat.history.md and return list of extracted entries."""
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        print(f"Error: File not found: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    entries = []
+    current_date: date | None = None
+
+    # Split into blocks by "#### aider" markers
+    # Each block is an AI response
+    blocks = re.split(r"(?=#### aider)", content)
+
+    for block in blocks:
+        if not block.strip():
+            continue
+
+        # Check for date header before this block
+        date_matches = re.findall(r"# aider chat started at (\d{4}-\d{2}-\d{2})", block)
+        if date_matches:
+            try:
+                current_date = date.fromisoformat(date_matches[-1])
+            except ValueError:
+                pass
+
+        if not block.startswith("#### aider"):
+            # Scan for date headers in non-AI blocks
+            continue
+
+        # Extract AI response text (everything after "#### aider\n")
+        response_text = re.sub(r"^#### aider\s*\n?", "", block, flags=re.MULTILINE).strip()
+        if not response_text:
+            continue
+
+        # Apply --since filter
+        if since is not None and current_date is not None and current_date < since:
+            continue
+
+        category = classify_response(response_text)
+        title = make_title(response_text)
+        if not title:
+            continue
+
+        now_iso = datetime.utcnow().isoformat()
+        entries.append(
+            {
+                "category": category,
+                "title": title,
+                "content": response_text,
+                "tags": "aider-import",
+                "confidence": 0.7,
+                "session_id": "aider-import",
+                "occurrence_count": 1,
+                "first_seen": now_iso,
+                "last_seen": now_iso,
+            }
+        )
+
+    return entries
+
+
+def ke_fts_exists(db: sqlite3.Connection) -> bool:
+    row = db.execute(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ke_fts'"
+    ).fetchone()
+    return bool(row and row[0])
+
+
+def ensure_schema(db: sqlite3.Connection) -> None:
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS knowledge_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            category TEXT,
+            title TEXT,
+            content TEXT,
+            tags TEXT,
+            confidence REAL DEFAULT 0.5,
+            occurrence_count INTEGER DEFAULT 1,
+            first_seen TEXT,
+            last_seen TEXT
+        )
+    """)
+    db.commit()
+
+
+def insert_entry(db: sqlite3.Connection, entry: dict, use_fts: bool) -> bool:
+    """Insert entry if title not already present. Returns True if inserted."""
+    count = db.execute(
+        "SELECT COUNT(*) FROM knowledge_entries WHERE title = ?", (entry["title"],)
+    ).fetchone()[0]
+    if count > 0:
+        return False
+
+    cur = db.execute(
+        """INSERT INTO knowledge_entries
+           (category, title, content, tags, confidence, session_id,
+            occurrence_count, first_seen, last_seen)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            entry["category"],
+            entry["title"],
+            entry["content"],
+            entry["tags"],
+            entry["confidence"],
+            entry["session_id"],
+            entry["occurrence_count"],
+            entry["first_seen"],
+            entry["last_seen"],
+        ),
+    )
+    new_id = cur.lastrowid
+    if use_fts and new_id:
+        db.execute(
+            "INSERT INTO ke_fts(rowid, title, content, tags, category) "
+            "SELECT id, title, content, tags, category FROM knowledge_entries WHERE id = ?",
+            (new_id,),
+        )
+    db.commit()
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Import Aider chat history into knowledge base")
+    parser.add_argument("--from", dest="from_path", default=None, help="Path to aider history file")
+    parser.add_argument("--dry-run", action="store_true", help="Parse but don't write to DB")
+    parser.add_argument("--since", default=None, help="Only import entries on/after YYYY-MM-DD")
+    parser.add_argument("--limit", type=int, default=None, help="Max entries to import")
+    parser.add_argument("--json", action="store_true", help="Output JSON instead of human-readable")
+    parser.add_argument("--db", default=None, help="Override DB path")
+    args = parser.parse_args()
+
+    src_path = Path(args.from_path) if args.from_path else DEFAULT_HISTORY
+    db_path = Path(args.db) if args.db else DB_PATH
+
+    since_date: date | None = None
+    if args.since:
+        try:
+            since_date = date.fromisoformat(args.since)
+        except ValueError:
+            print(f"Error: --since must be YYYY-MM-DD, got: {args.since}", file=sys.stderr)
+            sys.exit(1)
+
+    entries = parse_aider_history(src_path, since=since_date)
+    if args.limit:
+        entries = entries[: args.limit]
+
+    if args.dry_run:
+        if args.json:
+            print(json.dumps({"entries": entries, "dry_run": True}, indent=2))
+        else:
+            print(f"[dry-run] Would import {len(entries)} entries from {src_path}")
+            for e in entries:
+                print(f"  [{e['category']}] {e['title'][:60]}")
+        return
+
+    # Write to DB
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = sqlite3.connect(str(db_path))
+    try:
+        ensure_schema(db)
+        use_fts = ke_fts_exists(db)
+        imported = 0
+        skipped = 0
+        for entry in entries:
+            if insert_entry(db, entry, use_fts):
+                imported += 1
+            else:
+                skipped += 1
+    finally:
+        db.close()
+
+    if args.json:
+        print(json.dumps({"imported": imported, "skipped": skipped, "total_parsed": len(entries)}))
+    else:
+        print(f"Imported {imported} entries ({skipped} skipped as duplicates) from {src_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/aider-adapter.py
+++ b/aider-adapter.py
@@ -135,14 +135,31 @@ def ke_fts_exists(db: sqlite3.Connection) -> bool:
 
 
 def ensure_schema(db: sqlite3.Connection) -> None:
-    """Verify knowledge_entries table exists; prompt user to run migrate.py if not."""
-    row = db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='knowledge_entries'").fetchone()
-    if not row:
-        print(
-            "Error: knowledge_entries table not found. Run 'python migrate.py' first to create the canonical schema.",
-            file=sys.stderr,
+    """Ensure knowledge_entries table exists with canonical key constraints.
+
+    On a production DB, the full schema comes from migrate.py. For fresh
+    adapter-only DBs this creates the minimal subset the adapter needs,
+    including the canonical UNIQUE(category, title, session_id) constraint.
+    """
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS knowledge_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL DEFAULT '',
+            category TEXT NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL DEFAULT '',
+            tags TEXT DEFAULT '',
+            confidence REAL DEFAULT 0.7,
+            occurrence_count INTEGER DEFAULT 1,
+            first_seen TEXT,
+            last_seen TEXT,
+            est_tokens INTEGER DEFAULT 0,
+            UNIQUE(category, title, session_id)
         )
-        sys.exit(1)
+        """
+    )
+    db.commit()
 
 
 def insert_entry(db: sqlite3.Connection, entry: dict, use_fts: bool) -> bool:

--- a/install.py
+++ b/install.py
@@ -221,6 +221,8 @@ TOOL_FILES = [
     "embed.py",
     "sync_enqueue.py",
     "agent_adapters.py",
+    "aider-adapter.py",
+    "windsurf-adapter.py",
     "claude-adapter.py",
     "context-blocks.py",
     "cron-tasks.py",

--- a/sk.py
+++ b/sk.py
@@ -171,6 +171,8 @@ _DIRECT: dict[str, CommandMeta] = {
     "repo-map": CommandMeta("repo-map.py", "PageRank-ranked symbol map for AI context injection", ("index", "map")),
     "coverage": CommandMeta("coverage.py", "Per-file knowledge coverage heatmap showing blind spots", ("index", "map")),
     "trace": CommandMeta("trace.py", "Parse Copilot JSONL tool-call spans into SQLite", ("index", "observability")),
+    "aider-import": CommandMeta("aider-adapter.py", "Import Aider chat history into knowledge base", ("import", "adapters")),
+    "windsurf-import": CommandMeta("windsurf-adapter.py", "Import Windsurf session history into knowledge base", ("import", "adapters")),
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -11529,6 +11529,99 @@ except Exception as _e759:
         test(f"I759-{_label759}: tag-entries TF-IDF opt-in", False, str(_e759))
 
 # ---------------------------------------------------------------------------
+# I836 — Aider & Windsurf session adapters
+# ---------------------------------------------------------------------------
+try:
+    import importlib.util as _ilu836
+    import sqlite3 as _sq836
+    import tempfile as _tf836
+
+    _FIXTURES836 = REPO / "tests" / "fixtures"
+    _AIDER_FIXTURE = _FIXTURES836 / "sample_aider_history.md"
+    _WS_FIXTURE = _FIXTURES836 / "sample_windsurf_sessions.json"
+
+    # Load aider-adapter module
+    _spec_a836 = _ilu836.spec_from_file_location("aider_adapter", REPO / "aider-adapter.py")
+    _aa836 = _ilu836.module_from_spec(_spec_a836)
+    _spec_a836.loader.exec_module(_aa836)
+
+    # Load windsurf-adapter module
+    _spec_w836 = _ilu836.spec_from_file_location("windsurf_adapter", REPO / "windsurf-adapter.py")
+    _wa836 = _ilu836.module_from_spec(_spec_w836)
+    _spec_w836.loader.exec_module(_wa836)
+
+    # I836-1a: Parse aider fixture → extracts ≥1 entries
+    _aider_entries836 = _aa836.parse_aider_history(_AIDER_FIXTURE)
+    test("I836-1a: Parse aider fixture → extracts ≥1 entries", len(_aider_entries836) >= 1, str(len(_aider_entries836)))
+
+    # I836-1b: mistake entry has category="mistake"
+    _mistake_entries836 = [e for e in _aider_entries836 if e["category"] == "mistake"]
+    test("I836-1b: Parse aider fixture → mistake entry has category='mistake'", len(_mistake_entries836) >= 1, str(_aider_entries836))
+
+    # I836-1c: pattern entry has category="pattern"
+    _pattern_entries836 = [e for e in _aider_entries836 if e["category"] == "pattern"]
+    test("I836-1c: Parse aider fixture → pattern entry has category='pattern'", len(_pattern_entries836) >= 1, str(_aider_entries836))
+
+    # I836-1d: entries have tag "aider-import"
+    _tagged836 = all("aider-import" in e["tags"] for e in _aider_entries836)
+    test("I836-1d: Parse aider fixture → entries have tag 'aider-import'", _tagged836, str(_aider_entries836))
+
+    # I836-2a: dry-run produces no DB writes
+    _tmpdir836 = Path(_tf836.mkdtemp())
+    _tmpdb836 = _tmpdir836 / "test_dryrun.db"
+    _db836 = _sq836.connect(str(_tmpdb836))
+    _aa836.ensure_schema(_db836)
+    _count_before836 = _db836.execute("SELECT COUNT(*) FROM knowledge_entries").fetchone()[0]
+    _db836.close()
+    # Re-parse via parse_aider_history (dry-run means we don't call insert)
+    _dry_entries836 = _aa836.parse_aider_history(_AIDER_FIXTURE)
+    _db836 = _sq836.connect(str(_tmpdb836))
+    _count_after836 = _db836.execute("SELECT COUNT(*) FROM knowledge_entries").fetchone()[0]
+    _db836.close()
+    test("I836-2a: dry-run produces no DB writes (count before == count after)", _count_before836 == _count_after836, f"{_count_before836} vs {_count_after836}")
+
+    # I836-2b: dedup skips duplicate title (insert same entry twice → only one in DB)
+    _tmpdb836b = _tmpdir836 / "test_dedup.db"
+    _db836b = _sq836.connect(str(_tmpdb836b))
+    _aa836.ensure_schema(_db836b)
+    _e1_836 = _aider_entries836[0]
+    _r1_836 = _aa836.insert_entry(_db836b, _e1_836, False)
+    _r2_836 = _aa836.insert_entry(_db836b, _e1_836, False)
+    _cnt836b = _db836b.execute("SELECT COUNT(*) FROM knowledge_entries WHERE title = ?", (_e1_836["title"],)).fetchone()[0]
+    _db836b.close()
+    test("I836-2b: dedup skips duplicate title (insert same entry twice → only one in DB)", _r1_836 is True and _r2_836 is False and _cnt836b == 1, f"r1={_r1_836} r2={_r2_836} count={_cnt836b}")
+
+    # I836-3a: Parse windsurf fixture → extracts ≥1 entries
+    _ws_entries836 = _wa836.parse_windsurf_sessions(_WS_FIXTURE)
+    test("I836-3a: Parse windsurf fixture → extracts ≥1 entries", len(_ws_entries836) >= 1, str(len(_ws_entries836)))
+
+    # I836-3b: windsurf entries have tag "windsurf-import"
+    _ws_tagged836 = all("windsurf-import" in e["tags"] for e in _ws_entries836)
+    test("I836-3b: Parse windsurf fixture → entries have tag 'windsurf-import'", _ws_tagged836, str(_ws_entries836))
+
+    # I836-4a: sk routing works for aider-import
+    _res836a = subprocess.run(
+        [sys.executable, str(REPO / "sk.py"), "aider-import", "--dry-run", "--from", str(_AIDER_FIXTURE)],
+        capture_output=True, text=True
+    )
+    test("I836-4a: sk routing works for aider-import", _res836a.returncode == 0, _res836a.stderr[:200])
+
+    # I836-4b: sk routing works for windsurf-import
+    _res836b = subprocess.run(
+        [sys.executable, str(REPO / "sk.py"), "windsurf-import", "--dry-run", "--from", str(_WS_FIXTURE)],
+        capture_output=True, text=True
+    )
+    test("I836-4b: sk routing works for windsurf-import", _res836b.returncode == 0, _res836b.stderr[:200])
+
+    # Cleanup
+    import shutil as _sh836
+    _sh836.rmtree(str(_tmpdir836), ignore_errors=True)
+
+except Exception as _e836:
+    for _lbl836 in ["1a", "1b", "1c", "1d", "2a", "2b", "3a", "3b", "4a", "4b"]:
+        test(f"I836-{_lbl836}: Aider & Windsurf adapters", False, str(_e836))
+
+# ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")
 else:

--- a/tests/fixtures/sample_aider_history.md
+++ b/tests/fixtures/sample_aider_history.md
@@ -1,0 +1,21 @@
+# aider chat started at 2024-01-15 10:30:00
+
+> User: My code has a bug
+
+#### aider
+I found a mistake in the loop logic. The off-by-one error was causing incorrect results. Fixed by changing `< n` to `<= n`.
+
+> User: How should I structure this?
+
+#### aider
+A good pattern here is to use the repository pattern. I recommend separating data access from business logic for better testability.
+
+> User: What about the database design?
+
+#### aider
+The architectural decision here should be to use a single-table design. This approach is simpler and performs better for your use case.
+
+> User: Can you explain recursion?
+
+#### aider
+Recursion is when a function calls itself. It can be elegant for tree traversal.

--- a/tests/fixtures/sample_windsurf_sessions.json
+++ b/tests/fixtures/sample_windsurf_sessions.json
@@ -1,0 +1,20 @@
+{
+  "sessions": [
+    {
+      "id": "ws-session-001",
+      "created_at": "2024-01-15T10:30:00Z",
+      "messages": [
+        {"role": "user", "content": "I have a bug in my code"},
+        {"role": "assistant", "content": "I found a mistake in the authentication logic. The error was that tokens weren't being validated correctly. Fixed by adding proper JWT verification."}
+      ]
+    },
+    {
+      "id": "ws-session-002",
+      "created_at": "2024-01-16T09:00:00Z",
+      "messages": [
+        {"role": "user", "content": "Best approach for caching?"},
+        {"role": "assistant", "content": "A good pattern for caching is to use a write-through cache. I recommend Redis for distributed scenarios. This approach gives you consistency."}
+      ]
+    }
+  ]
+}

--- a/windsurf-adapter.py
+++ b/windsurf-adapter.py
@@ -147,14 +147,31 @@ def ke_fts_exists(db: sqlite3.Connection) -> bool:
 
 
 def ensure_schema(db: sqlite3.Connection) -> None:
-    """Verify knowledge_entries table exists; prompt user to run migrate.py if not."""
-    row = db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='knowledge_entries'").fetchone()
-    if not row:
-        print(
-            "Error: knowledge_entries table not found. Run 'python migrate.py' first to create the canonical schema.",
-            file=sys.stderr,
+    """Ensure knowledge_entries table exists with canonical key constraints.
+
+    On a production DB, the full schema comes from migrate.py. For fresh
+    adapter-only DBs this creates the minimal subset the adapter needs,
+    including the canonical UNIQUE(category, title, session_id) constraint.
+    """
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS knowledge_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL DEFAULT '',
+            category TEXT NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL DEFAULT '',
+            tags TEXT DEFAULT '',
+            confidence REAL DEFAULT 0.7,
+            occurrence_count INTEGER DEFAULT 1,
+            first_seen TEXT,
+            last_seen TEXT,
+            est_tokens INTEGER DEFAULT 0,
+            UNIQUE(category, title, session_id)
         )
-        sys.exit(1)
+        """
+    )
+    db.commit()
 
 
 def insert_entry(db: sqlite3.Connection, entry: dict, use_fts: bool) -> bool:

--- a/windsurf-adapter.py
+++ b/windsurf-adapter.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+windsurf-adapter.py — Parse Windsurf session JSON exports into knowledge.db format
+
+Reads Windsurf session export JSON and extracts AI responses as knowledge entries
+(mistakes, patterns, decisions) into the sk knowledge database.
+
+Usage:
+    python windsurf-adapter.py                          # Auto-detect session file
+    python windsurf-adapter.py --from sessions.json
+    python windsurf-adapter.py --dry-run
+    python windsurf-adapter.py --since 2024-01-01
+    python windsurf-adapter.py --limit 10
+    python windsurf-adapter.py --json
+
+Pure Python stdlib. No pip deps.
+"""
+
+import argparse
+import glob as glob_module
+import json
+import os
+import re
+import sqlite3
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+if os.name == "nt":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+DB_PATH = Path(
+    os.environ.get(
+        "SK_DB_PATH", str(Path.home() / ".copilot" / "session-state" / "knowledge.db")
+    )
+).expanduser()
+
+WINDSURF_EXPORT = Path.home() / ".windsurf" / "sessions" / "export.json"
+WINDSURF_GLOB = str(Path.home() / ".windsurf" / "sessions" / "*.json")
+
+MISTAKE_WORDS = {"mistake", "error", "fixed", "bug", "wrong", "incorrect"}
+PATTERN_WORDS = {"pattern", "learned", "best practice", "approach", "recommend"}
+DECISION_WORDS = {"decision", "architecture", "design", "decided", "chosen", "approach"}
+
+
+def classify_response(text: str) -> str:
+    """Classify an AI response into a category based on keywords."""
+    lower = text.lower()
+    if any(w in lower for w in MISTAKE_WORDS):
+        return "mistake"
+    if any(w in lower for w in PATTERN_WORDS):
+        return "pattern"
+    if any(w in lower for w in DECISION_WORDS):
+        return "decision"
+    return "note"
+
+
+def make_title(text: str) -> str:
+    """Extract first sentence, trimmed to 80 chars."""
+    m = re.match(r"([^.!?\n]+[.!?\n]?)", text.strip())
+    if m:
+        title = m.group(1).strip()
+    else:
+        title = text.strip().split("\n")[0].strip()
+    return title[:80]
+
+
+def find_windsurf_file() -> Path | None:
+    """Search for Windsurf session file in default locations."""
+    if WINDSURF_EXPORT.exists():
+        return WINDSURF_EXPORT
+    matches = sorted(glob_module.glob(WINDSURF_GLOB), key=os.path.getmtime, reverse=True)
+    if matches:
+        return Path(matches[0])
+    return None
+
+
+def load_sessions(path: Path) -> list[dict]:
+    """Load sessions from a JSON file. Handles both {sessions: [...]} and [...]."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Error reading {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and "sessions" in data:
+        return data["sessions"]
+    print(f"Error: Unexpected JSON structure in {path}", file=sys.stderr)
+    sys.exit(1)
+
+
+def parse_windsurf_sessions(path: Path, since: date | None = None) -> list[dict]:
+    """Parse Windsurf session JSON and return list of extracted entries."""
+    sessions = load_sessions(path)
+    entries = []
+    now_iso = datetime.utcnow().isoformat()
+
+    for session in sessions:
+        session_date: date | None = None
+        created_at = session.get("created_at", "")
+        if created_at:
+            try:
+                session_date = date.fromisoformat(created_at[:10])
+            except ValueError:
+                pass
+
+        if since is not None and session_date is not None and session_date < since:
+            continue
+
+        messages = session.get("messages", [])
+        for msg in messages:
+            if msg.get("role") != "assistant":
+                continue
+            response_text = msg.get("content", "").strip()
+            if not response_text:
+                continue
+
+            category = classify_response(response_text)
+            title = make_title(response_text)
+            if not title:
+                continue
+
+            entries.append(
+                {
+                    "category": category,
+                    "title": title,
+                    "content": response_text,
+                    "tags": "windsurf-import",
+                    "confidence": 0.7,
+                    "session_id": "windsurf-import",
+                    "occurrence_count": 1,
+                    "first_seen": now_iso,
+                    "last_seen": now_iso,
+                }
+            )
+
+    return entries
+
+
+def ke_fts_exists(db: sqlite3.Connection) -> bool:
+    row = db.execute(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ke_fts'"
+    ).fetchone()
+    return bool(row and row[0])
+
+
+def ensure_schema(db: sqlite3.Connection) -> None:
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS knowledge_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            category TEXT,
+            title TEXT,
+            content TEXT,
+            tags TEXT,
+            confidence REAL DEFAULT 0.5,
+            occurrence_count INTEGER DEFAULT 1,
+            first_seen TEXT,
+            last_seen TEXT
+        )
+    """)
+    db.commit()
+
+
+def insert_entry(db: sqlite3.Connection, entry: dict, use_fts: bool) -> bool:
+    """Insert entry if title not already present. Returns True if inserted."""
+    count = db.execute(
+        "SELECT COUNT(*) FROM knowledge_entries WHERE title = ?", (entry["title"],)
+    ).fetchone()[0]
+    if count > 0:
+        return False
+
+    cur = db.execute(
+        """INSERT INTO knowledge_entries
+           (category, title, content, tags, confidence, session_id,
+            occurrence_count, first_seen, last_seen)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            entry["category"],
+            entry["title"],
+            entry["content"],
+            entry["tags"],
+            entry["confidence"],
+            entry["session_id"],
+            entry["occurrence_count"],
+            entry["first_seen"],
+            entry["last_seen"],
+        ),
+    )
+    new_id = cur.lastrowid
+    if use_fts and new_id:
+        db.execute(
+            "INSERT INTO ke_fts(rowid, title, content, tags, category) "
+            "SELECT id, title, content, tags, category FROM knowledge_entries WHERE id = ?",
+            (new_id,),
+        )
+    db.commit()
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Import Windsurf session history into knowledge base"
+    )
+    parser.add_argument("--from", dest="from_path", default=None, help="Path to session JSON file")
+    parser.add_argument("--dry-run", action="store_true", help="Parse but don't write to DB")
+    parser.add_argument("--since", default=None, help="Only import entries on/after YYYY-MM-DD")
+    parser.add_argument("--limit", type=int, default=None, help="Max entries to import")
+    parser.add_argument("--json", action="store_true", help="Output JSON instead of human-readable")
+    parser.add_argument("--db", default=None, help="Override DB path")
+    args = parser.parse_args()
+
+    if args.from_path:
+        src_path = Path(args.from_path)
+        if not src_path.exists():
+            print(f"No Windsurf session file found. Tried: {[str(src_path)]}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        src_path = find_windsurf_file()
+        if src_path is None:
+            tried = [str(WINDSURF_EXPORT), WINDSURF_GLOB]
+            print(f"No Windsurf session file found. Tried: {tried}", file=sys.stderr)
+            sys.exit(1)
+
+    db_path = Path(args.db) if args.db else DB_PATH
+
+    since_date: date | None = None
+    if args.since:
+        try:
+            since_date = date.fromisoformat(args.since)
+        except ValueError:
+            print(f"Error: --since must be YYYY-MM-DD, got: {args.since}", file=sys.stderr)
+            sys.exit(1)
+
+    entries = parse_windsurf_sessions(src_path, since=since_date)
+    if args.limit:
+        entries = entries[: args.limit]
+
+    if args.dry_run:
+        if args.json:
+            print(json.dumps({"entries": entries, "dry_run": True}, indent=2))
+        else:
+            print(f"[dry-run] Would import {len(entries)} entries from {src_path}")
+            for e in entries:
+                print(f"  [{e['category']}] {e['title'][:60]}")
+        return
+
+    # Write to DB
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = sqlite3.connect(str(db_path))
+    try:
+        ensure_schema(db)
+        use_fts = ke_fts_exists(db)
+        imported = 0
+        skipped = 0
+        for entry in entries:
+            if insert_entry(db, entry, use_fts):
+                imported += 1
+            else:
+                skipped += 1
+    finally:
+        db.close()
+
+    if args.json:
+        print(json.dumps({"imported": imported, "skipped": skipped, "total_parsed": len(entries)}))
+    else:
+        print(f"Imported {imported} entries ({skipped} skipped as duplicates) from {src_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements #836. New session adapters for Aider and Windsurf that parse conversation histories and import knowledge entries into sk's knowledge.db.

### Changes
- `aider-adapter.py`: Parses `.aider.chat.history.md`, extracts mistakes/patterns/decisions with `aider-import` tag
- `windsurf-adapter.py`: Parses Windsurf session JSON exports with `windsurf-import` tag  
- Both support `--dry-run`, `--since`, `--limit`, `--json`, `--from`, deduplication by title
- Added to `install.py` TOOL_FILES and `sk.py` routing (`sk aider-import` / `sk windsurf-import`)
- Test fixtures in `tests/fixtures/` and I836-* tests in `test_fixes.py`

Closes #836