### PR TITLE
feat(#869): sk export — unified knowledge backup with JSONL format

### DIFF
--- a/knowledge-health.py
+++ b/knowledge-health.py
@@ -2565,8 +2565,8 @@ def main():
         if "--format" in args:
             idx = args.index("--format")
             fmt = args[idx + 1] if idx + 1 < len(args) else "json"
-        # --all-categories: ignore --category and export everything
-        all_categories = "--all-categories" in args
+        # --all-categories / --all: ignore --category and export everything
+        all_categories = "--all-categories" in args or "--all" in args
         category = None
         if not all_categories and "--category" in args:
             idx = args.index("--category")
@@ -2591,6 +2591,9 @@ def main():
             idx = args.index("--output")
             output_file = args[idx + 1] if idx + 1 < len(args) else None
         stdout_mode = "--stdout" in args
+        if stdout_mode and output_file:
+            print("⚠ --stdout and --output are mutually exclusive", file=sys.stderr)
+            return
 
         try:
             result = compute_knowledge_export(fmt=fmt, category=category, tag=tag, limit=limit, since=since)
@@ -2601,63 +2604,18 @@ def main():
         if fmt == "jsonl":
             if stdout_mode:
                 for entry in result["entries"]:
-                    line = json.dumps(
-                        {
-                            "id": entry.get("id"),
-                            "category": entry.get("category"),
-                            "title": entry.get("title"),
-                            "content": entry.get("content"),
-                            "tags": entry.get("tags"),
-                            "confidence": entry.get("confidence"),
-                            "first_seen": entry.get("first_seen"),
-                            "last_seen": entry.get("last_seen"),
-                        },
-                        ensure_ascii=False,
-                        default=str,
-                    )
-                    print(line)
+                    print(json.dumps(dict(entry), ensure_ascii=False, default=str))
             elif output_file:
                 try:
                     with open(output_file, "w", encoding="utf-8") as _f:
                         for entry in result["entries"]:
-                            _f.write(
-                                json.dumps(
-                                    {
-                                        "id": entry.get("id"),
-                                        "category": entry.get("category"),
-                                        "title": entry.get("title"),
-                                        "content": entry.get("content"),
-                                        "tags": entry.get("tags"),
-                                        "confidence": entry.get("confidence"),
-                                        "first_seen": entry.get("first_seen"),
-                                        "last_seen": entry.get("last_seen"),
-                                    },
-                                    ensure_ascii=False,
-                                    default=str,
-                                )
-                                + "\n"
-                            )
+                            _f.write(json.dumps(dict(entry), ensure_ascii=False, default=str) + "\n")
                     print(f"Exported {result['count']} entries to {output_file} (JSONL)")
                 except OSError as exc:
                     print(f"⚠ Could not write {output_file}: {exc}", file=sys.stderr)
             else:
                 for entry in result["entries"]:
-                    print(
-                        json.dumps(
-                            {
-                                "id": entry.get("id"),
-                                "category": entry.get("category"),
-                                "title": entry.get("title"),
-                                "content": entry.get("content"),
-                                "tags": entry.get("tags"),
-                                "confidence": entry.get("confidence"),
-                                "first_seen": entry.get("first_seen"),
-                                "last_seen": entry.get("last_seen"),
-                            },
-                            ensure_ascii=False,
-                            default=str,
-                        )
-                    )
+                    print(json.dumps(dict(entry), ensure_ascii=False, default=str))
             return
 
         if fmt == "markdown":

--- a/knowledge-health.py
+++ b/knowledge-health.py
@@ -2565,8 +2565,10 @@ def main():
         if "--format" in args:
             idx = args.index("--format")
             fmt = args[idx + 1] if idx + 1 < len(args) else "json"
+        # --all-categories: ignore --category and export everything
+        all_categories = "--all-categories" in args
         category = None
-        if "--category" in args:
+        if not all_categories and "--category" in args:
             idx = args.index("--category")
             category = args[idx + 1] if idx + 1 < len(args) else None
         tag = None
@@ -2588,11 +2590,74 @@ def main():
         if "--output" in args:
             idx = args.index("--output")
             output_file = args[idx + 1] if idx + 1 < len(args) else None
+        stdout_mode = "--stdout" in args
 
         try:
             result = compute_knowledge_export(fmt=fmt, category=category, tag=tag, limit=limit, since=since)
         except Exception as exc:
             print(f"⚠ export failed: {exc}", file=sys.stderr)
+            return
+
+        if fmt == "jsonl":
+            if stdout_mode:
+                for entry in result["entries"]:
+                    line = json.dumps(
+                        {
+                            "id": entry.get("id"),
+                            "category": entry.get("category"),
+                            "title": entry.get("title"),
+                            "content": entry.get("content"),
+                            "tags": entry.get("tags"),
+                            "confidence": entry.get("confidence"),
+                            "first_seen": entry.get("first_seen"),
+                            "last_seen": entry.get("last_seen"),
+                        },
+                        ensure_ascii=False,
+                        default=str,
+                    )
+                    print(line)
+            elif output_file:
+                try:
+                    with open(output_file, "w", encoding="utf-8") as _f:
+                        for entry in result["entries"]:
+                            _f.write(
+                                json.dumps(
+                                    {
+                                        "id": entry.get("id"),
+                                        "category": entry.get("category"),
+                                        "title": entry.get("title"),
+                                        "content": entry.get("content"),
+                                        "tags": entry.get("tags"),
+                                        "confidence": entry.get("confidence"),
+                                        "first_seen": entry.get("first_seen"),
+                                        "last_seen": entry.get("last_seen"),
+                                    },
+                                    ensure_ascii=False,
+                                    default=str,
+                                )
+                                + "\n"
+                            )
+                    print(f"Exported {result['count']} entries to {output_file} (JSONL)")
+                except OSError as exc:
+                    print(f"⚠ Could not write {output_file}: {exc}", file=sys.stderr)
+            else:
+                for entry in result["entries"]:
+                    print(
+                        json.dumps(
+                            {
+                                "id": entry.get("id"),
+                                "category": entry.get("category"),
+                                "title": entry.get("title"),
+                                "content": entry.get("content"),
+                                "tags": entry.get("tags"),
+                                "confidence": entry.get("confidence"),
+                                "first_seen": entry.get("first_seen"),
+                                "last_seen": entry.get("last_seen"),
+                            },
+                            ensure_ascii=False,
+                            default=str,
+                        )
+                    )
             return
 
         if fmt == "markdown":

--- a/sk.py
+++ b/sk.py
@@ -183,6 +183,11 @@ _DIRECT: dict[str, CommandMeta] = {
     ),
     "curate": CommandMeta("curate.py", "Automated stale/duplicate knowledge entry curation", ("knowledge", "curation")),
     "tui": CommandMeta("tui.py", "Interactive terminal knowledge browser (curses)", ("browse", "ui")),
+    "export": CommandMeta(
+        "knowledge-health.py",
+        "Export knowledge entries as JSONL, JSON, CSV, or Markdown backup",
+        ("export", "knowledge", "backup"),
+    ),
 }
 
 # Grouped namespace commands: group → {subcommand: script_name}
@@ -1112,6 +1117,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run("doctor.py", rest)
     if cmd == "init":
         return _run("setup-project.py", ["--init-mode"] + rest)
+    if cmd == "export":
+        return _run("knowledge-health.py", ["--export"] + rest, cmd=cmd)
     if cmd == "completion":
         return _run_completion(rest)
     if cmd in _DIRECT:

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -15995,6 +15995,175 @@ except Exception as _e867:
         test(f"I867-{_label867}: decay-adjusted confidence ranking", False, str(_e867))
 
 # ---------------------------------------------------------------------------
+# I869: sk export — unified knowledge backup with JSONL streaming
+# ---------------------------------------------------------------------------
+try:
+    import importlib.util as _ilu869
+    import io as _io869
+    import sqlite3 as _sqlite3869
+    import tempfile as _tf869
+
+    _spec869 = _ilu869.spec_from_file_location("kh869", REPO / "knowledge-health.py")
+    _kh869 = _ilu869.module_from_spec(_spec869)
+    _spec869.loader.exec_module(_kh869)
+
+    # Build an isolated in-memory DB with sample knowledge_entries
+    _conn869 = _sqlite3869.connect(":memory:")
+    _conn869.row_factory = _sqlite3869.Row
+    _conn869.execute(
+        """
+        CREATE TABLE knowledge_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            category TEXT DEFAULT 'mistake',
+            title TEXT NOT NULL,
+            content TEXT,
+            tags TEXT DEFAULT '',
+            confidence REAL DEFAULT 0.5,
+            occurrence_count INTEGER DEFAULT 1,
+            first_seen TEXT,
+            last_seen TEXT,
+            wing TEXT,
+            room TEXT,
+            affected_files TEXT,
+            facts TEXT,
+            est_tokens INTEGER,
+            task_id TEXT,
+            source_file TEXT,
+            start_line INTEGER,
+            end_line INTEGER
+        )
+        """
+    )
+    _conn869.execute(
+        """
+        INSERT INTO knowledge_entries (category, title, content, tags, confidence, first_seen, last_seen)
+        VALUES (?,?,?,?,?,?,?)
+        """,
+        ("mistake", "Test entry one", "Content one", "python,test", 0.9, "2024-01-01", "2024-06-01"),
+    )
+    _conn869.execute(
+        """
+        INSERT INTO knowledge_entries (category, title, content, tags, confidence, first_seen, last_seen)
+        VALUES (?,?,?,?,?,?,?)
+        """,
+        ("pattern", "Test entry two", "Content two with unicode: ñ", "rust,pattern", 0.7, "2024-02-01", "2024-07-01"),
+    )
+    _conn869.commit()
+
+    _orig_get_db869 = _kh869.get_db
+
+    class _NoCloseConn869:
+        """Proxy that forwards all calls to _conn869 but makes close() a no-op."""
+
+        def __getattr__(self, name):
+            return getattr(_conn869, name)
+
+        def close(self):
+            pass  # prevent teardown between tests
+
+    def _fake_get_db869():
+        return _NoCloseConn869()
+
+    _kh869.get_db = _fake_get_db869
+
+    # --- I869-1: JSONL format produces one JSON object per line ---
+    _stdout869a = _io869.StringIO()
+    _orig_stdout869 = sys.stdout
+    sys.stdout = _stdout869a
+    _orig_argv869 = sys.argv
+    sys.argv = ["knowledge-health.py", "--export", "--format", "jsonl"]
+    _kh869.main()
+    sys.argv = _orig_argv869
+    sys.stdout = _orig_stdout869
+    _jsonl869_lines = [ln for ln in _stdout869a.getvalue().splitlines() if ln.strip()]
+    test("I869-1a: JSONL export produces 2 lines", len(_jsonl869_lines) == 2, repr(_jsonl869_lines))
+    _parsed869 = [json.loads(ln) for ln in _jsonl869_lines]
+    test(
+        "I869-1b: each JSONL line has required keys",
+        all({"id", "category", "title", "content", "tags", "confidence", "first_seen", "last_seen"} <= set(p.keys()) for p in _parsed869),
+        repr(_parsed869),
+    )
+    test(
+        "I869-1c: JSONL entries contain expected titles",
+        any(p["title"] == "Test entry one" for p in _parsed869),
+        repr(_parsed869),
+    )
+
+    # --- I869-2: --stdout flag works the same as default stdout ---
+    _stdout869b = _io869.StringIO()
+    sys.stdout = _stdout869b
+    sys.argv = ["knowledge-health.py", "--export", "--format", "jsonl", "--stdout"]
+    _kh869.main()
+    sys.argv = _orig_argv869
+    sys.stdout = _orig_stdout869
+    _jsonl869b_lines = [ln for ln in _stdout869b.getvalue().splitlines() if ln.strip()]
+    test("I869-2: --stdout flag produces same output as default", len(_jsonl869b_lines) == 2, repr(_jsonl869b_lines))
+
+    # --- I869-3: --all-categories exports all categories (ignores --category) ---
+    _stdout869c = _io869.StringIO()
+    sys.stdout = _stdout869c
+    sys.argv = ["knowledge-health.py", "--export", "--format", "jsonl", "--all-categories"]
+    _kh869.main()
+    sys.argv = _orig_argv869
+    sys.stdout = _orig_stdout869
+    _jsonl869c_lines = [ln for ln in _stdout869c.getvalue().splitlines() if ln.strip()]
+    _cats869 = {json.loads(ln)["category"] for ln in _jsonl869c_lines}
+    test(
+        "I869-3: --all-categories exports both 'mistake' and 'pattern' entries",
+        "mistake" in _cats869 and "pattern" in _cats869,
+        repr(_cats869),
+    )
+
+    # --- I869-4: --format jsonl --output writes a valid JSONL file ---
+    _out869_path = REPO / "_test_i869_export.jsonl"
+    try:
+        _stdout869d = _io869.StringIO()
+        sys.stdout = _stdout869d
+        sys.argv = ["knowledge-health.py", "--export", "--format", "jsonl", "--output", str(_out869_path)]
+        _kh869.main()
+        sys.argv = _orig_argv869
+        sys.stdout = _orig_stdout869
+        _msg869 = _stdout869d.getvalue()
+        test("I869-4a: output message mentions 'Exported'", "Exported" in _msg869, repr(_msg869))
+        test("I869-4b: JSONL output file exists", _out869_path.exists(), str(_out869_path))
+        if _out869_path.exists():
+            _file869_lines = [ln for ln in _out869_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+            test(
+                "I869-4c: JSONL file contains 2 valid JSON lines",
+                len(_file869_lines) == 2 and all(json.loads(ln) for ln in _file869_lines),
+                repr(_file869_lines),
+            )
+    finally:
+        sys.argv = _orig_argv869
+        try:
+            _out869_path.unlink()
+        except Exception:
+            pass
+
+    # --- I869-5: sk.py routes 'export' → knowledge-health.py --export ---
+    _spec869sk = _ilu869.spec_from_file_location("sk869", REPO / "sk.py")
+    _sk869 = _ilu869.module_from_spec(_spec869sk)
+    _spec869sk.loader.exec_module(_sk869)
+    test(
+        "I869-5: 'export' is registered in sk.py _DIRECT",
+        "export" in _sk869._DIRECT,
+        str(list(_sk869._DIRECT.keys())),
+    )
+    test(
+        "I869-5b: sk.py 'export' points to knowledge-health.py",
+        "knowledge-health.py" in str(_sk869._DIRECT["export"]),
+        str(_sk869._DIRECT["export"]),
+    )
+
+    _kh869.get_db = _orig_get_db869
+    _conn869.close()
+
+except Exception as _e869:
+    for _label869 in ["1a", "1b", "1c", "2", "3", "4a", "4b", "4c", "5", "5b"]:
+        test(f"I869-{_label869}: sk export JSONL", False, str(_e869))
+
+# ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")
 else:

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -16001,7 +16001,6 @@ try:
     import importlib.util as _ilu869
     import io as _io869
     import sqlite3 as _sqlite3869
-    import tempfile as _tf869
 
     _spec869 = _ilu869.spec_from_file_location("kh869", REPO / "knowledge-health.py")
     _kh869 = _ilu869.module_from_spec(_spec869)
@@ -16067,21 +16066,27 @@ try:
 
     _kh869.get_db = _fake_get_db869
 
-    # --- I869-1: JSONL format produces one JSON object per line ---
-    _stdout869a = _io869.StringIO()
     _orig_stdout869 = sys.stdout
-    sys.stdout = _stdout869a
     _orig_argv869 = sys.argv
-    sys.argv = ["knowledge-health.py", "--export", "--format", "jsonl"]
-    _kh869.main()
-    sys.argv = _orig_argv869
-    sys.stdout = _orig_stdout869
+
+    # --- I869-1: JSONL format produces one JSON object per line ---
+    try:
+        _stdout869a = _io869.StringIO()
+        sys.stdout = _stdout869a
+        sys.argv = ["knowledge-health.py", "--export", "--format", "jsonl"]
+        _kh869.main()
+    finally:
+        sys.argv = _orig_argv869
+        sys.stdout = _orig_stdout869
     _jsonl869_lines = [ln for ln in _stdout869a.getvalue().splitlines() if ln.strip()]
     test("I869-1a: JSONL export produces 2 lines", len(_jsonl869_lines) == 2, repr(_jsonl869_lines))
     _parsed869 = [json.loads(ln) for ln in _jsonl869_lines]
     test(
         "I869-1b: each JSONL line has required keys",
-        all({"id", "category", "title", "content", "tags", "confidence", "first_seen", "last_seen"} <= set(p.keys()) for p in _parsed869),
+        all(
+            {"id", "category", "title", "content", "tags", "confidence", "first_seen", "last_seen"} <= set(p.keys())
+            for p in _parsed869
+        ),
         repr(_parsed869),
     )
     test(
@@ -16091,26 +16096,38 @@ try:
     )
 
     # --- I869-2: --stdout flag works the same as default stdout ---
-    _stdout869b = _io869.StringIO()
-    sys.stdout = _stdout869b
-    sys.argv = ["knowledge-health.py", "--export", "--format", "jsonl", "--stdout"]
-    _kh869.main()
-    sys.argv = _orig_argv869
-    sys.stdout = _orig_stdout869
+    try:
+        _stdout869b = _io869.StringIO()
+        sys.stdout = _stdout869b
+        sys.argv = ["knowledge-health.py", "--export", "--format", "jsonl", "--stdout"]
+        _kh869.main()
+    finally:
+        sys.argv = _orig_argv869
+        sys.stdout = _orig_stdout869
     _jsonl869b_lines = [ln for ln in _stdout869b.getvalue().splitlines() if ln.strip()]
     test("I869-2: --stdout flag produces same output as default", len(_jsonl869b_lines) == 2, repr(_jsonl869b_lines))
 
-    # --- I869-3: --all-categories exports all categories (ignores --category) ---
-    _stdout869c = _io869.StringIO()
-    sys.stdout = _stdout869c
-    sys.argv = ["knowledge-health.py", "--export", "--format", "jsonl", "--all-categories"]
-    _kh869.main()
-    sys.argv = _orig_argv869
-    sys.stdout = _orig_stdout869
+    # --- I869-3: --all-categories ignores --category filter ---
+    try:
+        _stdout869c = _io869.StringIO()
+        sys.stdout = _stdout869c
+        sys.argv = [
+            "knowledge-health.py",
+            "--export",
+            "--format",
+            "jsonl",
+            "--all-categories",
+            "--category",
+            "mistake",
+        ]
+        _kh869.main()
+    finally:
+        sys.argv = _orig_argv869
+        sys.stdout = _orig_stdout869
     _jsonl869c_lines = [ln for ln in _stdout869c.getvalue().splitlines() if ln.strip()]
     _cats869 = {json.loads(ln)["category"] for ln in _jsonl869c_lines}
     test(
-        "I869-3: --all-categories exports both 'mistake' and 'pattern' entries",
+        "I869-3: --all-categories ignores --category and exports all",
         "mistake" in _cats869 and "pattern" in _cats869,
         repr(_cats869),
     )
@@ -16122,8 +16139,10 @@ try:
         sys.stdout = _stdout869d
         sys.argv = ["knowledge-health.py", "--export", "--format", "jsonl", "--output", str(_out869_path)]
         _kh869.main()
+    finally:
         sys.argv = _orig_argv869
         sys.stdout = _orig_stdout869
+    try:
         _msg869 = _stdout869d.getvalue()
         test("I869-4a: output message mentions 'Exported'", "Exported" in _msg869, repr(_msg869))
         test("I869-4b: JSONL output file exists", _out869_path.exists(), str(_out869_path))
@@ -16135,7 +16154,6 @@ try:
                 repr(_file869_lines),
             )
     finally:
-        sys.argv = _orig_argv869
         try:
             _out869_path.unlink()
         except Exception:
@@ -16146,7 +16164,7 @@ try:
     _sk869 = _ilu869.module_from_spec(_spec869sk)
     _spec869sk.loader.exec_module(_sk869)
     test(
-        "I869-5: 'export' is registered in sk.py _DIRECT",
+        "I869-5a: 'export' registered in sk.py _DIRECT",
         "export" in _sk869._DIRECT,
         str(list(_sk869._DIRECT.keys())),
     )
@@ -16155,12 +16173,57 @@ try:
         "knowledge-health.py" in str(_sk869._DIRECT["export"]),
         str(_sk869._DIRECT["export"]),
     )
+    # Verify main() routes 'export' by capturing the _run call
+    _run_calls869 = []
+    _orig_run869 = _sk869._run
+
+    def _mock_run869(script, args, **kw):
+        _run_calls869.append((script, args))
+        return 0
+
+    _sk869._run = _mock_run869
+    try:
+        _sk869.main(["export", "--format", "jsonl"])
+    finally:
+        _sk869._run = _orig_run869
+    test(
+        "I869-5c: sk main routes export to knowledge-health.py --export",
+        len(_run_calls869) == 1 and _run_calls869[0][0] == "knowledge-health.py" and "--export" in _run_calls869[0][1],
+        repr(_run_calls869),
+    )
+
+    # --- I869-6: --stdout and --output are mutually exclusive ---
+    try:
+        _stdout869e = _io869.StringIO()
+        _stderr869e = _io869.StringIO()
+        sys.stdout = _stdout869e
+        _orig_stderr869 = sys.stderr
+        sys.stderr = _stderr869e
+        sys.argv = [
+            "knowledge-health.py",
+            "--export",
+            "--format",
+            "jsonl",
+            "--stdout",
+            "--output",
+            "/tmp/nope.jsonl",
+        ]
+        _kh869.main()
+    finally:
+        sys.argv = _orig_argv869
+        sys.stdout = _orig_stdout869
+        sys.stderr = _orig_stderr869
+    test(
+        "I869-6: --stdout + --output rejects with error",
+        "mutually exclusive" in _stderr869e.getvalue(),
+        repr(_stderr869e.getvalue()),
+    )
 
     _kh869.get_db = _orig_get_db869
     _conn869.close()
 
 except Exception as _e869:
-    for _label869 in ["1a", "1b", "1c", "2", "3", "4a", "4b", "4c", "5", "5b"]:
+    for _label869 in ["1a", "1b", "1c", "2", "3", "4a", "4b", "4c", "5a", "5b", "5c", "6"]:
         test(f"I869-{_label869}: sk export JSONL", False, str(_e869))
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements #869. 

## Changes
- **knowledge-health.py**: Added `--format jsonl` to `--export` handler — emits one JSON object per line, valid for `jq` piping
- **knowledge-health.py**: Added `--stdout` flag (explicit stdout mode for piping)  
- **knowledge-health.py**: Added `--all-categories` flag to bypass the `--category` filter
- **sk.py**: Added `export` top-level command alias that delegates to `knowledge-health.py --export`
- **test_fixes.py**: 10 new I869 tests covering JSONL structure, --stdout, --all-categories, file output, and sk routing

## Usage
```bash
sk export --format jsonl                                    # JSONL to stdout
sk export --format jsonl --stdout | jq '.title'            # pipe to jq
sk export --format jsonl --all-categories                   # all entry types
sk export --format jsonl --output knowledge.jsonl           # write to file
sk export --format json  --output backup.json               # JSON (existing)
```

Closes #869