### PR TITLE
fix(#940): merge toolArgs+toolInput so toolInput keys take precedence

### DIFF
--- a/hooks/rules/briefing.py
+++ b/hooks/rules/briefing.py
@@ -394,7 +394,9 @@ class EnforceBriefingRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        _ta = data.get("toolArgs"); _ti = data.get("toolInput"); tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
+        _ta = data.get("toolArgs")
+        _ti = data.get("toolInput")
+        tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
         if not isinstance(tool_args, dict):
             tool_args = {}
 

--- a/hooks/rules/briefing.py
+++ b/hooks/rules/briefing.py
@@ -394,7 +394,7 @@ class EnforceBriefingRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        tool_args = data.get("toolArgs", {})
+        _ta = data.get("toolArgs"); _ti = data.get("toolInput"); tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
         if not isinstance(tool_args, dict):
             tool_args = {}
 

--- a/hooks/rules/confidence_gate.py
+++ b/hooks/rules/confidence_gate.py
@@ -88,7 +88,7 @@ class ConfidenceGateRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        tool_args = data.get("toolArgs", {})
+        _ta = data.get("toolArgs"); _ti = data.get("toolInput"); tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
         if not isinstance(tool_args, dict):
             tool_args = {}
 

--- a/hooks/rules/confidence_gate.py
+++ b/hooks/rules/confidence_gate.py
@@ -88,7 +88,9 @@ class ConfidenceGateRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        _ta = data.get("toolArgs"); _ti = data.get("toolInput"); tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
+        _ta = data.get("toolArgs")
+        _ti = data.get("toolInput")
+        tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
         if not isinstance(tool_args, dict):
             tool_args = {}
 

--- a/hooks/rules/learn_gate.py
+++ b/hooks/rules/learn_gate.py
@@ -53,7 +53,7 @@ class EnforceLearnRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        tool_args = data.get("toolArgs", {})
+        _ta = data.get("toolArgs"); _ti = data.get("toolInput"); tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
         if not isinstance(tool_args, dict):
             tool_args = {}
 

--- a/hooks/rules/learn_gate.py
+++ b/hooks/rules/learn_gate.py
@@ -53,7 +53,9 @@ class EnforceLearnRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        _ta = data.get("toolArgs"); _ti = data.get("toolInput"); tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
+        _ta = data.get("toolArgs")
+        _ti = data.get("toolInput")
+        tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
         if not isinstance(tool_args, dict):
             tool_args = {}
 

--- a/hooks/rules/tentacle.py
+++ b/hooks/rules/tentacle.py
@@ -148,7 +148,9 @@ class TentacleEnforceRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        _ta = data.get("toolArgs"); _ti = data.get("toolInput"); tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
+        _ta = data.get("toolArgs")
+        _ti = data.get("toolInput")
+        tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
         if not isinstance(tool_args, dict):
             tool_args = {}
 
@@ -252,7 +254,9 @@ class TentacleSuggestRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        _ta = data.get("toolArgs"); _ti = data.get("toolInput"); tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
+        _ta = data.get("toolArgs")
+        _ti = data.get("toolInput")
+        tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
         if not isinstance(tool_args, dict):
             tool_args = {}
 

--- a/hooks/rules/tentacle.py
+++ b/hooks/rules/tentacle.py
@@ -148,7 +148,7 @@ class TentacleEnforceRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        tool_args = data.get("toolArgs", {})
+        _ta = data.get("toolArgs"); _ti = data.get("toolInput"); tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
         if not isinstance(tool_args, dict):
             tool_args = {}
 
@@ -252,7 +252,7 @@ class TentacleSuggestRule(Rule):
 
     def evaluate(self, event, data):
         tool_name = data.get("toolName", "")
-        tool_args = data.get("toolArgs", {})
+        _ta = data.get("toolArgs"); _ti = data.get("toolInput"); tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
         if not isinstance(tool_args, dict):
             tool_args = {}
 


### PR DESCRIPTION
Closes #940
Supersedes #937 (stronger fix)

## Problem

PR #937's `data.get("toolArgs") or data.get("toolInput")` is still wrong when CLI sends BOTH keys: if `toolArgs` is a non-empty metadata dict (truthy) and the real `command`/`path` is in `toolInput`, the expression picks the metadata dict and misses the actual payload.

## Fix

Merge both dicts so `toolInput` keys overwrite `toolArgs` keys:
```python
_ta = data.get("toolArgs"); _ti = data.get("toolInput")
tool_args = {**(_ta if isinstance(_ta, dict) else {}), **(_ti if isinstance(_ti, dict) else {})}
```

Applied at all 5 sites across 4 files (briefing.py, learn_gate.py, confidence_gate.py, tentacle.py ×2).

## Evidence
- All 4 files pass ast.parse() ✅
- test_fixes.py: all passed ✅
- test_security.py: 13/13 ✅