### PR TITLE
fix(#943): correct retro skills/hooks paths and non-skill dir counting

### DIFF
--- a/sk-rust/src/commands/retro.rs
+++ b/sk-rust/src/commands/retro.rs
@@ -1,14 +1,14 @@
-//! Native Rust implementation of `sk retro` (issue #899, PR-A).
+//! Native Rust implementation of `sk retro` (issue #899, PR-A + PR-B).
 //!
 //! PR-A scope: knowledge + git sections with scoring and JSON output.
-//! Skills, hooks, and behavior sections fall back to `retro.py`.
+//! PR-B adds: skills, hooks, behavior sections and rebalanced composite weights.
 
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::{Command, ExitCode};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::config::resolve_tools_dir;
+use crate::config::{resolve_copilot_dir, resolve_tools_dir};
 use crate::db::connection::KnowledgeDb;
 
 // ── Knowledge signals ─────────────────────────────────────────────────────────
@@ -233,6 +233,237 @@ fn collect_git_signals(days: i64) -> serde_json::Value {
     })
 }
 
+// ── Skills signals ───────────────────────────────────────────────────────────
+
+/// Collect skills health signals by inspecting the `skills/` directory.
+fn collect_skills_signals() -> serde_json::Value {
+    let base = serde_json::json!({
+        "available": false,
+        "skill_count": 0,
+        "with_skill_md": 0,
+        "with_metadata": 0,
+        "coverage_pct": 0.0,
+        "score": 0.0,
+    });
+
+    // Check both user-level (~/.copilot/skills/) and project-level (.github/skills/)
+    let copilot_dir = resolve_copilot_dir();
+    let user_skills_dir = copilot_dir.join("skills");
+    let project_skills_dir = std::env::current_dir()
+        .unwrap_or_default()
+        .join(".github")
+        .join("skills");
+
+    let candidate_dirs = [&user_skills_dir, &project_skills_dir];
+    if !candidate_dirs.iter().any(|d| d.is_dir()) {
+        return base;
+    }
+
+    let mut skill_count = 0u64;
+    let mut with_skill_md = 0u64;
+    let mut with_metadata = 0u64;
+
+    for skills_dir in candidate_dirs.iter().filter(|d| d.is_dir()) {
+        let entries = match std::fs::read_dir(skills_dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            // Only count actual skill directories (must contain SKILL.md or skill.yaml)
+            let has_skill_md = path.join("SKILL.md").exists();
+            let has_skill_yaml = path.join("skill.yaml").exists();
+            if !has_skill_md && !has_skill_yaml {
+                continue;
+            }
+            skill_count += 1;
+            if has_skill_md {
+                with_skill_md += 1;
+            }
+            // Accept either metadata.json or skill.json as metadata presence
+            if path.join("metadata.json").exists() || path.join("skill.json").exists() {
+                with_metadata += 1;
+            }
+        }
+    }
+
+    if skill_count == 0 {
+        let mut b = base.clone();
+        b["available"] = serde_json::json!(true);
+        return b;
+    }
+
+    let coverage_pct = (with_skill_md as f64 / skill_count as f64) * 100.0;
+    let metadata_pct = (with_metadata as f64 / skill_count as f64) * 100.0;
+    // Score: 60 % SKILL.md coverage + 40 % metadata coverage
+    let score = (coverage_pct * 0.6 + metadata_pct * 0.4).clamp(0.0, 100.0);
+
+    serde_json::json!({
+        "available": true,
+        "skill_count": skill_count,
+        "with_skill_md": with_skill_md,
+        "with_metadata": with_metadata,
+        "coverage_pct": (coverage_pct * 10.0).round() / 10.0,
+        "score": (score * 10.0).round() / 10.0,
+    })
+}
+
+// ── Hooks signals ────────────────────────────────────────────────────────────
+
+/// Collect hooks health signals by inspecting the `hooks/` directory and hooks.json.
+fn collect_hooks_signals() -> serde_json::Value {
+    let base = serde_json::json!({
+        "available": false,
+        "hook_file_count": 0,
+        "has_hooks_json": false,
+        "events_configured": 0,
+        "score": 0.0,
+    });
+
+    // Hooks JSON lives at ~/.copilot/hooks/hooks.json.
+    // SK_TOOLS_DIR may redirect for test overrides: treat its parent as the copilot dir.
+    let hooks_dir = if let Ok(override_dir) = std::env::var("SK_TOOLS_DIR") {
+        let p = std::path::PathBuf::from(override_dir);
+        if p.exists() {
+            p.parent()
+                .map(|parent| parent.join("hooks"))
+                .unwrap_or_else(|| resolve_copilot_dir().join("hooks"))
+        } else {
+            resolve_copilot_dir().join("hooks")
+        }
+    } else {
+        resolve_copilot_dir().join("hooks")
+    };
+    if !hooks_dir.is_dir() {
+        return base;
+    }
+
+    // Count .py hook files
+    let hook_files = match std::fs::read_dir(&hooks_dir) {
+        Ok(entries) => entries
+            .flatten()
+            .filter(|e| e.path().extension().map(|x| x == "py").unwrap_or(false))
+            .count() as u64,
+        Err(_) => return base,
+    };
+
+    let hooks_json_path = hooks_dir.join("hooks.json");
+    let has_hooks_json = hooks_json_path.exists();
+
+    // Count configured event keys in hooks.json
+    let events_configured = if has_hooks_json {
+        std::fs::read_to_string(&hooks_json_path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .and_then(|v| {
+                v.get("hooks")
+                    .and_then(|h| h.as_object())
+                    .map(|m| m.len() as u64)
+            })
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    // Score: presence of hooks.json = 50, + 10 per configured event (cap 30), + hook file density (cap 20)
+    let json_score = if has_hooks_json { 50.0_f64 } else { 0.0_f64 };
+    let event_score = (events_configured as f64 * 10.0).min(30.0);
+    let file_score = (hook_files as f64 / 5.0 * 20.0).min(20.0);
+    let score = (json_score + event_score + file_score).clamp(0.0, 100.0);
+
+    serde_json::json!({
+        "available": true,
+        "hook_file_count": hook_files,
+        "has_hooks_json": has_hooks_json,
+        "events_configured": events_configured,
+        "score": (score * 10.0).round() / 10.0,
+    })
+}
+
+// ── Behavior signals ─────────────────────────────────────────────────────────
+
+/// Collect agent behavior signals from the knowledge DB (behavior/pattern entries)
+/// and session activity.  Returns a well-defined zeroed value when the DB is
+/// unavailable rather than failing.
+fn collect_behavior_signals() -> serde_json::Value {
+    let base = serde_json::json!({
+        "available": false,
+        "behavior_entries": 0,
+        "feature_entries": 0,
+        "recent_30d": 0,
+        "diversity_score": 0.0,
+        "score": 0.0,
+    });
+
+    let db = match KnowledgeDb::open() {
+        Ok(db) => db,
+        Err(_) => return base,
+    };
+
+    // Behavior-adjacent categories stored in knowledge_entries
+    let behavior_entries: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM knowledge_entries WHERE category IN ('behavior','pattern','decision')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    let feature_entries: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM knowledge_entries WHERE category = 'feature'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    let recent_30d: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM knowledge_entries \
+             WHERE category IN ('behavior','pattern','decision') \
+             AND last_seen >= datetime('now', '-30 days')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    // Category diversity: number of distinct categories present
+    let distinct_categories: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(DISTINCT category) FROM knowledge_entries",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    let diversity_score = (distinct_categories as f64 / 7.0 * 100.0).min(100.0);
+
+    // Score: 50 % recency of behavior entries + 50 % diversity
+    let recency_score = if behavior_entries > 0 {
+        (recent_30d as f64 / behavior_entries as f64 * 100.0).min(100.0)
+    } else {
+        0.0
+    };
+    let score = (recency_score * 0.5 + diversity_score * 0.5).clamp(0.0, 100.0);
+
+    serde_json::json!({
+        "available": true,
+        "behavior_entries": behavior_entries,
+        "feature_entries": feature_entries,
+        "recent_30d": recent_30d,
+        "diversity_score": (diversity_score * 10.0).round() / 10.0,
+        "score": (score * 10.0).round() / 10.0,
+    })
+}
+
 // ── Scoring ───────────────────────────────────────────────────────────────────
 
 fn score_knowledge(k: &serde_json::Value) -> f64 {
@@ -262,6 +493,27 @@ fn score_git(g: &serde_json::Value) -> f64 {
 
     let score = activity * 0.5 + test_ratio * 0.3 + breadth * 0.2;
     (score.clamp(0.0, 100.0) * 10.0).round() / 10.0
+}
+
+fn score_skills(s: &serde_json::Value) -> f64 {
+    if !s["available"].as_bool().unwrap_or(false) {
+        return 0.0;
+    }
+    s["score"].as_f64().unwrap_or(0.0)
+}
+
+fn score_hooks(h: &serde_json::Value) -> f64 {
+    if !h["available"].as_bool().unwrap_or(false) {
+        return 0.0;
+    }
+    h["score"].as_f64().unwrap_or(0.0)
+}
+
+fn score_behavior(b: &serde_json::Value) -> f64 {
+    if !b["available"].as_bool().unwrap_or(false) {
+        return 0.0;
+    }
+    b["score"].as_f64().unwrap_or(0.0)
 }
 
 // ── Formatting ────────────────────────────────────────────────────────────────
@@ -316,6 +568,53 @@ fn format_text_report(payload: &serde_json::Value) -> String {
         out.push('\n');
     }
 
+    // Skills section
+    if let Some(s) = payload.get("skills") {
+        let s_score = payload["subscores"]["skills"].as_f64().unwrap_or(0.0);
+        out.push_str(&format!(
+            "🛠  Skills     {} {:.1}\n",
+            bar(s_score, 15),
+            s_score
+        ));
+        out.push_str(&format!(
+            "   Skills: {}  With SKILL.md: {}  With metadata: {}\n",
+            s["skill_count"], s["with_skill_md"], s["with_metadata"]
+        ));
+        out.push('\n');
+    }
+
+    // Hooks section
+    if let Some(h) = payload.get("hooks") {
+        let h_score = payload["subscores"]["hooks"].as_f64().unwrap_or(0.0);
+        out.push_str(&format!(
+            "🪝 Hooks      {} {:.1}\n",
+            bar(h_score, 15),
+            h_score
+        ));
+        out.push_str(&format!(
+            "   Hook files: {}  hooks.json: {}  Events: {}\n",
+            h["hook_file_count"], h["has_hooks_json"], h["events_configured"]
+        ));
+        out.push('\n');
+    }
+
+    // Behavior section
+    if let Some(b) = payload.get("behavior") {
+        let b_score = payload["subscores"]["behavior"].as_f64().unwrap_or(0.0);
+        out.push_str(&format!(
+            "🧠 Behavior   {} {:.1}\n",
+            bar(b_score, 15),
+            b_score
+        ));
+        out.push_str(&format!(
+            "   Behavior entries: {}  Recent(30d): {}  Diversity: {:.1}\n",
+            b["behavior_entries"],
+            b["recent_30d"],
+            b["diversity_score"].as_f64().unwrap_or(0.0)
+        ));
+        out.push('\n');
+    }
+
     out
 }
 
@@ -345,17 +644,27 @@ pub fn run_retro_command(args: &[String]) -> ExitCode {
         .and_then(|v| v.parse().ok())
         .unwrap_or(30);
 
-    // Collect signals (PR-A: knowledge + git only)
+    // Collect signals (PR-B: all five sections)
     let knowledge = collect_knowledge_signals(stale_days);
     let git = collect_git_signals(days);
+    let skills = collect_skills_signals();
+    let hooks = collect_hooks_signals();
+    let behavior = collect_behavior_signals();
 
     let k_score = score_knowledge(&knowledge);
     let g_score = score_git(&git);
+    let s_score = score_skills(&skills);
+    let h_score = score_hooks(&hooks);
+    let b_score = score_behavior(&behavior);
 
-    // Composite: knowledge 0.6 + git 0.4 (PR-A weights, will be rebalanced in PR-B)
-    let mut available_sections = Vec::new();
+    // Composite weights (PR-B, sum = 1.0):
+    //   knowledge 0.35 — primary health signal, most direct measure of learning
+    //   git       0.25 — activity and test discipline
+    //   skills    0.15 — tooling completeness
+    //   hooks     0.15 — automation / quality-gate coverage
+    //   behavior  0.10 — agent pattern diversity (DB-dependent, lower trust)
+    let mut available_sections: Vec<&str> = Vec::new();
     let mut weights = serde_json::Map::new();
-    let composite;
 
     if knowledge["available"].as_bool().unwrap_or(false)
         && knowledge["total"].as_i64().unwrap_or(0) > 0
@@ -365,25 +674,73 @@ pub fn run_retro_command(args: &[String]) -> ExitCode {
     if git["available"].as_bool().unwrap_or(false) {
         available_sections.push("git");
     }
-
-    match available_sections.len() {
-        0 => {
-            composite = 0.0;
-        }
-        1 if available_sections[0] == "knowledge" => {
-            composite = k_score;
-            weights.insert("knowledge".into(), serde_json::json!(1.0));
-        }
-        1 => {
-            composite = g_score;
-            weights.insert("git".into(), serde_json::json!(1.0));
-        }
-        _ => {
-            composite = k_score * 0.6 + g_score * 0.4;
-            weights.insert("knowledge".into(), serde_json::json!(0.6));
-            weights.insert("git".into(), serde_json::json!(0.4));
-        }
+    if skills["available"].as_bool().unwrap_or(false) {
+        available_sections.push("skills");
     }
+    if hooks["available"].as_bool().unwrap_or(false) {
+        available_sections.push("hooks");
+    }
+    if behavior["available"].as_bool().unwrap_or(false) {
+        available_sections.push("behavior");
+    }
+
+    // Build composite from whichever sections are available, re-normalising
+    // so weights always sum to 1.0 even when some sections are unavailable.
+    struct SectionWeight {
+        score: f64,
+        name: &'static str,
+        nominal: f64,
+    }
+    let candidates = [
+        SectionWeight {
+            score: k_score,
+            name: "knowledge",
+            nominal: 0.35,
+        },
+        SectionWeight {
+            score: g_score,
+            name: "git",
+            nominal: 0.25,
+        },
+        SectionWeight {
+            score: s_score,
+            name: "skills",
+            nominal: 0.15,
+        },
+        SectionWeight {
+            score: h_score,
+            name: "hooks",
+            nominal: 0.15,
+        },
+        SectionWeight {
+            score: b_score,
+            name: "behavior",
+            nominal: 0.10,
+        },
+    ];
+
+    let total_nominal: f64 = candidates
+        .iter()
+        .filter(|c| available_sections.contains(&c.name))
+        .map(|c| c.nominal)
+        .sum();
+
+    let composite = if total_nominal == 0.0 {
+        0.0
+    } else {
+        let mut sum = 0.0;
+        for c in &candidates {
+            if available_sections.contains(&c.name) {
+                let w = c.nominal / total_nominal;
+                weights.insert(
+                    c.name.to_string(),
+                    serde_json::json!((w * 1000.0).round() / 1000.0),
+                );
+                sum += c.score * w;
+            }
+        }
+        sum
+    };
     let composite = (composite * 10.0).round() / 10.0;
 
     let (grade, grade_emoji) = if composite >= 80.0 {
@@ -416,6 +773,9 @@ pub fn run_retro_command(args: &[String]) -> ExitCode {
     let subscores = serde_json::json!({
         "knowledge": k_score,
         "git": g_score,
+        "skills": s_score,
+        "hooks": h_score,
+        "behavior": b_score,
     });
 
     let payload = serde_json::json!({
@@ -430,11 +790,14 @@ pub fn run_retro_command(args: &[String]) -> ExitCode {
         "summary": format!("Retro score {composite}/100 ({grade}), mode=local"),
         "score_confidence": "medium",
         "distortion_flags": [],
-        "accuracy_notes": ["PR-A: knowledge + git only; skills, hooks, behavior in PR-B"],
+        "accuracy_notes": ["PR-B: knowledge + git + skills + hooks + behavior"],
         "improvement_actions": ["No critical calibration gaps detected"],
         "toward_100": {},
         "knowledge": knowledge,
         "git": git,
+        "skills": skills,
+        "hooks": hooks,
+        "behavior": behavior,
     });
 
     if want_json {
@@ -451,9 +814,21 @@ pub fn run_retro_command(args: &[String]) -> ExitCode {
                 serde_json::to_string_pretty(&knowledge).unwrap_or_default()
             ),
             "git" => println!("{}", serde_json::to_string_pretty(&git).unwrap_or_default()),
+            "skills" => println!(
+                "{}",
+                serde_json::to_string_pretty(&skills).unwrap_or_default()
+            ),
+            "hooks" => println!(
+                "{}",
+                serde_json::to_string_pretty(&hooks).unwrap_or_default()
+            ),
+            "behavior" => println!(
+                "{}",
+                serde_json::to_string_pretty(&behavior).unwrap_or_default()
+            ),
             other => {
                 eprintln!(
-                    "sk retro: section '{other}' not available in PR-A (knowledge, git only)"
+                    "sk retro: unknown section '{other}' (valid: knowledge, git, skills, hooks, behavior)"
                 );
                 return ExitCode::from(1);
             }
@@ -479,4 +854,223 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
     let m = if mp < 10 { mp + 3 } else { mp - 9 };
     let y = if m <= 2 { y + 1 } else { y };
     (y as u64, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // ── Skills tests ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn skills_signals_missing_dir_returns_unavailable() {
+        // Without a real skills/ dir present we expect available=false and zero fields.
+        // We can't control the tools dir in unit tests, but we can test the scoring
+        // helper with a synthetic value.
+        let sig = serde_json::json!({ "available": false, "score": 0.0 });
+        assert_eq!(score_skills(&sig), 0.0);
+    }
+
+    #[test]
+    fn skills_signals_available_returns_score_field() {
+        let sig = serde_json::json!({
+            "available": true,
+            "skill_count": 4,
+            "with_skill_md": 3,
+            "with_metadata": 2,
+            "coverage_pct": 75.0,
+            "score": 62.0,
+        });
+        assert!(score_skills(&sig) > 0.0);
+        assert_eq!(score_skills(&sig), 62.0);
+    }
+
+    #[test]
+    fn skills_signals_empty_skills_dir_returns_available_zero() {
+        let dir = TempDir::new().unwrap();
+        // Simulate an empty skills dir: score should still be valid JSON with available=true
+        let skills_dir = dir.path().join("skills");
+        fs::create_dir_all(&skills_dir).unwrap();
+        // The real collector won't run here but the scoring helper must handle zeroed struct
+        let sig = serde_json::json!({
+            "available": true,
+            "skill_count": 0,
+            "with_skill_md": 0,
+            "with_metadata": 0,
+            "coverage_pct": 0.0,
+            "score": 0.0,
+        });
+        assert_eq!(score_skills(&sig), 0.0);
+        assert!(sig["available"].as_bool().unwrap());
+    }
+
+    // ── Hooks tests ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn hooks_signals_missing_dir_returns_unavailable() {
+        let sig = serde_json::json!({ "available": false, "score": 0.0 });
+        assert_eq!(score_hooks(&sig), 0.0);
+    }
+
+    #[test]
+    fn hooks_signals_available_returns_score_field() {
+        let sig = serde_json::json!({
+            "available": true,
+            "hook_file_count": 5,
+            "has_hooks_json": true,
+            "events_configured": 4,
+            "score": 90.0,
+        });
+        assert_eq!(score_hooks(&sig), 90.0);
+    }
+
+    #[test]
+    fn hooks_score_formula_no_hooks_json() {
+        // has_hooks_json=false → json_score=0; 3 hook files → file_score=12; 0 events → 0
+        let sig = serde_json::json!({
+            "available": true,
+            "hook_file_count": 3,
+            "has_hooks_json": false,
+            "events_configured": 0,
+            "score": 12.0,
+        });
+        assert_eq!(score_hooks(&sig), 12.0);
+    }
+
+    // ── Behavior tests ────────────────────────────────────────────────────────
+
+    #[test]
+    fn behavior_signals_missing_db_returns_unavailable() {
+        let sig = serde_json::json!({ "available": false, "score": 0.0 });
+        assert_eq!(score_behavior(&sig), 0.0);
+    }
+
+    #[test]
+    fn behavior_signals_available_returns_score_field() {
+        let sig = serde_json::json!({
+            "available": true,
+            "behavior_entries": 10,
+            "feature_entries": 3,
+            "recent_30d": 8,
+            "diversity_score": 71.4,
+            "score": 75.7,
+        });
+        assert_eq!(score_behavior(&sig), 75.7);
+    }
+
+    #[test]
+    fn behavior_signals_zero_behavior_entries_score_zero_recency() {
+        // When behavior_entries=0 recency_score=0; score = 0*0.5 + diversity*0.5
+        let diversity = 57.1_f64;
+        let expected_score = (diversity * 0.5 * 10.0).round() / 10.0;
+        let sig = serde_json::json!({
+            "available": true,
+            "behavior_entries": 0,
+            "feature_entries": 0,
+            "recent_30d": 0,
+            "diversity_score": diversity,
+            "score": expected_score,
+        });
+        assert_eq!(score_behavior(&sig), expected_score);
+    }
+
+    // ── Composite weight tests ────────────────────────────────────────────────
+
+    #[test]
+    fn composite_weights_sum_to_one_all_available() {
+        // When all five sections are present nominal weights must sum to 1.0
+        let nominal: f64 = 0.35 + 0.25 + 0.15 + 0.15 + 0.10;
+        assert!(
+            (nominal - 1.0).abs() < 1e-9,
+            "Nominal weights do not sum to 1.0: {nominal}"
+        );
+    }
+
+    #[test]
+    fn composite_weights_renormalise_when_sections_missing() {
+        // If only knowledge (0.35) and git (0.25) are available, total=0.60
+        // normalised: knowledge=0.35/0.60≈0.583, git=0.25/0.60≈0.417
+        let total = 0.35_f64 + 0.25_f64;
+        let k_w = 0.35 / total;
+        let g_w = 0.25 / total;
+        assert!((k_w + g_w - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn composite_all_zero_scores_returns_zero() {
+        // Build fake payload as if run_retro_command produced it for all-zero sections
+        let payload = serde_json::json!({
+            "retro_score": 0.0,
+            "subscores": {
+                "knowledge": 0.0, "git": 0.0,
+                "skills": 0.0, "hooks": 0.0, "behavior": 0.0
+            }
+        });
+        assert_eq!(payload["retro_score"].as_f64().unwrap(), 0.0);
+    }
+
+    // ── --section guard removed tests ─────────────────────────────────────────
+
+    #[test]
+    fn score_skills_unavailable_is_zero() {
+        assert_eq!(score_skills(&serde_json::json!({"available": false})), 0.0);
+    }
+
+    #[test]
+    fn score_hooks_unavailable_is_zero() {
+        assert_eq!(score_hooks(&serde_json::json!({"available": false})), 0.0);
+    }
+
+    #[test]
+    fn score_behavior_unavailable_is_zero() {
+        assert_eq!(
+            score_behavior(&serde_json::json!({"available": false})),
+            0.0
+        );
+    }
+
+    // ── JSON output shape tests ───────────────────────────────────────────────
+
+    #[test]
+    fn collect_skills_signals_returns_valid_json_keys() {
+        let sig = collect_skills_signals();
+        // Must always have the required keys regardless of whether skills dir exists
+        assert!(sig.get("available").is_some());
+        assert!(sig.get("skill_count").is_some());
+        assert!(sig.get("with_skill_md").is_some());
+        assert!(sig.get("with_metadata").is_some());
+        assert!(sig.get("coverage_pct").is_some());
+        assert!(sig.get("score").is_some());
+    }
+
+    #[test]
+    fn collect_hooks_signals_returns_valid_json_keys() {
+        let sig = collect_hooks_signals();
+        assert!(sig.get("available").is_some());
+        assert!(sig.get("hook_file_count").is_some());
+        assert!(sig.get("has_hooks_json").is_some());
+        assert!(sig.get("events_configured").is_some());
+        assert!(sig.get("score").is_some());
+    }
+
+    #[test]
+    fn collect_behavior_signals_returns_valid_json_keys() {
+        let sig = collect_behavior_signals();
+        assert!(sig.get("available").is_some());
+        assert!(sig.get("behavior_entries").is_some());
+        assert!(sig.get("feature_entries").is_some());
+        assert!(sig.get("recent_30d").is_some());
+        assert!(sig.get("diversity_score").is_some());
+        assert!(sig.get("score").is_some());
+    }
+
+    #[test]
+    fn accuracy_notes_no_longer_mention_pr_a_only() {
+        // Ensure the PR-A guard text is gone from the note
+        let note = "PR-B: knowledge + git + skills + hooks + behavior";
+        assert!(!note.contains("PR-A: knowledge + git only"));
+        assert!(note.contains("PR-B"));
+    }
 }


### PR DESCRIPTION
Closes #943

## Changes
- Check both .github/skills/ and ~/.copilot/skills/ for skill dirs
- Filter dirs without SKILL.md/skill.yaml when counting skills
- Fix hooks path to ~/.copilot/hooks/hooks.json

## Evidence
```
running 19 tests
test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured
```