### PR TITLE
feat(#911): briefing pack/code-context budget edge cases

### DIFF
--- a/briefing.py
+++ b/briefing.py
@@ -4632,6 +4632,30 @@ def _format_code_context(snippets: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _select_pack_snippets(pack_payload: dict, snippets: list[dict], budget: int) -> list[dict]:
+    """Select as many code snippets as fit within the serialized pack budget (issue #911).
+
+    Edge cases handled:
+    - budget <= 0 (or falsy): treated as unbounded; all snippets selected
+    - a single snippet whose addition exceeds the budget is *skipped*, not used as a
+      hard stop, so one oversized snippet cannot starve smaller relevant ones that follow
+    - empty snippet list returns an empty selection
+    """
+    selected: list[dict] = []
+    for snippet in snippets:
+        candidate = selected + [snippet]
+        candidate_output = json.dumps(
+            {**pack_payload, "code_context": candidate},
+            indent=2,
+            ensure_ascii=False,
+        )
+        if budget and len(candidate_output) > budget:
+            # Skip this snippet but keep evaluating subsequent (possibly smaller) ones.
+            continue
+        selected = candidate
+    return selected
+
+
 def _parse_window(window: str) -> int:
     """Parse duration string like 1d, 7d, 24h, 2w into seconds."""
     import re
@@ -5813,7 +5837,7 @@ def main():
             },
         )
 
-    # TODO(issue #754): add focused coverage for pack/code-context budget interactions.
+    # Code-context budget allocation with edge-case coverage (issue #911, ref #754).
     if with_code_context and query and fmt != "json":
         snippets = _query_code_context(DB_PATH, query, token_budget=code_tokens)
         if snippets:
@@ -5823,17 +5847,7 @@ def main():
                 except json.JSONDecodeError:
                     pack_payload = None
                 if isinstance(pack_payload, dict):
-                    selected_snippets = []
-                    for snippet in snippets:
-                        candidate_snippets = selected_snippets + [snippet]
-                        candidate_output = json.dumps(
-                            {**pack_payload, "code_context": candidate_snippets},
-                            indent=2,
-                            ensure_ascii=False,
-                        )
-                        if budget and len(candidate_output) > budget:
-                            break
-                        selected_snippets = candidate_snippets
+                    selected_snippets = _select_pack_snippets(pack_payload, snippets, budget)
                     if selected_snippets:
                         output = json.dumps(
                             {**pack_payload, "code_context": selected_snippets},

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -17049,6 +17049,68 @@ try:
 except Exception as _e907:
     for _i907 in range(1, 10):
         test(f"I907-{_i907}: retro_summary MCP tool", False, str(_e907))
+# ---------------------------------------------------------------------------
+# I911: Briefing pack / code-context budget edge cases (ref #754)
+# ---------------------------------------------------------------------------
+try:
+    import importlib.util as _ilu911
+
+    _spec911 = _ilu911.spec_from_file_location("briefing911", REPO / "briefing.py")
+    _brief911 = _ilu911.module_from_spec(_spec911)
+    _spec911.loader.exec_module(_brief911)
+    _select911 = _brief911._select_pack_snippets
+
+    _payload911 = {"summary": "x"}
+    _small911 = [{"file_path": "a.py", "content": "short"}]
+    _big911 = [{"file_path": "b.py", "content": "Z" * 5000}]
+
+    # I911-1: helper exists and is callable
+    test("I911-1: _select_pack_snippets callable", callable(_select911))
+
+    # I911-2: empty sources return empty selection (no crash)
+    test("I911-2: empty snippets -> []", _select911(_payload911, [], 1000) == [])
+
+    # I911-3: zero/falsy budget treated as unbounded (all selected)
+    test(
+        "I911-3: budget=0 selects all snippets",
+        _select911(_payload911, _small911 + _big911, 0) == _small911 + _big911,
+    )
+
+    # I911-4: budget exhaustion stops adding once over budget
+    _fit911 = _select911(_payload911, _small911, 1000)
+    test("I911-4: small snippet fits within ample budget", _fit911 == _small911, _fit911)
+
+    # I911-5: single entry larger than budget is skipped, not fatal
+    _skip911 = _select911(_payload911, _big911, 200)
+    test("I911-5: oversized single snippet skipped", _skip911 == [], _skip911)
+
+    # I911-6: oversized snippet does not starve a smaller following snippet
+    _mixed911 = _select911(_payload911, _big911 + _small911, 400)
+    test(
+        "I911-6: smaller snippet still selected after oversized one",
+        _small911[0] in _mixed911 and _big911[0] not in _mixed911,
+        _mixed911,
+    )
+
+    # I911-7: unicode content counted by serialized length without crashing
+    _uni911 = [{"file_path": "u.py", "content": "café ünïcode 🚀" * 3}]
+    _ures911 = _select911(_payload911, _uni911, 100000)
+    test("I911-7: unicode snippet handled", _ures911 == _uni911, _ures911)
+
+    # I911-8: selection never exceeds the budget on serialized output
+    import json as _json911
+
+    _budget911 = 600
+    _sel911 = _select911(_payload911, _small911 * 20, _budget911)
+    _serial911 = _json911.dumps({**_payload911, "code_context": _sel911}, indent=2, ensure_ascii=False)
+    test(
+        "I911-8: serialized selection within budget",
+        len(_serial911) <= _budget911 or _sel911 == [],
+        len(_serial911),
+    )
+except Exception as _e911:
+    for _i911 in range(1, 9):
+        test(f"I911-{_i911}: briefing pack budget edge cases", False, str(_e911))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #911 (resolves TODO #754 in briefing.py)

## What
Hardens code-context budget allocation in `sk briefing` pack output and replaces the long-standing `TODO(issue #754)` with tested behavior.

## How
Extracts the inline snippet-selection loop into a module-level, unit-testable helper `_select_pack_snippets(pack_payload, snippets, budget)`:
- **empty sources** → empty selection (no crash)
- **falsy/zero budget** → unbounded (all snippets)
- **single snippet larger than budget** → skipped, not fatal
- **oversized snippet no longer starves smaller relevant snippets** that follow — changed a hard `break` to skip-and-continue
- **unicode** content counted via serialized JSON length

No behavioral change for the normal case where every snippet fits.

## Tests
8 new `I911-*` assertions (empty, unbounded budget, fit, oversized-skip, no-starvation, unicode, serialized-within-budget).

```
python3 test_security.py  # 13 passed
python3 test_fixes.py     # All tests passed (I911 green)
ruff check / ruff format --check  # clean
```