### PR TITLE
perf(#868): port loop_detector hook rule to native Rust

### DIFF
--- a/sk-rust/src/hooks/rules/guard.rs
+++ b/sk-rust/src/hooks/rules/guard.rs
@@ -978,3 +978,220 @@ impl HookRule for NewFileAdvisoryRule {
         )))
     }
 }
+
+// ---------------------------------------------------------------------------
+// LoopDetectorRule
+// ---------------------------------------------------------------------------
+
+/// Detect and block repeated identical tool calls within a session.
+///
+/// Ports `hooks/rules/loop_detector.py::LoopDetectorRule` (issue #663, #868).
+///
+/// Detection strategy
+/// ------------------
+/// * Fires on `preToolUse` for **all** tools.
+/// * Computes a SHA-256 signature of `{"tool": tool_name, "args": cleaned_args}`
+///   with transient metadata keys stripped (same keys as the Python version).
+/// * Tracks consecutive identical-signature calls via a per-session JSON state
+///   file `~/.copilot/markers/loop-state-{session_id}.json`.
+/// * Skips detection when `toolInput`/`toolArgs` is absent/empty (fail-open;
+///   prevents false positives when the hook payload omits tool arguments).
+///
+/// Thresholds (configurable via env vars)
+/// ---------------------------------------
+/// * **Soft** (default 3, `LOOP_SOFT_THRESHOLD`): `info()` warning — non-blocking,
+///   fires once per streak.
+/// * **Hard** (default 5, `LOOP_HARD_THRESHOLD`): `deny()` — blocks the tool call.
+///
+/// Fail-open: any I/O or parse error returns `None` (never blocks).
+pub struct LoopDetectorRule {
+    pub soft_threshold: usize,
+    pub hard_threshold: usize,
+}
+
+impl Default for LoopDetectorRule {
+    fn default() -> Self {
+        Self {
+            soft_threshold: 3,
+            hard_threshold: 5,
+        }
+    }
+}
+
+/// Metadata keys stripped before hashing — transient per-invocation fields.
+/// Mirrors `_STRIP_KEYS` in `loop_detector.py`.
+const STRIP_KEYS: &[&str] = &[
+    "_session_id",
+    "_timestamp",
+    "_request_id",
+    "_trace_id",
+    "sessionId",
+    "timestamp",
+];
+
+/// Recursively sort all JSON object keys for deterministic serialisation.
+/// Matches Python's `json.dumps(sort_keys=True)` which sorts at every depth.
+fn sort_value_recursive(v: &Value) -> Value {
+    match v {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let sorted: serde_json::Map<String, Value> = keys
+                .into_iter()
+                .map(|k| (k.clone(), sort_value_recursive(&map[k])))
+                .collect();
+            Value::Object(sorted)
+        }
+        Value::Array(arr) => Value::Array(arr.iter().map(sort_value_recursive).collect()),
+        other => other.clone(),
+    }
+}
+
+/// Compute SHA-256 hex digest of `{"tool": tool_name, "args": cleaned_args}`.
+pub(crate) fn loop_compute_signature(
+    tool_name: &str,
+    tool_args: &serde_json::Map<String, Value>,
+) -> String {
+    use sha2::{Digest, Sha256};
+
+    // Strip transient metadata keys.
+    let cleaned: serde_json::Map<String, Value> = tool_args
+        .iter()
+        .filter(|(k, _)| !STRIP_KEYS.contains(&k.as_str()))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
+    // Recursively sort keys (matches Python json.dumps(sort_keys=True)).
+    let sorted = sort_value_recursive(&Value::Object(cleaned));
+
+    let payload = serde_json::json!({"tool": tool_name, "args": sorted});
+    let raw = payload.to_string();
+    let hash = Sha256::digest(raw.as_bytes());
+    format!("{hash:x}")
+}
+
+/// Read the integer threshold from an env var, falling back to `default`.
+fn loop_threshold(env_var: &str, default: usize) -> usize {
+    std::env::var(env_var)
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+/// Resolve the per-session loop state file path.
+/// Reuses `session_state::{get_session_id, sanitize_session_id}` for
+/// consistent session-ID detection and filename sanitisation.
+pub(crate) fn loop_state_path(data: &Value) -> PathBuf {
+    let session_id = crate::hooks::session_state::get_session_id(data);
+    let sid = crate::hooks::session_state::sanitize_session_id(&session_id);
+    markers_dir().join(format!("loop-state-{sid}.json"))
+}
+
+/// Per-session loop detector state stored in the JSON state file.
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+struct LoopState {
+    #[serde(default)]
+    last_sig: String,
+    #[serde(default)]
+    streak: usize,
+    #[serde(default)]
+    soft_warned: bool,
+}
+
+/// Load loop state from the JSON file; return default on any error (fail-open).
+fn load_loop_state(path: &Path) -> LoopState {
+    let content = match fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return LoopState::default(),
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+/// Save loop state to the JSON file; best-effort atomic write, never panics.
+fn save_loop_state(path: &Path, state: &LoopState) {
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let json = match serde_json::to_string(state) {
+        Ok(j) => j,
+        Err(_) => return,
+    };
+    // Atomic write: write to a PID-unique temp file, then rename.
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+    if fs::write(&tmp, json.as_bytes()).is_ok() {
+        let _ = fs::rename(&tmp, path);
+    }
+}
+
+impl HookRule for LoopDetectorRule {
+    fn name(&self) -> &'static str {
+        "loop-detector"
+    }
+
+    fn events(&self) -> &'static [&'static str] {
+        &["preToolUse"]
+    }
+
+    fn tools(&self) -> &'static [&'static str] {
+        &[] // All tools
+    }
+
+    fn evaluate(&self, event: &str, data: &Value) -> Option<Value> {
+        if event != "preToolUse" {
+            return None;
+        }
+        // Fail-open: any error → None.
+        self.run(data)
+    }
+}
+
+impl LoopDetectorRule {
+    fn run(&self, data: &Value) -> Option<Value> {
+        let tool_name = data.get("toolName").and_then(|v| v.as_str()).unwrap_or("");
+
+        // Accept toolInput (Copilot) or toolArgs (legacy).
+        let tool_args_val = data.get("toolInput").or_else(|| data.get("toolArgs"));
+        let tool_args = tool_args_val.and_then(|v| v.as_object())?;
+
+        // Skip when args are empty — cannot distinguish calls.
+        if tool_args.is_empty() {
+            return None;
+        }
+
+        let soft = loop_threshold("LOOP_SOFT_THRESHOLD", self.soft_threshold);
+        let hard = loop_threshold("LOOP_HARD_THRESHOLD", self.hard_threshold);
+
+        let sig = loop_compute_signature(tool_name, tool_args);
+        let state_path = loop_state_path(data);
+        let mut state = load_loop_state(&state_path);
+
+        if sig == state.last_sig {
+            state.streak += 1;
+        } else {
+            state.last_sig = sig;
+            state.streak = 1;
+            state.soft_warned = false;
+        }
+
+        let streak = state.streak;
+        let result = if streak >= hard {
+            Some(deny(&format!(
+                "Loop detected: tool '{tool_name}' called {streak} times \
+                 with identical arguments (hard threshold {hard}). \
+                 Try a different approach."
+            )))
+        } else if streak >= soft && !state.soft_warned {
+            state.soft_warned = true;
+            Some(info(&format!(
+                "  Warning: tool '{tool_name}' called {streak} \
+                 times with identical arguments. Consider varying your \
+                 approach before the hard limit ({hard})."
+            )))
+        } else {
+            None
+        };
+
+        save_loop_state(&state_path, &state);
+        result
+    }
+}

--- a/sk-rust/src/hooks/rules/mod.rs
+++ b/sk-rust/src/hooks/rules/mod.rs
@@ -137,6 +137,7 @@ pub fn all_rules() -> Vec<Box<dyn HookRule>> {
         Box::new(EnforceLearnRule),
         Box::new(TentacleEnforceRule),
         Box::new(SubagentGitGuardRule),
+        Box::new(LoopDetectorRule::default()),
         Box::new(SyntaxGateRule),
         Box::new(BlockEditDistRule),
         Box::new(PnpmLockfileGuardRule),

--- a/sk-rust/src/hooks/rules/tests/guard.rs
+++ b/sk-rust/src/hooks/rules/tests/guard.rs
@@ -1212,3 +1212,204 @@ fn all_rules_includes_file_size_advisory() {
         "all_rules must include file-size-advisory"
     );
 }
+
+// --- LoopDetectorRule ---
+
+/// Build event data with a unique session state path so tests don't share state.
+fn loop_event(tool: &str, args: serde_json::Value, session_id: &str) -> serde_json::Value {
+    json!({
+        "toolName": tool,
+        "toolInput": args,
+        "sessionId": session_id,
+    })
+}
+
+#[test]
+fn loop_detector_passes_below_soft_threshold() {
+    let rule = LoopDetectorRule {
+        soft_threshold: 3,
+        hard_threshold: 5,
+    };
+    let sid = format!(
+        "test-loop-below-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+    );
+    let data = loop_event("bash", json!({"command": "ls"}), &sid);
+
+    // First and second calls: below soft threshold → None.
+    let r1 = rule.evaluate("preToolUse", &data);
+    let r2 = rule.evaluate("preToolUse", &data);
+    assert!(r1.is_none(), "call 1 should pass: {r1:?}");
+    assert!(r2.is_none(), "call 2 should pass: {r2:?}");
+
+    // Cleanup temp state.
+    let _ = std::fs::remove_file(loop_state_path(&data));
+}
+
+#[test]
+fn loop_detector_info_at_soft_threshold() {
+    let rule = LoopDetectorRule {
+        soft_threshold: 3,
+        hard_threshold: 5,
+    };
+    let sid = format!(
+        "test-loop-soft-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+    );
+    let data = loop_event("bash", json!({"command": "ls -la"}), &sid);
+
+    // Advance to streak = 3.
+    let _ = rule.evaluate("preToolUse", &data); // 1
+    let _ = rule.evaluate("preToolUse", &data); // 2
+    let r3 = rule.evaluate("preToolUse", &data); // 3 = soft
+
+    let r3 = r3.expect("soft threshold should produce info");
+    // info() returns {"message": "..."}
+    let msg = r3.get("message").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(msg.contains("bash"), "message should name the tool: {msg}");
+    assert!(msg.contains("3"), "message should mention streak: {msg}");
+
+    // 4th call: soft already warned — should not re-warn.
+    let r4 = rule.evaluate("preToolUse", &data);
+    assert!(r4.is_none(), "4th call below hard should pass: {r4:?}");
+
+    let _ = std::fs::remove_file(loop_state_path(&data));
+}
+
+#[test]
+fn loop_detector_deny_at_hard_threshold() {
+    let rule = LoopDetectorRule {
+        soft_threshold: 3,
+        hard_threshold: 5,
+    };
+    let sid = format!(
+        "test-loop-hard-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+    );
+    let data = loop_event("read", json!({"path": "/etc/hosts"}), &sid);
+
+    // Advance to hard threshold.
+    for _ in 0..4 {
+        let _ = rule.evaluate("preToolUse", &data);
+    }
+    let r5 = rule.evaluate("preToolUse", &data); // streak = 5 = hard
+
+    let r5 = r5.expect("hard threshold should produce deny");
+    assert_eq!(
+        r5.get("permissionDecision")
+            .and_then(|v| v.as_str())
+            .unwrap_or(""),
+        "deny",
+        "expected deny at hard threshold: {r5}"
+    );
+    let reason = r5
+        .get("permissionDecisionReason")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert!(
+        reason.contains("Loop detected"),
+        "reason should mention loop: {reason}"
+    );
+    assert!(
+        reason.contains("read"),
+        "reason should name the tool: {reason}"
+    );
+
+    let _ = std::fs::remove_file(loop_state_path(&data));
+}
+
+#[test]
+fn loop_detector_resets_on_different_args() {
+    let rule = LoopDetectorRule {
+        soft_threshold: 3,
+        hard_threshold: 5,
+    };
+    let sid = format!(
+        "test-loop-reset-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+    );
+
+    // Advance streak to 2 with one set of args.
+    let data_a = loop_event("bash", json!({"command": "echo a"}), &sid);
+    let _ = rule.evaluate("preToolUse", &data_a);
+    let _ = rule.evaluate("preToolUse", &data_a);
+
+    // Different args → streak resets → first call should pass.
+    let data_b = loop_event("bash", json!({"command": "echo b"}), &sid);
+    let r = rule.evaluate("preToolUse", &data_b);
+    assert!(r.is_none(), "different args should reset streak: {r:?}");
+
+    let _ = std::fs::remove_file(loop_state_path(&data_a));
+}
+
+#[test]
+fn loop_detector_skips_empty_args() {
+    let rule = LoopDetectorRule {
+        soft_threshold: 3,
+        hard_threshold: 5,
+    };
+    let sid = format!(
+        "test-loop-empty-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+    );
+    let data = json!({
+        "toolName": "bash",
+        "toolInput": {},
+        "sessionId": sid,
+    });
+    // Empty args → fail-open.
+    for _ in 0..10 {
+        assert!(rule.evaluate("preToolUse", &data).is_none());
+    }
+}
+
+#[test]
+fn loop_detector_strips_metadata_keys() {
+    // Same logical call but _timestamp differs — should still match signature.
+    let args_a = json!({"command": "ls", "_timestamp": "2024-01-01T00:00:00Z"});
+    let args_b = json!({"command": "ls", "_timestamp": "2024-01-02T00:00:00Z"});
+
+    let map_a = args_a.as_object().unwrap();
+    let map_b = args_b.as_object().unwrap();
+    let sig_a = loop_compute_signature("bash", map_a);
+    let sig_b = loop_compute_signature("bash", map_b);
+    assert_eq!(
+        sig_a, sig_b,
+        "signatures should match after stripping metadata"
+    );
+}
+
+#[test]
+fn loop_detector_ignores_wrong_event() {
+    let rule = LoopDetectorRule {
+        soft_threshold: 3,
+        hard_threshold: 5,
+    };
+    let data = json!({"toolName": "bash", "toolInput": {"command": "ls"}});
+    assert!(rule.evaluate("postToolUse", &data).is_none());
+    assert!(rule.evaluate("sessionEnd", &data).is_none());
+}
+
+#[test]
+fn all_rules_includes_loop_detector() {
+    let rules = all_rules();
+    assert!(
+        rules.iter().any(|r| r.name() == "loop-detector"),
+        "all_rules must include loop-detector"
+    );
+}

--- a/sk-rust/src/hooks/session_state.rs
+++ b/sk-rust/src/hooks/session_state.rs
@@ -27,7 +27,7 @@ pub struct DispatchStats {
 ///   2. COPILOT_SESSION_ID
 ///   3. basename of COPILOT_SESSION_STATE
 ///   4. ppid-{parent_pid}
-fn get_session_id(data: &Value) -> String {
+pub(crate) fn get_session_id(data: &Value) -> String {
     // Priority 0: event payload.
     if let Some(sid) = data.get("sessionId").and_then(|v| v.as_str()) {
         if !sid.is_empty() {
@@ -59,7 +59,7 @@ fn get_session_id(data: &Value) -> String {
 ///
 /// Mirrors Python `common.py::sanitize_session_id`: replaces path separators,
 /// removes null bytes, collapses dot-dots, keeps `[\w\-.:@]`, truncates to 128.
-fn sanitize_session_id(sid: &str) -> String {
+pub(crate) fn sanitize_session_id(sid: &str) -> String {
     if sid.is_empty() {
         return "default-session".to_string();
     }


### PR DESCRIPTION
Implements #868. LoopDetectorRule in guard.rs: SHA-256 signature + session state counter, fires at threshold=3 (soft, info) and threshold=5 (hard, deny). Registered in all_rules(). 8 Cargo tests cover detection, reset, metadata stripping, and registration. Python loop_detector.py kept as fallback. Closes #868