### PR TITLE
fix: toolArgs→toolInput fallback in 4 hook rule files

### DIFF
--- a/hooks/rules/briefing.py
+++ b/hooks/rules/briefing.py
@@ -394,7 +394,7 @@ class EnforceBriefingRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        tool_args = data.get("toolArgs", {})
+        tool_args = data.get("toolArgs") or data.get("toolInput") or {}
         if not isinstance(tool_args, dict):
             tool_args = {}
 

--- a/hooks/rules/confidence_gate.py
+++ b/hooks/rules/confidence_gate.py
@@ -88,7 +88,7 @@ class ConfidenceGateRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        tool_args = data.get("toolArgs", {})
+        tool_args = data.get("toolArgs") or data.get("toolInput") or {}
         if not isinstance(tool_args, dict):
             tool_args = {}
 

--- a/hooks/rules/learn_gate.py
+++ b/hooks/rules/learn_gate.py
@@ -53,7 +53,7 @@ class EnforceLearnRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        tool_args = data.get("toolArgs", {})
+        tool_args = data.get("toolArgs") or data.get("toolInput") or {}
         if not isinstance(tool_args, dict):
             tool_args = {}
 

--- a/hooks/rules/tentacle.py
+++ b/hooks/rules/tentacle.py
@@ -148,7 +148,7 @@ class TentacleEnforceRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        tool_args = data.get("toolArgs", {})
+        tool_args = data.get("toolArgs") or data.get("toolInput") or {}
         if not isinstance(tool_args, dict):
             tool_args = {}
 
@@ -252,7 +252,7 @@ class TentacleSuggestRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        tool_args = data.get("toolArgs", {})
+        tool_args = data.get("toolArgs") or data.get("toolInput") or {}
         if not isinstance(tool_args, dict):
             tool_args = {}
 


### PR DESCRIPTION
## Problem

Copilot CLI ≥1.0.56 sends tool input under the key `toolInput`, not `toolArgs`. All 4 blocking hook rules read `data.get("toolArgs", {})` → always received `{}` → `command` was always `""" → guards (briefing enforcement, learn gate, confidence gate, tentacle enforce) never fired correctly, and the kill-switch recovery bypass never triggered.

## Fix

```python
# Before (broken in CLI ≥1.0.56):
tool_args = data.get("toolArgs", {})

# After:
tool_args = data.get("toolArgs") or data.get("toolInput") or {}
```

Applied to 5 call sites across 4 files:
- `hooks/rules/briefing.py:397`
- `hooks/rules/learn_gate.py:56`
- `hooks/rules/confidence_gate.py:91`
- `hooks/rules/tentacle.py:151, 255`

## Note on deployment

The installed copies in `~/.copilot/tools/hooks/rules/` have `schg` (system immutable) flags set by `--lock-hooks`. After merging this PR, re-deploy with:
```bash
sudo python3 install.py --unlock-hooks
python3 install.py
sudo python3 install.py --lock-hooks
```

## Evidence
- All 4 files pass `ast.parse()` ✅
- `python3 test_fixes.py`: all passed ✅
- `python3 test_security.py`: 13/13 passed ✅