### PR TITLE
feat(#856): LLM-assisted category/tag inference via --llm flag

### DIFF
--- a/learn.py
+++ b/learn.py
@@ -61,6 +61,7 @@ import sqlite3
 import subprocess
 import sys
 import time
+import urllib.request
 from pathlib import Path
 
 if os.name == "nt":
@@ -93,6 +94,46 @@ RELATION_TYPES: dict[str, str] = {
     "documents": "documented_by",
     "tests": "tested_by",
 }
+
+
+def _llm_suggest_tags(title: str, content: str) -> list[str]:
+    """Call LLM API to suggest tags. Returns list of lowercase tag strings."""
+    api_key = os.environ.get("SK_LLM_API_KEY") or os.environ.get("OPENAI_API_KEY") or ""
+    if not api_key:
+        print(
+            "Error: LLM API key not set. Set SK_LLM_API_KEY or OPENAI_API_KEY.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    model = os.environ.get("SK_LLM_MODEL", "gpt-4o-mini")
+    prompt = (
+        f"Given this knowledge entry title and content, suggest 3-5 relevant tags "
+        f"as a JSON array of lowercase strings. Title: {title}. "
+        f"Content: {content[:500]}. Respond with only a JSON array."
+    )
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 100,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/chat/completions",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read())
+    raw = data["choices"][0]["message"]["content"].strip()
+    m = re.search(r"\[.*?\]", raw, re.DOTALL)
+    if not m:
+        return []
+    tags = json.loads(m.group(0))
+    return [str(t).lower().strip() for t in tags if isinstance(t, str)]
 
 
 def _should_use_writer_broker() -> bool:
@@ -3819,6 +3860,7 @@ def main():
 
     # Auto-PR flags (Issue #612)
     auto_pr = "--auto-pr" in args
+    use_llm = "--llm" in args
     auto_pr_threshold: float | None = None
     if "--confidence-threshold" in args:
         _ct_idx = args.index("--confidence-threshold")
@@ -4097,6 +4139,46 @@ def main():
     if affected_files:
         print(f"  Affecting {len(affected_files)} file(s): {', '.join(affected_files[:3])}")
     print("Done.")
+    if use_llm and entry_id >= 0:
+        try:
+            suggested = _llm_suggest_tags(title, content)
+            if suggested:
+                print(f"  LLM suggested tags: {', '.join(suggested)}")
+                _db = get_db()
+                now = time.strftime("%Y-%m-%dT%H:%M:%S")
+                _db.execute("SAVEPOINT _llm_tag")
+                try:
+                    _db.execute(
+                        "UPDATE knowledge_entries SET tags = ? WHERE id = ?",
+                        (", ".join(suggested), entry_id),
+                    )
+                    has_table = _db.execute(
+                        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='entry_concept_tags'"
+                    ).fetchone()
+                    if has_table:
+                        _db.execute(
+                            "DELETE FROM entry_concept_tags WHERE entry_id = ? AND source = 'llm'",
+                            (entry_id,),
+                        )
+                        _db.executemany(
+                            """INSERT INTO entry_concept_tags (entry_id, tag, source, tagged_at)
+                            VALUES (?, ?, 'llm', ?)
+                            ON CONFLICT(entry_id, tag) DO UPDATE SET
+                                source = 'llm', tagged_at = excluded.tagged_at""",
+                            [(entry_id, tag, now) for tag in suggested],
+                        )
+                    _db.execute("RELEASE _llm_tag")
+                except Exception:
+                    _db.execute("ROLLBACK TO _llm_tag")
+                    _db.execute("RELEASE _llm_tag")
+                    raise
+                _db.commit()
+                _db.close()
+                print(f"  Tags applied to entry #{entry_id}")
+        except SystemExit:
+            raise
+        except Exception as exc:
+            print(f"  [warn] LLM tagging failed, keeping auto tags: {exc}", file=sys.stderr)
     if update_cerebrum and entry_id >= 0:
         rc = _auto_update_cerebrum(cerebrum_output, cerebrum_sections)
         if rc != 0:

--- a/tag-entries.py
+++ b/tag-entries.py
@@ -18,11 +18,13 @@ Usage:
     python tag-entries.py --cross-session --dry-run    # Preview without writing
 """
 
+import json
 import os
 import re
 import sqlite3
 import sys
 import time
+import urllib.request
 from pathlib import Path
 
 if os.name == "nt":
@@ -279,6 +281,123 @@ def _seed_sync_policy(db: sqlite3.Connection):
         db.commit()
     except Exception:
         pass
+
+
+def _llm_suggest_tags(title: str, content: str) -> list[str]:
+    """Call LLM API to suggest tags. Returns list of lowercase tag strings."""
+    api_key = os.environ.get("SK_LLM_API_KEY") or os.environ.get("OPENAI_API_KEY") or ""
+    if not api_key:
+        print(
+            "Error: LLM API key not set. Set SK_LLM_API_KEY or OPENAI_API_KEY.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    model = os.environ.get("SK_LLM_MODEL", "gpt-4o-mini")
+    prompt = (
+        f"Given this knowledge entry title and content, suggest 3-5 relevant tags "
+        f"as a JSON array of lowercase strings. Title: {title}. "
+        f"Content: {content[:500]}. Respond with only a JSON array."
+    )
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 100,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/chat/completions",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read())
+    raw = data["choices"][0]["message"]["content"].strip()
+    m = re.search(r"\[.*?\]", raw, re.DOTALL)
+    if not m:
+        return []
+    tags = json.loads(m.group(0))
+    return [str(t).lower().strip() for t in tags if isinstance(t, str)]
+
+
+def run_llm_tag_batch(
+    retag_all: bool = False,
+    dry_run: bool = False,
+    limit: int = 0,
+    quiet: bool = False,
+) -> dict:
+    """Run LLM-assisted batch tagging."""
+    db = get_db()
+    try:
+        if not _ensure_concept_tags_table(db):
+            return {"processed": 0, "tagged": 0, "skipped": 0, "errors": 0, "available": False}
+        _seed_sync_policy(db)
+        if retag_all:
+            if limit > 0:
+                rows = db.execute(
+                    "SELECT id, title, content FROM knowledge_entries ORDER BY id LIMIT ?",
+                    (limit,),
+                ).fetchall()
+            else:
+                rows = db.execute("SELECT id, title, content FROM knowledge_entries ORDER BY id").fetchall()
+        else:
+            base_q = """SELECT ke.id, ke.title, ke.content FROM knowledge_entries ke
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM entry_concept_tags ect
+                    WHERE ect.entry_id = ke.id AND ect.source = 'llm'
+                ) ORDER BY ke.id"""
+            if limit > 0:
+                rows = db.execute(base_q + " LIMIT ?", (limit,)).fetchall()
+            else:
+                rows = db.execute(base_q).fetchall()
+        stats = {"processed": 0, "tagged": 0, "skipped": 0, "errors": 0, "available": True}
+        now = time.strftime("%Y-%m-%dT%H:%M:%S")
+        for row in rows:
+            entry_id = row["id"]
+            title = row["title"] or ""
+            content = row["content"] or ""
+            stats["processed"] += 1
+            try:
+                tags = _llm_suggest_tags(title, content)
+                if not tags:
+                    stats["skipped"] += 1
+                    continue
+                if not dry_run:
+                    db.execute("SAVEPOINT _llm_tag")
+                    try:
+                        db.execute(
+                            "DELETE FROM entry_concept_tags WHERE entry_id = ? AND source = 'llm'",
+                            (entry_id,),
+                        )
+                        db.executemany(
+                            """INSERT INTO entry_concept_tags (entry_id, tag, source, tagged_at)
+                            VALUES (?, ?, 'llm', ?)
+                            ON CONFLICT(entry_id, tag) DO UPDATE SET
+                                source = 'llm', tagged_at = excluded.tagged_at""",
+                            [(entry_id, tag, now) for tag in tags],
+                        )
+                        db.execute("RELEASE _llm_tag")
+                    except Exception:
+                        db.execute("ROLLBACK TO _llm_tag")
+                        db.execute("RELEASE _llm_tag")
+                        raise
+                stats["tagged"] += 1
+                if not quiet:
+                    mode = "[dry-run] " if dry_run else ""
+                    print(f"  {mode}#{entry_id}: {', '.join(tags)}")
+            except SystemExit:
+                raise
+            except Exception as e:
+                stats["errors"] += 1
+                print(f"  [error] entry #{entry_id}: {e}", file=sys.stderr)
+        if not dry_run:
+            db.commit()
+        return stats
+    finally:
+        db.close()
 
 
 # ---------------------------------------------------------------------------
@@ -565,6 +684,7 @@ def main(argv: list | None = None) -> int:
         default=3,
         help="Minimum distinct sessions for high-recurrence tagging (default: 3)",
     )
+    parser.add_argument("--llm", action="store_true", help="Use LLM API to suggest tags (opt-in)")
 
     args = parser.parse_args(argv)
 
@@ -604,6 +724,27 @@ def main(argv: list | None = None) -> int:
         )
         return 0
 
+    if args.llm:
+        mode = "LLM re-tagging all" if args.retag_all else "LLM tagging untagged"
+        if args.dry_run:
+            mode = f"[dry-run] {mode}"
+        limit_note = f" (limit {args.limit})" if args.limit > 0 else ""
+        print(f"LLM concept tag batch — {mode} entries{limit_note}...")
+        stats = run_llm_tag_batch(
+            retag_all=args.retag_all,
+            dry_run=args.dry_run,
+            limit=args.limit,
+            quiet=args.quiet,
+        )
+        if not stats.get("available"):
+            print("  Failed to initialize entry_concept_tags table.", file=sys.stderr)
+            return 1
+        print(
+            f"\nDone — processed={stats['processed']}  tagged={stats['tagged']}  "
+            f"skipped={stats['skipped']}  errors={stats['errors']}"
+        )
+        return 0
+
     mode = "re-tagging all" if args.retag_all else "tagging untagged"
     if args.dry_run:
         mode = f"[dry-run] {mode}"
@@ -633,3 +774,4 @@ def main(argv: list | None = None) -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+# TEST MARKER 856

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -16349,6 +16349,260 @@ except Exception as _e869:
     for _label869 in ["1a", "1b", "1c", "2", "3", "4a", "4b", "4c", "5a", "5b", "5c", "6"]:
         test(f"I869-{_label869}: sk export JSONL", False, str(_e869))
 
+
+# === I856: LLM-assisted tag inference ===
+try:
+    import importlib
+    import io
+    import json as _json856
+    import types
+    import unittest.mock
+
+    # Load learn.py as module
+    _spec856 = importlib.util.spec_from_file_location("learn856", "learn.py")
+    _learn856 = importlib.util.module_from_spec(_spec856)
+    _spec856.loader.exec_module(_learn856)
+
+    # Load tag-entries.py as module
+    _spec856t = importlib.util.spec_from_file_location("tagentries856", "tag-entries.py")
+    _tag856 = importlib.util.module_from_spec(_spec856t)
+    _spec856t.loader.exec_module(_tag856)
+
+    # --- Test 1: JSON array extraction from clean response ---
+    def _mock_urlopen_856(req, **kw):
+        resp_data = _json856.dumps({"choices": [{"message": {"content": '["python", "testing", "ci"]'}}]}).encode()
+        resp = io.BytesIO(resp_data)
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        resp.read = resp.read
+        return resp
+
+    with unittest.mock.patch.dict(os.environ, {"SK_LLM_API_KEY": "test-key-123"}):
+        with unittest.mock.patch.object(_learn856.urllib.request, "urlopen", _mock_urlopen_856):
+            _tags1 = _learn856._llm_suggest_tags("Test title", "Test content")
+    test("I856-1: JSON array extraction from clean LLM response", _tags1 == ["python", "testing", "ci"], repr(_tags1))
+
+    # --- Test 2: JSON extraction from wrapped response ---
+    def _mock_urlopen_856_wrapped(req, **kw):
+        resp_data = _json856.dumps(
+            {"choices": [{"message": {"content": 'Here are tags: ["debug", "error"]'}}]}
+        ).encode()
+        resp = io.BytesIO(resp_data)
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    with unittest.mock.patch.dict(os.environ, {"SK_LLM_API_KEY": "test-key-123"}):
+        with unittest.mock.patch.object(_learn856.urllib.request, "urlopen", _mock_urlopen_856_wrapped):
+            _tags2 = _learn856._llm_suggest_tags("Debug issue", "Some error trace")
+    test("I856-2: JSON extraction from wrapped response", _tags2 == ["debug", "error"], repr(_tags2))
+
+    # --- Test 3: Empty/malformed response returns empty list ---
+    def _mock_urlopen_856_bad(req, **kw):
+        resp_data = _json856.dumps({"choices": [{"message": {"content": "I cannot generate tags"}}]}).encode()
+        resp = io.BytesIO(resp_data)
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    with unittest.mock.patch.dict(os.environ, {"SK_LLM_API_KEY": "test-key-123"}):
+        with unittest.mock.patch.object(_learn856.urllib.request, "urlopen", _mock_urlopen_856_bad):
+            _tags3 = _learn856._llm_suggest_tags("No tags", "Bad content")
+    test("I856-3: Malformed response returns empty list", _tags3 == [], repr(_tags3))
+
+    # --- Test 4: Missing API key exits ---
+    _exited856 = False
+    with unittest.mock.patch.dict(os.environ, {}, clear=True):
+        _env_backup856 = os.environ.copy()
+        os.environ.pop("SK_LLM_API_KEY", None)
+        os.environ.pop("OPENAI_API_KEY", None)
+        try:
+            _learn856._llm_suggest_tags("Title", "Content")
+        except SystemExit:
+            _exited856 = True
+    test("I856-4: Missing API key causes sys.exit", _exited856, "Did not exit")
+
+    # --- Test 5: SK_LLM_API_KEY takes precedence over OPENAI_API_KEY ---
+    _captured_auth856 = [None]
+
+    def _mock_urlopen_856_capture(req, **kw):
+        _captured_auth856[0] = req.get_header("Authorization")
+        resp_data = _json856.dumps({"choices": [{"message": {"content": '["tag1"]'}}]}).encode()
+        resp = io.BytesIO(resp_data)
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    with unittest.mock.patch.dict(
+        os.environ,
+        {
+            "SK_LLM_API_KEY": "sk-primary",
+            "OPENAI_API_KEY": "sk-fallback",
+        },
+    ):
+        with unittest.mock.patch.object(_learn856.urllib.request, "urlopen", _mock_urlopen_856_capture):
+            _learn856._llm_suggest_tags("Title", "Content")
+    test(
+        "I856-5: SK_LLM_API_KEY takes precedence",
+        _captured_auth856[0] == "Bearer sk-primary",
+        repr(_captured_auth856[0]),
+    )
+
+    # --- Test 6: SK_LLM_MODEL passthrough ---
+    _captured_payload856 = [None]
+
+    def _mock_urlopen_856_model(req, **kw):
+        _captured_payload856[0] = _json856.loads(req.data)
+        resp_data = _json856.dumps({"choices": [{"message": {"content": '["tag1"]'}}]}).encode()
+        resp = io.BytesIO(resp_data)
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    with unittest.mock.patch.dict(
+        os.environ,
+        {
+            "SK_LLM_API_KEY": "test-key",
+            "SK_LLM_MODEL": "gpt-4o",
+        },
+    ):
+        with unittest.mock.patch.object(_learn856.urllib.request, "urlopen", _mock_urlopen_856_model):
+            _learn856._llm_suggest_tags("Title", "Content")
+    test(
+        "I856-6: SK_LLM_MODEL passthrough",
+        _captured_payload856[0] and _captured_payload856[0].get("model") == "gpt-4o",
+        repr(_captured_payload856[0]),
+    )
+
+    # --- Test 7: tag-entries _llm_suggest_tags identical behavior ---
+    with unittest.mock.patch.dict(os.environ, {"SK_LLM_API_KEY": "test-key-123"}):
+        with unittest.mock.patch.object(_tag856.urllib.request, "urlopen", _mock_urlopen_856):
+            _tags7 = _tag856._llm_suggest_tags("Test title", "Test content")
+    test("I856-7: tag-entries _llm_suggest_tags works", _tags7 == ["python", "testing", "ci"], repr(_tags7))
+
+    # --- Test 8: tag-entries batch dry-run writes no rows ---
+    import sqlite3 as _sql856
+    import tempfile as _tmp856
+
+    _tmpdir856 = _tmp856.mkdtemp()
+    _dbpath856 = os.path.join(_tmpdir856, "test856.db")
+
+    def _make_db856():
+        _c = _sql856.connect(_dbpath856)
+        _c.row_factory = _sql856.Row
+        return _c
+
+    _init856 = _make_db856()
+    _init856.execute("""CREATE TABLE IF NOT EXISTS knowledge_entries (
+        id INTEGER PRIMARY KEY, title TEXT, content TEXT, tags TEXT)""")
+    _init856.execute("""CREATE TABLE IF NOT EXISTS entry_concept_tags (
+        entry_id INTEGER, tag TEXT, source TEXT, tagged_at TEXT,
+        PRIMARY KEY (entry_id, tag))""")
+    _init856.execute("INSERT OR IGNORE INTO knowledge_entries VALUES (1, 'Test', 'Content', '')")
+    _init856.commit()
+    _init856.close()
+
+    _orig_get_db856 = _tag856.get_db
+    _tag856.get_db = _make_db856
+
+    with unittest.mock.patch.dict(os.environ, {"SK_LLM_API_KEY": "test-key-123"}):
+        with unittest.mock.patch.object(_tag856.urllib.request, "urlopen", _mock_urlopen_856):
+            _stats8 = _tag856.run_llm_tag_batch(dry_run=True, quiet=True)
+
+    _chk856 = _make_db856()
+    _rows8 = _chk856.execute("SELECT * FROM entry_concept_tags").fetchall()
+    _chk856.close()
+    test(
+        "I856-8: dry-run writes no rows",
+        len(_rows8) == 0 and _stats8["tagged"] == 1,
+        f"rows={len(_rows8)} stats={_stats8}",
+    )
+
+    # --- Test 9: batch run writes rows with source='llm' ---
+    with unittest.mock.patch.dict(os.environ, {"SK_LLM_API_KEY": "test-key-123"}):
+        with unittest.mock.patch.object(_tag856.urllib.request, "urlopen", _mock_urlopen_856):
+            _stats9 = _tag856.run_llm_tag_batch(quiet=True)
+
+    _chk856b = _make_db856()
+    _rows9 = _chk856b.execute("SELECT * FROM entry_concept_tags WHERE source = 'llm'").fetchall()
+    _chk856b.close()
+    test(
+        "I856-9: batch writes rows with source='llm'",
+        len(_rows9) == 3 and _stats9["tagged"] == 1,
+        f"rows={len(_rows9)} stats={_stats9}",
+    )
+
+    # --- Test 10: learn.py LLM exception handling (non-SystemExit) ---
+    def _mock_urlopen_856_error(req, **kw):
+        raise ConnectionError("Network timeout")
+
+    _err856_caught = False
+    with unittest.mock.patch.dict(os.environ, {"SK_LLM_API_KEY": "test-key-123"}):
+        with unittest.mock.patch.object(_learn856.urllib.request, "urlopen", _mock_urlopen_856_error):
+            try:
+                _learn856._llm_suggest_tags("Title", "Content")
+            except ConnectionError:
+                _err856_caught = True
+    # _llm_suggest_tags itself raises — the caller in main() wraps it
+    test("I856-10: _llm_suggest_tags propagates network errors", _err856_caught, "Error was not raised")
+
+    # --- Test 11: tags lowercase normalization ---
+    def _mock_urlopen_856_upper(req, **kw):
+        resp_data = _json856.dumps({"choices": [{"message": {"content": '["Python", "CI/CD", "TESTING"]'}}]}).encode()
+        resp = io.BytesIO(resp_data)
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    with unittest.mock.patch.dict(os.environ, {"SK_LLM_API_KEY": "test-key-123"}):
+        with unittest.mock.patch.object(_learn856.urllib.request, "urlopen", _mock_urlopen_856_upper):
+            _tags11 = _learn856._llm_suggest_tags("Title", "Content")
+    test("I856-11: tags are lowercased", all(t == t.lower() for t in _tags11) and len(_tags11) == 3, repr(_tags11))
+
+    # --- Test 12: non-string items filtered ---
+    def _mock_urlopen_856_mixed(req, **kw):
+        resp_data = _json856.dumps(
+            {"choices": [{"message": {"content": '["valid", 42, "also-valid", null]'}}]}
+        ).encode()
+        resp = io.BytesIO(resp_data)
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    with unittest.mock.patch.dict(os.environ, {"SK_LLM_API_KEY": "test-key-123"}):
+        with unittest.mock.patch.object(_learn856.urllib.request, "urlopen", _mock_urlopen_856_mixed):
+            _tags12 = _learn856._llm_suggest_tags("Title", "Content")
+    test("I856-12: non-string items filtered from response", _tags12 == ["valid", "also-valid"], repr(_tags12))
+
+    # --- Test 13: OPENAI_API_KEY fallback works ---
+    _captured_auth856b = [None]
+
+    def _mock_urlopen_856_fb(req, **kw):
+        _captured_auth856b[0] = req.get_header("Authorization")
+        resp_data = _json856.dumps({"choices": [{"message": {"content": '["tag1"]'}}]}).encode()
+        resp = io.BytesIO(resp_data)
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    _env_856fb = {"OPENAI_API_KEY": "sk-fallback-key"}
+    with unittest.mock.patch.dict(os.environ, _env_856fb, clear=False):
+        os.environ.pop("SK_LLM_API_KEY", None)
+        with unittest.mock.patch.object(_learn856.urllib.request, "urlopen", _mock_urlopen_856_fb):
+            _learn856._llm_suggest_tags("Title", "Content")
+    test(
+        "I856-13: OPENAI_API_KEY fallback",
+        _captured_auth856b[0] == "Bearer sk-fallback-key",
+        repr(_captured_auth856b[0]),
+    )
+
+    _tag856.get_db = _orig_get_db856
+
+except Exception as _e856:
+    for _label856 in range(1, 14):
+        test(f"I856-{_label856}: LLM tag inference", False, str(_e856))
+
+
 # ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")


### PR DESCRIPTION
## Summary

Add opt-in `--llm` flag to `learn.py` and `tag-entries.py` for LLM-assisted category/tag inference using stdlib `urllib.request`.

## Changes

### `learn.py`
- `_llm_suggest_tags(title, content)` — calls OpenAI-compatible API, extracts JSON array from response
- `--llm` flag — after writing entry, calls LLM to suggest tags and applies them via parameterized SQL UPDATE

### `tag-entries.py`  
- `_llm_suggest_tags(title, content)` — identical extraction logic
- `run_llm_tag_batch()` — batch processing with `--dry-run` support, SAVEPOINT atomicity, `source='llm'`
- `--llm` argparse flag wired into `main()`

### `test_fixes.py`
- 13 I856 test cases covering: JSON extraction, error handling, missing API key exit, env var precedence (`SK_LLM_API_KEY` > `OPENAI_API_KEY`), `SK_LLM_MODEL` passthrough, dry-run no-write, DB write verification, source attribution

## Design Decisions
- **Pure stdlib** — `urllib.request` only, zero pip dependencies
- **Opt-in** — no behavior change without `--llm` flag
- **Env vars** — `SK_LLM_API_KEY` or `OPENAI_API_KEY` for key, `SK_LLM_MODEL` for model (default: `gpt-4o-mini`)
- **Standalone** — no inter-script imports per architecture rules

Closes #856