### PR TITLE
fix(marker-auth): SK_MARKERS_DIR env override prevents test from writing real hooks-tampered marker

### DIFF
--- a/sk-rust/Cargo.toml
+++ b/sk-rust/Cargo.toml
@@ -13,6 +13,10 @@ native-embed   = ["dep:reqwest", "dep:tokio"]
 native-sync    = ["dep:reqwest", "dep:tokio"]
 native-watch   = ["dep:notify"]
 native-hooks   = []
+# Enables SK_MARKERS_DIR env override in markers_dir() for integration tests
+# that must not write to the real ~/.copilot/markers/ directory.
+# Never enable in production builds.
+test-helpers   = []
 # Wave-14/16/17/19: hot-path classification/write loop, deterministic relation
 # extraction, native residual helpers, and SEMANTIC_PROXIMITY (TF-IDF cosine).
 # In scope: knowledge_entries write, ke_fts sync, knowledge_relations for

--- a/sk-rust/src/hooks/marker_auth.rs
+++ b/sk-rust/src/hooks/marker_auth.rs
@@ -52,7 +52,11 @@ fn secret_path() -> PathBuf {
 }
 
 /// Path to `~/.copilot/markers/` directory.
+/// Override with `SK_MARKERS_DIR` env var (used in tests to avoid writing to real dir).
 pub fn markers_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("SK_MARKERS_DIR") {
+        return PathBuf::from(dir);
+    }
     resolve_home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".copilot")
@@ -817,8 +821,13 @@ mod tests {
 
     #[test]
     fn create_tamper_marker_does_not_panic() {
-        // Best-effort — must not panic.
+        // Use a temp dir via SK_MARKERS_DIR to avoid writing to real ~/.copilot/markers/.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("SK_MARKERS_DIR", tmp.path());
         create_tamper_marker();
+        std::env::remove_var("SK_MARKERS_DIR");
+        // Marker file must exist in the temp dir (not the real markers dir).
+        assert!(tmp.path().join("hooks-tampered").exists());
     }
 
     // -----------------------------------------------------------------------

--- a/sk-rust/src/hooks/marker_auth.rs
+++ b/sk-rust/src/hooks/marker_auth.rs
@@ -52,8 +52,13 @@ fn secret_path() -> PathBuf {
 }
 
 /// Path to `~/.copilot/markers/` directory.
-/// Override with `SK_MARKERS_DIR` env var (used in tests to avoid writing to real dir).
+///
+/// In test builds the `SK_MARKERS_DIR` environment variable may override the
+/// directory so tests do not write to the real `~/.copilot/markers/`.  The
+/// override is **not** compiled into production binaries; setting
+/// `SK_MARKERS_DIR` at runtime has no effect outside of test builds.
 pub fn markers_dir() -> PathBuf {
+    #[cfg(any(test, feature = "test-helpers"))]
     if let Ok(dir) = std::env::var("SK_MARKERS_DIR") {
         return PathBuf::from(dir);
     }
@@ -431,6 +436,7 @@ pub fn create_tamper_marker() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::path::PathBuf;
 
     // -----------------------------------------------------------------------
@@ -820,6 +826,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn create_tamper_marker_does_not_panic() {
         // Use a temp dir via SK_MARKERS_DIR to avoid writing to real ~/.copilot/markers/.
         let tmp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Root Cause Fix

Prevents recurrence of the hooks-tampered incident that blocked all development operations.

### Root Cause
`create_tamper_marker_does_not_panic` test in `marker_auth.rs` called `create_tamper_marker()` without isolation. Since `markers_dir()` hardcoded `~/.copilot/markers/`, the test wrote a valid HMAC-signed `hooks-tampered` marker to the real filesystem and never cleaned it up. This permanently activated the hooks kill-switch.

### Fix
- Add `SK_MARKERS_DIR` env var override to `markers_dir()` so tests (and future callers) can redirect marker writes to a temp dir
- Update the test to use `tempfile::tempdir()` via `SK_MARKERS_DIR` and assert the marker lands in the temp dir, not `~/.copilot/markers/`

### Evidence
- `cargo test marker_auth`: 19 tests, all passing ✅
- `create_tamper_marker_does_not_panic` no longer touches the real filesystem ✅