### PR TITLE
fix(opencode-bridge): P1 critical fixes — multi-line JSON, tool mappings, resultType, cwd

### DIFF
--- a/docs/PHASE2-PLAN.md
+++ b/docs/PHASE2-PLAN.md
@@ -1,0 +1,215 @@
+# Phase 2: OpenCode Bridge — Gap Analysis & Implementation Plan
+
+## Overview
+
+Make the `copilot-tools-bridge` plugin work 100% with opencode (not just Copilot CLI).
+Phase 1 (PR #972) established the bridge foundation with 8 hooks and 20 tests.
+Phase 2 closes the remaining gaps to achieve feature parity with the Copilot CLI runtime.
+
+---
+
+## Architecture (Current State)
+
+```
+opencode runtime
+  │
+  ├── session.start ──────► hook_runner sessionStart
+  ├── session.stop ───────► hook_runner sessionEnd
+  ├── tool.execute.before ──► hook_runner preToolUse
+  ├── tool.execute.after ───► hook_runner postToolUse
+  ├── tool.use ────────────► hook_runner preToolUse
+  ├── chat.message ────────► hook_runner userPromptSubmitted
+  ├── task ────────────────► hook_runner preToolUse (toolName: "task")
+  └── event ──────────────► session.created → sessionStart
+                            session.idle → sessionEnd
+                            session.error → errorOccurred
+```
+
+**Current bridge source**: `opencode-plugin/copilot-tools-bridge.ts` (255 lines, 8 hooks)
+**Hook runner**: `hooks/hook_runner.py` (356 lines, dispatches to 38 rules)
+**Tests**: `tests/test_opencode_bridge.py` (310 lines, 20 tests)
+
+---
+
+## Gaps Analysis
+
+### G1: Multi-line JSON output from hook_runner (P1)
+
+`hook_runner.py` prints **one JSON object per line** (line 323 `print(json.dumps(result))`).
+When multiple rules return results for the same event, stdout contains multiple JSON objects.
+Bridge does `JSON.parse(result)` on the entire blob — fails on multi-line output.
+
+**Affects**: `chat.message` (→ userPromptSubmitted), `tool.execute.after` (→ postToolUse)
+
+### G2: `additionalContext` format mismatch (P1)
+
+`common.py`'s `context()` returns `{"additionalContext": "string"}`. Bridge checks `Array.isArray(parsed.additionalContext)` which is always false for a string. Briefing/AutoBriefing context injection is silently broken.
+
+### G3: `mapToolName` incomplete (P1)
+
+| opencode tool | Current map | Rules expect | Fix |
+|--------------|------------|-------------|-----|
+| `read` | `"read"` (unchanged) | `"view"` | Add `"read" → "view"` |
+| `write` | `"create"` ✓ | `"create"` | OK |
+| `apply_patch` | `"apply_patch"` (unchanged) | `"edit"` | Add `"apply_patch" → "edit"` |
+| `skill` | `"skill"` (unchanged) | `"skill"` | OK (but no handler) |
+| `edit` | `"edit"` ✓ | `"edit"` | OK |
+
+### G4: `toolResult` too sparse (P1)
+
+Rules expect `resultType: "success"|"error"`, `exitCode`, `isError` in `toolResult`.
+Bridge only sets `title`, `output`, `filePath`.
+
+### G5: Missing `cwd` in tool events (P1)
+
+`ConstitutionGateRule` needs `data.cwd` to resolve `.copilot/constitution.md`.
+Bridge doesn't pass it.
+
+### G6: Missing session lifecycle events (P3)
+
+| opencode hook | Maps to | Status |
+|--------------|---------|--------|
+| `experimental.session.compacting` | `preCompact`/`postCompact` | Not handled |
+| Subagent lifecycle | `agentStop`/`subagentStop` | Not handled |
+
+### G7: Missing tool coverage (P2)
+
+| Tool | Handler status |
+|------|---------------|
+| `skill` | Not handled (SkillUsageRule, SkillNudgeRule silent) |
+| `question` | Not handled |
+| `webfetch`/`websearch` | Not handled (not critical) |
+| `lsp` | Not handled (non-granular permission, low priority) |
+
+### G8: Tool argument normalization (P5)
+
+Rules expect Copilot CLI field names in `toolArgs`:
+- `old_str` / `new_str` (edit tool changes)
+- `file_text` (create tool full content)
+- `path` (file path, already covered via `filePath` fallback)
+
+Need to verify opencode's actual parameter names and add mapping.
+
+### G9: Output protocol gaps (P4)
+
+| Hook runner output | Bridge support |
+|-------------------|---------------|
+| `{"permissionDecision": "deny", ...}` | ✓ (throws on deny) |
+| `{"additionalContext": "..."}` | Buggy (string vs array) |
+| `{"modifiedPrompt": "..."}` | Not handled |
+| `{"sessionSummary": "..."}` | Not handled |
+
+### G10: Rules compatibility audit
+
+| Tier | Count | Confidence | Criteria |
+|------|-------|-----------|----------|
+| Works now | 3 rules | High | Generic logic, no CLI-specific shapes |
+| P1 fixes unlocks | 9 rules | Med-High | Need `additionalContext`, cwd, resultType, read→view |
+| P3+ events unlocks | 11 rules | Medium | Need lifecycle events + agentStop |
+| P5 arg mapping | 5 rules | Low | Need CLI field name mapping |
+| Deeply tied to CLI | 10 rules | Low | Major refactor needed |
+
+---
+
+## Priority Plan
+
+### P1 — Critical Fixes (NOW)
+
+| # | Fix | Confidence | Files |
+|---|-----|-----------|-------|
+| P1.1 | Handle multi-line JSON output | High | `copilot-tools-bridge.ts` |
+| P1.2 | Fix `additionalContext` string vs array | High | `copilot-tools-bridge.ts` |
+| P1.3 | `mapToolName` read→view, apply_patch→edit | High | `copilot-tools-bridge.ts` |
+| P1.4 | Add `resultType` to `toolResult` | High | `copilot-tools-bridge.ts` |
+| P1.5 | Add `cwd` to tool events | High | `copilot-tools-bridge.ts` |
+| P1.6 | Update tests | High | `tests/test_opencode_bridge.py` |
+
+Unlocks 9 rules: IntegrityRule, SkillNudgeRule, SkillImprovementAdvisorRule,
+AutoBriefingRule, NewFileAdvisoryRule, BlockEditDistRule, SubagentGitGuardRule,
+PostCommitBriefingRule, TrackEditsRule, WorkflowStateRule, EnforceBriefingRule.
+
+### P2 — Tool Coverage (NEXT)
+
+- Add `skill` tool handler (maps to hook_runner `"skill"` toolName)
+- Add `question` handler (advisory-only)
+- Verify `webfetch`/`websearch` don't need rules (likely not critical)
+
+### P3 — Session Lifecycle Events
+
+- Add `agentStop`/`subagentStop` handler
+- Map `experimental.session.compacting` → `preCompact`/`postCompact`
+
+### P4 — Output Protocol
+
+- Handle `modifiedPrompt` in `chat.message`
+- Handle `sessionSummary` in appropriate hooks
+- Aggregate structured output from multi-rule results
+
+### P5 — Tool Argument Normalization
+
+- Map opencode edit args → `old_str`/`new_str` (SyntaxGateRule, BlockUnsafeHtmlRule, etc.)
+- Map opencode write args → `file_text` (FileSizeAdvisoryRule)
+- Need to verify actual opencode parameter names first (research task)
+
+---
+
+## Rules Compatibility Heatmap
+
+```
+                                     Now   P1    P3    P5   Deep
+IntegrityRule                        ████
+SkillNudgeRule                       ████
+SkillImprovementAdvisorRule          ████
+AutoBriefingRule                     ███░  ████
+NewFileAdvisoryRule                  ███░  ████
+BlockEditDistRule                    ███░  ████
+PnpmLockfileGuardRule                ███░  ████
+SubagentGitGuardRule                 ███░  ████
+PostCommitBriefingRule               ███░  ████
+TrackEditsRule                       ███░  ████
+WorkflowStateRule                    ███░  ████
+EnforceBriefingRule                  ██░░  ███░
+ReadBeforeEditRule                   ██░░  ███░
+EpisodeBatcherRule                   ██░░  ███░
+ErrorFixNudgeRule                    ██░░  ███░
+SessionEndRule                       ██░░  ███░
+RecurrenceDetectorRule               ██░░  ███░
+SessionCompilerRule                  ██░░  ███░
+UserPromptContextRule                ██░░  ███░
+SkillNudgeRule (skill)               ██░░  ███░
+LoopDetectorRule                     ██░░  ███░   ███░
+ReadTrackerRule                      █░░░  ██░░
+EnforceLearnRule                     █░░░  ██░░
+TentacleEnforceRule                  █░░░  ██░░
+VerificationGateRule                 █░░░  █░██
+ConfidenceGateRule                   █░░░  █░██
+ConstitutionGateRule                 █░░░  █░██
+SyntaxGateRule                       █░░░       ████
+BlockUnsafeHtmlRule                  █░░░       ████
+FileSizeAdvisoryRule                 █░░░       ████
+AutoBugDetectorRule                  █░░░       ████
+TestReminderRule                     █░░░       ███░
+TentacleSuggestRule                  █░░░       ██░░
+LearnReminderRule                    █░░░  ██░░
+TokenTrackerRule                     █░░░  ██░░
+ErrorKBRule                          █░░░  ██░░
+SubagentStopRule                     ░░░░  ████
+CompactLifecycleRule                 ░░░░  ████
+SkillUsageRule                       ░░░░  ███░
+```
+
+Legend: █ = works, ░ = gap
+
+---
+
+## Research Notes
+
+- `chat.message` and `task` hooks are NOT in public plugin API docs at opencode.ai/docs/plugins
+  — may be internal/experimental, could break on upgrade
+- opencode 1.16.2 installed at `/opt/homebrew/bin/opencode`, Bun 1.3.9
+- Session knowledge DB at `~/.local/share/opencode/opencode.db`
+  (separate from tools' `~/.copilot/session-state/knowledge.db`)
+- 50+ hooks available in opencode plugin API, we only use ~9
+- `write` tool uses `edit` permission (not `create`) in opencode's permission system
+- Rules checked against `common.py` output protocol: `deny()`, `context()`, `info()`,
+  `session_summary()`, `modified_prompt()`

--- a/docs/PHASE2-PLAN.md
+++ b/docs/PHASE2-PLAN.md
@@ -43,7 +43,7 @@ Bridge does `JSON.parse(result)` on the entire blob — fails on multi-line outp
 
 ### G2: `additionalContext` format mismatch (P1)
 
-`common.py`'s `context()` returns `{"additionalContext": "string"}`. Bridge checks `Array.isArray(parsed.additionalContext)` which is always false for a string. Briefing/AutoBriefing context injection is silently broken.
+`hooks/rules/common.py`'s `context()` returns `{"additionalContext": "string"}`. Bridge checks `Array.isArray(parsed.additionalContext)` which is always false for a string. Briefing/AutoBriefing context injection is silently broken.
 
 ### G3: `mapToolName` incomplete (P1)
 
@@ -86,7 +86,7 @@ Bridge doesn't pass it.
 Rules expect Copilot CLI field names in `toolArgs`:
 - `old_str` / `new_str` (edit tool changes)
 - `file_text` (create tool full content)
-- `path` (file path, already covered via `filePath` fallback)
+- `path` (file path — `hook_runner.py` reads both `path` and `filePath`, but many rules read `toolArgs.path` directly; the bridge must pass `filePath` from opencode args under both keys for full coverage)
 
 Need to verify opencode's actual parameter names and add mapping.
 
@@ -124,7 +124,7 @@ Need to verify opencode's actual parameter names and add mapping.
 | P1.5 | Add `cwd` to tool events | High | `copilot-tools-bridge.ts` |
 | P1.6 | Update tests | High | `tests/test_opencode_bridge.py` |
 
-Unlocks 9 rules: IntegrityRule, SkillNudgeRule, SkillImprovementAdvisorRule,
+Unlocks 11 rules: IntegrityRule, SkillNudgeRule, SkillImprovementAdvisorRule,
 AutoBriefingRule, NewFileAdvisoryRule, BlockEditDistRule, SubagentGitGuardRule,
 PostCommitBriefingRule, TrackEditsRule, WorkflowStateRule, EnforceBriefingRule.
 

--- a/docs/PHASE2-PLAN.md
+++ b/docs/PHASE2-PLAN.md
@@ -104,7 +104,7 @@ Need to verify opencode's actual parameter names and add mapping.
 | Tier | Count | Confidence | Criteria |
 |------|-------|-----------|----------|
 | Works now | 3 rules | High | Generic logic, no CLI-specific shapes |
-| P1 fixes unlocks | 9 rules | Med-High | Need `additionalContext`, cwd, resultType, read→view |
+| P1 fixes unlocks | 11 rules | Med-High | Need `additionalContext`, cwd, resultType, read→view |
 | P3+ events unlocks | 11 rules | Medium | Need lifecycle events + agentStop |
 | P5 arg mapping | 5 rules | Low | Need CLI field name mapping |
 | Deeply tied to CLI | 10 rules | Low | Major refactor needed |

--- a/opencode-plugin/copilot-tools-bridge.ts
+++ b/opencode-plugin/copilot-tools-bridge.ts
@@ -36,18 +36,20 @@ async function callHookRunner(
       log(client, "warn", `hook_runner ${event} exited ${exitCode}: ${stderr.trim()}`)
       return null
     }
-    const text = stdout.trim()
-    if (text && stderr.trim()) {
-      log(client, "debug", `[${event}] ${stderr.trim()}`)
+    const stderrText = stderr.trim()
+    if (stderrText) {
+      log(client, "debug", `[${event}] ${stderrText}`)
     }
+    const text = stdout.trim()
     if (!text) return null
-    const lines = text.split("\n").filter(l => l.trim())
+    const lines = text.split("\n").map(l => l.replace(/\r$/, ""))
     const results: Record<string, unknown>[] = []
     for (const line of lines) {
+      if (!line) continue
       try {
         results.push(JSON.parse(line))
       } catch {
-        log(client, "debug", `[${event}] non-JSON output: ${line}`)
+        results.push({ message: line })
       }
     }
     return results.length > 0 ? results : null
@@ -147,6 +149,9 @@ export const CopilotToolsBridge: Plugin = async ({ project, client, $, directory
 
       for (const parsed of results) {
         if (parsed.title) output.title = parsed.title
+        if (parsed.message) {
+          output.output = (output.output || "") + "\n" + parsed.message
+        }
       }
     },
 

--- a/opencode-plugin/copilot-tools-bridge.ts
+++ b/opencode-plugin/copilot-tools-bridge.ts
@@ -17,7 +17,7 @@ async function callHookRunner(
   client: any,
   event: string,
   data: Record<string, unknown>,
-): Promise<string | null> {
+): Promise<Record<string, unknown>[] | null> {
   const json = JSON.stringify(data)
   const signal = AbortSignal.timeout(HOOK_TIMEOUT)
   try {
@@ -40,7 +40,17 @@ async function callHookRunner(
     if (text && stderr.trim()) {
       log(client, "debug", `[${event}] ${stderr.trim()}`)
     }
-    return text || null
+    if (!text) return null
+    const lines = text.split("\n").filter(l => l.trim())
+    const results: Record<string, unknown>[] = []
+    for (const line of lines) {
+      try {
+        results.push(JSON.parse(line))
+      } catch {
+        log(client, "debug", `[${event}] non-JSON output: ${line}`)
+      }
+    }
+    return results.length > 0 ? results : null
   } catch (e) {
     if ((e as any)?.name === "TimeoutError") {
       log(client, "warn", `hook_runner ${event} timed out after ${HOOK_TIMEOUT}ms`)
@@ -53,6 +63,8 @@ async function callHookRunner(
 
 function mapToolName(tool: string): string {
   if (tool === "write") return "create"
+  if (tool === "read") return "view"
+  if (tool === "apply_patch") return "edit"
   return tool
 }
 
@@ -92,27 +104,21 @@ export const CopilotToolsBridge: Plugin = async ({ project, client, $, directory
     "tool.execute.before": async (input, output) => {
       const toolName = mapToolName(input.tool)
 
-      const result = await callHookRunner($, client, "preToolUse", {
+      const results = await callHookRunner($, client, "preToolUse", {
         toolName,
         toolArgs: output.args,
         toolInput: output.args,
         sessionId: input.sessionID,
         callId: input.callID,
+        cwd: process.cwd(),
       })
 
-      if (!result) return
+      if (!results) return
 
-      try {
-        const parsed = JSON.parse(result)
+      for (const parsed of results) {
         if (parsed.permissionDecision === "deny") {
           throw new Error(parsed.permissionDecisionReason || `Blocked by ${toolName} rule`)
         }
-      } catch (e) {
-        if (e instanceof SyntaxError) {
-          if (result) process.stderr.write("[copilot-tools] " + result + "\n")
-          return
-        }
-        throw e
       }
     },
 
@@ -122,55 +128,46 @@ export const CopilotToolsBridge: Plugin = async ({ project, client, $, directory
       const toolResult: Record<string, unknown> = {
         title: output.title,
         output: output.output,
+        resultType: output.isError ? "error" : "success",
       }
       if (typeof input.args === "object" && input.args && (input.args as any).filePath) {
         toolResult.filePath = (input.args as any).filePath
       }
 
-      const result = await callHookRunner($, client, "postToolUse", {
+      const results = await callHookRunner($, client, "postToolUse", {
         toolName,
         toolArgs: input.args,
         toolInput: input.args,
         toolResult,
         sessionId: input.sessionID,
+        cwd: process.cwd(),
       })
 
-      if (!result) return
+      if (!results) return
 
-      try {
-        const parsed = JSON.parse(result)
+      for (const parsed of results) {
         if (parsed.title) output.title = parsed.title
-      } catch {
-        if (result) {
-          output.output = (output.output || "") + "\n" + result
-        }
       }
     },
 
     "tool.use": async (input, output) => {
       const toolName = mapToolName(input.tool)
 
-      const result = await callHookRunner($, client, "preToolUse", {
+      const results = await callHookRunner($, client, "preToolUse", {
         toolName,
         toolArgs: output.args,
         toolInput: output.args,
         sessionId: input.sessionID,
         callId: input.callID,
+        cwd: process.cwd(),
       })
 
-      if (!result) return
+      if (!results) return
 
-      try {
-        const parsed = JSON.parse(result)
+      for (const parsed of results) {
         if (parsed.permissionDecision === "deny") {
           throw new Error(parsed.permissionDecisionReason || `Blocked by ${toolName} rule`)
         }
-      } catch (e) {
-        if (e instanceof SyntaxError) {
-          if (result) process.stderr.write("[copilot-tools] " + result + "\n")
-          return
-        }
-        throw e
       }
     },
 
@@ -182,54 +179,53 @@ export const CopilotToolsBridge: Plugin = async ({ project, client, $, directory
       const parts = output.parts || []
       const prompt = parts.map((p: any) => p.text || "").filter(Boolean).join("\n")
 
-      const result = await callHookRunner($, client, "userPromptSubmitted", {
+      const results = await callHookRunner($, client, "userPromptSubmitted", {
         sessionId: input.sessionID,
         prompt,
         additionalContext: [],
       })
 
-      if (!result) return
-      try {
-        const parsed = JSON.parse(result)
-        if (parsed.additionalContext && Array.isArray(parsed.additionalContext)) {
-          const targetParts = output.parts || []
-          for (const ctx of parsed.additionalContext) {
-            if (typeof ctx === "string") {
-              targetParts.push({
-                type: "text",
-                text: ctx,
-                synthetic: true,
-              } as any)
+      if (!results) return
+
+      const targetParts = output.parts || []
+      for (const parsed of results) {
+        if (parsed.additionalContext) {
+          const ctx = parsed.additionalContext
+          const texts = Array.isArray(ctx) ? ctx : [ctx]
+          for (const text of texts) {
+            if (typeof text === "string") {
+              targetParts.push({ type: "text", text, synthetic: true } as any)
             }
           }
-          output.parts = targetParts
         }
-      } catch {
+        if (parsed.modifiedPrompt && typeof parsed.modifiedPrompt === "string") {
+          for (let i = targetParts.length - 1; i >= 0; i--) {
+            if (!(targetParts[i] as any).synthetic) {
+              ;(targetParts[i] as any).text = parsed.modifiedPrompt
+              break
+            }
+          }
+        }
       }
+      output.parts = targetParts
     },
 
     task: async (input, output) => {
-      const result = await callHookRunner($, client, "preToolUse", {
+      const results = await callHookRunner($, client, "preToolUse", {
         toolName: "task",
         toolArgs: { description: input.description, subtask: input.subtask },
         toolInput: { description: input.description, subtask: input.subtask },
         sessionId: input.sessionID,
         callId: input.callID,
+        cwd: process.cwd(),
       })
 
-      if (!result) return
+      if (!results) return
 
-      try {
-        const parsed = JSON.parse(result)
+      for (const parsed of results) {
         if (parsed.permissionDecision === "deny") {
           throw new Error(parsed.permissionDecisionReason || "Blocked by task rule")
         }
-      } catch (e) {
-        if (e instanceof SyntaxError) {
-          if (result) process.stderr.write("[copilot-tools] " + result + "\n")
-          return
-        }
-        throw e
       }
     },
 

--- a/tests/test_opencode_bridge.py
+++ b/tests/test_opencode_bridge.py
@@ -93,10 +93,12 @@ class TestPluginSource(unittest.TestCase):
         text = PLUGIN_SRC.read_text(encoding="utf-8")
         self.assertIn("hook_runner.py", text)
 
-    def test_plugin_maps_write_to_create(self):
+    def test_plugin_maps_tool_names(self):
         text = PLUGIN_SRC.read_text(encoding="utf-8")
         self.assertIn("mapToolName", text)
-        self.assertIn("create", text)
+        self.assertIn('return "create"', text)
+        self.assertIn('return "view"', text)
+        self.assertIn('return "edit"', text)
 
 
 class TestInstallSandboxed(unittest.TestCase):
@@ -185,6 +187,20 @@ class TestInstallSandboxed(unittest.TestCase):
 class TestHookRunnerCompat(unittest.TestCase):
     """Verify hook_runner.py handles the JSON format the bridge sends."""
 
+    def test_pre_tool_use_includes_cwd(self):
+        proc = _run_hook(
+            "preToolUse",
+            {
+                "toolName": "bash",
+                "toolArgs": {"command": "echo hello"},
+                "toolInput": {"command": "echo hello"},
+                "sessionId": "bridge-test-cwd",
+                "callId": "call-cwd",
+                "cwd": "/tmp",
+            },
+        )
+        self.assertEqual(proc.returncode, 0)
+
     def test_pre_tool_use_bash_passthrough(self):
         proc = _run_hook(
             "preToolUse",
@@ -260,6 +276,23 @@ class TestHookRunnerCompat(unittest.TestCase):
         )
         self.assertEqual(proc.returncode, 0, f"sessionEnd failed:\n{proc.stderr}")
 
+    def test_post_tool_use_includes_result_type(self):
+        proc = _run_hook(
+            "postToolUse",
+            {
+                "toolName": "bash",
+                "toolArgs": {"command": "echo hello"},
+                "toolInput": {"command": "echo hello"},
+                "toolResult": {
+                    "title": "Run command",
+                    "output": "hello",
+                    "resultType": "success",
+                },
+                "sessionId": "bridge-test-rt",
+            },
+        )
+        self.assertEqual(proc.returncode, 0)
+
     def test_post_tool_use_tracking(self):
         proc = _run_hook(
             "postToolUse",
@@ -271,6 +304,7 @@ class TestHookRunnerCompat(unittest.TestCase):
                     "title": "Edit test file",
                     "output": "Done",
                     "filePath": os.path.join(tempfile.gettempdir(), "bridge-test-track.txt"),
+                    "resultType": "success",
                 },
                 "sessionId": "bridge-test-006",
             },


### PR DESCRIPTION
## Summary

P1 critical fixes from the Phase 2 gap analysis (docs/PHASE2-PLAN.md).

## Changes

### Multi-line JSON output
hook_runner.py outputs one JSON per line per rule. Bridge now returns Record<string, unknown>[] — splits stdout by newlines, parses each line.

### additionalContext string vs array
context() returns string, not array. Now normalizes both forms.

### modifiedPrompt support
Replaces last non-synthetic user message part.

### Tool name mapping
read → view, apply_patch → edit

### resultType in toolResult
Set from output.isError.

### cwd in tool events
Added to all tool hooks.

## Testing
- All 22 bridge tests pass
- All 13 security tests pass
- All fixes/regression tests pass