### PR TITLE
feat(#872): cross-session recurrence auto-tagging

### DIFF
--- a/knowledge-health.py
+++ b/knowledge-health.py
@@ -227,11 +227,15 @@ def compute_health(stale_days: int = 30) -> dict:
 
     # Concept tag coverage (informational stat only — does NOT affect weighted score)
     concept_tagged = 0
+    high_recurrence_count = 0
     try:
         has_ect = db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='entry_concept_tags'").fetchone()
         if has_ect:
             concept_tagged = db.execute(
                 "SELECT COUNT(DISTINCT entry_id) FROM entry_concept_tags WHERE source = 'auto'"
+            ).fetchone()[0]
+            high_recurrence_count = db.execute(
+                "SELECT COUNT(DISTINCT entry_id) FROM entry_concept_tags WHERE tag = 'high-recurrence' AND source = 'auto'"
             ).fetchone()[0]
     except sqlite3.OperationalError:
         pass
@@ -308,6 +312,8 @@ def compute_health(stale_days: int = 30) -> dict:
         "rooms": rooms,
         "sessions": sessions,
         "concept_tag_coverage_pct": concept_tag_coverage_pct,
+        "high_recurrence_count": high_recurrence_count,
+        "high_recurrence_pct": round((high_recurrence_count / total) * 100, 1) if total > 0 else 0.0,
         "subscores": {k: round(v, 1) for k, v in scores.items()},
         "toward_100": toward_100,
     }

--- a/sk.py
+++ b/sk.py
@@ -195,6 +195,7 @@ _GROUPS: dict[str, dict[str, str]] = {
         "health": "knowledge-health.py",
         "embed": "embed.py",
         "tag": "tag-entries.py",
+        "cross-tag": "tag-entries.py",
     },
     "sync": {
         "run": "sync-daemon.py",
@@ -1152,6 +1153,8 @@ def main(argv: list[str] | None = None) -> int:
             return _run(_GROUPS[cmd][sub], [sub] + sub_rest)
         if cmd == "knowledge" and sub == "bulk-tag":
             return _run(_GROUPS[cmd][sub], ["bulk-tag"] + sub_rest)
+        if cmd == "index" and sub == "cross-tag":
+            return _run(_GROUPS[cmd][sub], ["--cross-session"] + sub_rest)
         return _run(_GROUPS[cmd][sub], sub_rest)
 
     # Unknown

--- a/tag-entries.py
+++ b/tag-entries.py
@@ -13,6 +13,9 @@ Usage:
     python tag-entries.py --limit N      # Process at most N entries
     python tag-entries.py --tfidf        # Opt into TF-IDF scoring for batch tagging
     python tag-entries.py --stats        # Show current concept-tag coverage stats
+    python tag-entries.py --cross-session              # Tag high-recurrence entries (>=3 sessions)
+    python tag-entries.py --cross-session --threshold N  # Custom session threshold
+    python tag-entries.py --cross-session --dry-run    # Preview without writing
 """
 
 import os
@@ -435,6 +438,102 @@ def run_stats() -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Cross-session recurrence tagging
+# ---------------------------------------------------------------------------
+
+_HIGH_RECURRENCE_TAG = "high-recurrence"
+
+
+def run_cross_session_tag(
+    threshold: int = 3,
+    dry_run: bool = False,
+    quiet: bool = False,
+) -> dict:
+    """Tag entries whose concept appears in >= threshold distinct sessions.
+
+    For each concept tag in entry_concept_tags, count distinct session_id values
+    across linked knowledge_entries rows.  Any entry that belongs to at least one
+    concept meeting the threshold receives the 'high-recurrence' tag
+    (source='auto').
+
+    Args:
+        threshold: Minimum number of distinct sessions required (default 3).
+        dry_run:   Preview only; do not write to DB.
+        quiet:     Suppress per-entry output.
+
+    Returns:
+        Stats dict: scanned, tagged, already_tagged, errors, available.
+    """
+    db = get_db()
+    try:
+        if not _ensure_concept_tags_table(db):
+            return {"scanned": 0, "tagged": 0, "already_tagged": 0, "errors": 0, "available": False}
+
+        _seed_sync_policy(db)
+
+        # Find entry IDs that belong to at least one concept spanning >= threshold sessions.
+        candidate_rows = db.execute(
+            """
+            SELECT DISTINCT ect.entry_id
+            FROM entry_concept_tags ect
+            JOIN knowledge_entries ke ON ect.entry_id = ke.id
+            WHERE ect.source = 'auto'
+              AND ect.tag IN (
+                  SELECT ect2.tag
+                  FROM entry_concept_tags ect2
+                  JOIN knowledge_entries ke2 ON ect2.entry_id = ke2.id
+                  WHERE ect2.source = 'auto'
+                    AND ke2.session_id IS NOT NULL
+                    AND ke2.session_id != ''
+                  GROUP BY ect2.tag
+                  HAVING COUNT(DISTINCT ke2.session_id) >= ?
+              )
+            """,
+            (threshold,),
+        ).fetchall()
+
+        candidate_ids = [r[0] for r in candidate_rows]
+
+        stats: dict = {"scanned": len(candidate_ids), "tagged": 0, "already_tagged": 0, "errors": 0, "available": True}
+        now = time.strftime("%Y-%m-%dT%H:%M:%S")
+
+        for entry_id in candidate_ids:
+            try:
+                existing = db.execute(
+                    "SELECT 1 FROM entry_concept_tags WHERE entry_id = ? AND tag = ?",
+                    (entry_id, _HIGH_RECURRENCE_TAG),
+                ).fetchone()
+
+                if existing:
+                    stats["already_tagged"] += 1
+                    continue
+
+                if not dry_run:
+                    db.execute(
+                        """
+                        INSERT INTO entry_concept_tags (entry_id, tag, source, tagged_at)
+                        VALUES (?, ?, 'auto', ?)
+                        ON CONFLICT(entry_id, tag) DO UPDATE SET tagged_at = excluded.tagged_at
+                        """,
+                        (entry_id, _HIGH_RECURRENCE_TAG, now),
+                    )
+
+                stats["tagged"] += 1
+                if not quiet:
+                    mode_prefix = "[dry-run] " if dry_run else ""
+                    print(f"  {mode_prefix}#{entry_id}: → {_HIGH_RECURRENCE_TAG}")
+            except Exception as e:
+                stats["errors"] += 1
+                print(f"  [error] entry #{entry_id}: {e}", file=sys.stderr)
+
+        if not dry_run:
+            db.commit()
+        return stats
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -454,8 +553,24 @@ def main(argv: list | None = None) -> int:
     parser.add_argument("--stats", action="store_true", help="Show concept tag coverage statistics")
     parser.add_argument("--quiet", action="store_true", help="Suppress per-entry output")
     parser.add_argument("--tfidf", action="store_true", help="Opt into TF-IDF scoring for batch tagging")
+    parser.add_argument(
+        "--cross-session",
+        dest="cross_session",
+        action="store_true",
+        help="Tag entries with 'high-recurrence' when their concept appears in >= threshold sessions",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=3,
+        help="Minimum distinct sessions for high-recurrence tagging (default: 3)",
+    )
 
     args = parser.parse_args(argv)
+
+    if args.cross_session and args.threshold < 1:
+        print("Error: --threshold must be a positive integer (>= 1).", file=sys.stderr)
+        return 1
 
     if args.stats:
         s = run_stats()
@@ -470,6 +585,23 @@ def main(argv: list | None = None) -> int:
             print("\n  Top concept tags:")
             for t in s["top_tags"][:10]:
                 print(f"    {t['freq']:5d}x  {t['tag']}")
+        return 0
+
+    if args.cross_session:
+        mode = "[dry-run] cross-session recurrence" if args.dry_run else "cross-session recurrence"
+        print(f"Concept tag batch — {mode} (threshold={args.threshold})...")
+        stats = run_cross_session_tag(
+            threshold=args.threshold,
+            dry_run=args.dry_run,
+            quiet=args.quiet,
+        )
+        if not stats.get("available"):
+            print("  Failed to initialize entry_concept_tags table.", file=sys.stderr)
+            return 1
+        print(
+            f"\nDone — scanned={stats['scanned']}  tagged={stats['tagged']}  "
+            f"already_tagged={stats['already_tagged']}  errors={stats['errors']}"
+        )
         return 0
 
     mode = "re-tagging all" if args.retag_all else "tagging untagged"

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -14980,6 +14980,243 @@ except Exception as _e870:
         test(f"I870-{_label870}: sk tui browser", False, str(_e870))
 
 # ---------------------------------------------------------------------------
+# === I872: cross-session recurrence auto-tagging ===
+print("\n🔍 I872: cross-session recurrence auto-tagging")
+
+try:
+    import importlib.util as _ilu872
+    import os as _os872
+    import sqlite3 as _sq872
+
+    _spec872 = _ilu872.spec_from_file_location("tag_entries_i872", REPO / "tag-entries.py")
+    _te872 = _ilu872.module_from_spec(_spec872)  # type: ignore[arg-type]
+    _spec872.loader.exec_module(_te872)  # type: ignore[union-attr]
+
+    _src872 = (REPO / "tag-entries.py").read_text(encoding="utf-8")
+    _sk872_src = (REPO / "sk.py").read_text(encoding="utf-8")
+    _kh872_src = (REPO / "knowledge-health.py").read_text(encoding="utf-8")
+
+    # 1. Source-level checks
+    test(
+        "I872-1a: --cross-session flag in tag-entries.py",
+        '"--cross-session"' in _src872 or "'--cross-session'" in _src872,
+    )
+    test("I872-1b: --threshold flag in tag-entries.py", '"--threshold"' in _src872 or "'--threshold'" in _src872)
+    test("I872-1c: run_cross_session_tag function defined", "def run_cross_session_tag(" in _src872)
+    test("I872-1d: high-recurrence tag constant defined", "high-recurrence" in _src872)
+    test("I872-1e: HAVING COUNT(DISTINCT session_id) query present", "HAVING COUNT(DISTINCT" in _src872)
+    test("I872-1f: sk.py has cross-tag subcommand", '"cross-tag"' in _sk872_src or "'cross-tag'" in _sk872_src)
+    test("I872-1g: sk.py routes cross-tag to --cross-session", "--cross-session" in _sk872_src)
+    test("I872-1h: knowledge-health.py has high_recurrence_count metric", "high_recurrence_count" in _kh872_src)
+    test("I872-1i: knowledge-health.py has high_recurrence_pct metric", "high_recurrence_pct" in _kh872_src)
+
+    def _make_cross_db872(name: str) -> Path:
+        """Create a test DB with entries spread across multiple sessions."""
+        _path = REPO / f".test_i872_{_os872.getpid()}_{name}.db"
+        try:
+            _path.unlink()
+        except FileNotFoundError:
+            pass
+        _db = _sq872.connect(str(_path))
+        _db.execute(
+            """CREATE TABLE knowledge_entries (
+                id INTEGER PRIMARY KEY,
+                title TEXT DEFAULT '',
+                content TEXT DEFAULT '',
+                session_id TEXT DEFAULT ''
+            )"""
+        )
+        _db.execute(
+            """CREATE TABLE entry_concept_tags (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                entry_id INTEGER NOT NULL,
+                tag TEXT NOT NULL,
+                source TEXT NOT NULL DEFAULT 'auto',
+                tagged_at TEXT DEFAULT (datetime('now')),
+                UNIQUE(entry_id, tag)
+            )"""
+        )
+        # 3 entries with concept tag 'python' from 3 distinct sessions → meets threshold=3
+        for _i, _sess in enumerate(["sess-A", "sess-B", "sess-C"], start=1):
+            _db.execute(
+                "INSERT INTO knowledge_entries (id, title, content, session_id) VALUES (?,?,?,?)",
+                (_i, f"Python entry {_i}", "Python content", _sess),
+            )
+            _db.execute("INSERT INTO entry_concept_tags (entry_id, tag, source) VALUES (?,?,?)", (_i, "python", "auto"))
+        # 2 entries with concept tag 'rust' from 2 distinct sessions → below threshold=3
+        for _i, _sess in enumerate(["sess-X", "sess-Y"], start=4):
+            _db.execute(
+                "INSERT INTO knowledge_entries (id, title, content, session_id) VALUES (?,?,?,?)",
+                (_i, f"Rust entry {_i}", "Rust content", _sess),
+            )
+            _db.execute("INSERT INTO entry_concept_tags (entry_id, tag, source) VALUES (?,?,?)", (_i, "rust", "auto"))
+        _db.commit()
+        _db.close()
+        return _path
+
+    _orig_db872 = _te872.DB_PATH
+    _db872_path = _make_cross_db872("main")
+    try:
+        _te872.DB_PATH = _db872_path
+
+        # 2. Dry-run: no writes but scanned count correct
+        _dry872 = _te872.run_cross_session_tag(threshold=3, dry_run=True, quiet=True)
+        test("I872-2a: dry-run returns available=True", _dry872.get("available") is True, str(_dry872))
+        test("I872-2b: dry-run scanned=3 (python entries)", _dry872.get("scanned") == 3, str(_dry872))
+        test("I872-2c: dry-run tagged=3 (would tag)", _dry872.get("tagged") == 3, str(_dry872))
+        test("I872-2d: dry-run errors=0", _dry872.get("errors") == 0, str(_dry872))
+
+        # Confirm no writes happened
+        _check872 = _sq872.connect(str(_db872_path))
+        _written_dry = _check872.execute(
+            "SELECT COUNT(*) FROM entry_concept_tags WHERE tag='high-recurrence'"
+        ).fetchone()[0]
+        _check872.close()
+        test("I872-2e: dry-run writes nothing to DB", _written_dry == 0, f"found {_written_dry} rows")
+
+        # 3. Live run: tags entries meeting threshold
+        _live872 = _te872.run_cross_session_tag(threshold=3, dry_run=False, quiet=True)
+        test("I872-3a: live run tagged=3", _live872.get("tagged") == 3, str(_live872))
+        test("I872-3b: live run errors=0", _live872.get("errors") == 0, str(_live872))
+
+        _check872b = _sq872.connect(str(_db872_path))
+        _tagged_ids = {
+            r[0]
+            for r in _check872b.execute(
+                "SELECT entry_id FROM entry_concept_tags WHERE tag='high-recurrence'"
+            ).fetchall()
+        }
+        _check872b.close()
+        test("I872-3c: entries 1,2,3 (python) tagged high-recurrence", _tagged_ids == {1, 2, 3}, str(_tagged_ids))
+
+        # 4. Rust entries (below threshold) not tagged
+        test(
+            "I872-4a: entries 4,5 (rust, 2 sessions) NOT tagged",
+            4 not in _tagged_ids and 5 not in _tagged_ids,
+            str(_tagged_ids),
+        )
+
+        # 5. Idempotency: re-run should skip already-tagged entries
+        _idem872 = _te872.run_cross_session_tag(threshold=3, dry_run=False, quiet=True)
+        test("I872-5a: second run tagged=0 (already tagged)", _idem872.get("tagged") == 0, str(_idem872))
+        test("I872-5b: second run already_tagged=3", _idem872.get("already_tagged") == 3, str(_idem872))
+
+        # 6. Higher threshold: nothing should be tagged
+        _db872_high = _make_cross_db872("high")
+        _te872.DB_PATH = _db872_high
+        _high872 = _te872.run_cross_session_tag(threshold=4, dry_run=False, quiet=True)
+        test(
+            "I872-6a: threshold=4 tags nothing (python only has 3 sessions)", _high872.get("tagged") == 0, str(_high872)
+        )
+        try:
+            _db872_high.unlink()
+        except Exception:
+            pass
+
+    finally:
+        _te872.DB_PATH = _orig_db872
+        try:
+            _db872_path.unlink()
+        except Exception:
+            pass
+
+    # 7. knowledge-health.py high_recurrence_count field
+    import importlib.util as _ilu872kh
+
+    _spec872kh = _ilu872kh.spec_from_file_location("knowledge_health_i872", REPO / "knowledge-health.py")
+    _kh872 = _ilu872kh.module_from_spec(_spec872kh)  # type: ignore[arg-type]
+    _spec872kh.loader.exec_module(_kh872)  # type: ignore[union-attr]
+
+    _db872_kh = REPO / f".test_i872_{_os872.getpid()}_kh.db"
+    try:
+        _db872_kh.unlink()
+    except FileNotFoundError:
+        pass
+    _kdb = _sq872.connect(str(_db872_kh))
+    _kdb.execute(
+        "CREATE TABLE knowledge_entries (id INTEGER PRIMARY KEY, title TEXT, content TEXT, "
+        "session_id TEXT, category TEXT, last_seen TEXT, first_seen TEXT, confidence REAL, "
+        "wing TEXT, room TEXT)"
+    )
+    _kdb.execute(
+        "CREATE TABLE entry_concept_tags (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "entry_id INTEGER NOT NULL, tag TEXT NOT NULL, source TEXT DEFAULT 'auto', "
+        "tagged_at TEXT DEFAULT (datetime('now')), UNIQUE(entry_id, tag))"
+    )
+    for _i in range(1, 4):
+        _kdb.execute(
+            "INSERT INTO knowledge_entries (id, title, content, session_id, category, confidence) VALUES (?,?,?,?,?,?)",
+            (_i, f"Entry {_i}", "content", f"sess-{_i}", "pattern", 0.9),
+        )
+        _kdb.execute(
+            "INSERT INTO entry_concept_tags (entry_id, tag, source) VALUES (?,?,?)",
+            (_i, "high-recurrence", "auto"),
+        )
+    _kdb.commit()
+    _kdb.close()
+
+    _orig_kh872_db = _kh872.DB_PATH
+    try:
+        _kh872.DB_PATH = _db872_kh
+        _health872 = _kh872.compute_health()
+        test(
+            "I872-7a: health dict has high_recurrence_count key",
+            "high_recurrence_count" in _health872,
+            str(list(_health872.keys())),
+        )
+        test(
+            "I872-7b: high_recurrence_count=3",
+            _health872.get("high_recurrence_count") == 3,
+            str(_health872.get("high_recurrence_count")),
+        )
+        test(
+            "I872-7c: high_recurrence_pct present",
+            "high_recurrence_pct" in _health872,
+            str(list(_health872.keys())),
+        )
+        test(
+            "I872-7d: high_recurrence_pct=100.0 (3/3 entries)",
+            _health872.get("high_recurrence_pct") == 100.0,
+            str(_health872.get("high_recurrence_pct")),
+        )
+    finally:
+        _kh872.DB_PATH = _orig_kh872_db
+        try:
+            _db872_kh.unlink()
+        except Exception:
+            pass
+
+except Exception as _e872:
+    for _label872 in [
+        "1a",
+        "1b",
+        "1c",
+        "1d",
+        "1e",
+        "1f",
+        "1g",
+        "1h",
+        "1i",
+        "2a",
+        "2b",
+        "2c",
+        "2d",
+        "2e",
+        "3a",
+        "3b",
+        "3c",
+        "4a",
+        "5a",
+        "5b",
+        "6a",
+        "7a",
+        "7b",
+        "7c",
+        "7d",
+    ]:
+        test(f"I872-{_label872}: cross-session recurrence auto-tagging", False, str(_e872))
+
+# ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")
 else:


### PR DESCRIPTION
Implements #872. tag-entries.py --cross-session tags entries with high-recurrence when concept appears in >=3 sessions. sk index cross-tag alias. Closes #872