### PR TITLE
feat(#837): sk learn --amend <id> — in-place knowledge entry refinement

### DIFF
--- a/learn.py
+++ b/learn.py
@@ -2621,6 +2621,78 @@ def soft_delete_entry(entry_id: int) -> bool:
     return True
 
 
+def amend_entry(
+    entry_id: int,
+    *,
+    content: str | None = None,
+    title: str | None = None,
+    tags: str | None = None,
+    confidence: float | None = None,
+) -> bool:
+    """Update specific fields of an existing knowledge entry in-place (#837).
+
+    Only the supplied keyword arguments are modified; omitted fields are left unchanged.
+    A history row is written to ``knowledge_entry_history`` when content or confidence
+    changes (fail-open: non-critical if the table is absent).
+
+    Returns True on success, False when the entry does not exist.
+    """
+    db = get_db()
+    row = db.execute(
+        "SELECT id, title, content, tags, confidence, category FROM knowledge_entries WHERE id = ?",
+        (entry_id,),
+    ).fetchone()
+    if not row:
+        print(f"  ⚠ Entry #{entry_id} not found.", file=sys.stderr)
+        db.close()
+        return False
+
+    now = __import__("datetime").datetime.now().isoformat()
+    updates: dict[str, object] = {}
+    if content is not None:
+        updates["content"] = content[:10000]
+    if title is not None:
+        updates["title"] = title[:200]
+    if tags is not None:
+        updates["tags"] = tags
+    if confidence is not None:
+        updates["confidence"] = confidence
+    updates["last_seen"] = now
+
+    set_clause = ", ".join(f"{k} = ?" for k in updates)
+    db.execute(
+        f"UPDATE knowledge_entries SET {set_clause} WHERE id = ?",  # noqa: S608
+        list(updates.values()) + [entry_id],
+    )
+    db.commit()
+
+    # Write history row when content or confidence changes (fail-open)
+    _has_history = db.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='knowledge_entry_history'"
+    ).fetchone()
+    if _has_history:
+        try:
+            old_content = row["content"] or ""
+            new_content = str(updates.get("content", old_content))
+            old_conf = float(row["confidence"] or 0.0)
+            new_conf = float(updates.get("confidence", old_conf))
+            if new_content != old_content or new_conf != old_conf:
+                db.execute(
+                    """INSERT INTO knowledge_entry_history
+                       (entry_id, changed_at, content_before, content_after,
+                        confidence_before, confidence_after, change_source)
+                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    (entry_id, now, old_content, new_content, old_conf, new_conf, "amend"),
+                )
+                db.commit()
+        except Exception:
+            pass  # fail-open: history tracking is non-critical
+
+    db.close()
+    print(f"  ✏ Amended #{entry_id} [{row['category']}] {row['title'][:60]}")
+    return True
+
+
 def _insert_supersedes_relation(source_id: int, target_id: int, session_id: str | None = None) -> None:
     """Insert a SUPERSEDES relation from source_id to target_id in knowledge_relations.
 
@@ -3204,6 +3276,46 @@ def main():
             sys.exit(1)
         result = soft_delete_entry(entry_id)
         if not result:
+            sys.exit(1)
+        return
+
+    # --amend <id>: update specific fields of an existing entry without creating a duplicate (#837)
+    if "--amend" in args:
+        idx = args.index("--amend")
+        raw_id = args[idx + 1] if idx + 1 < len(args) else ""
+        if not raw_id or raw_id.startswith("--"):
+            print("Error: --amend requires an integer entry ID", file=sys.stderr)
+            sys.exit(1)
+        try:
+            amend_id = int(raw_id)
+        except ValueError:
+            print(f"Error: --amend value must be an integer ID (got {raw_id!r})", file=sys.stderr)
+            sys.exit(1)
+        _amend_content: str | None = None
+        if "--content" in args:
+            _ci = args.index("--content")
+            _amend_content = args[_ci + 1] if _ci + 1 < len(args) else None
+        _amend_title: str | None = None
+        if "--title" in args:
+            _ti2 = args.index("--title")
+            _amend_title = args[_ti2 + 1] if _ti2 + 1 < len(args) else None
+        _amend_tags: str | None = None
+        if "--tags" in args:
+            _tgi = args.index("--tags")
+            _amend_tags = args[_tgi + 1] if _tgi + 1 < len(args) else None
+        _amend_conf: float | None = None
+        if "--confidence" in args:
+            _confi = args.index("--confidence")
+            try:
+                _amend_conf = float(args[_confi + 1]) if _confi + 1 < len(args) else None
+            except (ValueError, TypeError):
+                print("Error: --confidence requires a float value", file=sys.stderr)
+                sys.exit(1)
+        if _amend_content is None and _amend_title is None and _amend_tags is None and _amend_conf is None:
+            print("No fields to update. Use --content, --title, --tags, or --confidence with --amend.")
+            return
+        ok = amend_entry(amend_id, content=_amend_content, title=_amend_title, tags=_amend_tags, confidence=_amend_conf)
+        if not ok:
             sys.exit(1)
         return
 

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -12272,6 +12272,123 @@ except Exception as _e819:
         test(f"I819-{_lbl819}: knowledge entry version history", False, str(_e819))
 
 # ---------------------------------------------------------------------------
+# I837: sk learn --amend <id> — in-place knowledge entry refinement
+# ---------------------------------------------------------------------------
+print("\n🔍 I837: sk learn --amend <id> — in-place knowledge entry refinement")
+try:
+    import importlib as _il837
+    import sqlite3 as _sq837
+    import subprocess as _sp837
+    import tempfile as _tf837
+
+    _learn837 = _il837.import_module("learn")
+
+    _tf837_dir = _tf837.mkdtemp(prefix="sk_test_i837_")
+    _db837_path = Path(_tf837_dir) / "knowledge.db"
+
+    # Bootstrap full schema via migrate.py subprocess
+    _mg837_res = _sp837.run(
+        [sys.executable, str(REPO / "migrate.py"), str(_db837_path)],
+        capture_output=True,
+        text=True,
+    )
+    if _mg837_res.returncode != 0:
+        raise RuntimeError(f"migrate.py failed: {_mg837_res.stderr[:200]}")
+
+    _orig_db837 = _learn837.DB_PATH
+    _learn837.DB_PATH = _db837_path
+
+    # Insert a base entry to amend
+    _id837 = _learn837.add_entry(
+        "mistake",
+        "Amend base entry",
+        "original content for amend test",
+        tags="original-tag",
+        skip_gate=True,
+        skip_scan=True,
+        skip_similar_check=True,
+        quiet=True,
+    )
+    test("I837-0: base entry inserted for amend tests", _id837 >= 0, str(_id837))
+
+    # I837-1: amend content only
+    _ok837_1 = _learn837.amend_entry(_id837, content="updated content after amend")
+    _conn837b = _sq837.connect(str(_db837_path))
+    _conn837b.row_factory = _sq837.Row
+    _row837 = _conn837b.execute(
+        "SELECT content, tags FROM knowledge_entries WHERE id = ?", (_id837,)
+    ).fetchone()
+    test("I837-1a: amend_entry returns True", _ok837_1 is True)
+    test("I837-1b: content updated", _row837 and "updated content after amend" in _row837["content"],
+         str(_row837["content"] if _row837 else "no row"))
+    test("I837-1c: tags unchanged after content-only amend", _row837 and "original-tag" in _row837["tags"],
+         str(_row837["tags"] if _row837 else "no row"))
+
+    # I837-2: amend tags only
+    _ok837_2 = _learn837.amend_entry(_id837, tags="new-tag,amended")
+    _row837b = _conn837b.execute(
+        "SELECT tags FROM knowledge_entries WHERE id = ?", (_id837,)
+    ).fetchone()
+    test("I837-2a: amend tags returns True", _ok837_2 is True)
+    test("I837-2b: tags updated", _row837b and "new-tag" in _row837b["tags"],
+         str(_row837b["tags"] if _row837b else "no row"))
+
+    # I837-3: amend title only
+    _ok837_3 = _learn837.amend_entry(_id837, title="Amended Title")
+    _row837c = _conn837b.execute(
+        "SELECT title FROM knowledge_entries WHERE id = ?", (_id837,)
+    ).fetchone()
+    test("I837-3: title updated", _row837c and _row837c["title"] == "Amended Title",
+         str(_row837c["title"] if _row837c else "no row"))
+
+    # I837-4: amend confidence and verify history row written
+    _ok837_4 = _learn837.amend_entry(_id837, confidence=0.99)
+    _hist837 = _conn837b.execute(
+        "SELECT confidence_after, change_source FROM knowledge_entry_history WHERE entry_id = ? ORDER BY id DESC LIMIT 1",
+        (_id837,),
+    ).fetchone()
+    test("I837-4a: amend confidence returns True", _ok837_4 is True)
+    test("I837-4b: history row written on confidence change",
+         _hist837 is not None and abs(float(_hist837[0]) - 0.99) < 0.001,
+         str(_hist837[0] if _hist837 else "no history"))
+    test("I837-4c: change_source is 'amend'", _hist837 is not None and _hist837[1] == "amend",
+         str(_hist837[1] if _hist837 else "no history"))
+
+    # I837-5: unknown ID returns False and does not crash
+    _ok837_5 = _learn837.amend_entry(999999, content="should not exist")
+    test("I837-5: unknown ID returns False", _ok837_5 is False)
+
+    # I837-6: no fields supplied — main() prints message and returns without error
+    import io as _io837
+    import sys as _sys837
+
+    _argv837_save = _sys837.argv
+    _sys837.argv = ["learn.py", "--amend", str(_id837)]
+    _buf837 = _io837.StringIO()
+    _exit837 = None
+    try:
+        from contextlib import redirect_stdout as _rs837
+        with _rs837(_buf837):
+            _learn837.main()
+    except SystemExit as _se837:
+        _exit837 = _se837.code
+    finally:
+        _sys837.argv = _argv837_save
+    _out837 = _buf837.getvalue()
+    test("I837-6: no fields supplied prints usage message", "No fields to update" in _out837, repr(_out837[:200]))
+    test("I837-6b: no fields supplied exits 0", _exit837 is None or _exit837 == 0, str(_exit837))
+
+    _conn837b.close()
+    _learn837.DB_PATH = _orig_db837
+
+    import shutil as _sh837
+    _sh837.rmtree(_tf837_dir, ignore_errors=True)
+
+except Exception as _e837:
+    for _lbl837 in ["0", "1a", "1b", "1c", "2a", "2b", "3", "4a", "4b", "4c", "5", "6", "6b"]:
+        test(f"I837-{_lbl837}: sk learn --amend", False, str(_e837))
+
+# ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")
 else:


### PR DESCRIPTION
Implements #837.

## Changes
- **`amend_entry()`** — updates `content`, `title`, `tags`, and/or `confidence` in-place; only specified fields are changed
- **History row** written to `knowledge_entry_history` when content or confidence changes (fail-open; no-op if table absent)
- **`--amend <id>`** CLI handler with `--content`, `--title`, `--tags`, `--confidence` flags
- Unknown ID prints clear error and exits 1
- No fields supplied prints usage hint and exits 0
- 13 I837-* tests covering: field updates, unchanged fields, history write, change_source='amend', unknown ID, and no-op case

Closes #837