### PR TITLE
feat(#909): add knowledge_health MCP tool

### DIFF
--- a/mcp-server.py
+++ b/mcp-server.py
@@ -84,6 +84,11 @@ except Exception as exc:  # pragma: no cover - startup failure path
     print(f"Failed to load tool modules: {exc}", file=sys.stderr)
     raise
 
+try:
+    knowledge_health_mod = _load_script_module("mcp_knowledge_health", "knowledge-health.py")
+except Exception:  # pragma: no cover - optional module path
+    knowledge_health_mod = None
+
 
 TOOLS = [
     {
@@ -442,6 +447,19 @@ TOOLS = [
                     "description": "Output format: text (default), json (structured), or markdown.",
                 },
             },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "knowledge_health",
+        "description": "Check knowledge base health: entry counts, orphans, FTS sync, embedding coverage, recall telemetry",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "include_recall": {"type": "boolean", "default": False},
+                "verbose": {"type": "boolean", "default": False},
+            },
+            "required": [],
             "additionalProperties": False,
         },
     },
@@ -1399,6 +1417,28 @@ def _run_retro_summary(arguments: dict) -> dict:
     return {"content": [{"type": "text", "text": json.dumps(body, ensure_ascii=False)}], "structuredContent": body}
 
 
+def _run_knowledge_health(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Delegate to knowledge-health.py --json and return the parsed health dict."""
+    include_recall = _optional_bool(arguments, "include_recall", default=False)
+    verbose = _optional_bool(arguments, "verbose", default=False)
+    try:
+        if knowledge_health_mod is None:
+            raise RuntimeError("knowledge-health.py could not be loaded")
+        argv = ["--json"]
+        if include_recall:
+            argv.append("--recall")
+        if verbose:
+            argv.append("--verbose")
+        _exit, stdout, _stderr = _capture_module_main(knowledge_health_mod, argv)
+        body = json.loads(stdout)
+    except Exception as exc:
+        body = {"error": str(exc), "healthy": False}
+    return {
+        "content": [{"type": "text", "text": json.dumps(body, ensure_ascii=False)}],
+        "structuredContent": body,
+    }
+
+
 def _run_diff_brief(arguments: dict[str, Any]) -> dict[str, Any]:
     """Return knowledge entries relevant to the current git diff (issue #894)."""
     budget = _optional_int(arguments, "budget", default=2000, minimum=100, maximum=50000)
@@ -1469,6 +1509,8 @@ def _handle_tools_call(params: dict[str, Any]) -> dict[str, Any]:
         return _run_diff_brief(arguments)
     if name == "retro_summary":
         return _run_retro_summary(arguments)
+    if name == "knowledge_health":
+        return _run_knowledge_health(arguments)
     raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"Unknown tool: {name}")
 
 

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -17052,6 +17052,49 @@ except Exception as _e907:
 
 
 # ---------------------------------------------------------------------------
+# I909: knowledge_health MCP tool
+# ---------------------------------------------------------------------------
+try:
+    import importlib as _il909
+
+    _mcp909 = _il909.import_module("mcp-server")
+    _names909 = [t["name"] for t in _mcp909.TOOLS]
+    test("I909-1: knowledge_health tool registered", "knowledge_health" in _names909, _names909)
+
+    _kh909 = next(t for t in _mcp909.TOOLS if t["name"] == "knowledge_health")
+    _props909 = _kh909["inputSchema"]["properties"]
+    test("I909-2: include_recall param present", "include_recall" in _props909, list(_props909.keys()))
+    test("I909-3: verbose param present", "verbose" in _props909, list(_props909.keys()))
+    test(
+        "I909-4: no required params",
+        len(_kh909["inputSchema"].get("required", [])) == 0,
+        _kh909["inputSchema"].get("required", []),
+    )
+    test(
+        "I909-5: additionalProperties is False",
+        _kh909["inputSchema"].get("additionalProperties") is False,
+        _kh909["inputSchema"].get("additionalProperties"),
+    )
+    test("I909-6: _run_knowledge_health callable", callable(getattr(_mcp909, "_run_knowledge_health", None)))
+
+    _src909 = open(_mcp909.__file__).read()
+    test("I909-7: knowledge_health wired in dispatch", 'name == "knowledge_health"' in _src909, "dispatch check")
+
+    # I909-8: invoking returns an MCP-shaped envelope with structuredContent (never raises)
+    _res909 = _mcp909._run_knowledge_health({})
+    test(
+        "I909-8: returns content + structuredContent envelope",
+        isinstance(_res909, dict)
+        and isinstance(_res909.get("content"), list)
+        and isinstance(_res909.get("structuredContent"), dict),
+        _res909,
+    )
+except Exception as _e909:
+    for _i909 in range(1, 9):
+        test(f"I909-{_i909}: knowledge_health MCP tool", False, str(_e909))
+
+
+# ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")
 else:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -104,7 +104,7 @@ class TestToolsList(unittest.TestCase):
 
     def test_exactly_two_tools(self):
         # Updated: wave 8 added learn, status, session_list; code_search added later; rate_entry (#820); batch_learn (#833); sk_compact_session; bulk_learn (#898); now 11 tools total
-        self.assertEqual(len(mcp.TOOLS), 13)
+        self.assertEqual(len(mcp.TOOLS), 14)
 
     def test_briefing_tool_present(self):
         self.assertIn("briefing", self.tools)
@@ -1099,7 +1099,7 @@ class TestQueryMemoryTool(unittest.TestCase):
 
     def test_exactly_three_tools(self):
         # Updated: wave 8 added learn, status, session_list; code_search added later; rate_entry (#820); batch_learn (#833); sk_compact_session; bulk_learn (#898); now 11 tools total
-        self.assertEqual(len(mcp.TOOLS), 13)
+        self.assertEqual(len(mcp.TOOLS), 14)
 
     def test_rate_entry_tool_present(self):
         self.assertIn("rate_entry", self.tools)


### PR DESCRIPTION
Adds the `knowledge_health` MCP tool exposing knowledge-base health metrics (entry counts, staleness, coverage) over JSON-RPC.

- New `_run_knowledge_health` dispatch + TOOLS entry (count 13→14)
- Optional `knowledge_health_mod` loader
- 8 I909 tests in test_fixes.py; TOOLS-count assertions updated to 14 in tests/test_mcp_server.py

Rebased onto main after #915 (#907) merged; replaces auto-closed #916 (base branch was deleted on merge).

Closes #909