### PR TITLE
fix(#938): address PR#929 review comments on repo_map MCP tool

### DIFF
--- a/mcp-server.py
+++ b/mcp-server.py
@@ -1491,12 +1491,16 @@ def _run_repo_map(arguments: dict) -> dict:
     project_id = _optional_string(arguments, "project_id", max_length=200)
     fmt = arguments.get("format", "markdown")
     if not isinstance(fmt, str) or fmt not in ("markdown", "concise", "full"):
-        fmt = "markdown"
+        raise JsonRpcError(
+            JSONRPC_INVALID_PARAMS,
+            f"invalid format: {fmt!r}; accepted values: 'markdown', 'concise', 'full'",
+        )
     tokens = _optional_int(arguments, "tokens", default=4000, minimum=100, maximum=100000)
 
-    argv = [path, "--format", fmt, "--top", str(top), "--tokens", str(tokens)]
+    argv = ["--format", fmt, "--top", str(top), "--tokens", str(tokens)]
     if project_id:
         argv += ["--project-id", project_id]
+    argv += ["--", path]
 
     try:
         if repo_map_mod is None:

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -17188,8 +17188,8 @@ try:
     test("I922-9: repo_map wired in dispatch", 'name == "repo_map"' in _src922, "dispatch check")
 
     # I922-10: invoking returns an MCP-shaped envelope with content + structuredContent
-    import tempfile as _tempfile922
     import os as _os922
+    import tempfile as _tempfile922
 
     with _tempfile922.TemporaryDirectory() as _td922:
         _os922.path.join(_td922, "test.py")

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -17188,7 +17188,13 @@ try:
     test("I922-9: repo_map wired in dispatch", 'name == "repo_map"' in _src922, "dispatch check")
 
     # I922-10: invoking returns an MCP-shaped envelope with content + structuredContent
-    _res922 = _mcp922._run_repo_map({})
+    import tempfile as _tempfile922
+    import os as _os922
+
+    with _tempfile922.TemporaryDirectory() as _td922:
+        _os922.path.join(_td922, "test.py")
+        open(_os922.path.join(_td922, "test.py"), "w").write("def hello(): pass\n")
+        _res922 = _mcp922._run_repo_map({"path": _td922, "format": "markdown"})
     test(
         "I922-10: returns content + structuredContent envelope",
         isinstance(_res922, dict)


### PR DESCRIPTION
Closes #938

Addresses all 5 inline review comments from PR #929.

## Changes
- `_run_repo_map`: validates `format` param; raises `JsonRpcError(INVALID_PARAMS)` for unknown values
- `argv`: adds `'--'` separator before path argument to prevent leading-`-` dir name injection
- `test_mcp_server.py`: fixes stale tool-count comments at two locations
- `test_fixes.py I922-10`: uses `tempfile.TemporaryDirectory()` instead of repo root

## Evidence
- test_fixes.py: all passed ✅
- test_security.py: 13/13 ✅