### PR TITLE
fix(hooks): session-state exemption checks filePath key for Create tool

### DIFF
--- a/hooks/enforce-tentacle.py
+++ b/hooks/enforce-tentacle.py
@@ -219,8 +219,13 @@ def main():
 
     # FP-1: session-state files (e.g. /research outputs) are not project source;
     # skip threshold check so create/edit to these paths is never blocked.
+    # Note: Create tool sends path as filePath in toolInput/input, not "path" in toolArgs.
     if tool_name in ("edit", "create"):
-        file_path = (data.get("toolArgs") or {}).get("path", "")
+        file_path = (
+            (data.get("toolArgs") or {}).get("path", "")
+            or (data.get("toolInput") or {}).get("filePath", "")
+            or (data.get("input") or {}).get("filePath", "")
+        )
         _ss_abs = str(Path.home() / ".copilot" / "session-state")
         if file_path and (file_path.startswith(_ss_abs) or ".copilot/session-state" in file_path):
             return

--- a/hooks/enforce-tentacle.py
+++ b/hooks/enforce-tentacle.py
@@ -223,6 +223,7 @@ def main():
     if tool_name in ("edit", "create"):
         file_path = (
             (data.get("toolArgs") or {}).get("path", "")
+            or (data.get("toolArgs") or {}).get("filePath", "")
             or (data.get("toolInput") or {}).get("filePath", "")
             or (data.get("input") or {}).get("filePath", "")
         )

--- a/hooks/rules/tentacle.py
+++ b/hooks/rules/tentacle.py
@@ -204,8 +204,13 @@ class TentacleEnforceRule(Rule):
 
         # FP-1: session-state files (e.g. /research outputs) are not project source;
         # skip threshold check so create/edit to these paths is never blocked.
+        # Note: Create tool sends path as filePath in toolInput/input, not "path" in toolArgs.
         if tool_name in ("edit", "create"):
-            file_path = tool_args.get("path", "")
+            file_path = (
+                tool_args.get("path", "")
+                or tool_args.get("filePath", "")
+                or (data.get("input") or {}).get("filePath", "")
+            )
             if file_path and is_session_path(file_path):
                 return None
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -3614,6 +3614,46 @@ try:
         f"Expected deny output, got: {_out19e_deny!r}",
     )
 
+    # FP-1 parity: standalone create to session-state via toolInput.filePath
+    def _run_standalone19e_raw(payload):
+        import sys as _sys
+
+        _old_in, _old_out = _sys.stdin, _sys.stdout
+        _sys.stdin = _io19e.StringIO(payload)
+        _sys.stdout = _io19e.StringIO()
+        try:
+            _mod19e.main()
+            return _sys.stdout.getvalue().strip()
+        finally:
+            _sys.stdin, _sys.stdout = _old_in, _old_out
+
+    _out19e_toolInput = _run_standalone19e_raw(
+        json.dumps({"toolName": "create", "toolInput": {"filePath": _ss_create19e}})
+    )
+    test(
+        "FP-1 parity: standalone create to session-state via toolInput.filePath → no output",
+        _out19e_toolInput == "",
+        f"Expected no output (allow), got: {_out19e_toolInput!r}",
+    )
+
+    _out19e_input = _run_standalone19e_raw(
+        json.dumps({"toolName": "create", "input": {"filePath": _ss_create19e}})
+    )
+    test(
+        "FP-1 parity: standalone create to session-state via input.filePath → no output",
+        _out19e_input == "",
+        f"Expected no output (allow), got: {_out19e_input!r}",
+    )
+
+    _out19e_toolArgs_filePath = _run_standalone19e_raw(
+        json.dumps({"toolName": "create", "toolArgs": {"filePath": _ss_create19e}})
+    )
+    test(
+        "FP-1 parity: standalone create to session-state via toolArgs.filePath → no output",
+        _out19e_toolArgs_filePath == "",
+        f"Expected no output (allow), got: {_out19e_toolArgs_filePath!r}",
+    )
+
     test("Section 19e standalone parity tests ran without exception", True)
 except Exception as _e19e:
     test("Section 19e standalone parity tests ran without exception", False, str(_e19e))

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -3420,7 +3420,7 @@ try:
         f"Expected None, got: {_r19_create!r}",
     )
 
-    # FP-1: edit to session-state path must be allowed
+    # FP-1: edit to session-state path (toolArgs.path) must be allowed
     _r19_edit = _ter19.evaluate(
         "preToolUse",
         {
@@ -3432,6 +3432,34 @@ try:
         "FP-1: TentacleEnforceRule edit to session-state → None (allowed)",
         _r19_edit is None,
         f"Expected None, got: {_r19_edit!r}",
+    )
+
+    # FP-1: create to session-state via toolInput.filePath must be allowed
+    _r19_create_input = _ter19.evaluate(
+        "preToolUse",
+        {
+            "toolName": "create",
+            "toolInput": {"filePath": _ss_create_path19},
+        },
+    )
+    test(
+        "FP-1: TentacleEnforceRule create to session-state via toolInput.filePath → None",
+        _r19_create_input is None,
+        f"Expected None, got: {_r19_create_input!r}",
+    )
+
+    # FP-1: create to session-state via input.filePath must be allowed
+    _r19_create_input2 = _ter19.evaluate(
+        "preToolUse",
+        {
+            "toolName": "create",
+            "input": {"filePath": _ss_create_path19},
+        },
+    )
+    test(
+        "FP-1: TentacleEnforceRule create to session-state via input.filePath → None",
+        _r19_create_input2 is None,
+        f"Expected None, got: {_r19_create_input2!r}",
     )
 
     # Non-session edit at threshold must still deny


### PR DESCRIPTION
## Root Cause

FP-1 session-state exemption (allowing `Create`/ `Edit` to `.copilot/session-state/`) checked only `toolArgs["path"]`, but Copilot CLI `Create` tool sends the file path as `filePath` in `toolInput` / `input`, not as `path` in `toolArgs`.

This caused the exemption to **never match** — `TentacleEnforceRule` falsely denied `Create` calls writing research reports to `.copilot/session-state/*/research/`.

## Changes

### `hooks/rules/tentacle.py`
- `TentacleEnforceRule.evaluate()`: now checks `toolArgs.path`, `toolArgs.filePath`, and `input.filePath`

### `hooks/enforce-tentacle.py`
- Standalone mirror: same fix — checks `toolArgs.path`, `toolInput.filePath`, and `input.filePath`

## Verification

| Test | Input | Result |
|------|-------|--------|
| `Create` → `.copilot/session-state/` (`toolInput.filePath`) | **ALLOW** ✅ |
| `Create` → `src/main.py` (project code) | **DENY** ✅ (tentacle still enforces real multi-module edits) |
| `Create` → `.copilot/session-state/` (old `toolArgs.path`) | **ALLOW** ✅ (backward compatible) |

Closes false positive `TENTACLE REQUIRED` denial when writing research files to session-state.