### PR TITLE
feat(#853): file-glob + wing/room context filters on hooks

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -455,6 +455,32 @@ security gates are never suppressed.
 > (`sk-rust/src/commands/hooks.rs`) do not implement debounce yet. A follow-up
 > issue will track the native-runner port.
 
+### Context filter environment variables
+
+Two optional environment variables let you scope hook rule evaluation to the active working context:
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `SK_WING` | Declares the current *wing* (domain/team area). Rules with `require_wing` are skipped when the value doesn't match. | `SK_WING=backend` |
+| `SK_ROOM` | Declares the current *room* (feature area or sub-module). Rules with `require_room` are skipped when the value doesn't match. | `SK_ROOM=api` |
+
+Set these in your shell profile or export them before starting a session:
+
+```bash
+export SK_WING=backend
+export SK_ROOM=api
+```
+
+**Rule-level filter fields** (declare in any `Rule` subclass):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `file_patterns` | `list[str]` | Glob patterns matched against the extracted file path via `pathlib.PurePath.match()`. Rule is skipped when no pattern matches. Empty list = match all. Example: `["**/*.py", "*.py"]` |
+| `require_wing` | `str` | Skip this rule unless `SK_WING` matches exactly. Empty string = no filtering. |
+| `require_room` | `str` | Skip this rule unless `SK_ROOM` matches exactly. Empty string = no filtering. |
+
+All three filters are evaluated before `rule.evaluate()` is called — skipped rules incur no evaluation cost.
+
 ## preToolUse Routing-Flip Specification
 
 This section records the verified state of the managed routing flip for `preToolUse`.

--- a/hooks/hook_runner.py
+++ b/hooks/hook_runner.py
@@ -25,7 +25,7 @@ import os
 import sys
 import time
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePath
 
 # Windows encoding fix (once, not per-hook)
 if os.name == "nt":
@@ -40,6 +40,24 @@ MARKERS_DIR = Path.home() / ".copilot" / "markers"
 SYNC_NUDGE_MARKER = MARKERS_DIR / "sync-nudge.json"
 SYNC_FLUSH_MARKER = MARKERS_DIR / "sync-flush.json"
 DEBOUNCE_DIR = Path.home() / ".copilot" / "markers" / "hook-debounce"
+
+
+def _extract_file_path(data: dict) -> str:
+    """Extract file path from tool event data (preToolUse or postToolUse).
+
+    Checks ``toolArgs``, ``toolInput``, ``toolResult``, and ``input``
+    containers for both ``path`` and ``filePath`` keys so that edit, create,
+    and other tool event shapes are all handled.
+    Returns the first non-empty value found, or ``""`` if absent.
+    """
+    for key in ("toolArgs", "toolInput", "toolResult", "input"):
+        args = data.get(key)
+        if isinstance(args, dict):
+            for field in ("path", "filePath"):
+                val = args.get(field, "")
+                if val:
+                    return val
+    return ""
 
 
 def _audit_log(event, tool, rule_name, decision, detail=""):
@@ -236,6 +254,24 @@ def main():
     for rule in rules:
         # Tool matching (empty tools list = match all)
         if rule.tools and tool_name not in rule.tools:
+            continue
+
+        # File-pattern filtering (empty file_patterns = match all)
+        # Use getattr() so rules that don't inherit from Rule base class still work.
+        _file_pats = getattr(rule, "file_patterns", [])
+        if _file_pats:
+            _fp = _extract_file_path(data)
+            if not _fp or not any(PurePath(_fp).match(pat) for pat in _file_pats):
+                continue
+
+        # Wing context filtering
+        _wing = getattr(rule, "require_wing", "")
+        if _wing and os.environ.get("SK_WING", "") != _wing:
+            continue
+
+        # Room context filtering
+        _room = getattr(rule, "require_room", "")
+        if _room and os.environ.get("SK_ROOM", "") != _room:
             continue
 
         # Debounce: skip preToolUse hooks that fired within the window (issue #832)

--- a/hooks/rules/__init__.py
+++ b/hooks/rules/__init__.py
@@ -12,6 +12,11 @@ class Rule:
     events = []  # e.g., ["preToolUse"]
     tools = []  # e.g., ["edit", "create", "bash"]. Empty = all tools
 
+    # Optional context filters (all empty = no filtering, rule always runs)
+    file_patterns = []  # e.g., ["**/*.py"] — filter by extracted file path (pathlib.PurePath.match)
+    require_wing = ""  # e.g., "backend" — skip rule when SK_WING env var doesn't match
+    require_room = ""  # e.g., "api"     — skip rule when SK_ROOM env var doesn't match
+
     def evaluate(self, event, data):
         """Evaluate this rule. Returns dict with decision or None to pass."""
         return None

--- a/hooks/rules/file_size_advisory.py
+++ b/hooks/rules/file_size_advisory.py
@@ -22,6 +22,7 @@ class FileSizeAdvisoryRule(Rule):
     name = "file-size-advisory"
     events = ["preToolUse"]
     tools = ["edit", "create"]
+    file_patterns = ["**/*.py", "*.py"]
 
     MAX_PYTHON_LINES = 400
 

--- a/hooks/rules/syntax_gate.py
+++ b/hooks/rules/syntax_gate.py
@@ -28,6 +28,7 @@ class SyntaxGateRule(Rule):
     name = "syntax-gate"
     events = ["preToolUse"]
     tools = ["edit", "create"]
+    file_patterns = ["**/*.py", "*.py"]
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -14047,6 +14047,188 @@ try:
 except Exception as _e851:
     for _lbl851 in ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]:
         test(f"I851-{_lbl851}: briefing semantic dedup", False, str(_e851))
+# === I853: hook rule context filters (file_patterns, require_wing, require_room) ===
+print("\n🪝 I853: hook rule context filters")
+
+try:
+    import os as _os853
+    from pathlib import PurePath as _PP853
+
+    sys.path.insert(0, str(Path(__file__).parent / "hooks"))
+    from rules import Rule as _Rule853
+
+    # I853-1: Rule base class has file_patterns field
+    test("I853-1: Rule has file_patterns field", hasattr(_Rule853, "file_patterns"), "missing field")
+    # I853-2: Rule base class has require_wing field
+    test("I853-2: Rule has require_wing field", hasattr(_Rule853, "require_wing"), "missing field")
+    # I853-3: Rule base class has require_room field
+    test("I853-3: Rule has require_room field", hasattr(_Rule853, "require_room"), "missing field")
+
+    # I853-4: _extract_file_path importable from hook_runner
+    sys.path.insert(0, str(Path(__file__).parent / "hooks"))
+    import importlib as _il853
+    import importlib.util as _ilu853
+
+    _spec853 = _ilu853.spec_from_file_location("hook_runner853", Path(__file__).parent / "hooks" / "hook_runner.py")
+    _hr853 = _il853.util.module_from_spec(_spec853)
+    _spec853.loader.exec_module(_hr853)
+    _extract_fp853 = _hr853._extract_file_path
+    test("I853-4: _extract_file_path defined in hook_runner", callable(_extract_fp853), "not found")
+
+    # I853-5/6: file_patterns filtering logic (using production _extract_file_path)
+    class _MockFP853(_Rule853):
+        name = "mock-fp853"
+        events = ["preToolUse"]
+        tools = []
+        file_patterns = ["**/*.py", "*.py"]
+        _called = False
+
+        def evaluate(self, event, data):
+            _MockFP853._called = True
+            return None
+
+    def _simulate_filter853(rule, data):
+        """Apply file_patterns filter using production _extract_file_path."""
+        pats = getattr(rule, "file_patterns", [])
+        if pats:
+            fp = _extract_fp853(data)
+            if not fp or not any(_PP853(fp).match(pat) for pat in pats):
+                return False  # skip
+        return True  # proceed
+
+    _mr853 = _MockFP853()
+    _skip853 = _simulate_filter853(_mr853, {"toolArgs": {"path": "config.json"}})
+    test("I853-5: file_patterns=*.py — skipped for config.json", not _skip853, f"skip={_skip853}")
+
+    _run853 = _simulate_filter853(_mr853, {"toolArgs": {"path": "script.py"}})
+    test("I853-6: file_patterns=*.py — triggered for script.py", _run853, f"run={_run853}")
+
+    # Nested path matching
+    _run853_nested = _simulate_filter853(_mr853, {"toolArgs": {"path": "src/hooks/rules/foo.py"}})
+    test("I853-6b: file_patterns=*.py — triggered for nested path/*.py", _run853_nested, f"run={_run853_nested}")
+
+    # I853-7/8: require_wing filtering
+    class _MockWing853(_Rule853):
+        name = "mock-wing853"
+        events = ["preToolUse"]
+        tools = []
+        require_wing = "backend"
+
+    def _simulate_wing853(rule, env_wing):
+        old = _os853.environ.get("SK_WING", "")
+        try:
+            if env_wing is None:
+                _os853.environ.pop("SK_WING", None)
+            else:
+                _os853.environ["SK_WING"] = env_wing
+            return _os853.environ.get("SK_WING", "") == rule.require_wing
+        finally:
+            if old:
+                _os853.environ["SK_WING"] = old
+            else:
+                _os853.environ.pop("SK_WING", None)
+
+    _mw853 = _MockWing853()
+    test(
+        "I853-7: require_wing=backend — skipped when SK_WING=frontend",
+        not _simulate_wing853(_mw853, "frontend"),
+        "should skip",
+    )
+    test(
+        "I853-8: require_wing=backend — triggered when SK_WING=backend",
+        _simulate_wing853(_mw853, "backend"),
+        "should run",
+    )
+
+    # I853-9/10: require_room filtering
+    class _MockRoom853(_Rule853):
+        name = "mock-room853"
+        events = ["preToolUse"]
+        tools = []
+        require_room = "api"
+
+    def _simulate_room853(rule, env_room):
+        old = _os853.environ.get("SK_ROOM", "")
+        try:
+            if env_room is None:
+                _os853.environ.pop("SK_ROOM", None)
+            else:
+                _os853.environ["SK_ROOM"] = env_room
+            return _os853.environ.get("SK_ROOM", "") == rule.require_room
+        finally:
+            if old:
+                _os853.environ["SK_ROOM"] = old
+            else:
+                _os853.environ.pop("SK_ROOM", None)
+
+    _mr2853 = _MockRoom853()
+    test("I853-9: require_room=api — skipped when SK_ROOM=ui", not _simulate_room853(_mr2853, "ui"), "should skip")
+    test("I853-10: require_room=api — triggered when SK_ROOM=api", _simulate_room853(_mr2853, "api"), "should run")
+
+    # I853-11: SyntaxGateRule has file_patterns declared
+    from rules.syntax_gate import SyntaxGateRule as _SGR853
+
+    _sg853 = _SGR853()
+    test(
+        "I853-11: SyntaxGateRule has file_patterns",
+        bool(_sg853.file_patterns),
+        f"file_patterns={_sg853.file_patterns!r}",
+    )
+
+    # I853-12: FileSizeAdvisoryRule has file_patterns declared
+    from rules.file_size_advisory import FileSizeAdvisoryRule as _FSA853
+
+    _fsa853 = _FSA853()
+    test(
+        "I853-12: FileSizeAdvisoryRule has file_patterns",
+        bool(_fsa853.file_patterns),
+        f"file_patterns={_fsa853.file_patterns!r}",
+    )
+
+    # I853-13: SyntaxGateRule NOT invoked for .json file via filter
+    _skip_json853 = not _simulate_filter853(_sg853, {"toolArgs": {"path": "config.json"}})
+    test("I853-13: SyntaxGateRule skipped for config.json", _skip_json853, f"skip={_skip_json853}")
+
+    # I853-14: FileSizeAdvisoryRule NOT invoked for .ts file via filter
+    _skip_ts853 = not _simulate_filter853(_fsa853, {"toolArgs": {"path": "app.ts"}})
+    test("I853-14: FileSizeAdvisoryRule skipped for app.ts", _skip_ts853, f"skip={_skip_ts853}")
+
+    # I853-15: empty file path with file_patterns → skipped (safe default)
+    _skip_empty853 = not _simulate_filter853(_sg853, {"toolArgs": {}})
+    test("I853-15: file_patterns — empty path skips rule safely", _skip_empty853, f"skip={_skip_empty853}")
+
+    # I853-16: _extract_file_path handles filePath key (edit/create payloads)
+    _fp_result853 = _extract_fp853({"toolResult": {"filePath": "src/app.py"}})
+    test(
+        "I853-16: _extract_file_path reads toolResult.filePath", _fp_result853 == "src/app.py", f"got={_fp_result853!r}"
+    )
+
+    # I853-17: _extract_file_path handles input container
+    _fp_input853 = _extract_fp853({"input": {"filePath": "lib/core.ts"}})
+    test("I853-17: _extract_file_path reads input.filePath", _fp_input853 == "lib/core.ts", f"got={_fp_input853!r}")
+
+except Exception as _e853:
+    for _label853 in [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "6b",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "13",
+        "14",
+        "15",
+        "16",
+        "17",
+    ]:
+        test(f"I853-{_label853}: hook rule context filters", False, str(_e853))
 
 # ---------------------------------------------------------------------------
 if FAIL == 0:


### PR DESCRIPTION
Implements #853. Hook rules can now declare `file_patterns`, `require_wing`, and `require_room` filters. Rules are skipped when context doesn't match. `SK_WING`/`SK_ROOM` env vars set context. Closes #853