### PR TITLE
feat(statusline): daily model-price refresh via auto-update; cached overlay

### DIFF
--- a/auto-update-tools.py
+++ b/auto-update-tools.py
@@ -29,6 +29,7 @@ Usage:
     python auto-update-tools.py --skill-metrics-status  # Show skill outcome metrics
     python auto-update-tools.py --skill-metrics-audit   # Run skill metrics audit
     python auto-update-tools.py --list-coverage  # Print all tracked paths/patterns
+    python auto-update-tools.py --refresh-prices # Fetch model pricing → price-cache.json
     python auto-update-tools.py --skip-pull    # Run pipeline without pulling (used by self-exec)
 """
 
@@ -36,6 +37,7 @@ import contextlib
 import json
 import os
 import platform
+import re
 import shutil
 import signal
 import subprocess
@@ -66,6 +68,13 @@ CLONE_URL = f"https://github.com/{SOURCE_REPO}.git"
 COOLDOWN = 86400  # 24 hours
 STATE_FILE = TOOLS_DIR / ".update-state.json"
 MANIFEST_FILE = TOOLS_DIR / ".update-manifest.json"
+
+# Model pricing: refreshed ~daily (gated by COOLDOWN) from the public github/docs
+# pricing YAML and written to price-cache.json, which statusline.py reads to
+# estimate session cost.  Fail-open: errors leave the previous cache in place.
+PRICING_REPO = "github/docs"
+PRICING_YAML_PATH = "data/tables/copilot/models-and-pricing.yml"
+PRICE_CACHE_FILE = HOME / ".copilot" / "markers" / "price-cache.json"
 
 # Registry written by setup-project.py and install.py --deploy-skill; records
 # every project that has received a skill deployment so that auto-update can
@@ -2344,6 +2353,132 @@ def check_cooldown() -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Model pricing refresh (daily) — github/docs pricing YAML → price-cache.json
+# ---------------------------------------------------------------------------
+def _price_to_float(raw) -> float | None:
+    """Parse a '$1.75'-style price into a float; return None when not numeric."""
+    if raw is None:
+        return None
+    s = str(raw).strip().lstrip("$").replace(",", "")
+    try:
+        return float(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pricing_model_to_id(name: str) -> str:
+    """Map a YAML display name ('Claude Opus 4.8') to a model id ('claude-opus-4.8')."""
+    mid = str(name).strip().strip("'\"").lower()
+    mid = re.sub(r"\s+", "-", mid)
+    mid = re.sub(r"-+", "-", mid).strip("-")
+    return mid
+
+
+def parse_pricing_yaml(text: str) -> dict:
+    """Parse github/docs models-and-pricing.yml into {model_id: rate} dict.
+
+    Hand-rolled parser (the repo is pure-stdlib, no PyYAML).  The source is a flat
+    list of records, each starting with '- model:' followed by indented
+    'key: value' lines.  Several models appear twice (a Default tier and a
+    Long-context tier that collapse to the same id); we explicitly prefer the
+    Default tier rather than relying on source ordering, so an upstream reorder
+    can never silently select the higher long-context price.  A model that only
+    ever appears as long-context is still kept (better than dropping it).
+    """
+    rates: dict = {}
+    is_long_stored: dict = {}
+    cur: dict | None = None
+
+    def _is_long_context(rec) -> bool:
+        tier = str(rec.get("tier", "")).strip().lower()
+        thr = str(rec.get("threshold", "")).strip()
+        return ("long" in tier) or thr.startswith(">")
+
+    def _flush(rec) -> None:
+        if not rec:
+            return
+        mid = _pricing_model_to_id(rec.get("model", ""))
+        if not mid:
+            return
+        inp = _price_to_float(rec.get("input"))
+        cin = _price_to_float(rec.get("cached_input"))
+        out = _price_to_float(rec.get("output"))
+        if inp is None or cin is None or out is None:
+            return
+        long_ctx = _is_long_context(rec)
+        # Keep an existing entry unless it is a long-context tier being superseded
+        # by a Default one (Default always wins, regardless of source order).
+        if mid in rates and not (is_long_stored.get(mid) and not long_ctx):
+            return
+        rate = {"input": inp, "cached_input": cin, "output": out}
+        cw = _price_to_float(rec.get("cache_write"))
+        if cw is not None:
+            rate["cache_write"] = cw
+        rates[mid] = rate
+        is_long_stored[mid] = long_ctx
+
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- model:"):
+            _flush(cur)
+            cur = {"model": stripped[len("- model:") :].strip().strip("'\"")}
+        elif cur is not None and ":" in stripped:
+            key, _, val = stripped.partition(":")
+            cur[key.strip()] = val.strip().strip("'\"")
+    _flush(cur)
+    return rates
+
+
+def refresh_model_prices() -> bool:
+    """Fetch the latest model pricing YAML and write price-cache.json.
+
+    Runs ~daily (gated by the update cooldown) and is read by statusline.py to
+    estimate session cost.  Fail-open: on any error the previous cache (or the
+    statusline's hardcoded table) remains in effect.
+    """
+    try:
+        if shutil.which("gh") is None:
+            log("Price refresh: gh CLI not found; keeping existing price cache.")
+            return False
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{PRICING_REPO}/contents/{PRICING_YAML_PATH}",
+                "-H",
+                "Accept: application/vnd.github.raw",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            warn("Price refresh: gh fetch failed; keeping existing price cache.")
+            return False
+        rates = parse_pricing_yaml(result.stdout)
+        if not rates:
+            warn("Price refresh: parsed 0 rates; keeping existing price cache.")
+            return False
+        payload = {
+            "_ts": int(time.time()),
+            "source": f"{PRICING_REPO}/{PRICING_YAML_PATH}",
+            "model_count": len(rates),
+            "rates": rates,
+        }
+        PRICE_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write_text(PRICE_CACHE_FILE, json.dumps(payload, indent=2))
+        ok(f"Price cache refreshed: {len(rates)} models → {PRICE_CACHE_FILE.name}")
+        return True
+    except Exception as exc:
+        warn(f"Price refresh error (non-fatal): {exc}")
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 def main():
@@ -2409,6 +2544,8 @@ def main():
         elif arg == "--list-coverage":
             list_coverage()
             return
+        elif arg == "--refresh-prices":
+            raise SystemExit(0 if refresh_model_prices() else 1)
         elif arg == "--heal-copilot-cli":
             _issues = _try_healer_check()
             if _issues is None:
@@ -2490,6 +2627,10 @@ def main():
         else:
             # Even if no update, ensure post-merge hook exists
             ensure_post_merge_hook()
+
+        # Refresh model pricing table (daily; independent of repo changes so it
+        # tracks GitHub price updates even when the tools repo itself is unchanged).
+        refresh_model_prices()
 
 
 if __name__ == "__main__":

--- a/auto-update-tools.py
+++ b/auto-update-tools.py
@@ -2622,15 +2622,17 @@ def main():
 
         # Pull
         updated, old_sha, new_sha = pull_latest()
+
+        # Refresh model pricing table (daily; independent of repo changes).  Done
+        # BEFORE post_pull_pipeline() because that may self-exec (os.execl/Popen)
+        # when auto-update-tools.py itself changed and never return here.
+        refresh_model_prices()
+
         if updated:
             post_pull_pipeline(old_sha, new_sha)
         else:
             # Even if no update, ensure post-merge hook exists
             ensure_post_merge_hook()
-
-        # Refresh model pricing table (daily; independent of repo changes so it
-        # tracks GitHub price updates even when the tools repo itself is unchanged).
-        refresh_model_prices()
 
 
 if __name__ == "__main__":

--- a/statusline.py
+++ b/statusline.py
@@ -55,7 +55,15 @@ AI_CREDIT_USD = 0.01  # 1 AI Credit = $0.01 USD (from June 2026)
 PREMIUM_REQUEST_USD = 0.04  # $0.04 per overage premium request (current billing)
 MARKERS_DIR = Path.home() / ".copilot" / "markers"
 QUOTA_CACHE_FILE = MARKERS_DIR / "quota-cache.json"
+QUOTA_CACHE_FILE = MARKERS_DIR / "quota-cache.json"
 QUOTA_CACHE_TTL = 300  # seconds between quota API refreshes
+# Optional per-model rate overrides, refreshed ~daily by auto-update-tools.py from
+# the github/docs pricing YAML.  Read-only here: the statusline never makes a
+# network call; it falls back to the hardcoded _MODEL_RATES when this is absent.
+PRICE_CACHE_FILE = MARKERS_DIR / "price-cache.json"
+# Ignore a price cache older than this (s).  Guards against a stalled updater
+# letting a months-old cache override a newer hardcoded _MODEL_RATES forever.
+PRICE_CACHE_MAX_AGE_S = 30 * 24 * 3600  # 30 days
 
 # Per-model rates in USD per 1M tokens (effective with AI Credit billing June 2026).
 # Source: github/docs:data/tables/copilot/models-and-pricing.yml (SHA 00152a3d)
@@ -208,15 +216,68 @@ def _normalize_model(raw: str) -> str:
     return raw.lower().strip()
 
 
+# Per-process cache of price-cache.json overrides (None = not yet loaded).
+_PRICE_OVERRIDES: dict[str, dict[str, float]] | None = None
+# Timestamp (_ts) of the loaded price cache, for staleness display.
+_PRICE_CACHE_TS: float | None = None
+
+
+def _load_price_overrides() -> dict[str, dict[str, float]]:
+    """Return per-model rate overrides from price-cache.json (cached per process).
+
+    Written daily by auto-update-tools.py.  A cache with a missing/invalid or
+    stale (> PRICE_CACHE_MAX_AGE_S) timestamp is ignored so it can never override
+    a newer hardcoded _MODEL_RATES indefinitely.  Fail-open: any error yields an
+    empty dict and the caller falls back to the hardcoded table.
+    """
+    global _PRICE_OVERRIDES, _PRICE_CACHE_TS
+    if _PRICE_OVERRIDES is not None:
+        return _PRICE_OVERRIDES
+    overrides: dict[str, dict[str, float]] = {}
+    try:
+        if PRICE_CACHE_FILE.exists():
+            obj = json.loads(PRICE_CACHE_FILE.read_text(encoding="utf-8"))
+            ts = obj.get("_ts") if isinstance(obj, dict) else None
+            rates = obj.get("rates") if isinstance(obj, dict) else None
+            if isinstance(ts, (int, float)):
+                _PRICE_CACHE_TS = float(ts)  # recorded even when stale, for the status line
+            fresh = isinstance(ts, (int, float)) and (time.time() - ts) <= PRICE_CACHE_MAX_AGE_S
+            if fresh and isinstance(rates, dict):
+                for key, val in rates.items():
+                    if isinstance(val, dict) and all(
+                        isinstance(val.get(k), (int, float)) for k in ("input", "cached_input", "output")
+                    ):
+                        rate = {
+                            "input": float(val["input"]),
+                            "cached_input": float(val["cached_input"]),
+                            "output": float(val["output"]),
+                        }
+                        if isinstance(val.get("cache_write"), (int, float)):
+                            rate["cache_write"] = float(val["cache_write"])
+                        overrides[_normalize_model(key)] = rate
+    except Exception:
+        overrides = {}
+    _PRICE_OVERRIDES = overrides
+    return overrides
+
+
 def _get_rate(model_id: str) -> dict[str, float]:
-    """Return per-token rates for *model_id*; fall back to claude-sonnet-4.6."""
+    """Return per-token rates for *model_id*.
+
+    Prefers daily-refreshed overrides from price-cache.json, then the hardcoded
+    _MODEL_RATES, then a claude-sonnet-4.6 fallback.
+    """
     mid = _normalize_model(model_id)
+    overrides = _load_price_overrides()
+    if mid in overrides:
+        return overrides[mid]
     if mid in _MODEL_RATES:
         return _MODEL_RATES[mid]
-    # Fuzzy: find a key that is a substring of mid or vice-versa
-    for key, rate in _MODEL_RATES.items():
-        if key in mid or mid in key:
-            return rate
+    # Fuzzy: find a key that is a substring of mid or vice-versa (overrides first)
+    for source in (overrides, _MODEL_RATES):
+        for key, rate in source.items():
+            if key in mid or mid in key:
+                return rate
     return _MODEL_RATES["claude-sonnet-4.6"]
 
 
@@ -531,7 +592,24 @@ def _print_status_table(force_quota: bool = False) -> None:
 
     print()
     print(f"  {_ansi(DIM)}Cost note: $* = estimated from token counts × model rates.{_ansi(RST)}")
-    print(f"  {_ansi(DIM)}Models from github/docs pricing YAML. Not exact GitHub billing.{_ansi(RST)}")
+    _ov = _load_price_overrides()
+    if _ov:
+        age = ""
+        if _PRICE_CACHE_TS:
+            days = int((time.time() - _PRICE_CACHE_TS) / 86400)
+            age = f", {days}d old"
+        print(
+            f"  {_ansi(DIM)}Prices: {len(_ov)} models from price-cache.json{age}. Not exact GitHub billing.{_ansi(RST)}"
+        )
+    elif _PRICE_CACHE_TS:
+        days = int((time.time() - _PRICE_CACHE_TS) / 86400)
+        print(
+            f"  {_ansi(DIM)}Prices: built-in table (cache {days}d old, stale — run 'sk update'). Not exact GitHub billing.{_ansi(RST)}"
+        )
+    else:
+        print(
+            f"  {_ansi(DIM)}Prices: built-in table (run 'sk update' to fetch latest). Not exact GitHub billing.{_ansi(RST)}"
+        )
     print()
 
 

--- a/statusline.py
+++ b/statusline.py
@@ -595,14 +595,14 @@ def _print_status_table(force_quota: bool = False) -> None:
     _ov = _load_price_overrides()
     if _ov:
         age = ""
-        if _PRICE_CACHE_TS:
-            days = int((time.time() - _PRICE_CACHE_TS) / 86400)
+        if _PRICE_CACHE_TS is not None:
+            days = max(0, int((time.time() - _PRICE_CACHE_TS) / 86400))
             age = f", {days}d old"
         print(
             f"  {_ansi(DIM)}Prices: {len(_ov)} models from price-cache.json{age}. Not exact GitHub billing.{_ansi(RST)}"
         )
-    elif _PRICE_CACHE_TS:
-        days = int((time.time() - _PRICE_CACHE_TS) / 86400)
+    elif _PRICE_CACHE_TS is not None:
+        days = max(0, int((time.time() - _PRICE_CACHE_TS) / 86400))
         print(
             f"  {_ansi(DIM)}Prices: built-in table (cache {days}d old, stale — run 'sk update'). Not exact GitHub billing.{_ansi(RST)}"
         )

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -1375,6 +1375,107 @@ with tempfile.TemporaryDirectory(prefix="global-skills-test-") as _gs_tmp:
         sys.path[:] = _orig_gs_sys_path
 
 
+# ─── Model Pricing Refresh (Pp1–Pp7) ─────────────────────────────────────────
+# Offline tests for parse_pricing_yaml + --refresh-prices CLI wiring (PR #968 review).
+# No network: the parser is pure, and the CLI test stubs refresh_model_prices().
+print("\n💲 Model Pricing Refresh Tests (Pp)")
+
+_PRICING_YAML_SAMPLE = """\
+# OpenAI
+- model: 'GPT-5 mini'
+  provider: openai
+  threshold: Not applicable
+  tier: Default
+  input: $0.25
+  cached_input: $0.025
+  output: $2.00
+
+- model: GPT-5.4
+  provider: openai
+  threshold: '> 272K'
+  tier: Long context
+  input: $5.00
+  cached_input: $0.50
+  output: $22.50
+
+- model: GPT-5.4
+  provider: openai
+  tier: Default
+  input: $2.50
+  cached_input: $0.25
+  output: $15.00
+
+# Anthropic
+- model: Claude Opus 4.8
+  provider: anthropic
+  input: $5.00
+  cached_input: $0.50
+  output: $25.00
+  cache_write: $6.25
+"""
+
+_pp_rates = _autoupdate_mod.parse_pricing_yaml(_PRICING_YAML_SAMPLE)
+
+test(
+    "Pp1: parses all distinct model ids",
+    set(_pp_rates) == {"gpt-5-mini", "gpt-5.4", "claude-opus-4.8"},
+    f"ids: {sorted(_pp_rates)}",
+)
+test(
+    "Pp2: display name -> id mapping (spaces/quotes lower-cased, spaces -> hyphens)",
+    "gpt-5-mini" in _pp_rates and "claude-opus-4.8" in _pp_rates,
+    f"ids: {sorted(_pp_rates)}",
+)
+test(
+    "Pp3: $-prefixed prices parsed to floats",
+    _pp_rates["gpt-5-mini"] == {"input": 0.25, "cached_input": 0.025, "output": 2.0},
+    f"gpt-5-mini: {_pp_rates.get('gpt-5-mini')}",
+)
+test(
+    "Pp4: Default tier preferred over Long-context regardless of source order",
+    _pp_rates["gpt-5.4"]["input"] == 2.5 and _pp_rates["gpt-5.4"]["output"] == 15.0,
+    f"gpt-5.4 (want input 2.5/output 15.0): {_pp_rates.get('gpt-5.4')}",
+)
+test(
+    "Pp5: Anthropic cache_write captured",
+    _pp_rates["claude-opus-4.8"].get("cache_write") == 6.25,
+    f"opus-4.8: {_pp_rates.get('claude-opus-4.8')}",
+)
+test(
+    "Pp6: garbage / empty input fails open to empty dict",
+    _autoupdate_mod.parse_pricing_yaml("not a record\njust: text\n") == {}
+    and _autoupdate_mod.parse_pricing_yaml("") == {},
+    "non-record input did not yield empty dict",
+)
+
+# Pp7: --refresh-prices CLI flag stays wired (stub refresh_model_prices, no network).
+_pp_called = {"n": 0}
+_pp_orig_refresh = _autoupdate_mod.refresh_model_prices
+_pp_orig_argv = sys.argv[:]
+_pp_exit = None
+try:
+
+    def _pp_stub_refresh():
+        _pp_called["n"] += 1
+        return True
+
+    _autoupdate_mod.refresh_model_prices = _pp_stub_refresh
+    sys.argv = ["auto-update-tools.py", "--refresh-prices"]
+    try:
+        _autoupdate_mod.main()
+    except SystemExit as _pp_e:
+        _pp_exit = _pp_e.code
+finally:
+    _autoupdate_mod.refresh_model_prices = _pp_orig_refresh
+    sys.argv = _pp_orig_argv
+
+test(
+    "Pp7: --refresh-prices invokes refresh_model_prices and exits 0",
+    _pp_called["n"] == 1 and _pp_exit == 0,
+    f"called={_pp_called['n']} exit={_pp_exit}",
+)
+
+
 # ─── Summary ────────────────────────────────────────────────────────────
 
 # ─── launchd Restart / Doctor Semantics (Ld1–Ld4) ────────────────────────────


### PR DESCRIPTION
Adds a daily model-price refresh so the statusline cost estimate tracks GitHub published prices automatically, with no network call in the render hot path. The updater fetches the pricing table once per day and writes a small cache file that the statusline reads as an overlay over its built-in table (cache, then built-in, then a safe fallback). Hardened per Opus review: Default pricing tier is preferred over long-context regardless of source order; a cache older than 30 days is ignored so a stalled updater cannot mask a newer built-in table; fetched bytes are decoded as UTF-8; everything is fail-open. Verified: 22 models cached, security 13/13, fixes 272/272, lint and format clean. Full detail is in the commit message.