### PR TITLE
feat(#851): briefing semantic dedup & compression

### DIFF
--- a/briefing.py
+++ b/briefing.py
@@ -32,6 +32,7 @@ Usage:
     python briefing.py "task" --pinned 5                   # Also show top-5 P0 pinned entries
     python briefing.py "task" --no-repeat                  # Skip entries already served this session
     python briefing.py "task" --no-repeat=off              # Disable session-scoped deduplication
+    python briefing.py "task" --no-dedup                   # Disable semantic near-duplicate collapse (issue #851)
     python briefing.py "task" --available-tokens 5000 --pressure-compact  # Auto-compact if < 20% context left
 
 Default output is compact (~500 tokens): titles + 1-line summaries with entry IDs.
@@ -470,6 +471,60 @@ def _save_briefed_ids(session_id: str, ids: set[int]) -> None:
 
 def _estimate_tokens(output_chars: int) -> int:
     return int(math.ceil(output_chars / 4)) if output_chars > 0 else 0
+
+
+def _dedup_entries(entries: list, threshold: float = 0.85) -> list:
+    """Remove near-duplicate entries using TF-IDF cosine similarity.
+
+    Keeps the highest-confidence entry from each cluster.  Pure stdlib —
+    no scikit-learn required.  Applied in compact mode to collapse entries
+    that cover the same topic with different phrasing (issue #851).
+    """
+    if len(entries) <= 1:
+        return entries
+
+    from collections import Counter
+
+    def _tfidf(texts: list[str]) -> list[dict]:
+        tokenized = [set(t.lower().split()) for t in texts]
+        N = len(texts)
+        df: Counter = Counter(w for doc in tokenized for w in doc)
+        idf = {w: math.log(N / (1 + df[w])) for w in df}
+        vecs = []
+        for doc in tokenized:
+            tf: Counter = Counter(doc)
+            total = len(doc) or 1
+            vec = {w: (tf[w] / total) * idf[w] for w in doc}
+            norm = math.sqrt(sum(v * v for v in vec.values())) or 1.0
+            vecs.append({w: v / norm for w, v in vec.items()})
+        return vecs
+
+    texts = [f"{e.get('title', '')} {e.get('content', '')[:200]}" for e in entries]
+    vecs = _tfidf(texts)
+
+    def _cosine(a: dict, b: dict) -> float:
+        return sum(a.get(w, 0.0) * b.get(w, 0.0) for w in a)
+
+    kept: list = []
+    used: set = set()
+    for i in range(len(entries)):
+        if i in used:
+            continue
+        cluster = [i]
+        for j in range(i + 1, len(entries)):
+            if j not in used and _cosine(vecs[i], vecs[j]) >= threshold:
+                cluster.append(j)
+                used.add(j)
+        best = max(cluster, key=lambda k: entries[k].get("confidence", 0))
+        if len(cluster) > 1:
+            # Annotate the kept entry so renderers can show the merge notice
+            kept_entry = dict(entries[best])
+            merged_ids = [str(entries[k].get("id", "?")) for k in cluster if k != best]
+            kept_entry["_merged_ids"] = merged_ids
+            kept.append(kept_entry)
+        else:
+            kept.append(entries[best])
+    return kept
 
 
 def _check_pressure_compact(available_tokens: int, threshold: float = 0.20) -> bool:
@@ -2716,6 +2771,7 @@ def generate_briefing(
     include_resolved: bool = False,
     pinned_n: int = 0,
     exclude_ids: "set[int] | None" = None,
+    no_dedup: bool = False,
 ):
     """Generate a structured briefing from the knowledge base.
 
@@ -2726,6 +2782,9 @@ def generate_briefing(
 
     ``pinned_n``: when > 0, always prepend the top-N P0 priority entries to the
     briefing output regardless of the query (issue #708 --pinned flag).
+
+    ``no_dedup``: when True, skip the semantic near-duplicate collapse pass
+    (issue #851).  Dedup is applied by default in compact mode only.
     """
     db = get_db()
     rewritten_query = _rewrite_query_local(query)
@@ -2822,7 +2881,21 @@ def generate_briefing(
                 safe_entries.append(e)
         briefing_data[cat] = safe_entries
 
-    # Past related work
+    # Issue #851: semantic near-duplicate collapse — compact mode only, not full/wakeup.
+    # Applied after the per-category safety filter so dedup never bypasses suppression.
+    # Emits a briefing_merge_event for telemetry when entries are actually collapsed.
+    if not no_dedup and fmt == "compact":
+        total_before = sum(len(v) for v in briefing_data.values())
+        for cat in list(briefing_data.keys()):
+            briefing_data[cat] = _dedup_entries(briefing_data[cat])
+        total_after = sum(len(v) for v in briefing_data.values())
+        merged_count = total_before - total_after
+        if merged_count > 0:
+            _emit_knowledge_event_fail_open(
+                "briefing_merge_event",
+                {"merged_count": merged_count, "query": query[:120], "fmt": fmt},
+            )
+
     past_work = search_past_work(db, rewritten_query, limit)
 
     # Blast radius analysis
@@ -5166,6 +5239,9 @@ def main():
     if no_repeat and _no_repeat_session_id:
         already_served = _load_briefed_ids(_no_repeat_session_id)
 
+    # --no-dedup: disable semantic near-duplicate collapse (issue #851).
+    no_dedup = "--no-dedup" in args
+
     if auto_mode:
         query = auto_detect_context()
         print(f"[briefing] auto-detected: {query}", file=sys.stderr)
@@ -5271,6 +5347,7 @@ def main():
             include_resolved="--include-resolved" in args,
             pinned_n=pinned_n,
             exclude_ids=already_served if (no_repeat and _no_repeat_session_id) else None,
+            no_dedup=no_dedup,
         )
 
     if budget > 0 and len(output) > budget:
@@ -5309,6 +5386,7 @@ def main():
                     include_resolved="--include-resolved" in args,
                     pinned_n=pinned_n,
                     exclude_ids=already_served if (no_repeat and _no_repeat_session_id) else None,
+                    no_dedup=no_dedup,
                 )
             if len(output) <= budget:
                 break

--- a/briefing.py
+++ b/briefing.py
@@ -489,7 +489,7 @@ def _dedup_entries(entries: list, threshold: float = 0.85) -> list:
         tokenized = [set(t.lower().split()) for t in texts]
         N = len(texts)
         df: Counter = Counter(w for doc in tokenized for w in doc)
-        idf = {w: math.log(N / (1 + df[w])) for w in df}
+        idf = {w: math.log(1 + N / (1 + df[w])) for w in df}
         vecs = []
         for doc in tokenized:
             tf: Counter = Counter(doc)
@@ -3590,10 +3590,12 @@ def _format_compact(
             recurrence = int(entry.get("recurrence_after_briefing") or 0)
             recurring_badge = f"[RECURRING×{recurrence}] " if recurrence > 0 else ""
             pinned_badge = "📌 " if (entry.get("priority") or "") == "P0" else ""
+            merged_ids = entry.get("_merged_ids")
+            merge_tag = f" [merged #{',#'.join(merged_ids)}]" if merged_ids else ""
             if first_line.lower().startswith(title_prefix[:60]):
-                rendered.append(f"- {pinned_badge}{recurring_badge}{title}")
+                rendered.append(f"- {pinned_badge}{recurring_badge}{title}{merge_tag}")
             else:
-                rendered.append(f"- {pinned_badge}{recurring_badge}{title}: {first_line}")
+                rendered.append(f"- {pinned_badge}{recurring_badge}{title}: {first_line}{merge_tag}")
         if not rendered:
             return
         lines.append(f"<{cat}s>")

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -11571,7 +11571,12 @@ try:
     # I851-5: dissimilar entries both kept
     _e851_diff = [
         {"id": 10, "title": "fix null pointer exception", "content": "crash on startup null ref", "confidence": 0.8},
-        {"id": 11, "title": "deploy to kubernetes cluster", "content": "helm chart ingress tls cert", "confidence": 0.8},
+        {
+            "id": 11,
+            "title": "deploy to kubernetes cluster",
+            "content": "helm chart ingress tls cert",
+            "confidence": 0.8,
+        },
     ]
     _r851_5 = _dedup851(_e851_diff, threshold=0.85)
     test(
@@ -11580,11 +11585,11 @@ try:
         str(_r851_5),
     )
 
-    # I851-6: threshold=0.0 collapses everything into one cluster (extreme)
+    # I851-6: threshold=0.0 collapses everything into one cluster (cosine 0 >= 0.0)
     _r851_6 = _dedup851(_e851_diff, threshold=0.0)
     test(
-        "I851-6: threshold=0.0 collapses any pair sharing at least one token",
-        len(_r851_6) <= 2,  # may or may not share tokens; just verify no crash
+        "I851-6: threshold=0.0 collapses any pair into one cluster",
+        len(_r851_6) == 1,
         str(_r851_6),
     )
 
@@ -11606,6 +11611,7 @@ try:
 
     # I851-9: generate_briefing accepts no_dedup keyword argument
     import inspect as _inspect851
+
     _sig851 = _inspect851.signature(_bmod851.generate_briefing)
     test(
         "I851-9: generate_briefing has no_dedup parameter",
@@ -11616,12 +11622,19 @@ try:
     # I851-10: dedup only runs for compact fmt (not full/md/json in generate_briefing logic)
     test(
         "I851-10: dedup pass keyed on fmt == 'compact' in source",
-        "fmt == \"compact\"" in _src851 or 'fmt == "compact"' in _src851,
+        'fmt == "compact"' in _src851 or 'fmt == "compact"' in _src851,
+        "",
+    )
+
+    # I851-11: compact renderer shows merge notice for collapsed entries
+    test(
+        "I851-11: compact renderer reads _merged_ids for merge notice",
+        "_merged_ids" in _src851 and "merge_tag" in _src851,
         "",
     )
 
 except Exception as _e851:
-    for _lbl851 in ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:
+    for _lbl851 in ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]:
         test(f"I851-{_lbl851}: briefing semantic dedup", False, str(_e851))
 
 # ---------------------------------------------------------------------------

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -11529,6 +11529,102 @@ except Exception as _e759:
         test(f"I759-{_label759}: tag-entries TF-IDF opt-in", False, str(_e759))
 
 # ---------------------------------------------------------------------------
+# === I851: briefing semantic dedup — TF-IDF cosine near-duplicate collapse ===
+print("\n🔍 I851: briefing semantic dedup — _dedup_entries TF-IDF cosine collapse")
+
+try:
+    import importlib.util as _ilu851
+    import sys as _sys851
+
+    _spec851 = _ilu851.spec_from_file_location("briefing851", Path(__file__).parent / "briefing.py")
+    _bmod851 = _ilu851.module_from_spec(_spec851)
+    _spec851.loader.exec_module(_bmod851)  # type: ignore[union-attr]
+    _dedup851 = _bmod851._dedup_entries
+
+    # I851-1: empty list → empty list (no-op)
+    test("I851-1: empty list → empty list", _dedup851([]) == [], "")
+
+    # I851-2: single entry → returned unchanged
+    _e851_single = [{"id": 1, "title": "foo", "content": "bar", "confidence": 0.9}]
+    test("I851-2: single entry returned unchanged", _dedup851(_e851_single) == _e851_single, "")
+
+    # I851-3: two identical entries → only one kept (highest confidence wins)
+    _txt851 = "fix null pointer exception crash on startup"
+    _e851_dups = [
+        {"id": 1, "title": _txt851, "content": _txt851, "confidence": 0.7},
+        {"id": 2, "title": _txt851, "content": _txt851, "confidence": 0.9},
+    ]
+    _r851_3 = _dedup851(_e851_dups, threshold=0.85)
+    test(
+        "I851-3: identical entries collapse to one (highest confidence kept)",
+        len(_r851_3) == 1 and _r851_3[0].get("id") == 2,
+        str(_r851_3),
+    )
+
+    # I851-4: merged entry carries _merged_ids annotation
+    test(
+        "I851-4: merged entry has _merged_ids annotation",
+        len(_r851_3) == 1 and "1" in _r851_3[0].get("_merged_ids", []),
+        str(_r851_3),
+    )
+
+    # I851-5: dissimilar entries both kept
+    _e851_diff = [
+        {"id": 10, "title": "fix null pointer exception", "content": "crash on startup null ref", "confidence": 0.8},
+        {"id": 11, "title": "deploy to kubernetes cluster", "content": "helm chart ingress tls cert", "confidence": 0.8},
+    ]
+    _r851_5 = _dedup851(_e851_diff, threshold=0.85)
+    test(
+        "I851-5: dissimilar entries both kept",
+        len(_r851_5) == 2,
+        str(_r851_5),
+    )
+
+    # I851-6: threshold=0.0 collapses everything into one cluster (extreme)
+    _r851_6 = _dedup851(_e851_diff, threshold=0.0)
+    test(
+        "I851-6: threshold=0.0 collapses any pair sharing at least one token",
+        len(_r851_6) <= 2,  # may or may not share tokens; just verify no crash
+        str(_r851_6),
+    )
+
+    # I851-7: threshold=1.0 keeps all entries (nothing matches perfectly unless identical)
+    _r851_7 = _dedup851(_e851_diff, threshold=1.0)
+    test(
+        "I851-7: threshold=1.0 keeps all dissimilar entries",
+        len(_r851_7) == len(_e851_diff),
+        str(_r851_7),
+    )
+
+    # I851-8: --no-dedup flag is parsed from args (present in CLI arg list)
+    _src851 = Path(__file__).parent.joinpath("briefing.py").read_text(encoding="utf-8")
+    test(
+        "I851-8: --no-dedup flag present in CLI arg parsing",
+        '"--no-dedup"' in _src851 or "'--no-dedup'" in _src851,
+        "",
+    )
+
+    # I851-9: generate_briefing accepts no_dedup keyword argument
+    import inspect as _inspect851
+    _sig851 = _inspect851.signature(_bmod851.generate_briefing)
+    test(
+        "I851-9: generate_briefing has no_dedup parameter",
+        "no_dedup" in _sig851.parameters,
+        str(list(_sig851.parameters.keys())),
+    )
+
+    # I851-10: dedup only runs for compact fmt (not full/md/json in generate_briefing logic)
+    test(
+        "I851-10: dedup pass keyed on fmt == 'compact' in source",
+        "fmt == \"compact\"" in _src851 or 'fmt == "compact"' in _src851,
+        "",
+    )
+
+except Exception as _e851:
+    for _lbl851 in ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:
+        test(f"I851-{_lbl851}: briefing semantic dedup", False, str(_e851))
+
+# ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")
 else:


### PR DESCRIPTION
Implements #851. TF-IDF cosine similarity dedup pass collapses near-duplicates (>=0.85) keeping highest-confidence entry. On by default for --compact, disabled with --no-dedup. Closes #851