### PR TITLE
feat(#835): sk doctor — MCP server smoke-test check

### DIFF
--- a/doctor.py
+++ b/doctor.py
@@ -202,6 +202,121 @@ def check_mcp() -> dict:
         return _check("mcp", "mcp", WARN, f"mcp-server.py error: {e}")
 
 
+def check_mcp_smoke(timeout: int = 5) -> dict:
+    """Spawn mcp-server.py, send initialize + tools/list, verify expected tools.
+
+    The server uses LSP-style framing: Content-Length header + CRLF + body.
+    """
+    import threading
+    import time
+
+    mcp_path = TOOLS_DIR / "mcp-server.py"
+    if not mcp_path.exists():
+        return _check("mcp_smoke", "mcp", INFO, "mcp-server.py not found — skipping smoke test")
+
+    def _encode(payload: dict) -> bytes:
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        return header + body
+
+    def _read_response(stream) -> dict:
+        """Read one LSP-framed JSON-RPC message from stream."""
+        headers: dict[str, str] = {}
+        while True:
+            line = stream.readline()
+            if not line:
+                raise EOFError("stdout closed")
+            if line in (b"\r\n", b"\n"):
+                break
+            decoded = line.decode("ascii")
+            if ":" in decoded:
+                k, v = decoded.split(":", 1)
+                headers[k.strip().lower()] = v.strip()
+        content_length = int(headers["content-length"])
+        body = stream.read(content_length)
+        return json.loads(body.decode("utf-8"))
+
+    t0 = time.time()
+    proc = None
+    result_holder: list = []
+    error_holder: list = []
+
+    def _run() -> None:
+        nonlocal proc
+        try:
+            proc = subprocess.Popen(
+                [sys.executable, str(mcp_path)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            proc.stdin.write(
+                _encode(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {},
+                            "clientInfo": {"name": "doctor", "version": "1.0"},
+                        },
+                    }
+                )
+            )
+            proc.stdin.flush()
+            _read_response(proc.stdout)  # initialize response; validate it parses
+
+            proc.stdin.write(_encode({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}))
+            proc.stdin.flush()
+            resp2 = _read_response(proc.stdout)
+            result_holder.append(resp2)
+        except Exception as exc:
+            error_holder.append(exc)
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(timeout)
+
+    latency = round((time.time() - t0) * 1000)
+
+    if proc is not None:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+    if t.is_alive() or (not result_holder and not error_holder):
+        return _check(
+            "mcp_smoke",
+            "mcp",
+            ERROR,
+            f"MCP smoke FAIL — server timed out after {timeout}s",
+            "Run: python3 mcp-server.py",
+        )
+    if error_holder:
+        return _check("mcp_smoke", "mcp", ERROR, f"MCP smoke FAIL — {error_holder[0]}", "Run: python3 mcp-server.py")
+
+    resp2 = result_holder[0]
+    tool_names = {t["name"] for t in resp2.get("result", {}).get("tools", [])}
+    expected = {"briefing", "learn", "query_session"}
+    missing = expected - tool_names
+    if missing:
+        return _check(
+            "mcp_smoke",
+            "mcp",
+            ERROR,
+            f"MCP smoke FAIL — missing tools: {sorted(missing)} (latency {latency}ms)",
+            "Check mcp-server.py tool registration",
+        )
+    return _check(
+        "mcp_smoke",
+        "mcp",
+        OK,
+        f"MCP smoke PASS — {len(tool_names)} tools registered (latency {latency}ms)",
+    )
+
+
 def check_binary() -> dict:
     sk_bin = shutil.which("sk")
     if sk_bin:
@@ -402,6 +517,7 @@ ALL_CHECKS = [
     check_embedding_config,
     check_hooks,
     check_mcp,
+    check_mcp_smoke,
     check_binary,
     # recall health checks
     check_recall_hit_rate,
@@ -415,7 +531,7 @@ CATEGORY_MAP = {
     "db": [check_db_exists, check_db_schema, check_db_migrate],
     "config": [check_embedding_config],
     "hooks": [check_hooks],
-    "mcp": [check_mcp],
+    "mcp": [check_mcp, check_mcp_smoke],
     "binary": [check_binary],
     "recall": [check_recall_hit_rate, check_knowledge_growth, check_stale_knowledge, check_recurring_mistakes],
 }

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -12272,6 +12272,82 @@ except Exception as _e819:
         test(f"I819-{_lbl819}: knowledge entry version history", False, str(_e819))
 
 # ---------------------------------------------------------------------------
+# I835: sk doctor — MCP server smoke-test check
+# ---------------------------------------------------------------------------
+try:
+    import importlib.util as _ilu835
+    import types as _types835
+
+    _spec835 = _ilu835.spec_from_file_location("doctor835", REPO / "doctor.py")
+    _doc835 = _ilu835.module_from_spec(_spec835)
+    _spec835.loader.exec_module(_doc835)
+
+    # I835-1: check_mcp_smoke function exists
+    test("I835-1: check_mcp_smoke exists in doctor.py", hasattr(_doc835, "check_mcp_smoke"))
+
+    # I835-2: check_mcp_smoke is registered in ALL_CHECKS
+    test(
+        "I835-2: check_mcp_smoke in ALL_CHECKS",
+        _doc835.check_mcp_smoke in _doc835.ALL_CHECKS,
+    )
+
+    # I835-3: check_mcp_smoke is in CATEGORY_MAP["mcp"]
+    test(
+        "I835-3: check_mcp_smoke in CATEGORY_MAP['mcp']",
+        _doc835.check_mcp_smoke in _doc835.CATEGORY_MAP.get("mcp", []),
+    )
+
+    # I835-4: returns SKIP/INFO when mcp-server.py absent
+    import unittest.mock as _mock835
+
+    with _mock835.patch.object(_doc835.Path, "exists", return_value=False):
+        # Patch TOOLS_DIR / "mcp-server.py" path.exists
+        _fake_path835 = _mock835.MagicMock()
+        _fake_path835.exists.return_value = False
+        with _mock835.patch.object(_doc835, "TOOLS_DIR", new=Path("/nonexistent_path_835xyz")):
+            _r835_skip = _doc835.check_mcp_smoke()
+    test(
+        "I835-4: check_mcp_smoke returns INFO when mcp-server.py absent",
+        _r835_skip["status"] in ("info", "skip"),
+        str(_r835_skip),
+    )
+
+    # I835-5: result dict has required keys
+    test(
+        "I835-5: result has id/category/status/message keys",
+        all(k in _r835_skip for k in ("id", "category", "status", "message")),
+        str(_r835_skip),
+    )
+
+    # I835-6: check_mcp_smoke id is "mcp_smoke"
+    test("I835-6: result id is 'mcp_smoke'", _r835_skip["id"] == "mcp_smoke", str(_r835_skip))
+
+    # I835-7: check_mcp_smoke category is "mcp"
+    test("I835-7: result category is 'mcp'", _r835_skip["category"] == "mcp", str(_r835_skip))
+
+    # I835-8: live smoke test when mcp-server.py present
+    _mcp835_path = REPO / "mcp-server.py"
+    if _mcp835_path.exists():
+        _r835_live = _doc835.check_mcp_smoke(timeout=10)
+        test(
+            "I835-8: live smoke PASS or FAIL (not exception)",
+            _r835_live["status"] in ("ok", "error"),
+            str(_r835_live),
+        )
+        test(
+            "I835-8b: live smoke result has latency or reason",
+            "latency" in _r835_live["message"] or "reason" in _r835_live or "FAIL" in _r835_live["message"],
+            str(_r835_live),
+        )
+    else:
+        test("I835-8: live smoke skipped (mcp-server.py not present)", True)
+        test("I835-8b: live smoke latency skipped", True)
+
+except Exception as _e835:
+    for _lbl835 in ["1", "2", "3", "4", "5", "6", "7", "8", "8b"]:
+        test(f"I835-{_lbl835}: mcp smoke check", False, str(_e835))
+
+# ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")
 else:


### PR DESCRIPTION
Implements #835. Adds `mcp_smoke` check to `doctor.py`: spawns `mcp-server.py`, sends LSP-framed `initialize` + `tools/list`, verifies expected tools (briefing, learn, query_session) are registered, reports PASS/FAIL with latency. Uses threading with 5s timeout to prevent hangs. Closes #835