### PR TITLE
feat(#831): uniform SQLite WAL + busy-timeout across all scripts

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -56,6 +56,7 @@ def _open_db(db_path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
     _ensure_table(conn)
     return conn
 

--- a/briefing.py
+++ b/briefing.py
@@ -482,6 +482,8 @@ def get_db() -> sqlite3.Connection:
         print("Error: Knowledge database not found. Run build-session-index.py first.", file=sys.stderr)
         sys.exit(1)
     db = sqlite3.connect(str(DB_PATH))
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute("PRAGMA busy_timeout=5000")
     db.row_factory = sqlite3.Row
     return db
 
@@ -660,6 +662,8 @@ def _record_recall_event(
     db = None
     try:
         db = sqlite3.connect(str(DB_PATH))
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA busy_timeout=5000")
         db.execute(
             """
             INSERT INTO recall_events (
@@ -4305,6 +4309,8 @@ def generate_briefing_history(days: int = 7, fmt: str = "text") -> str:
 
     try:
         db = sqlite3.connect(str(DB_PATH))
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA busy_timeout=5000")
         db.row_factory = sqlite3.Row
     except Exception as exc:
         msg = f"Cannot open database: {exc}"
@@ -4402,6 +4408,8 @@ def generate_never_recalled(fmt: str = "text") -> str:
 
     try:
         db = sqlite3.connect(str(DB_PATH))
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA busy_timeout=5000")
         db.row_factory = sqlite3.Row
     except Exception as exc:
         msg = f"Cannot open database: {exc}"
@@ -4463,6 +4471,8 @@ def _query_code_context(db_path: Path, query: str, token_budget: int = 1000) -> 
     """Query code_fts for relevant snippets. Returns [] if table missing or error."""
     try:
         db = sqlite3.connect(str(db_path))
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA busy_timeout=5000")
         has = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='code_index'").fetchone()
         if not has:
             db.close()
@@ -4624,6 +4634,8 @@ def _delta_report(db_path: "Path", window: str) -> None:
 
     try:
         db = sqlite3.connect(str(db_path))
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA busy_timeout=5000")
         db.row_factory = sqlite3.Row
     except Exception as exc:
         print(f"Cannot open database: {exc}", file=sys.stderr)
@@ -4911,6 +4923,8 @@ def _statistical_reflect(entries: list[dict], question: str) -> str:
 def _run_reflect(db_path: str, question: str, store: bool = True) -> None:
     """Run --reflect mode: fetch entries, synthesize insight, optionally store."""
     db = sqlite3.connect(db_path)
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute("PRAGMA busy_timeout=5000")
     entries = _fetch_reflect_entries(db, question)
 
     if not entries:
@@ -5011,6 +5025,8 @@ def _group_by_relations(db: sqlite3.Connection, entries: list[dict]) -> dict[str
 def _run_rag_briefing(db_path: str, query: str, mode: str = "auto") -> None:
     """RAG synthesis mode: retrieve top entries then synthesize into prose."""
     db = sqlite3.connect(db_path)
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute("PRAGMA busy_timeout=5000")
     db.row_factory = sqlite3.Row
     entries = _fetch_rag_entries(db, query)
     if not entries:
@@ -5082,6 +5098,8 @@ def main():
         if not no_danger and DB_PATH.exists():
             try:
                 _db = sqlite3.connect(str(DB_PATH))
+                _db.execute("PRAGMA journal_mode=WAL")
+                _db.execute("PRAGMA busy_timeout=5000")
                 _db.row_factory = sqlite3.Row
                 danger = _fetch_danger_lane(_db)
                 if danger:
@@ -5656,6 +5674,8 @@ def main():
     if not no_danger and fmt in ("compact", "pack", "md") and DB_PATH.exists():
         try:
             _dl_db = sqlite3.connect(str(DB_PATH))
+            _dl_db.execute("PRAGMA journal_mode=WAL")
+            _dl_db.execute("PRAGMA busy_timeout=5000")
             _dl_db.row_factory = sqlite3.Row
             danger = _fetch_danger_lane(_dl_db, since_date=since_date)
             if danger:

--- a/coverage.py
+++ b/coverage.py
@@ -21,7 +21,10 @@ def _get_db(db_path: Path) -> sqlite3.Connection:
     if not db_path.exists():
         print(f"Error: DB not found at {db_path}", file=sys.stderr)
         sys.exit(1)
-    return sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
 
 
 def _coverage_report(db: sqlite3.Connection, path_filter: str | None, limit: int) -> list[dict]:

--- a/curate.py
+++ b/curate.py
@@ -26,7 +26,10 @@ def _get_db(db_path: Path) -> sqlite3.Connection:
     if not db_path.exists():
         print(f"Error: DB not found at {db_path}", file=sys.stderr)
         sys.exit(1)
-    return sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
 
 
 def _jaccard_similarity(a: str, b: str) -> float:

--- a/knowledge-health.py
+++ b/knowledge-health.py
@@ -92,6 +92,8 @@ def get_db() -> sqlite3.Connection:
         print("Error: Knowledge database not found.", file=sys.stderr)
         sys.exit(1)
     db = sqlite3.connect(str(DB_PATH))
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute("PRAGMA busy_timeout=5000")
     db.row_factory = sqlite3.Row
     return db
 

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -876,6 +876,8 @@ def _run_rate_entry(arguments: dict[str, Any]) -> dict[str, Any]:
 
     try:
         db = sqlite3.connect(str(_DB_PATH))
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA busy_timeout=5000")
     except sqlite3.OperationalError as exc:
         raise JsonRpcError(JSONRPC_INTERNAL_ERROR, f"DB open error: {exc}") from exc
 

--- a/migrate.py
+++ b/migrate.py
@@ -108,7 +108,11 @@ def _create_backup_copy(db_path: str, backup_path: str | None = None) -> Path:
         raise FileExistsError(f"backup destination already exists: {destination}")
     destination.parent.mkdir(parents=True, exist_ok=True)
     src_conn = sqlite3.connect(str(source))
+    src_conn.execute("PRAGMA journal_mode=WAL")
+    src_conn.execute("PRAGMA busy_timeout=5000")
     dst_conn = sqlite3.connect(str(destination))
+    dst_conn.execute("PRAGMA journal_mode=WAL")
+    dst_conn.execute("PRAGMA busy_timeout=5000")
     backup_error = None
     try:
         src_conn.backup(dst_conn)
@@ -122,6 +126,8 @@ def _create_backup_copy(db_path: str, backup_path: str | None = None) -> Path:
         raise backup_error
 
     verify_conn = sqlite3.connect(str(destination))
+    verify_conn.execute("PRAGMA journal_mode=WAL")
+    verify_conn.execute("PRAGMA busy_timeout=5000")
     verify_error = None
     try:
         row = verify_conn.execute("PRAGMA quick_check").fetchone()
@@ -1049,6 +1055,8 @@ if __name__ == "__main__":
 
     try:
         db = sqlite3.connect(db_path)
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA busy_timeout=5000")
     except sqlite3.Error as exc:
         _print_database_recovery_hint(db_path, str(exc))
         raise SystemExit(1) from None

--- a/query-session.py
+++ b/query-session.py
@@ -312,6 +312,8 @@ def get_db() -> sqlite3.Connection:
         print("Run 'python build-session-index.py' first to build the index.")
         sys.exit(1)
     db = sqlite3.connect(str(DB_PATH))
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute("PRAGMA busy_timeout=5000")
     db.row_factory = sqlite3.Row
     return db
 

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -12272,6 +12272,103 @@ except Exception as _e819:
         test(f"I819-{_lbl819}: knowledge entry version history", False, str(_e819))
 
 # ---------------------------------------------------------------------------
+# === I831: Uniform SQLite WAL + busy-timeout ===
+# ---------------------------------------------------------------------------
+
+print("\n🗃️  I831: SQLite WAL + busy-timeout pragmas")
+
+try:
+    import importlib.util as _ilu831
+    import tempfile as _tf831
+
+    with _tf831.TemporaryDirectory() as _td831:
+        _db831_path = Path(_td831) / "knowledge.db"
+
+        # Bootstrap a minimal DB by importing briefing.py with a custom SK_DB_PATH
+        _old_env_831 = os.environ.get("SK_DB_PATH")
+        os.environ["SK_DB_PATH"] = str(_db831_path)
+
+        _br831_spec = _ilu831.spec_from_file_location("briefing831", REPO / "briefing.py")
+        _br831 = _ilu831.module_from_spec(_br831_spec)
+        _br831_spec.loader.exec_module(_br831)
+        _br831.DB_PATH = _db831_path
+
+        # Create a minimal DB so get_db() won't sys.exit
+        _setup_conn = sqlite3.connect(str(_db831_path))
+        _setup_conn.execute("CREATE TABLE IF NOT EXISTS knowledge_entries (id INTEGER PRIMARY KEY, title TEXT)")
+        _setup_conn.commit()
+        _setup_conn.close()
+
+        # I831-1: briefing.py get_db() sets journal_mode=WAL
+        _conn831 = _br831.get_db()
+        _jm831 = _conn831.execute("PRAGMA journal_mode").fetchone()[0]
+        _conn831.close()
+        test("I831-1: briefing.py get_db() sets journal_mode=WAL", _jm831 == "wal", f"got {_jm831!r}")
+
+        # I831-2: briefing.py get_db() sets busy_timeout=5000
+        _conn831b = _br831.get_db()
+        _bt831 = _conn831b.execute("PRAGMA busy_timeout").fetchone()[0]
+        _conn831b.close()
+        test("I831-2: briefing.py get_db() sets busy_timeout=5000", _bt831 == 5000, f"got {_bt831!r}")
+
+        # I831-3: query-session.py get_db() sets journal_mode=WAL
+        _qs831_spec = _ilu831.spec_from_file_location("query_session831", REPO / "query-session.py")
+        _qs831 = _ilu831.module_from_spec(_qs831_spec)
+        _qs831_spec.loader.exec_module(_qs831)
+        _qs831.DB_PATH = _db831_path
+        _conn831c = _qs831.get_db()
+        _jm831c = _conn831c.execute("PRAGMA journal_mode").fetchone()[0]
+        _conn831c.close()
+        test("I831-3: query-session.py get_db() sets journal_mode=WAL", _jm831c == "wal", f"got {_jm831c!r}")
+
+        # I831-4: query-session.py get_db() sets busy_timeout=5000
+        _conn831d = _qs831.get_db()
+        _bt831d = _conn831d.execute("PRAGMA busy_timeout").fetchone()[0]
+        _conn831d.close()
+        test("I831-4: query-session.py get_db() sets busy_timeout=5000", _bt831d == 5000, f"got {_bt831d!r}")
+
+        # I831-5: knowledge-health.py get_db() sets journal_mode=WAL
+        _kh831_spec = _ilu831.spec_from_file_location("knowledge_health831", REPO / "knowledge-health.py")
+        _kh831 = _ilu831.module_from_spec(_kh831_spec)
+        _kh831_spec.loader.exec_module(_kh831)
+        _kh831.DB_PATH = _db831_path
+        _conn831e = _kh831.get_db()
+        _jm831e = _conn831e.execute("PRAGMA journal_mode").fetchone()[0]
+        _conn831e.close()
+        test("I831-5: knowledge-health.py get_db() sets journal_mode=WAL", _jm831e == "wal", f"got {_jm831e!r}")
+
+        # I831-6: knowledge-health.py get_db() sets busy_timeout=5000
+        _conn831f = _kh831.get_db()
+        _bt831f = _conn831f.execute("PRAGMA busy_timeout").fetchone()[0]
+        _conn831f.close()
+        test("I831-6: knowledge-health.py get_db() sets busy_timeout=5000", _bt831f == 5000, f"got {_bt831f!r}")
+
+        # I831-7: curate.py _get_db() sets journal_mode=WAL
+        _cu831_spec = _ilu831.spec_from_file_location("curate831", REPO / "curate.py")
+        _cu831 = _ilu831.module_from_spec(_cu831_spec)
+        _cu831_spec.loader.exec_module(_cu831)
+        _conn831g = _cu831._get_db(_db831_path)
+        _jm831g = _conn831g.execute("PRAGMA journal_mode").fetchone()[0]
+        _conn831g.close()
+        test("I831-7: curate.py _get_db() sets journal_mode=WAL", _jm831g == "wal", f"got {_jm831g!r}")
+
+        # I831-8: curate.py _get_db() sets busy_timeout=5000
+        _conn831h = _cu831._get_db(_db831_path)
+        _bt831h = _conn831h.execute("PRAGMA busy_timeout").fetchone()[0]
+        _conn831h.close()
+        test("I831-8: curate.py _get_db() sets busy_timeout=5000", _bt831h == 5000, f"got {_bt831h!r}")
+
+        # Restore SK_DB_PATH
+        if _old_env_831 is None:
+            os.environ.pop("SK_DB_PATH", None)
+        else:
+            os.environ["SK_DB_PATH"] = _old_env_831
+
+except Exception as _e831:
+    for _lbl831 in ["1", "2", "3", "4", "5", "6", "7", "8"]:
+        test(f"I831-{_lbl831}: WAL+busy_timeout pragma", False, str(_e831))
+
+# ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")
 else:

--- a/tests/test_rollback_runbook.py
+++ b/tests/test_rollback_runbook.py
@@ -241,6 +241,12 @@ class RollbackRunbookTests(unittest.TestCase):
 
         for suffix in ("-wal", "-shm"):
             (db_path.with_name(db_path.name + suffix)).unlink(missing_ok=True)
+        # Checkpoint + switch journal mode so the backup is self-contained
+        with sqlite3.connect(backup_path) as _bak:
+            _bak.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            _bak.execute("PRAGMA journal_mode=DELETE")
+        for suffix in ("-wal", "-shm"):
+            backup_path.with_name(backup_path.name + suffix).unlink(missing_ok=True)
         shutil.copy2(backup_path, db_path)
 
         self.assertEqual(_db_scalar(db_path, "PRAGMA quick_check"), "ok")

--- a/trace.py
+++ b/trace.py
@@ -155,6 +155,9 @@ def _open_db(readonly: bool = False) -> sqlite3.Connection | None:
     uri = _DB_PATH.as_uri() + ("?mode=ro" if readonly else "")
     db = sqlite3.connect(uri, uri=True)
     db.row_factory = sqlite3.Row
+    if not readonly:
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA busy_timeout=5000")
     return db
 
 
@@ -317,6 +320,8 @@ def _cmd_list(args: argparse.Namespace) -> int:
 def _cmd_analyze(args: argparse.Namespace) -> int:
     """Analyze tool-call patterns from indexed spans."""
     db = sqlite3.connect(str(_DB_PATH))
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute("PRAGMA busy_timeout=5000")
     report = getattr(args, "report", "tool-frequency")
     limit = getattr(args, "limit", 20)
 


### PR DESCRIPTION
Implements #831. Adds `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout=5000` to all scripts opening knowledge.db. Closes #831