### PR TITLE
feat(#922): register repo_map as MCP tool

### DIFF
--- a/mcp-server.py
+++ b/mcp-server.py
@@ -89,6 +89,11 @@ try:
 except Exception:  # pragma: no cover - optional module path
     knowledge_health_mod = None
 
+try:
+    repo_map_mod = _load_script_module("mcp_repo_map", "repo-map.py")
+except Exception:  # pragma: no cover - optional module path
+    repo_map_mod = None
+
 
 TOOLS = [
     {
@@ -458,6 +463,46 @@ TOOLS = [
             "properties": {
                 "include_recall": {"type": "boolean", "default": False},
                 "verbose": {"type": "boolean", "default": False},
+            },
+            "required": [],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "repo_map",
+        "description": (
+            "Generate a PageRank-ranked symbol map for a directory to inject into AI context. "
+            "Uses code_index DB when available, falls back to filesystem scan."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Root directory to map (default: '.').",
+                },
+                "top": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 500,
+                    "description": "Number of top symbols to show (default 30).",
+                },
+                "project_id": {
+                    "type": "string",
+                    "description": "project_id in code_index table (default: auto-detect from dir).",
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["markdown", "concise", "full"],
+                    "default": "markdown",
+                    "description": "Output format: markdown (default), concise, or full.",
+                },
+                "tokens": {
+                    "type": "integer",
+                    "minimum": 100,
+                    "maximum": 100000,
+                    "description": "Approximate output token budget (default 4000).",
+                },
             },
             "required": [],
             "additionalProperties": False,
@@ -1439,6 +1484,40 @@ def _run_knowledge_health(arguments: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _run_repo_map(arguments: dict) -> dict:
+    """Generate PageRank-ranked symbol map via repo-map.py."""
+    path = _optional_string(arguments, "path", max_length=500) or "."
+    top = _optional_int(arguments, "top", default=30, minimum=1, maximum=500)
+    project_id = _optional_string(arguments, "project_id", max_length=200)
+    fmt = arguments.get("format", "markdown")
+    if not isinstance(fmt, str) or fmt not in ("markdown", "concise", "full"):
+        fmt = "markdown"
+    tokens = _optional_int(arguments, "tokens", default=4000, minimum=100, maximum=100000)
+
+    argv = [path, "--format", fmt, "--top", str(top), "--tokens", str(tokens)]
+    if project_id:
+        argv += ["--project-id", project_id]
+
+    try:
+        if repo_map_mod is None:
+            raise RuntimeError("repo-map.py could not be loaded")
+        exit_code, stdout_text, stderr_text = _capture_module_main(repo_map_mod, argv)
+    except Exception as exc:
+        body: dict = {"error": str(exc), "path": path}
+        return {"content": [{"type": "text", "text": json.dumps(body)}], "structuredContent": body}
+
+    if exit_code != 0:
+        body = {"error": stderr_text.strip() or stdout_text.strip() or "repo-map failed", "path": path}
+        return {"content": [{"type": "text", "text": json.dumps(body)}], "structuredContent": body}
+
+    text = stdout_text.strip()
+    body = {"output": text, "path": path, "format": fmt, "top": top}
+    return {
+        "content": [{"type": "text", "text": text}],
+        "structuredContent": body,
+    }
+
+
 def _run_diff_brief(arguments: dict[str, Any]) -> dict[str, Any]:
     """Return knowledge entries relevant to the current git diff (issue #894)."""
     budget = _optional_int(arguments, "budget", default=2000, minimum=100, maximum=50000)
@@ -1511,6 +1590,8 @@ def _handle_tools_call(params: dict[str, Any]) -> dict[str, Any]:
         return _run_retro_summary(arguments)
     if name == "knowledge_health":
         return _run_knowledge_health(arguments)
+    if name == "repo_map":
+        return _run_repo_map(arguments)
     raise JsonRpcError(JSONRPC_INVALID_PARAMS, f"Unknown tool: {name}")
 
 

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -17157,6 +17157,51 @@ except Exception as _e909:
 
 
 # ---------------------------------------------------------------------------
+# I922: repo_map MCP tool
+# ---------------------------------------------------------------------------
+try:
+    import importlib as _il922
+
+    _mcp922 = _il922.import_module("mcp-server")
+    _names922 = [t["name"] for t in _mcp922.TOOLS]
+    test("I922-1: repo_map tool registered", "repo_map" in _names922, _names922)
+
+    _rm922 = next(t for t in _mcp922.TOOLS if t["name"] == "repo_map")
+    _props922 = _rm922["inputSchema"]["properties"]
+    test("I922-2: path param present", "path" in _props922, list(_props922.keys()))
+    test("I922-3: top param present", "top" in _props922, list(_props922.keys()))
+    test("I922-4: format param present", "format" in _props922, list(_props922.keys()))
+    test("I922-5: tokens param present", "tokens" in _props922, list(_props922.keys()))
+    test(
+        "I922-6: no required params",
+        len(_rm922["inputSchema"].get("required", [])) == 0,
+        _rm922["inputSchema"].get("required", []),
+    )
+    test(
+        "I922-7: additionalProperties is False",
+        _rm922["inputSchema"].get("additionalProperties") is False,
+        _rm922["inputSchema"].get("additionalProperties"),
+    )
+    test("I922-8: _run_repo_map callable", callable(getattr(_mcp922, "_run_repo_map", None)))
+
+    _src922 = open(_mcp922.__file__).read()
+    test("I922-9: repo_map wired in dispatch", 'name == "repo_map"' in _src922, "dispatch check")
+
+    # I922-10: invoking returns an MCP-shaped envelope with content + structuredContent
+    _res922 = _mcp922._run_repo_map({})
+    test(
+        "I922-10: returns content + structuredContent envelope",
+        isinstance(_res922, dict)
+        and isinstance(_res922.get("content"), list)
+        and isinstance(_res922.get("structuredContent"), dict),
+        _res922,
+    )
+except Exception as _e922:
+    for _i922 in range(1, 11):
+        test(f"I922-{_i922}: repo_map MCP tool", False, str(_e922))
+
+
+# ---------------------------------------------------------------------------
 if FAIL == 0:
     print("🎉 All tests passed!")
 else:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -104,7 +104,7 @@ class TestToolsList(unittest.TestCase):
 
     def test_exactly_two_tools(self):
         # Updated: wave 8 added learn, status, session_list; code_search added later; rate_entry (#820); batch_learn (#833); sk_compact_session; bulk_learn (#898); now 11 tools total
-        self.assertEqual(len(mcp.TOOLS), 14)
+        self.assertEqual(len(mcp.TOOLS), 15)
 
     def test_briefing_tool_present(self):
         self.assertIn("briefing", self.tools)
@@ -1099,7 +1099,7 @@ class TestQueryMemoryTool(unittest.TestCase):
 
     def test_exactly_three_tools(self):
         # Updated: wave 8 added learn, status, session_list; code_search added later; rate_entry (#820); batch_learn (#833); sk_compact_session; bulk_learn (#898); now 11 tools total
-        self.assertEqual(len(mcp.TOOLS), 14)
+        self.assertEqual(len(mcp.TOOLS), 15)
 
     def test_rate_entry_tool_present(self):
         self.assertIn("rate_entry", self.tools)


### PR DESCRIPTION
## Summary
Closes #922

Exposes the existing `repo-map.py` as an MCP tool so agents can request repository structure maps over JSON-RPC.

## Changes
- **mcp-server.py**: Load `repo-map.py` module, add `repo_map` tool definition with `path`/`top`/`format`/`tokens`/`project_id` params, implement `_run_repo_map()` handler, wire dispatch
- **tests/test_mcp_server.py**: Update TOOLS count assertion 14 → 15
- **test_fixes.py**: Add I922 tests (10 tests, all passing)

## Evidence
- `python3 test_security.py`: 13 passed ✅
- `python3 test_fixes.py`: All tests passed ✅ (including I922-1..10)
- `python3 -m pytest tests/test_mcp_server.py`: 123 passed ✅