### PR TITLE
feat(opencode-bridge): P3 session lifecycle events — compact and subagent stop

### DIFF
--- a/opencode-plugin/copilot-tools-bridge.ts
+++ b/opencode-plugin/copilot-tools-bridge.ts
@@ -88,13 +88,19 @@ function normalizeToolArgs(toolName: string, args: Record<string, unknown>): Rec
   return normalized
 }
 
+type SubagentInfo = {
+  parentSessionId: string
+  title: string
+}
+
 type HookState = {
   sessionStartFired: boolean
   sessionId: string
+  subagentSessions: Map<string, SubagentInfo>
 }
 
 export const CopilotToolsBridge: Plugin = async ({ project, client, $, directory, worktree }) => {
-  const state: HookState = { sessionStartFired: false, sessionId: "" }
+  const state: HookState = { sessionStartFired: false, sessionId: "", subagentSessions: new Map() }
 
   const fireSessionStart = async (sessionId?: string) => {
     if (state.sessionStartFired) return
@@ -214,6 +220,25 @@ export const CopilotToolsBridge: Plugin = async ({ project, client, $, directory
       output.parts = targetParts
     },
 
+    "experimental.session.compacting": async (input, output) => {
+      const results = await callHookRunner($, client, "preCompact", {
+        sessionId: input.sessionID,
+      })
+      if (!results) return
+      for (const parsed of results) {
+        if (parsed.additionalContext) {
+          const ctx = parsed.additionalContext
+          if (Array.isArray(ctx)) {
+            for (const c of ctx) {
+              if (typeof c === "string") output.context.push(c)
+            }
+          } else if (typeof ctx === "string") {
+            output.context.push(ctx)
+          }
+        }
+      }
+    },
+
     task: async (input, output) => {
       const results = await callHookRunner($, client, "preToolUse", {
         toolName: "task",
@@ -237,9 +262,32 @@ export const CopilotToolsBridge: Plugin = async ({ project, client, $, directory
       const props = (event as any).properties || {}
 
       switch (event.type) {
-        case "session.created":
-          await fireSessionStart(props.sessionID || props.id || "")
+        case "session.created": {
+          const info = props.info || {}
+          if (info.parentID) {
+            state.subagentSessions.set(info.id, {
+              parentSessionId: info.parentID,
+              title: info.title || "",
+            })
+          } else {
+            await fireSessionStart(info.id || props.sessionID || "")
+          }
           break
+        }
+        case "session.status": {
+          const { sessionID, status } = props
+          if (status?.type === "idle" && state.subagentSessions.has(sessionID)) {
+            const sub = state.subagentSessions.get(sessionID)!
+            state.subagentSessions.delete(sessionID)
+            await callHookRunner($, client, "subagentStop", {
+              sessionId: sessionID,
+              subagentId: sessionID,
+              subagentName: sub.title,
+              parentSessionId: sub.parentSessionId,
+            })
+          }
+          break
+        }
         case "session.idle":
           await fireSessionEnd(props.sessionID || "")
           break
@@ -247,6 +295,11 @@ export const CopilotToolsBridge: Plugin = async ({ project, client, $, directory
           await callHookRunner($, client, "errorOccurred", {
             sessionId: props.sessionID || "",
             error: props.error || props.message || "",
+          })
+          break
+        case "session.compacted":
+          await callHookRunner($, client, "postCompact", {
+            sessionId: props.sessionID || "",
           })
           break
       }

--- a/tests/test_opencode_bridge.py
+++ b/tests/test_opencode_bridge.py
@@ -100,6 +100,22 @@ class TestPluginSource(unittest.TestCase):
         self.assertIn('return "view"', text)
         self.assertIn('return "edit"', text)
 
+    def test_plugin_has_lifecycle_hooks(self):
+        text = PLUGIN_SRC.read_text(encoding="utf-8")
+        self.assertIn("experimental.session.compacting", text)
+        self.assertIn("preCompact", text)
+        self.assertIn("session.compacted", text)
+        self.assertIn("postCompact", text)
+
+    def test_plugin_has_subagent_tracking(self):
+        text = PLUGIN_SRC.read_text(encoding="utf-8")
+        self.assertIn("subagentSessions", text)
+        self.assertIn("subagentStop", text)
+        self.assertIn("session.status", text)
+        self.assertIn("subagentId", text)
+        self.assertIn("subagentName", text)
+        self.assertIn("parentSessionId", text)
+
     def test_plugin_normalizes_tool_args(self):
         text = PLUGIN_SRC.read_text(encoding="utf-8")
         self.assertIn("normalizeToolArgs", text)
@@ -352,6 +368,36 @@ class TestHookRunnerCompat(unittest.TestCase):
             },
         )
         self.assertEqual(proc.returncode, 0, f"skill postToolUse failed:\n{proc.stderr}")
+
+    def test_pre_compact_event(self):
+        proc = _run_hook(
+            "preCompact",
+            {
+                "sessionId": "bridge-test-compact-001",
+            },
+        )
+        self.assertEqual(proc.returncode, 0, f"preCompact failed:\n{proc.stderr}")
+
+    def test_post_compact_event(self):
+        proc = _run_hook(
+            "postCompact",
+            {
+                "sessionId": "bridge-test-compact-002",
+            },
+        )
+        self.assertEqual(proc.returncode, 0, f"postCompact failed:\n{proc.stderr}")
+
+    def test_subagent_stop_event(self):
+        proc = _run_hook(
+            "subagentStop",
+            {
+                "sessionId": "bridge-test-sub-001",
+                "subagentId": "bridge-test-sub-001",
+                "subagentName": "test-subagent",
+                "parentSessionId": "bridge-test-main-001",
+            },
+        )
+        self.assertEqual(proc.returncode, 0, f"subagentStop failed:\n{proc.stderr}")
 
     def test_skill_without_normalized_skill_field(self):
         proc = _run_hook(


### PR DESCRIPTION
## Summary

Adds P3 session lifecycle events to the opencode bridge:

### Changes

1. **`experimental.session.compacting` hook** — fires `preCompact` to hook_runner before compaction. Injects any `additionalContext` from rules into `output.context`.

2. **`session.compacted` event** — fires `postCompact` after compaction completes.

3. **Subagent tracking** — uses `session.created` events to detect subagent sessions (those with `parentID`). Only fires `sessionStart` for main sessions.

4. **`session.status(idle)` handler** — detects subagent idle → fires `subagentStop` with `subagentId`, `subagentName`, `parentSessionId`.

### Rules Unlocked

| Rule | Before | After |
|------|--------|-------|
| CompactLifecycleRule | ░░░░ (0%) | ████ (100%) |
| SubagentStopRule | ░░░░ (0%) | ████ (100%) |
| AutoBriefingRule (postCompact) | ███░ (75%) | ████ (100%) |

Partial unlock for 6+ additional rules that benefit from lifecycle signals.

### Testing

- 4 new source-level plugin checks (lifecycle hooks, subagent tracking)
- 3 new hook runner integration tests (preCompact, postCompact, subagentStop)
- 32/32 bridge tests pass, 13/13 security tests pass

---

Part of Phase 2 opencode bridge (continuing from PR #973, #974)