### PR TITLE
feat(#894): add diff_brief MCP tool for git-diff-scoped knowledge recall

### DIFF
--- a/mcp-server.py
+++ b/mcp-server.py
@@ -401,6 +401,28 @@ TOOLS = [
             "additionalProperties": False,
         },
     },
+    {
+        "name": "diff_brief",
+        "description": (
+            "Return knowledge entries relevant to the files changed in the current git diff. "
+            "Useful during PR review or before committing to recall past mistakes and patterns. "
+            "Issue #894."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "budget": {
+                    "type": "integer",
+                    "description": "Max output characters (default 2000).",
+                },
+                "compact": {
+                    "type": "boolean",
+                    "description": "Titles-only compact format (default true).",
+                },
+            },
+            "additionalProperties": False,
+        },
+    },
 ]
 
 
@@ -1287,6 +1309,39 @@ def _run_bulk_learn_ndjson(arguments: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _run_diff_brief(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Return knowledge entries relevant to the current git diff (issue #894)."""
+    budget = _optional_int(arguments, "budget", default=2000, minimum=100, maximum=50000)
+    compact = _optional_bool(arguments, "compact", default=True)
+    argv = ["--diff", "--export", "json", "--budget", str(budget)]
+    if compact:
+        argv.append("--compact")
+    exit_code, stdout_text, stderr_text = _capture_module_main(query_session_mod, argv)
+    if exit_code != 0:
+        # Non-git directory or other expected failures — return gracefully
+        msg = stderr_text.strip() or stdout_text.strip() or "diff_brief failed"
+        if "not a git" in msg.lower() or "git diff failed" in msg.lower():
+            result: dict[str, Any] = {"entries": [], "file_count": 0, "error": msg}
+            return {
+                "content": [{"type": "text", "text": json.dumps(result)}],
+                "structuredContent": result,
+            }
+        raise JsonRpcError(JSONRPC_INTERNAL_ERROR, msg)
+    text = stdout_text.strip()
+    # Parse JSON output from query-session.py --export json
+    try:
+        parsed = json.loads(text) if text else {}
+    except json.JSONDecodeError:
+        parsed = {}
+    entries = parsed.get("entries", [])
+    file_count = len(parsed.get("changed_files", []))
+    result = {"entries": entries, "file_count": file_count}
+    return {
+        "content": [{"type": "text", "text": json.dumps(result, ensure_ascii=False)}],
+        "structuredContent": result,
+    }
+
+
 def _handle_tools_call(params: dict[str, Any]) -> dict[str, Any]:
     name = params.get("name")
     if not isinstance(name, str) or not name:
@@ -1320,6 +1375,8 @@ def _handle_tools_call(params: dict[str, Any]) -> dict[str, Any]:
         return _run_batch_learn(arguments, progress_token=progress_token)
     if name == "bulk_learn":
         return _run_bulk_learn_ndjson(arguments)
+    if name == "diff_brief":
+        return _run_diff_brief(arguments)
     raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"Unknown tool: {name}")
 
 

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -16809,15 +16809,39 @@ except Exception as _e895:
     for _lbl895 in [str(i) for i in range(1, 22)]:
         test(f"I895-{_lbl895}: quota pattern matrix", False, str(_e895))
 # ---------------------------------------------------------------------------
-if FAIL == 0:
-    print("🎉 All tests passed!")
-else:
-    print(f"⚠️  {FAIL} test(s) need attention")
-    for _fn in FAIL_NAMES:
-        print(f"    ❌ {_fn}")
-sys.exit(0 if FAIL == 0 else 1)
+# === I894: diff_brief MCP tool =============================================
+# ---------------------------------------------------------------------------
+try:
+    import importlib
 
+    _mcp894 = importlib.import_module("mcp-server")
 
+    # I894-1: diff_brief tool exists in TOOLS list
+    _diff_names = [t["name"] for t in _mcp894.TOOLS]
+    test("I894-1: diff_brief in TOOLS", "diff_brief" in _diff_names, _diff_names)
+
+    # I894-2: diff_brief schema has budget (integer) and compact (boolean) params
+    _diff_schema = next(t for t in _mcp894.TOOLS if t["name"] == "diff_brief")
+    _diff_props = _diff_schema["inputSchema"]["properties"]
+    test("I894-2: diff_brief has budget param", "budget" in _diff_props, list(_diff_props.keys()))
+    test("I894-3: budget type is integer", _diff_props["budget"]["type"] == "integer", _diff_props["budget"])
+    test("I894-4: diff_brief has compact param", "compact" in _diff_props, list(_diff_props.keys()))
+    test("I894-5: compact type is boolean", _diff_props["compact"]["type"] == "boolean", _diff_props["compact"])
+
+    # I894-6: _run_diff_brief function exists
+    test("I894-6: _run_diff_brief callable", callable(getattr(_mcp894, "_run_diff_brief", None)), dir(_mcp894))
+
+    # I894-7: diff_brief wired in dispatch
+    _src894 = open(_mcp894.__file__).read()
+    test("I894-7: diff_brief in dispatch", 'name == "diff_brief"' in _src894, "dispatch check")
+
+    # I894-8: no required params (budget and compact are optional)
+    _diff_required = _diff_schema["inputSchema"].get("required", [])
+    test("I894-8: no required params", len(_diff_required) == 0, _diff_required)
+
+except Exception as _e894:
+    for _lbl894 in [str(i) for i in range(1, 9)]:
+        test(f"I894-{_lbl894}: diff_brief MCP tool", False, str(_e894))
 # ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -104,7 +104,7 @@ class TestToolsList(unittest.TestCase):
 
     def test_exactly_two_tools(self):
         # Updated: wave 8 added learn, status, session_list; code_search added later; rate_entry (#820); batch_learn (#833); sk_compact_session; bulk_learn (#898); now 11 tools total
-        self.assertEqual(len(mcp.TOOLS), 11)
+        self.assertEqual(len(mcp.TOOLS), 12)
 
     def test_briefing_tool_present(self):
         self.assertIn("briefing", self.tools)
@@ -1099,7 +1099,7 @@ class TestQueryMemoryTool(unittest.TestCase):
 
     def test_exactly_three_tools(self):
         # Updated: wave 8 added learn, status, session_list; code_search added later; rate_entry (#820); batch_learn (#833); sk_compact_session; bulk_learn (#898); now 11 tools total
-        self.assertEqual(len(mcp.TOOLS), 11)
+        self.assertEqual(len(mcp.TOOLS), 12)
 
     def test_rate_entry_tool_present(self):
         self.assertIn("rate_entry", self.tools)


### PR DESCRIPTION
## Summary
Add `diff_brief` MCP tool that returns knowledge entries relevant to the files changed in the current git diff. Useful during PR review or before committing to recall past mistakes and patterns.

## Changes
- Add `diff_brief` to `TOOLS` list with optional `budget` (integer, default 2000) and `compact` (bool, default true)
- Add `_run_diff_brief()` handler delegating to `query-session.py --diff` via `_capture_module_main`
- Wire in `_handle_tools_call()` dispatch
- Non-git directories return `{entries: [], file_count: 0, error: msg}` gracefully
- 8 I894 tests in test_fixes.py
- Tool count 11→12 in tests/test_mcp_server.py

## Test Evidence
```
✅ I894-1: diff_brief in TOOLS
✅ I894-2: diff_brief has budget param
✅ I894-3: budget type is integer
✅ I894-4: diff_brief has compact param
✅ I894-5: compact type is boolean
✅ I894-6: _run_diff_brief callable
✅ I894-7: diff_brief in dispatch
✅ I894-8: no required params
🎉 All tests passed!

Ran 122 tests in 0.091s — OK (test_mcp_server.py)
Results: 13 passed, 0 failed — All security tests passed! (test_security.py)
```

Closes #894