### PR TITLE
fix(#942): cfg-gate SK_MARKERS_DIR and add serial_test

### DIFF
--- a/sk-rust/Cargo.toml
+++ b/sk-rust/Cargo.toml
@@ -13,6 +13,10 @@ native-embed   = ["dep:reqwest", "dep:tokio"]
 native-sync    = ["dep:reqwest", "dep:tokio"]
 native-watch   = ["dep:notify"]
 native-hooks   = []
+# Enables SK_MARKERS_DIR env override in markers_dir() for integration tests
+# that must not write to the real ~/.copilot/markers/ directory.
+# Never enable in production builds.
+test-helpers   = []
 # Wave-14/16/17/19: hot-path classification/write loop, deterministic relation
 # extraction, native residual helpers, and SEMANTIC_PROXIMITY (TF-IDF cosine).
 # In scope: knowledge_entries write, ke_fts sync, knowledge_relations for

--- a/sk-rust/src/hooks/marker_auth.rs
+++ b/sk-rust/src/hooks/marker_auth.rs
@@ -52,7 +52,16 @@ fn secret_path() -> PathBuf {
 }
 
 /// Path to `~/.copilot/markers/` directory.
+///
+/// In test builds the `SK_MARKERS_DIR` environment variable may override the
+/// directory so tests do not write to the real `~/.copilot/markers/`.  The
+/// override is **not** compiled into production binaries; setting
+/// `SK_MARKERS_DIR` at runtime has no effect outside of test builds.
 pub fn markers_dir() -> PathBuf {
+    #[cfg(any(test, feature = "test-helpers"))]
+    if let Ok(dir) = std::env::var("SK_MARKERS_DIR") {
+        return PathBuf::from(dir);
+    }
     resolve_home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".copilot")
@@ -427,6 +436,7 @@ pub fn create_tamper_marker() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::path::PathBuf;
 
     // -----------------------------------------------------------------------
@@ -816,9 +826,15 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn create_tamper_marker_does_not_panic() {
-        // Best-effort — must not panic.
+        // Use a temp dir via SK_MARKERS_DIR to avoid writing to real ~/.copilot/markers/.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("SK_MARKERS_DIR", tmp.path());
         create_tamper_marker();
+        std::env::remove_var("SK_MARKERS_DIR");
+        // Marker file must exist in the temp dir (not the real markers dir).
+        assert!(tmp.path().join("hooks-tampered").exists());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #942

## Changes
- Gate SK_MARKERS_DIR env read behind cfg(test) to prevent production bypass
- Add `test-helpers` feature to `Cargo.toml` for explicit opt-in by integration test harnesses
- Add `#[serial]` attribute to `create_tamper_marker_does_not_panic` to prevent parallel env-mutation races

## Evidence
```
cargo test marker_auth
running 38 tests
test result: ok. 38 passed; 0 failed; 0 ignored
```